### PR TITLE
build: organize frontend crates workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,26 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install
 
-      - name: Cache cargo registry and tools
+      - name: Cache cargo tools
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin/cargo-deny
             ~/.cargo/bin/cargo-machete
-            ~/.cargo/registry/
-            ~/.cargo/git/
           key: ${{ runner.os }}-cargo-tools-deny-${{ env.CARGO_DENY_VERSION }}-machete-${{ env.CARGO_MACHETE_VERSION }}-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-tools-
+
+      - name: Install cargo tools
+        run: |
+          cargo-deny --version 2>/dev/null | grep -qF "${CARGO_DENY_VERSION}" || cargo install "cargo-deny@${CARGO_DENY_VERSION}" --locked
+          cargo-machete --version 2>/dev/null | grep -qF "${CARGO_MACHETE_VERSION}" || cargo install "cargo-machete@${CARGO_MACHETE_VERSION}" --locked
+
+      - name: Check unused dependencies
+        run: cargo machete
+
+      - name: Check dependency policy
+        run: cargo deny --all-features check bans licenses
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -49,14 +58,3 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-
-      - name: Install cargo tools
-        run: |
-          cargo-deny --version 2>/dev/null | grep -qF "${CARGO_DENY_VERSION}" || cargo install "cargo-deny@${CARGO_DENY_VERSION}" --locked
-          cargo-machete --version 2>/dev/null | grep -qF "${CARGO_MACHETE_VERSION}" || cargo install "cargo-machete@${CARGO_MACHETE_VERSION}" --locked
-
-      - name: Check unused dependencies
-        run: cargo machete
-
-      - name: Check dependency policy
-        run: cargo deny --all-features check bans licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CARGO_DENY_VERSION: "0.19.4"
+      CARGO_MACHETE_VERSION: "0.9.2"
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -28,7 +31,7 @@ jobs:
             ~/.cargo/bin/cargo-machete
             ~/.cargo/registry/
             ~/.cargo/git/
-          key: ${{ runner.os }}-cargo-tools-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '.github/workflows/ci.yml') }}
+          key: ${{ runner.os }}-cargo-tools-deny-${{ env.CARGO_DENY_VERSION }}-machete-${{ env.CARGO_MACHETE_VERSION }}-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-tools-
 
@@ -49,8 +52,8 @@ jobs:
 
       - name: Install cargo tools
         run: |
-          cargo-deny --version 2>/dev/null | grep -qF '0.19.4' || cargo install cargo-deny@0.19.4 --locked
-          cargo-machete --version 2>/dev/null | grep -qF '0.9.2' || cargo install cargo-machete@0.9.2 --locked
+          cargo-deny --version 2>/dev/null | grep -qF "${CARGO_DENY_VERSION}" || cargo install "cargo-deny@${CARGO_DENY_VERSION}" --locked
+          cargo-machete --version 2>/dev/null | grep -qF "${CARGO_MACHETE_VERSION}" || cargo install "cargo-machete@${CARGO_MACHETE_VERSION}" --locked
 
       - name: Check unused dependencies
         run: cargo machete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,13 @@ permissions:
 jobs:
   rust:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.93.1
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        run: rustup toolchain install
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -41,23 +36,8 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
-  hygiene:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.93.1
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-
       - name: Install cargo tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny,cargo-machete
+        run: cargo install cargo-deny@0.19.4 cargo-machete@0.9.2 --locked
 
       - name: Check unused dependencies
         run: cargo machete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install
 
+      - name: Cache cargo registry and tools
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-deny
+            ~/.cargo/bin/cargo-machete
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: ${{ runner.os }}-cargo-tools-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '.github/workflows/ci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-tools-
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -36,7 +48,9 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
       - name: Install cargo tools
