### PR TITLE
ci: hourly sync-check; auto-open tracking issue on drift

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -2,16 +2,24 @@ name: sync-check
 
 # Runs the dry-run sync against ai-dynamo/dynamo main and fails if dynamo's
 # lib/{protocols,tokenizers,parsers}/{src,tests} have drifted from this repo's
-# copies. Auto-pings on schedule so we don't fall behind silently.
+# copies.
+#
+# On the hourly cron schedule, drift also opens a tracking issue (and the
+# issue gets auto-closed when the sync is restored). PRs and manual runs
+# just surface a red check; they don't touch issues.
 
 on:
   schedule:
-    - cron: '17 13 * * *'   # daily ~13:17 UTC
+    - cron: '17 * * * *'   # hourly at :17
   workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   sync-check:
@@ -24,6 +32,10 @@ jobs:
       - name: Clone ai-dynamo/dynamo (shallow)
         run: |
           git clone --depth 1 --branch main https://github.com/ai-dynamo/dynamo.git "$RUNNER_TEMP/dynamo"
+          {
+            echo "DYNAMO_SHA=$(git -C "$RUNNER_TEMP/dynamo" rev-parse HEAD)"
+            echo "DYNAMO_SHORT=$(git -C "$RUNNER_TEMP/dynamo" rev-parse --short HEAD)"
+          } >> "$GITHUB_ENV"
           echo "dynamo HEAD: $(git -C "$RUNNER_TEMP/dynamo" rev-parse HEAD)"
 
       - name: Run sync check
@@ -33,13 +45,91 @@ jobs:
           out=$(scripts/sync-from-dynamo.sh "$RUNNER_TEMP/dynamo" 2>&1)
           rc=$?
           echo "$out"
+
+          # Stash output and rc for downstream steps.
+          {
+            echo "rc=$rc"
+            echo 'out<<SYNC_EOF'
+            echo "$out"
+            echo 'SYNC_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          # Job summary on every run.
           {
             echo "## Sync check vs ai-dynamo/dynamo main"
             echo ""
-            echo "dynamo HEAD: \`$(git -C "$RUNNER_TEMP/dynamo" rev-parse --short HEAD)\`"
+            echo "dynamo HEAD: \`${DYNAMO_SHORT}\`"
             echo ""
             echo '```'
             echo "$out"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          exit $rc
+
+          # Don't fail yet — let the issue-management steps run first.
+          exit 0
+
+      - name: Open tracking issue if drift detected
+        if: github.event_name == 'schedule' && steps.check.outputs.rc != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_OUT: ${{ steps.check.outputs.out }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Make sure the label exists (idempotent).
+          gh label create sync-drift --color FBCA04 \
+            --description "Code drift detected vs ai-dynamo/dynamo main" 2>/dev/null || true
+
+          existing=$(gh issue list --state open --label sync-drift --json number --jq '.[0].number // empty')
+          body=$(cat <<EOF
+          The hourly sync-check job detected code drift between this repo and \`ai-dynamo/dynamo@main\`.
+
+          - Dynamo HEAD: [\`${DYNAMO_SHORT}\`](https://github.com/ai-dynamo/dynamo/commit/${DYNAMO_SHA})
+          - Workflow run: ${RUN_URL}
+
+          <details><summary>sync-from-dynamo.sh output</summary>
+
+          \`\`\`
+          ${CHECK_OUT}
+          \`\`\`
+
+          </details>
+
+          ## How to resolve
+
+          \`\`\`bash
+          git clone --depth 1 https://github.com/ai-dynamo/dynamo.git /tmp/dynamo
+          scripts/sync-from-dynamo.sh --apply /tmp/dynamo
+          # then review, commit, and PR
+          \`\`\`
+
+          This issue will auto-close on the next hourly run if the sync is restored.
+          EOF
+          )
+
+          if [ -n "$existing" ]; then
+            echo "issue #$existing already open for sync drift; not opening another"
+          else
+            gh issue create \
+              --title "Sync drift detected vs ai-dynamo/dynamo@${DYNAMO_SHORT}" \
+              --label sync-drift \
+              --body "$body"
+          fi
+
+      - name: Close tracking issue if back in sync
+        if: github.event_name == 'schedule' && steps.check.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --state open --label sync-drift --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Sync is back in line with [\`${DYNAMO_SHORT}\`](https://github.com/ai-dynamo/dynamo/commit/${DYNAMO_SHA}). Closing automatically."
+          fi
+
+      - name: Fail job if drift detected
+        if: steps.check.outputs.rc != '0'
+        run: |
+          echo "code drift detected vs ai-dynamo/dynamo main — failing job"
+          exit 1


### PR DESCRIPTION
## Summary

Make the existing sync-check workflow more useful for catching upstream drift in near-real time and routing it to a tracking issue.

- **Hourly cron** (\`17 * * * *\`) instead of daily. Each run takes about 10 seconds, so cost is negligible.
- **Auto-open issue on drift**, labeled \`sync-drift\`. Body has the dynamo HEAD (with link), full sync-script output in a `<details>` block, and a one-line apply command. The label is created on demand if it doesn't exist.
- **Deduped**: if an open \`sync-drift\` issue is already there, we don't open another — saves us from hour-over-hour spam.
- **Auto-close**: when a later run reports sync is restored, the open \`sync-drift\` issue gets closed with a confirmation comment pinning the dynamo HEAD that brought us back in line.
- **PR / manual runs are unchanged behavior-wise**: they surface a red check on drift but don't touch issues. (Contributor PRs shouldn't leave tracking issues behind.)
- Adds \`permissions: { contents: read, issues: write }\` so the default \`GITHUB_TOKEN\` can manage issues.

## Test plan

- [x] YAML validates locally
- [ ] CI on this PR is green (no drift currently expected)
- [ ] On the first hourly cron firing post-merge: confirm no spurious issues open
- [ ] Manual test: temporarily land a no-op change in \`ai-dynamo/dynamo\` to force drift, observe the issue gets opened with the expected body, then resolve the drift and observe the issue auto-close on the next hourly run