-        run: cargo install cargo-deny@0.19.4 cargo-machete@0.9.2 --locked
+        run: |
+          cargo-deny --version 2>/dev/null | grep -qF '0.19.4' || cargo install cargo-deny@0.19.4 --locked
+          cargo-machete --version 2>/dev/null | grep -qF '0.9.2' || cargo install cargo-machete@0.9.2 --locked
 
       - name: Check unused dependencies
         run: cargo machete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.93.1
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check workspace
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Run tests
+        run: cargo test --workspace --all-targets --locked
+
+      - name: Run doctests
+        run: cargo test --workspace --doc --locked
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  hygiene:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.93.1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny,cargo-machete
+
+      - name: Check unused dependencies
+        run: cargo machete
+
+      - name: Check dependency policy
+        run: cargo deny --all-features check bans licenses

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,12 @@
 debug
 target
 
-# Library Cargo.lock files are not committed (libraries don't ship a lock;
-# the binary in examples/ commits its own lock for reproducible builds).
+# The workspace Cargo.lock is committed for reproducible CI and demo builds.
+# Nested crate/demo lockfiles are not used.
 /protocols/Cargo.lock
 /tokenizers/Cargo.lock
 /parsers/Cargo.lock
+/examples/*/Cargo.lock
 
 # rustfmt backups
 **/*.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -841,6 +840,7 @@ dependencies = [
  "num-traits",
  "openai-harmony",
  "regex",
+ "rstest",
  "rustpython-parser",
  "serde",
  "serde_json",
@@ -859,6 +859,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-test",
  "tracing",
  "url",
  "uuid",
@@ -876,6 +878,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "tempfile",
  "tiktoken-rs",
  "tokenizers",
  "tracing",
@@ -1004,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1226,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1774,6 +1795,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2343,6 +2370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +2785,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2825,28 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -3205,6 +3299,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3518,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3539,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -4188,6 +4336,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,50 @@
+[workspace]
+resolver = "3"
+members = [
+    "protocols",
+    "parsers",
+    "tokenizers",
+    "examples/dynamo-demo-server",
+]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.93.1"
+authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
+homepage = "https://github.com/ai-dynamo/frontend-crates"
+repository = "https://github.com/ai-dynamo/frontend-crates.git"
+
+[workspace.dependencies]
+anyhow = "1"
+async-openai = { version = "0.34", default-features = false }
+async-stream = "0.3"
+axum = "0.8"
+base64 = "0.22"
+clap = "4"
+derive_builder = "0.20"
+dynamo-parsers = { path = "parsers", version = "0.1.0" }
+dynamo-protocols = { path = "protocols", version = "0.1.0" }
+dynamo-tokenizers = { path = "tokenizers", version = "0.1.0" }
+fastokens = "0.1.0"
+futures = "0.3"
+hf-hub = { version = "0.4", default-features = false }
+num-traits = "0.2"
+openai-harmony = "0.0.3"
+rayon = "1"
+regex = "1"
+rstest = "0.25"
+rustc-hash = "1.1"
+rustpython-parser = "0.4.0"
+serde = "1"
+serde_json = "1"
+strum = "0.27"
+tempfile = "3"
+thiserror = "2.0.17"
+tiktoken-rs = { version = "0.9", default-features = false }
+tokio = "=1.48.0"
+tokio-test = "0.4.4"
+tokenizers = { version = "0.21.4", default-features = false }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+url = "2.5"
+uuid = "1.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93.1"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
 homepage = "https://github.com/ai-dynamo/frontend-crates"
 repository = "https://github.com/ai-dynamo/frontend-crates.git"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Three standalone Rust crates for building OpenAI/Anthropic-compatible inference 
 | [`dynamo-tokenizers`](./tokenizers/) | HuggingFace + tiktoken + FastTokenizer wrappers with fast incremental detokenization. |
 | [`dynamo-parsers`](./parsers/)       | Reasoning + tool-calling parsers across 18+ model families (DeepSeek R1/V4, Qwen3, GPT-OSS, Kimi K2, Gemma 4, Llama, Hermes, ...). Streaming-first. |
 
-Each crate is independently published to crates.io and can be adopted on its own. `dynamo-parsers` depends on `dynamo-protocols`; the other two have no internal deps.
+Each crate is independently published to crates.io and can be adopted on its own. `dynamo-parsers` depends on `dynamo-protocols`; the other two have no internal deps. The repository itself is a Cargo workspace so shared dependency versions, CI checks, and the demo build stay consistent.
 
 ## Layout
 
@@ -25,18 +25,32 @@ frontend-crates/
 
 ## Building
 
-Each crate builds standalone:
+This repo pins Rust with [`rust-toolchain.toml`](./rust-toolchain.toml). Use the workspace commands from the repository root:
 
 ```bash
-cd protocols   && cargo build
-cd tokenizers  && cargo build
-cd parsers     && cargo build
+cargo check --workspace --all-targets --locked
+cargo test --workspace --all-targets --locked
+cargo test --workspace --doc --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 ```
 
-The demo server pulls all three via path deps:
+The root [`Cargo.lock`](./Cargo.lock) is committed for reproducible CI and demo-server builds. Library crates still publish normally; consumers resolve their own lockfiles.
+
+Each crate can still be built or tested directly:
 
 ```bash
-cd examples/dynamo-demo-server && cargo build --release
+cargo build -p dynamo-protocols
+cargo build -p dynamo-tokenizers
+cargo build -p dynamo-parsers
+cargo build -p dynamo-demo-server --release
+```
+
+Repository hygiene checks:
+
+```bash
+cargo fmt --all -- --check
+cargo machete
+cargo deny --all-features check bans licenses
 ```
 
 ## Where the code lives

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,24 @@
+[graph]
+all-features = true
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "LGPL-3.0-only",
+    "MIT",
+    "MPL-2.0",
+    "NCSA",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"

--- a/examples/dynamo-demo-server/Cargo.toml
+++ b/examples/dynamo-demo-server/Cargo.toml
@@ -2,7 +2,6 @@
 name = "dynamo-demo-server"
 version = "0.1.0"
 edition.workspace = true
-rust-version.workspace = true
 license = "Apache-2.0"
 publish = false
 

--- a/examples/dynamo-demo-server/Cargo.toml
+++ b/examples/dynamo-demo-server/Cargo.toml
@@ -1,33 +1,35 @@
 [package]
 name = "dynamo-demo-server"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
+license = "Apache-2.0"
+publish = false
 
 [dependencies]
 # Three sibling crates from this repo.
-dynamo-protocols  = { path = "../../protocols" }
-dynamo-parsers    = { path = "../../parsers" }
-dynamo-tokenizers = { path = "../../tokenizers" }
+dynamo-protocols.workspace = true
+dynamo-parsers.workspace = true
+dynamo-tokenizers.workspace = true
 
 # Web framework
-axum = "0.8"
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
+axum.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 # SSE streaming
-futures = "0.3"
-async-stream = "0.3"
+futures.workspace = true
+async-stream.workspace = true
 
 # Utilities
-uuid = { version = "1", features = ["v4"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { workspace = true, features = ["v4"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # CLI + HF Hub fetch (downloads tokenizer.json on demand via --model)
-clap = { version = "4", features = ["derive", "env"] }
-hf-hub = { version = "0.4", default-features = false, features = ["tokio", "rustls-tls"] }
-anyhow = "1"
+clap = { workspace = true, features = ["derive", "env"] }
+hf-hub = { workspace = true, features = ["tokio", "rustls-tls"] }
+anyhow.workspace = true

--- a/examples/dynamo-demo-server/src/handlers/anthropic.rs
+++ b/examples/dynamo-demo-server/src/handlers/anthropic.rs
@@ -6,7 +6,10 @@
 use std::convert::Infallible;
 
 use axum::Json;
-use axum::response::{IntoResponse, Response, sse::{Event, KeepAlive, Sse}};
+use axum::response::{
+    IntoResponse, Response,
+    sse::{Event, KeepAlive, Sse},
+};
 use futures::stream::Stream;
 
 use dynamo_protocols::types::anthropic::*;
@@ -21,7 +24,9 @@ pub async fn handler(Json(req): Json<AnthropicCreateMessageRequest>) -> Response
 
     if req.stream {
         let stream = make_stream(id, model, echo_text);
-        Sse::new(stream).keep_alive(KeepAlive::default()).into_response()
+        Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response()
     } else {
         let resp = AnthropicMessageResponse {
             id,

--- a/examples/dynamo-demo-server/src/handlers/chat.rs
+++ b/examples/dynamo-demo-server/src/handlers/chat.rs
@@ -8,7 +8,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::Json;
 use axum::extract::State;
-use axum::response::{IntoResponse, Response, sse::{Event, KeepAlive, Sse}};
+use axum::response::{
+    IntoResponse, Response,
+    sse::{Event, KeepAlive, Sse},
+};
 use futures::stream::Stream;
 
 use dynamo_protocols::types::*;
@@ -62,7 +65,9 @@ pub async fn handler(
 
     if req.stream == Some(true) {
         let stream = make_stream(id, model, created, text, tool_call_result);
-        Sse::new(stream).keep_alive(KeepAlive::default()).into_response()
+        Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response()
     } else {
         let tool_calls = tool_call_result.map(|calls| {
             calls

--- a/examples/dynamo-demo-server/src/handlers/completions.rs
+++ b/examples/dynamo-demo-server/src/handlers/completions.rs
@@ -8,7 +8,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response, sse::{Event, KeepAlive, Sse}};
+use axum::response::{
+    IntoResponse, Response,
+    sse::{Event, KeepAlive, Sse},
+};
 use futures::stream::Stream;
 
 use dynamo_protocols::types::*;
@@ -34,7 +37,9 @@ pub async fn handler(
 
     if req.stream == Some(true) {
         let stream = make_stream(id, model, created, text);
-        Sse::new(stream).keep_alive(KeepAlive::default()).into_response()
+        Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response()
     } else {
         let echo_text = format!("[echo] {text}");
         let resp = CreateCompletionResponse {

--- a/examples/dynamo-demo-server/src/handlers/responses.rs
+++ b/examples/dynamo-demo-server/src/handlers/responses.rs
@@ -19,15 +19,19 @@ pub async fn handler(Json(req): Json<serde_json::Value>) -> Response {
                         let content = item.get("content")?;
                         match content {
                             serde_json::Value::String(s) => Some(s.clone()),
-                            serde_json::Value::Array(parts) => {
-                                Some(parts.iter().filter_map(|p| {
-                                    if p.get("type")?.as_str()? == "input_text" {
-                                        p.get("text")?.as_str().map(String::from)
-                                    } else {
-                                        None
-                                    }
-                                }).collect::<Vec<_>>().join(" "))
-                            }
+                            serde_json::Value::Array(parts) => Some(
+                                parts
+                                    .iter()
+                                    .filter_map(|p| {
+                                        if p.get("type")?.as_str()? == "input_text" {
+                                            p.get("text")?.as_str().map(String::from)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join(" "),
+                            ),
                             _ => None,
                         }
                     } else {
@@ -40,10 +44,7 @@ pub async fn handler(Json(req): Json<serde_json::Value>) -> Response {
         _ => "(no input)".to_string(),
     };
 
-    let model = req
-        .get("model")
-        .and_then(|v| v.as_str())
-        .unwrap_or("echo");
+    let model = req.get("model").and_then(|v| v.as_str()).unwrap_or("echo");
     let echo_text = format!("[echo] {input_text}");
     let id = format!("resp_{}", uuid::Uuid::new_v4().simple());
 

--- a/examples/dynamo-demo-server/src/handlers/tool_parse.rs
+++ b/examples/dynamo-demo-server/src/handlers/tool_parse.rs
@@ -4,13 +4,12 @@
 //! This is NOT part of any standard API -- it exists to showcase dynamo-parsers directly.
 
 use axum::Json;
-use axum::response::{IntoResponse, Response};
 use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
 use dynamo_parsers::tool_calling::{
-    ToolDefinition, detect_and_parse_tool_call,
-    parsers::get_available_tool_parsers,
+    ToolDefinition, detect_and_parse_tool_call, parsers::get_available_tool_parsers,
 };
 
 #[derive(Deserialize)]

--- a/examples/dynamo-demo-server/src/main.rs
+++ b/examples/dynamo-demo-server/src/main.rs
@@ -4,7 +4,10 @@ mod handlers;
 
 use std::path::PathBuf;
 
-use axum::{Router, routing::{get, post}};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 use clap::Parser;
 
 use crate::engine::AppState;
@@ -40,8 +43,7 @@ struct Cli {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 
@@ -67,7 +69,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/tokenize", post(handlers::tokenize::encode))
         .route("/v1/detokenize", post(handlers::tokenize::decode))
         .route("/v1/tool-parse", post(handlers::tool_parse::handler))
-        .route("/v1/reasoning-parse", post(handlers::reasoning_parse::handler))
+        .route(
+            "/v1/reasoning-parse",
+            post(handlers::reasoning_parse::handler),
+        )
         .route("/health", get(|| async { "ok" }))
         .with_state(state);
 
@@ -86,7 +91,11 @@ async fn main() -> anyhow::Result<()> {
 async fn fetch_hf_tokenizer(repo_id: &str, revision: &str) -> anyhow::Result<PathBuf> {
     use hf_hub::{Repo, RepoType, api::tokio::ApiBuilder};
 
-    tracing::info!(repo = repo_id, revision, "fetching tokenizer.json from HF Hub");
+    tracing::info!(
+        repo = repo_id,
+        revision,
+        "fetching tokenizer.json from HF Hub"
+    );
     let api = ApiBuilder::new().with_progress(true).build()?;
     let repo = api.repo(Repo::with_revision(
         repo_id.to_string(),

--- a/parsers/Cargo.toml
+++ b/parsers/Cargo.toml
@@ -5,27 +5,28 @@
 name = "dynamo-parsers"
 readme = "README.md"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
 description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
-authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
+authors.workspace = true
 license = "Apache-2.0"
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
+homepage.workspace = true
+repository.workspace = true
 keywords = ["llm", "parser", "tool-calling", "reasoning", "inference"]
 
 [dependencies]
-anyhow = "1"
-dynamo-protocols = { path = "../protocols", version = "0.1" }
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-tokio = { version = "=1.48.0", features = ["full"] }
-tracing = "0.1"
-uuid = { version = "1.18.1", features = ["v4", "serde"] }
+anyhow.workspace = true
+dynamo-protocols.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }
 
-regex = "1"
-openai-harmony = "0.0.3"
-rustpython-parser = "0.4.0"
-num-traits = "0.2"
+regex.workspace = true
+openai-harmony.workspace = true
+rustpython-parser.workspace = true
+num-traits.workspace = true
 
 [dev-dependencies]
-rstest = "0.25"
+rstest.workspace = true

--- a/parsers/Cargo.toml
+++ b/parsers/Cargo.toml
@@ -6,7 +6,6 @@ name = "dynamo-parsers"
 readme = "README.md"
 version = "0.1.0"
 edition.workspace = true
-rust-version.workspace = true
 description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
 authors.workspace = true
 license = "Apache-2.0"

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -13,7 +13,6 @@ name = "dynamo-protocols"
 readme = "README.md"
 version = "0.1.0"
 edition.workspace = true
-rust-version.workspace = true
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 authors.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -12,17 +12,18 @@
 name = "dynamo-protocols"
 readme = "README.md"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
-authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
+authors.workspace = true
 license = "Apache-2.0 AND MIT"
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
+homepage.workspace = true
+repository.workspace = true
 keywords = ["llm", "genai", "inference", "openai", "anthropic"]
 
 [dependencies]
 # Upstream OpenAI types (types-only, no HTTP client)
-async-openai = { version = "0.34", default-features = false, features = [
+async-openai = { workspace = true, features = [
     "chat-completion-types",
     "response-types",
     "completion-types",
@@ -31,21 +32,21 @@ async-openai = { version = "0.34", default-features = false, features = [
 ] }
 
 # Serialization
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-derive_builder = "0.20"
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json.workspace = true
+derive_builder.workspace = true
 
 # Type support
-thiserror = "2.0.17"
-tracing = "0.1"
-url = { version = "2.5", features = ["serde"] }
-uuid = { version = "1.18.1", features = ["v4", "serde"] }
-futures = "0.3"
+thiserror.workspace = true
+tracing.workspace = true
+url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+futures.workspace = true
 
 [dev-dependencies]
-tokio = { version = "=1.48.0", features = ["full"] }
-tokio-test = "0.4.4"
-serde_json = "1"
+tokio = { workspace = true, features = ["full"] }
+tokio-test.workspace = true
+serde_json.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.93.1"
+profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -5,31 +5,32 @@
 name = "dynamo-tokenizers"
 readme = "README.md"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+rust-version.workspace = true
 description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
-authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
+authors.workspace = true
 license = "Apache-2.0"
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
+homepage.workspace = true
+repository.workspace = true
 keywords = ["llm", "tokenizer", "huggingface", "tiktoken", "inference"]
 
 [dependencies]
-anyhow = "1"
-fastokens = "0.1.0"
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-strum = { version = "0.27", features = ["derive"] }
-tracing = "0.1"
+anyhow.workspace = true
+fastokens.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json.workspace = true
+strum = { workspace = true, features = ["derive"] }
+tracing.workspace = true
 
-base64 = "0.22"
-rayon = "1"
-rustc-hash = "1.1"
-tiktoken-rs = { version = "0.9", default-features = false }
-tokenizers = { version = "0.21.4", default-features = false, features = [
+base64.workspace = true
+rayon.workspace = true
+rustc-hash.workspace = true
+tiktoken-rs.workspace = true
+tokenizers = { workspace = true, features = [
   "onig",
   "esaxx_fast",
   "rustls-tls",
 ] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -6,7 +6,6 @@ name = "dynamo-tokenizers"
 readme = "README.md"
 version = "0.1.0"
 edition.workspace = true
-rust-version.workspace = true
 description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
 authors.workspace = true
 license = "Apache-2.0"

--- a/tokenizers/src/fastokens.rs
+++ b/tokenizers/src/fastokens.rs
@@ -68,7 +68,7 @@ mod tests {
     // compatible with fastokens. Vocab covers: H,T,a,d,e,h,i,l,o,r,s,t,w + punctuation.
     const TOKENIZER_PATH: &str = concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/../llm/tests/data/sample-models/minimal-bpe/tokenizer.json"
+        "/tests/data/minimal-bpe/tokenizer.json"
     );
 
     #[test]

--- a/tokenizers/tests/data/minimal-bpe/tokenizer.json
+++ b/tokenizers/tests/data/minimal-bpe/tokenizer.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {
+      "id": 0,
+      "content": "[UNK]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }
+  ],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": false,
+    "ignore_merges": false,
+    "vocab": {
+      "[UNK]": 0,
+      "H": 1,
+      "e": 2,
+      "l": 3,
+      "o": 4,
+      ",": 5,
+      " ": 6,
+      "w": 7,
+      "r": 8,
+      "d": 9,
+      "!": 10
+    },
+    "merges": []
+  }
+}


### PR DESCRIPTION
Add a root Cargo workspace, shared dependency metadata, pinned Rust toolchain, CI validation, and dependency hygiene config. Move the demo lockfile to the workspace root and add the fastokens test fixture under tokenizers/tests so workspace tests pass without monorepo-local paths.