### PR TITLE
sync(parsers): pull dynamo @ ad997e7

### DIFF
--- a/parsers/Cargo.toml
+++ b/parsers/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["llm", "parser", "tool-calling", "reasoning", "inference"]
 anyhow = "1"
 dynamo-protocols = { path = "../protocols", version = "0.1" }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 tokio = { version = "=1.48.0", features = ["full"] }
 tracing = "0.1"
 uuid = { version = "1.18.1", features = ["v4", "serde"] }

--- a/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/parsers/src/reasoning/gpt_oss_parser.rs
@@ -16,6 +16,8 @@ use std::sync::OnceLock;
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
+static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
+const HARMONY_CALL_MARKER: &str = "<|call|>";
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -71,6 +73,57 @@ fn encode_text_to_tokens(text: &str) -> anyhow::Result<Vec<u32>> {
         .as_ref()
         .map_err(|e| anyhow::anyhow!("Failed to get harmony encoding: {e}"))?;
     Ok(enc.tokenizer().encode_with_special_tokens(text))
+}
+
+fn harmony_call_token_ids() -> Option<&'static [u32]> {
+    let ids = HARMONY_CALL_TOKEN_IDS.get_or_init(|| {
+        get_harmony_encoding()
+            .as_ref()
+            .map(|enc| {
+                enc.tokenizer()
+                    .encode_with_special_tokens(HARMONY_CALL_MARKER)
+            })
+            .unwrap_or_default()
+    });
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids.as_slice())
+    }
+}
+
+fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
+    !marker_ids.is_empty()
+        && marker_ids.len() <= token_ids.len()
+        && token_ids
+            .windows(marker_ids.len())
+            .any(|window| window == marker_ids)
+}
+
+fn input_contains_call_marker(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> bool {
+    if !token_ids.is_empty()
+        && let Some(call_ids) = harmony_call_token_ids()
+    {
+        return token_ids_contain_sequence(token_ids, call_ids);
+    }
+
+    !caller_supplied_token_ids && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn raw_input_text_for_tool_parser(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> String {
+    if caller_supplied_token_ids && let Ok(enc) = get_harmony_encoding() {
+        return enc.tokenizer().decode_utf8(token_ids).unwrap_or_default();
+    }
+
+    text.to_string()
 }
 
 impl ReasoningParser for GptOssReasoningParser {
@@ -179,6 +232,7 @@ impl ReasoningParser for GptOssReasoningParser {
         text: &str,
         token_ids: &[u32],
     ) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
             let encoded_tokens = match encode_text_to_tokens(text) {
@@ -223,6 +277,12 @@ impl ReasoningParser for GptOssReasoningParser {
                     _ => {}
                 }
             }
+        }
+
+        if input_contains_call_marker(text, token_ids, caller_supplied_token_ids) {
+            let raw_input_text =
+                raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
+            normal_delta.push_str(&raw_input_text);
         }
 
         if !normal_delta.is_empty() || !reasoning_delta.is_empty() {

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -77,6 +77,34 @@ pub struct XmlParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// When true, the function- and parameter-regex omit the `|$` end-of-block
+    /// fallback (so missing `</function>` / `</parameter>` causes the match to
+    /// fail rather than being silently recovered), AND `detect_and_parse_tool_
+    /// call_with_recovery` does not flip `allow_eof_recovery=true` for this
+    /// config. Used by families whose official reference parser is
+    /// strict-match (e.g. MiniMax-M2 — see
+    /// https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md).
+    #[serde(default)]
+    pub strict_match: bool,
+
+    /// When true, if `function_start_token` is absent anywhere in the input,
+    /// short-circuit `try_tool_call_parse_xml` and return
+    /// `(calls=[], normal_text=<input>)`. Matches the early-return passthrough
+    /// in Qwen3-Coder's official reference parser
+    /// (https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py).
+    #[serde(default)]
+    pub passthrough_when_no_function: bool,
+
+    /// When true, if `tool_call_start_token` is absent but `function_start_
+    /// token` is present, parse the entire input as a single tool-call block
+    /// (back-off strategy). Matches the `if len(raw_tool_calls) == 0:
+    /// raw_tool_calls = [model_output]` back-off in Qwen3-Coder's reference
+    /// parser. Independent of `passthrough_when_no_function` (different
+    /// trigger: this one fires when function tags exist but the outer wrapper
+    /// does not).
+    #[serde(default)]
+    pub backoff_when_no_wrapper: bool,
 }
 
 impl Default for XmlParserConfig {
@@ -89,7 +117,24 @@ impl Default for XmlParserConfig {
             parameter_start_token: "<parameter=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: false,
+            strict_match: false,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         }
+    }
+}
+
+impl XmlParserConfig {
+    /// Returns true when the chunk lacks the outer `<tool_call>` wrapper but
+    /// contains `<function=...>`, and the family opts into back-off parsing
+    /// (qwen3_coder, nemotron_nano). In this mode the function-level tokens
+    /// act as the tool-call boundary for both start detection and end-position
+    /// search, mirroring the wrapped path's behavior so streaming and batch
+    /// agree on what counts as a tool call.
+    pub fn is_bare_function_mode(&self, chunk: &str) -> bool {
+        self.backoff_when_no_wrapper
+            && !chunk.contains(self.tool_call_start_token.as_str())
+            && chunk.contains(self.function_start_token.as_str())
     }
 }
 
@@ -394,8 +439,17 @@ impl ToolCallConfig {
 
     pub fn qwen3_coder() -> Self {
         // <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+        // Behavior aligned with Qwen3-Coder's official reference parser
+        // (huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/.../qwen3coder_tool_parser.py):
+        //  - passthrough: when no `<function=` in input, return raw input as content
+        //  - back-off: when `<function=` present but no `<tool_call>` wrapper,
+        //              parse the entire input as a tool block
         Self {
-            parser_config: ParserConfig::Xml(XmlParserConfig::default()),
+            parser_config: ParserConfig::Xml(XmlParserConfig {
+                passthrough_when_no_function: true,
+                backoff_when_no_wrapper: true,
+                ..XmlParserConfig::default()
+            }),
         }
     }
 
@@ -447,6 +501,13 @@ impl ToolCallConfig {
         // </invoke>
         // </minimax:tool_call>
         // Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
+        //
+        // MiniMax's official reference parser is strict-match — its three
+        // regexes (outer/invoke/parameter) all require paired fences and
+        // return [] on any mismatch. `strict_match=true` enforces that:
+        // it drops the `|$` end-of-block fallback from the function- and
+        // parameter-regex AND prevents the PyO3 `with_recovery` shim from
+        // flipping `allow_eof_recovery=true`.
         Self {
             parser_config: ParserConfig::Xml(XmlParserConfig {
                 tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -456,6 +517,9 @@ impl ToolCallConfig {
                 parameter_start_token: "<parameter name=".to_string(),
                 parameter_end_token: "</parameter>".to_string(),
                 allow_eof_recovery: false,
+                strict_match: true,
+                passthrough_when_no_function: false,
+                backoff_when_no_wrapper: false,
             }),
         }
     }

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -71,8 +71,19 @@ fn build_block_regex(config: &DsmlParserConfig) -> anyhow::Result<Regex> {
     Ok(Regex::new(&block_pattern)?)
 }
 
-/// Parse DSML formatted tool calls from a message
-/// Returns (parsed_tool_calls, normal_text_content)
+/// Parse DSML formatted tool calls from a message.
+///
+/// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
+/// text BEFORE the first `<｜DSML｜tool_calls>` / `<｜DSML｜function_calls>`
+/// start marker. Text between blocks, after the last block, and any
+/// back-to-back-block content are all dropped — matching upstream vLLM
+/// (`vllm/tool_parsers/deepseek_v4_tool_parser.py` and the V3.2 sibling),
+/// which compute `content = model_output[:content_end]` where
+/// `content_end = model_output.find(self.tool_call_start_token)`.
+///
+/// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
+/// after the wrapper across XML-style families; this aligns Dynamo to that
+/// behavior. Cases: PARSER.batch.{2.b, 2.c, 8.b, 8.c, 8.d}.
 pub fn try_tool_call_parse_dsml(
     message: &str,
     config: &DsmlParserConfig,
@@ -94,10 +105,17 @@ pub fn try_tool_call_parse_dsml(
     let block_regex = build_block_regex(config)?;
     let tool_calls = extract_tool_calls_with_regex(trimmed, &block_regex, config)?;
 
+    // Whether or not invokes parsed, normal_text is the prefix before the
+    // first block_start — mirrors vLLM's success path. On no-invokes the
+    // markup-leak warning still fires for the diagnostic trail.
+    let pre_block_text = start_idx
+        .map(|idx| trimmed[..idx].to_string())
+        .unwrap_or_default();
+
     if tool_calls.is_empty() {
         // A block-start was detected but no valid invokes parsed. Do NOT leak
-        // the DSML markup back to the client; return only the pre-block text
-        // and emit a diagnostic with a prefix of the failed block.
+        // the DSML markup back to the client; emit a diagnostic with a prefix
+        // of the failed block.
         //
         // Note: an unterminated block-start here means `block_regex` finds no
         // match at all, so any valid block *after* the unterminated one is
@@ -106,22 +124,35 @@ pub fn try_tool_call_parse_dsml(
             let failed = &trimmed[idx..];
             let prefix: String = failed.chars().take(120).collect();
             tracing::warn!(
-                "DSML tool_calls block parsed no invokes; suppressing markup. prefix={:?}",
+                why = "no_invokes_parsed",
+                stripped_bytes = failed.len(),
+                "DSML strip (recovery): block_start detected but extract_tool_calls returned 0 invokes; suppressing all bytes from block_start onward so tool-call markup never bleeds into normal_text. preview={:?}",
                 prefix
             );
         }
-        let pre_block_text = start_idx
-            .map(|idx| trimmed[..idx].to_string())
-            .unwrap_or_default();
         return Ok((vec![], Some(pre_block_text)));
     }
 
-    // Preserve inter-block and trailing text: strip every complete block span
-    // from the trimmed input rather than slicing up to the first start token.
-    // Without this we silently lose text between and after multiple blocks.
-    let normal_text = block_regex.replace_all(trimmed, "").to_string();
+    // Success path: prefix-only contract — everything from the first block_start
+    // onward (the block(s) themselves plus any inter-block / trailing narration)
+    // is stripped from normal_text. Mirrors vLLM's
+    // `content = model_output[:content_end]`.
+    if let Some(idx) = start_idx {
+        let stripped = &trimmed[idx..];
+        if !stripped.is_empty() {
+            let preview: String = stripped.chars().take(120).collect();
+            tracing::debug!(
+                why = "prefix_only_contract",
+                n_calls = tool_calls.len(),
+                kept_prefix_bytes = pre_block_text.len(),
+                stripped_bytes = stripped.len(),
+                "DSML strip (success): kept prefix before first block_start; dropped parsed-block(s) + any inter-block / trailing narration. preview={:?}",
+                preview
+            );
+        }
+    }
 
-    Ok((tool_calls, Some(normal_text)))
+    Ok((tool_calls, Some(pre_block_text)))
 }
 
 /// Extract all tool calls matched by `block_regex` from the DSML formatted text.
@@ -275,6 +306,12 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // DEPRECATED(parser-fixture-duplicate): Legacy V4 coverage manifest.
+    // The blackbox case mapping now lives in the YAML parser fixtures under
+    // tests/parity/parser/fixtures/deepseek_v4/ and the taxonomy in
+    // lib/parsers/PARSER_CASES.md; keep this temporarily as a pointer while
+    // the duplicate Rust tests are being retired.
+    //
     // DeepSeek V4 coverage (see lib/parsers/PARSER_CASES.md for PARSER.* taxonomy).
     //
     // Covered by the V4 tests below (or by a shared DSML generic test):
@@ -366,6 +403,7 @@ mod tests {
         assert_eq!(&text[pos..], "more");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_single_tool_call_string_param() {
         let input = r#"<｜DSML｜function_calls>
@@ -394,6 +432,7 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_single_tool_call_mixed_params() {
         let input = r#"<｜DSML｜function_calls>
@@ -413,6 +452,7 @@ mod tests {
         assert_eq!(args["topn"], 10);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<｜DSML｜function_calls>
@@ -440,6 +480,7 @@ mod tests {
     }
 
     /// `PARSER.batch.2` multi-calls + `PARSER.batch.8` interleaved-text (prefix text before the block).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_multiple_tool_calls() {
         let input = r#"Let's check this. <｜DSML｜tool_calls>
@@ -473,6 +514,7 @@ mod tests {
     }
 
     /// `PARSER.batch.6` — empty args (no-parameter invoke).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_no_parameters() {
         let input = r#"<｜DSML｜tool_calls>
@@ -490,6 +532,7 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"Here's the result: <｜DSML｜function_calls>
@@ -537,6 +580,7 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_json_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
@@ -555,6 +599,7 @@ mod tests {
         assert_eq!(args["config"]["count"], 42);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_array_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
@@ -573,6 +618,7 @@ mod tests {
         assert_eq!(args["items"][2], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_boolean_parameters() {
         let input = r#"<｜DSML｜function_calls>
@@ -591,6 +637,7 @@ mod tests {
         assert_eq!(args["disabled"], false);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_number_parameters() {
         let input = r#"<｜DSML｜function_calls>
@@ -611,6 +658,7 @@ mod tests {
         assert_eq!(args["negative"], -100);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_mixed_types_realistic() {
         // Realistic example based on test data
@@ -633,6 +681,7 @@ mod tests {
         assert_eq!(args["source"], "web");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_nested_object_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -653,6 +702,7 @@ mod tests {
         assert_eq!(args["settings"]["endpoints"][0], "a");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_empty_string_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -772,10 +822,10 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_block_preserves_inter_and_trailing_text() {
+    fn test_multi_block_drops_inter_and_trailing_text() {
         // Two complete DSML blocks with text before, between, and after.
-        // Both blocks must be parsed AND the inter-block / trailing text must
-        // survive in normal_content.
+        // Both blocks must be parsed; only the pre-block prefix survives in
+        // normal_content — matches vLLM (drops inter / trailing).
         let input = "pre <｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"a\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> middle <｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"b\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> tail";
 
         let config = get_v4_test_config();
@@ -785,12 +835,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "b");
 
         let normal = normal.unwrap();
-        assert!(
-            normal.contains(" middle "),
-            "inter-block text lost: {:?}",
-            normal
-        );
-        assert!(normal.contains(" tail"), "trailing text lost: {:?}", normal);
+        assert_eq!(normal, "pre ", "only pre-block text survives: {:?}", normal);
         assert!(
             !normal.contains("<｜DSML｜"),
             "normal_content leaked DSML markup: {:?}",
@@ -821,29 +866,18 @@ mod tests {
             "outer invoke name is matched first (non-greedy)"
         );
 
+        // After alignment to vLLM, normal_text is the prefix BEFORE the first
+        // block_start only — trailing text after the block is dropped.
         let normal = normal.unwrap();
-        assert!(
-            normal.starts_with("pre"),
-            "pre-block text must survive: {:?}",
-            normal
-        );
-        assert!(
-            normal.contains(" tail"),
-            "trailing text must survive: {:?}",
-            normal
-        );
+        assert_eq!(normal, "pre ", "only pre-block text survives: {:?}", normal);
         assert!(
             !normal.contains("<｜DSML｜tool_calls>"),
             "normal_content leaked block_start: {:?}",
             normal
         );
-        assert!(
-            !normal.contains("</｜DSML｜tool_calls>"),
-            "normal_content leaked block_end: {:?}",
-            normal
-        );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a, PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.7, PARSER.batch.9
     fn test_parse_null_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -882,6 +916,7 @@ mod tests {
     /// into `normal_text` when block-start appears but no invokes parse —
     /// it returns the pre-block text only (empty here, since the input
     /// starts with the block-start fence). The call is still dropped.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_missing_end_token() {
         // Start fence + complete invoke, but no </｜DSML｜tool_calls>.
@@ -913,6 +948,7 @@ mod tests {
     /// absence of the closing fence prevents the block regex from matching.
     /// All calls are dropped. If the parser ever gains partial-block
     /// recovery, this test will fail and force an intentional update.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.5, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_end_token_multiple_calls() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -938,6 +974,7 @@ mod tests {
     /// (unwrap_or_else → Value::String). Pin the fallback so removing it
     /// (which would cause the whole call to 500 on ragged-edge JSON) is a
     /// deliberate change.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_malformed_json_value_falls_back_to_string() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -962,6 +999,7 @@ mod tests {
     /// `PARSER.batch.4` — malformed invoke (missing `</｜DSML｜invoke>` but block fences
     /// intact). The invoke regex requires its own close tag, so the call is
     /// silently dropped. Pin the behavior.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_invoke_close_drops_call() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -986,6 +1024,7 @@ mod tests {
     /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: parser silently loses the parameter
     /// and ships an under-specified call to the user. The fix should keep
     /// the raw value up to `</｜DSML｜invoke>`. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_parameter_close_loses_param() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -1016,6 +1055,7 @@ mod tests {
     /// silently dropped — caller receives wrong args for A and never sees
     /// B at all. Fix: anchor on `<｜DSML｜invoke name=` to re-sync between
     /// invokes. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -1065,6 +1105,7 @@ mod tests {
     /// `<think>...</think>` before the DSML block; the tool parser is
     /// concerned only with the DSML, but normal text must round-trip
     /// the reasoning markup verbatim for the reasoning parser to pick up.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_reasoning_plus_tool_v4() {
         let input = "<think>Let me check the weather.</think>\
@@ -1136,6 +1177,7 @@ mod tests {
 
     /// `PARSER.batch.9` — empty / null content variants. Pin behavior on truly
     /// empty bytes and whitespace-only inputs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_empty_and_whitespace_inputs_v4() {
         let config = get_v4_test_config();
@@ -1159,6 +1201,7 @@ mod tests {
 
     /// `PARSER.batch.10` — duplicate calls (same invoke name twice in one block).
     /// Universal gap noted in the test taxonomy; first DSML coverage.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_duplicate_invokes_same_name_v4() {
         let input = "<｜DSML｜tool_calls>\n\

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -70,34 +70,30 @@ pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
 
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
 ///
-/// Returns `(parsed_tool_calls, normal_text_content)`. Text outside any
-/// `<|tool_call>call:NAME{...}<tool_call|>` match is returned as `normal_text`.
-/// When a tool call is truncated (start marker present but no `}<tool_call|>`
-/// terminator — typically because the model hit `max_tokens` mid-call), the
-/// regex finds no match and the raw bytes after the start marker are echoed
-/// back as `normal_text` so the caller can detect the truncation and surface
-/// it to the user.
+/// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
+/// text BEFORE the first `<|tool_call>` start marker, trimmed of whitespace.
+/// Text between calls, after the last call, and truncated-incomplete-call
+/// tails are all dropped — matching upstream vLLM
+/// (`vllm/tool_parsers/gemma4_tool_parser.py::extract_tool_calls`) which
+/// computes `content = model_output[:content_end].strip()` where
+/// `content_end = model_output.find(self.tool_call_start_token)`.
 ///
-/// Mirrors upstream's `extract_tool_calls` in `vllm/tool_parsers/
-/// gemma4_tool_parser.py`, which uses `tool_call_regex.findall(model_output)`
-/// directly. The `}<tool_call|>` adjacency requirement in the regex means
-/// embedded `<tool_call|>` literals inside string-typed args (e.g. a
-/// `description` field documenting the tool-call format) don't truncate the
-/// match prematurely.
+/// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
+/// after the wrapper across XML-style families; this aligns Dynamo to that
+/// behavior. Cases: PARSER.batch.{2.c, 8.b, 8.c, 8.d}.
+///
+/// The `}<tool_call|>` adjacency requirement in the regex means embedded
+/// `<tool_call|>` literals inside string-typed args (e.g. a `description`
+/// field documenting the tool-call format) don't truncate the match
+/// prematurely.
 pub fn try_tool_call_parse_gemma4(
     message: &str,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let regex = tool_call_regex();
     let mut calls = Vec::new();
-    let mut normal_parts = Vec::new();
-    let mut cursor = 0;
 
     for caps in regex.captures_iter(message) {
-        let whole = caps.get(0).expect("capture 0 always present");
-        normal_parts.push(&message[cursor..whole.start()]);
-        cursor = whole.end();
-
         let name = caps
             .name("name")
             .map(|m| m.as_str().to_string())
@@ -136,20 +132,66 @@ pub fn try_tool_call_parse_gemma4(
         });
     }
 
-    // Anything after the last complete match — including a truncated
-    // `<|tool_call>call:...` with no closing `}<tool_call|>` — is returned to
-    // the caller as `normal_text` so model truncation is visible rather than
-    // silently swallowed.
-    normal_parts.push(&message[cursor..]);
-
-    let normal_text = normal_parts.join("").trim().to_string();
-    let normal_content = if normal_text.is_empty() {
-        Some(String::new())
+    // No-leak contract for `normal_text`:
+    //   - Success path (≥1 call extracted): prefix BEFORE the first
+    //     `<|tool_call>` start marker — mirrors vLLM's
+    //     `content = model_output[:content_end].strip()`. Inter-call,
+    //     trailing, and truncation tails after a successful call are dropped.
+    //   - Recovery path (zero calls extracted): if the message contains ANY
+    //     gemma4 markup token (`<|tool_call>`, `<tool_call|>`, `<|"|>`),
+    //     return empty — Dynamo intentionally diverges from vLLM's
+    //     exception-fallback (which echoes raw bytes) so tool-call markup
+    //     never leaks into normal_text on malformed / truncated / orphan-
+    //     close / no-body inputs. Cases flagged by the parity chart's `↯`:
+    //     PARSER.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
+    //   - Plain-text path (zero calls AND no markup): return the message
+    //     as-is.
+    let has_markup = message.contains(TOOL_CALL_START)
+        || message.contains(TOOL_CALL_END)
+        || message.contains(STRING_DELIM);
+    let normal_text = if calls.is_empty() {
+        if has_markup {
+            // Recovery: malformed/truncated/orphan-close/no-body shapes.
+            // Suppress the whole message so tool-call markup doesn't leak.
+            let preview: String = message.chars().take(120).collect();
+            tracing::warn!(
+                why = "no_calls_with_markup",
+                stripped_bytes = message.len(),
+                has_start = message.contains(TOOL_CALL_START),
+                has_end = message.contains(TOOL_CALL_END),
+                has_string_delim = message.contains(STRING_DELIM),
+                "gemma4 strip (recovery): zero calls extracted but gemma4 markup present (<|tool_call>, <tool_call|>, <|\"|>); suppressing entire message to prevent leak into normal_text. preview={:?}",
+                preview
+            );
+            String::new()
+        } else {
+            // No markup at all → plain text passes through unchanged. No strip.
+            message.trim().to_string()
+        }
     } else {
-        Some(normal_text)
+        // Success: prefix-only contract — drop everything from the first
+        // `<|tool_call>` onward (inter-call text, trailing narration,
+        // truncation tails). Mirrors vLLM's
+        // `content = model_output[:content_end].strip()`.
+        match message.find(TOOL_CALL_START) {
+            Some(idx) => {
+                let stripped = &message[idx..];
+                let preview: String = stripped.chars().take(120).collect();
+                tracing::debug!(
+                    why = "prefix_only_contract",
+                    n_calls = calls.len(),
+                    kept_prefix_bytes = idx,
+                    stripped_bytes = stripped.len(),
+                    "gemma4 strip (success): kept prefix before first <|tool_call>; dropped parsed-call(s) + any inter-call / trailing narration. preview={:?}",
+                    preview
+                );
+                message[..idx].trim().to_string()
+            }
+            None => String::new(),
+        }
     };
 
-    Ok((calls, normal_content))
+    Ok((calls, Some(normal_text)))
 }
 
 // ---------------------------------------------------------------------------
@@ -434,6 +476,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.1 — single string argument
     fn parse_single_string_argument() {
         let input = r#"<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>"#;
@@ -442,6 +485,7 @@ mod tests {
         assert_eq!(args["location"], "Tokyo");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml, tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7 — multiple typed arguments
     fn parse_multiple_typed_arguments() {
         let input = r#"<|tool_call>call:f{loc:<|"|>San Francisco, CA<|"|>,unit:<|"|>celsius<|"|>,count:42,flag:true,nope:null}<tool_call|>"#;
@@ -454,6 +498,7 @@ mod tests {
         assert_eq!(args["nope"], Value::Null);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — empty argument object
     fn parse_no_arg_call() {
         let input = "<|tool_call>call:get_time{}<tool_call|>";
@@ -462,6 +507,7 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — nested object value
     fn parse_nested_object_value() {
         let input = r#"<|tool_call>call:f{cfg:{ssl:true,pool:{min:5,max:20}}}<tool_call|>"#;
@@ -471,6 +517,7 @@ mod tests {
         assert_eq!(args["cfg"]["pool"]["max"], 20);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — array of strings
     fn parse_array_of_strings() {
         let input = r#"<|tool_call>call:f{tags:[<|"|>a<|"|>,<|"|>b<|"|>,<|"|>c<|"|>]}<tool_call|>"#;
@@ -478,6 +525,7 @@ mod tests {
         assert_eq!(args["tags"], serde_json::json!(["a", "b", "c"]));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — array of mixed primitives
     fn parse_array_of_mixed_primitives() {
         let input = "<|tool_call>call:f{xs:[1,2,3.5,true,false,null]}<tool_call|>";
@@ -490,6 +538,7 @@ mod tests {
         assert_eq!(args["xs"][5], Value::Null);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — multiple parallel calls, zero spacing
     fn parse_multiple_parallel_calls() {
         let input = concat!(
@@ -505,12 +554,12 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    #[test] // PARSER.batch.8 — surrounding normal text preserved
+    #[test] // PARSER.batch.8.c — prefix narration preserved, trailing dropped (matches vLLM)
     fn parse_with_surrounding_text() {
         let input = r#"Sure thing. <|tool_call>call:f{x:1}<tool_call|> All set."#;
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(normal, Some("Sure thing.  All set.".to_string()));
+        assert_eq!(normal, Some("Sure thing.".to_string()));
     }
 
     #[test] // PARSER.batch.3 — no tool calls at all
@@ -520,8 +569,9 @@ mod tests {
         assert_eq!(normal, Some("just plain prose here".to_string()));
     }
 
-    #[test] // PARSER.batch.5 — complete prior calls survive; truncated tail is echoed
-    fn truncated_tail_echoed_complete_prior_survives() {
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
+    #[test] // PARSER.batch.5 — complete prior call survives; truncated tail dropped (matches vLLM)
+    fn truncated_tail_dropped_complete_prior_survives() {
         let input = concat!(
             "<|tool_call>call:complete{x:1}<tool_call|>",
             "<|tool_call>call:partial{y:<|\"|>incomp", // no end marker
@@ -529,16 +579,13 @@ mod tests {
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "complete");
-        // Truncated bytes are surfaced rather than silently dropped — matches
-        // upstream `vllm.tool_parsers.gemma4_tool_parser.extract_tool_calls`
-        // when no complete tool call could be parsed past the start marker.
-        let normal = normal.unwrap();
-        assert!(
-            normal.contains("<|tool_call>call:partial"),
-            "expected truncated bytes echoed in normal_text, got: {normal:?}"
-        );
+        // vLLM computes content as text BEFORE the first start marker; here that
+        // is empty (message starts with `<|tool_call>`), so normal_text is "".
+        // The truncated tail bytes are dropped, not echoed.
+        assert_eq!(normal, Some(String::new()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — malformed args body falls back to empty object, call still emitted
     fn malformed_args_falls_back_to_empty_object() {
         let input = "<|tool_call>call:f{garbage no colons here}<tool_call|>";
@@ -571,6 +618,7 @@ mod tests {
         }
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — angle brackets / HTML inside string values
     fn parse_html_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><div class="x"><h1>Hi</h1></div><|"|>}<tool_call|>"#;
@@ -578,6 +626,7 @@ mod tests {
         assert_eq!(args["html"], "<div class=\"x\"><h1>Hi</h1></div>");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — newlines inside string values
     fn parse_newlines_in_string_value() {
         let input = "<|tool_call>call:f{body:<|\"|>line1\nline2\nline3<|\"|>}<tool_call|>";
@@ -593,6 +642,7 @@ mod tests {
         assert_eq!(args["y"], "z");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — negative numbers and floats
     fn parse_signed_numbers_and_floats() {
         let input = "<|tool_call>call:f{a:-1,b:-2.5,c:0,d:0.0}<tool_call|>";
@@ -694,21 +744,23 @@ mod tests {
         let _ = parse_args_object("x:nullable").unwrap_err();
     }
 
-    #[test] // PARSER.batch.5 — missing end-marker, raw bytes echoed (upstream test_incomplete_tool_call)
-    fn incomplete_tool_call_echoes_raw_bytes() {
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
+    #[test] // PARSER.batch.5 — missing end-marker, markup suppressed (no-leak contract)
+    fn incomplete_tool_call_suppresses_markup() {
         let input = "<|tool_call>call:foo{x:1";
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 0);
-        let normal = normal.unwrap();
-        assert!(
-            normal.contains("<|tool_call>call:foo"),
-            "expected raw bytes echoed; got: {normal:?}"
-        );
+        // No calls extracted → return the prefix BEFORE the first `<|tool_call>`
+        // start marker (here: empty). Dynamo intentionally diverges from vLLM's
+        // exception fallback (which echoes the raw bytes) so tool-call markup
+        // never leaks into normal_text on the recovery path.
+        assert_eq!(normal, Some(String::new()));
     }
 
     #[test] // PARSER.batch.7 — `<tool_call|>` literal inside a string-typed argument
     // must not truncate the call. The extraction regex requires
     // `}<tool_call|>` adjacency, so a bare embedded marker is safe.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     fn embedded_tool_call_marker_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><tool_call|> example<|"|>}<tool_call|>"#;
         let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -730,6 +782,7 @@ mod tests {
     // (in production the reasoning parser runs first and strips `<|channel>`,
     // but the tool-call parser must remain correct if it sees the full
     // emission, e.g. when reasoning parsing is disabled).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml.
     fn paired_reasoning_and_tool_call_in_same_emission() {
         let input = concat!(
             "<|channel>thought\nthinking about the request<channel|>",
@@ -745,6 +798,7 @@ mod tests {
         assert!(normal.unwrap().contains("<|channel>thought"));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — empty input, no tool calls
     fn empty_input_yields_zero_calls_empty_content() {
         let (calls, normal) = try_tool_call_parse_gemma4("", None).unwrap();
@@ -752,6 +806,7 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — `null` argument values round-trip as JSON null
     fn null_argument_values_preserved() {
         let input = "<|tool_call>call:f{x:null,y:none,z:nil}<tool_call|>";
@@ -766,6 +821,7 @@ mod tests {
     #[test] // PARSER.batch.10 — duplicate calls to the same function name. Both must
     // appear with distinct IDs; client decides whether duplicate invocation
     // is intended.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     fn duplicate_tool_call_same_name() {
         let input = concat!(
             "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",

--- a/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -2,45 +2,188 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ToolDefinition;
-use super::super::json::base_json_parser::try_repair_truncated_json;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 use openai_harmony::chat::{Content::Text, Role};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding};
-use regex::Regex;
+use regex::{Captures, Regex};
 use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static MESSAGE_CALL_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
-/// a call, never fabricating one (full structural signature required).
+/// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
         // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
-        // Args end at either `<|call|>` (normal close) or end-of-string
-        // (`\z`, the bare-envelope PARSER.batch.5 variant where the model never
-        // emitted `<|call|>` before EOS / max_tokens).
+        // Args must end at `<|call|>`, the required Harmony tool-call stop token.
         Regex::new(
-            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
     })
 }
 
+fn commentary_block_cleanup_regex() -> &'static Regex {
+    COMMENTARY_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*?<\|message\|>.*?(?:<\|call\|>|\z)",
+        )
+        .expect("commentary block cleanup regex")
+    })
+}
+
+fn commentary_header_cleanup_regex() -> &'static Regex {
+    COMMENTARY_HEADER_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*\z",
+        )
+        .expect("commentary header cleanup regex")
+    })
+}
+
+fn analysis_block_cleanup_regex() -> &'static Regex {
+    ANALYSIS_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>(?P<body>.*?)(?:<\|end\|>|\z)")
+            .expect("analysis block cleanup regex")
+    })
+}
+
+fn message_call_cleanup_regex() -> &'static Regex {
+    MESSAGE_CALL_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)<\|message\|>.*?(?:<\|call\|>|\z)").expect("message call cleanup regex")
+    })
+}
+
+fn special_token_regex() -> &'static Regex {
+    SPECIAL_TOKEN_REGEX.get_or_init(|| {
+        Regex::new(r"<\|(?:start|channel|constrain|message|call|end|return)\|>")
+            .expect("special token cleanup regex")
+    })
+}
+
+fn push_unique(items: &mut Vec<String>, item: String) {
+    if !items.iter().any(|existing| existing == &item) {
+        items.push(item);
+    }
+}
+
+fn record_special_tokens(text: &str, items: &mut Vec<String>) {
+    for m in special_token_regex().find_iter(text) {
+        push_unique(items, format!("special_token:{}", m.as_str()));
+    }
+}
+
+fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> String {
+    let mut stripped = Vec::new();
+
+    let cleaned = commentary_block_cleanup_regex()
+        .replace_all(text, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call:functions.{name}"),
+                None => "commentary_tool_call:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = commentary_header_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call_without_message:functions.{name}"),
+                None => "commentary_tool_call_without_message:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = analysis_block_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "analysis_envelope".to_string());
+            ""
+        })
+        .into_owned();
+
+    let cleaned = message_call_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "message_call_payload".to_string());
+            ""
+        })
+        .into_owned();
+
+    let cleaned = special_token_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            push_unique(&mut stripped, format!("special_token:{}", &caps[0]));
+            ""
+        })
+        .into_owned();
+
+    if stripped.is_empty() {
+        return text.to_string();
+    }
+
+    let cleaned = cleaned.trim().to_string();
+
+    tracing::warn!(
+        family = "harmony",
+        reason,
+        stripped = ?stripped,
+        original_len = text.len(),
+        cleaned_len = cleaned.len(),
+        "stripped harmony protocol content from normal_text"
+    );
+
+    cleaned
+}
+
+fn normal_text_after_parse_failure(text: &str, reason: &'static str) -> String {
+    let cleaned = strip_harmony_protocol_from_normal_text(text, reason);
+    if cleaned == text && !text.trim().is_empty() {
+        tracing::warn!(
+            family = "harmony",
+            reason,
+            original_len = text.len(),
+            "dropped bare text without a Harmony final/commentary message"
+        );
+        String::new()
+    } else {
+        cleaned
+    }
+}
+
+fn serialize_harmony_arguments(raw_args: &str) -> String {
+    let trimmed = raw_args.trim();
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_string()),
+        Err(_) => trimmed.to_string(),
+    }
+}
+
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
 /// Returns (calls, residual_text) where residual_text is everything not
-/// consumed by a matched commentary block — preserved so analysis prose and
-/// non-tool suffixes aren't dropped.
+/// consumed by a matched commentary block — preserved so non-tool user-visible
+/// spans aren't dropped.
 fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
+    for cap in commentary_block_regex().captures_iter(text) {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -50,17 +193,10 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
         if name.is_empty() {
             continue;
         }
-        let args_json = match serde_json::from_str::<Value>(raw_args) {
-            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-            Err(_) => match try_repair_truncated_json(raw_args)
-                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-            {
-                Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-                None => raw_args.to_string(),
-            },
-        };
+        let args_json = serialize_harmony_arguments(raw_args);
+        let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
-            id: format!("call-{}", i + 1),
+            id: format!("call-{call_idx}"),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -100,9 +236,9 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// or token-by-token streaming, making it more efficient for complete chunks.
 ///
 /// # Arguments
-/// * `text` - The full Harmony-format string to be parsed, excluding any trailing stop tokens.
+/// * `text` - The full Harmony-format string to be parsed, including required Harmony stop tokens.
 ///   Example:
-///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}`
+///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>`
 /// * `_config` - Parser configuration (currently unused but kept for API consistency)
 ///
 /// # Returns
@@ -110,14 +246,15 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    config: &JsonParserConfig,
+    _config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
         Ok(e) => e,
         Err(e) => {
             tracing::debug!("Failed to load harmony encoding: {e}. Tool calls will not be parsed.");
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text = normal_text_after_parse_failure(text, "harmony_encoding_unavailable");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
@@ -129,24 +266,29 @@ pub async fn parse_tool_calls_harmony_complete(
             tracing::debug!(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
-            // Recovery: harmony rejects parallel commentary blocks and
-            // truncated JSON. Gated on `allow_eof_recovery` so streaming
-            // jails (where the tokenizer often rejects mid-chunk before all
-            // tokens have arrived) don't extract a partial call.
-            if config.allow_eof_recovery {
-                let (calls, residual) = extract_calls_via_regex(text);
-                if !calls.is_empty() {
-                    return Ok((calls, Some(residual)));
-                }
+            // Recovery: harmony rejects parallel commentary blocks even when
+            // every call is explicitly closed. Only EOF/truncated recovery is
+            // gated, so streaming jails do not synthesize incomplete calls.
+            // Harmony differs from generic JSON/XML recovery: a tool call is
+            // complete only once `<|call|>` is present. Do not synthesize a
+            // call from EOF; that would diverge from vLLM/openai_harmony.
+            let (calls, residual) = extract_calls_via_regex(text);
+            if !calls.is_empty() {
+                let normal_text =
+                    strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");
+                return Ok((calls, Some(normal_text)));
             }
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text =
+                normal_text_after_parse_failure(text, "parse_failed_no_recovered_calls");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
-    let mut normal_text = String::new();
-
     let mut res = Vec::with_capacity(messages.len());
     let mut call_idx = 0; // Index of the tool call
+    let mut final_text: Option<String> = None;
+    let mut commentary_text: Option<String> = None;
+    let has_tool_call_stop = text.contains("<|call|>");
 
     for message in messages.iter() {
         if message.author.role != Role::Assistant {
@@ -158,6 +300,10 @@ pub async fn parse_tool_calls_harmony_complete(
 
         // Handle commentary channel
         if channel == Some("commentary") && recipient.starts_with("functions.") {
+            if !has_tool_call_stop {
+                continue;
+            }
+
             let Some(fname) = message
                 .recipient
                 .as_ref()
@@ -168,49 +314,38 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            let args = match message.content.first() {
-                Some(Text(text)) => {
-                    let trimmed = text.text.trim();
-                    match serde_json::from_str::<Value>(trimmed) {
-                        Ok(value) => value,
-                        Err(_) if config.allow_eof_recovery => {
-                            // Truncation recovery: balance unclosed strings /
-                            // braces (max_tokens / EOS pattern) and retry.
-                            // Gated so streaming early-exit doesn't extract
-                            // a partial call with synthesized closers.
-                            try_repair_truncated_json(trimmed)
-                                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-                                .unwrap_or(Value::Null)
-                        }
-                        Err(_) => Value::Null,
-                    }
-                }
-                _ => {
-                    Value::Null // Set args to null if it's not a text content
-                }
+            let Some(args_json) = message.content.first().and_then(|content| match content {
+                Text(text) => Some(serialize_harmony_arguments(&text.text)),
+                _ => None,
+            }) else {
+                continue;
             };
-            // Add tool call to result if args is valid JSON
-            if !args.is_null() {
-                call_idx += 1;
-                res.push(ToolCallResponse {
-                    id: format!("call-{}", call_idx),
-                    tp: ToolCallType::Function,
-                    function: CalledFunction {
-                        name: fname.to_string(),
-                        // Safety: `Value::Object` is always valid JSON, so serialization cannot fail
-                        arguments: serde_json::to_string(&args).unwrap(),
-                    },
-                });
-            }
-        // Handle reasoning(analysis) channel
-        } else if channel == Some("analysis") {
-            normal_text.push_str(match &message.content[0] {
-                Text(t) => &t.text,
-                _ => "",
+
+            call_idx += 1;
+            res.push(ToolCallResponse {
+                id: format!("call-{}", call_idx),
+                tp: ToolCallType::Function,
+                function: CalledFunction {
+                    name: fname.to_string(),
+                    arguments: args_json,
+                },
             });
+        } else if channel == Some("final") {
+            if let Some(Text(text)) = message.content.first() {
+                final_text = Some(text.text.clone());
+            }
+        } else if channel == Some("commentary")
+            && recipient.is_empty()
+            && let Some(Text(text)) = message.content.first()
+        {
+            commentary_text = Some(text.text.clone());
         }
     }
-    Ok((res, Some(normal_text.to_string())))
+    let normal_text = final_text
+        .filter(|text| !text.is_empty())
+        .or_else(|| commentary_text.filter(|text| !text.is_empty()))
+        .unwrap_or_default();
+    Ok((res, Some(normal_text)))
 }
 
 pub fn detect_tool_call_start_harmony(
@@ -294,9 +429,10 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
@@ -308,6 +444,7 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
     #[tokio::test] // PARSER.batch.4, PARSER.harmony.2
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
@@ -315,10 +452,11 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some(text.trim().to_string()));
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.7, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
@@ -326,10 +464,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -337,6 +472,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.8, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
@@ -344,41 +480,49 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
         assert_eq!(args["location"], "San Francisco");
     }
 
-    // Harmony's `<|call|>` plays the role of an outer end-token. When
-    // max_tokens fires before it lands, the existing `analysis ... <|end|>`
-    // envelope still gives the parser enough context to recover the call —
-    // this test pins that recovery behavior. The bare-envelope variant
-    // (no preceding analysis block) currently does NOT recover, but adding
-    // a test for that is a parser-change discussion.
-    // Pin current behavior on two back-to-back commentary blocks. The
-    // harmony parser today does NOT extract both calls — the second
-    // `<|start|>assistant<|channel|>commentary` block is left in normal
-    // content. Same failure class as PARSER.batch.5: parser drops in-flight work,
-    // customer sees HTTP 200 with fewer tool_calls than the model emitted.
-    // Promoting this to recovery is a parser change.
+    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    async fn test_parse_harmony_bare_text_without_final_message_is_dropped() {
+        let text = "Hello, how can I help you today?";
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal_content, Some("".to_string()));
+    }
+
+    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    async fn test_parse_harmony_final_message_returns_normal_text() {
+        let text = r#"<|channel|>final<|message|>Hello, how can I help you today?<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(
+            normal_content,
+            Some("Hello, how can I help you today?".to_string())
+        );
+    }
+
+    // Harmony's strict tokenizer rejects two back-to-back commentary
+    // blocks, so EOF recovery falls back to regex extraction and pins that
+    // both calls are surfaced without leaking the raw envelopes.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml.
     #[tokio::test] // PARSER.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
-            text,
-            &JsonParserConfig {
-                allow_eof_recovery: true,
-                ..Default::default()
-            },
-            None,
-        )
-        .await
-        .unwrap();
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
         assert_eq!(tool_calls.len(), 2);
         let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
         let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
@@ -388,11 +532,22 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // Pin current behavior on truncated JSON args. harmony today drops the
-    // call entirely rather than falling back to a string-form arguments or
-    // surfacing an explicit error.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
     #[tokio::test] // PARSER.batch.4 — gpt-oss
-    async fn test_parse_harmony_truncated_json_recovers() {
+    async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, "not json at all");
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
+    #[tokio::test] // PARSER.batch.4 — gpt-oss
+    async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
             text,
@@ -405,18 +560,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
     // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
-    // at the end. harmony's tokenizer rejects this; the regex fallback
-    // accepts EOS as a synthetic close.
+    // at the end. Harmony requires the explicit call stop token, so fallback
+    // must not accept EOS as a synthetic close.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml.
     #[tokio::test] // PARSER.batch.5 — gpt-oss
-    async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
+    async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
                 allow_eof_recovery: true,
@@ -426,10 +581,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
     }
 
     // The regex fallback must preserve any non-tool spans (prose before
@@ -457,8 +610,45 @@ mod tests {
             normal.contains("SUFFIX"),
             "normal must keep suffix: {normal:?}"
         );
+        assert!(
+            !normal.contains("<|start|>"),
+            "normal must not leak harmony start token: {normal:?}"
+        );
+        assert!(
+            !normal.contains("assistant"),
+            "normal must not leak harmony assistant marker: {normal:?}"
+        );
     }
 
+    #[tokio::test]
+    async fn test_parse_harmony_parse_failure_strips_protocol_from_normal_text() {
+        let text = r#"Before <|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
+        let (tool_calls, normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        let normal = normal.unwrap_or_default();
+        assert_eq!(normal, "Before  After");
+        for token in [
+            "<|start|>",
+            "<|channel|>",
+            "<|constrain|>",
+            "<|message|>",
+            "<|call|>",
+        ] {
+            assert!(
+                !normal.contains(token),
+                "normal_text must not leak {token}: {normal:?}"
+            );
+        }
+        assert!(
+            !normal.contains("commentary"),
+            "normal_text must not leak tool-call metadata: {normal:?}"
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.4, PARSER.batch.5, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
@@ -466,12 +656,8 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("We need to call get_weather function. The user asks \"What's the weather like in San Francisco in Celsius?\" So location: \"San Francisco, CA\" unit: \"celsius\". Let's call function.".to_string()));
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "San Francisco, CA");
-        assert_eq!(args["unit"], "celsius");
+        assert_eq!(normal_content, Some("".to_string()));
+        assert!(tool_calls.is_empty());
     }
 
     /// Parser-level invariant: the harmony parser is byte-stable — it
@@ -482,7 +668,7 @@ mod tests {
     /// cross-parser finish_reason mapping work-item (tracked separately).
     #[tokio::test]
     async fn test_harmony_parser_output_independent_of_upstream_finish() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
@@ -491,10 +677,10 @@ mod tests {
 
     /// PARSER.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
     /// the function name.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml.
     #[tokio::test] // PARSER.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
-        let text =
-            r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}"#;
+        let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
@@ -509,6 +695,7 @@ mod tests {
     /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
     /// harmony parser passes the input verbatim through to normal_text —
     /// pin that distinction here.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.9 — gpt-oss
     async fn test_parse_harmony_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -534,6 +721,7 @@ mod tests {
     /// back-to-back commentary blocks for the same function. Pin
     /// parser-level behavior — both calls returned with distinct ids
     /// and distinct args.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.10 — gpt-oss
     async fn test_parse_harmony_duplicate_calls_same_name() {
         let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -1,28 +1,34 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
 use regex::RegexBuilder;
-use serde_json::Value;
+use serde_json::value::RawValue;
 use uuid::Uuid;
 
 use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
-// Same as CalledFunction with named parameters
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+// Same as CalledFunction with named parameters.
+//
+// `parameters` / `arguments` are deserialized as `Box<RawValue>` so the
+// original byte span — including key order, whitespace, and number
+// formatting — is preserved verbatim. Going through `HashMap<String, Value>`
+// here would normalize via `serde_json::to_string`, which strips spaces and
+// reorders keys based on HashMap iteration. That broke append-only KV-cache
+// prefix matching: when the model's emitted `arguments` were re-rendered
+// through this parser and round-tripped back into the next turn's prompt,
+// the bytes diverged from what the model originally emitted.
+#[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionParameters {
     pub name: String,
-    pub parameters: HashMap<String, Value>,
+    pub parameters: Box<RawValue>,
 }
 
-// Same as CalledFunction with named parameters
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionArguments {
     pub name: String,
-    pub arguments: HashMap<String, Value>,
+    pub arguments: Box<RawValue>,
 }
 
 // Extract the contents between start and end tokens using regex parsing.
@@ -81,46 +87,79 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
         return None;
     }
 
-    // Split on the start token and keep only JSON-looking segments
+    // Split on the start token and collect valid JSON objects/arrays.
     let mut items: Vec<String> = Vec::new();
     for seg in input.split(start_token) {
         let s = seg.trim();
         if s.is_empty() {
             continue;
         }
-        // Only consider segments that start like JSON (objects or arrays)
         if s.starts_with('{') {
-            // Trim trailing non-JSON by cutting at the last closing brace
-            if let Some(pos) = s.rfind('}') {
-                let candidate = &s[..=pos].trim();
-                // Keep only valid JSON candidates
-                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                    items.push(candidate.to_string());
+            // Stream consecutive JSON objects from the segment, skipping ';'
+            // separators between them.  This correctly handles both:
+            //   • a single call whose argument contains ';' — the streaming
+            //     deserializer parses the whole object in one shot without
+            //     ever looking at the internal semicolon.
+            //   • parallel calls separated by ';' where one argument also
+            //     contains a ';' inside a string — the deserializer tracks
+            //     string/depth context so byte_offset() lands exactly after
+            //     the closing '}' of each complete object.
+            let mut remaining = s.trim_start();
+            while !remaining.is_empty() {
+                // Use StreamDeserializer (.into_iter().next()) rather than
+                // from_str so the parse succeeds even when there is trailing
+                // non-JSON text after the closing '}' — e.g.
+                //   {"name":"q","arguments":{}} Let me know if you need more
+                // from_str would Err on the trailing text; StreamDeserializer
+                // reads one value and stops.
+                let mut stream =
+                    serde_json::Deserializer::from_str(remaining).into_iter::<Box<RawValue>>();
+                match stream.next() {
+                    Some(Ok(rv)) => {
+                        let raw = rv.get();
+                        if raw.is_empty() {
+                            break; // defensive: zero-advance guard
+                        }
+                        items.push(raw.to_string());
+                        // Advance past the consumed bytes.  `RawValue` captures
+                        // exactly the JSON token bytes (no surrounding whitespace),
+                        // and `remaining` starts at a non-whitespace byte because
+                        // we called `trim_start()` at every step.
+                        remaining = remaining[raw.len()..].trim_start();
+                        // Skip the ';' separator between parallel calls (if any).
+                        if let Some(rest) = remaining.strip_prefix(';') {
+                            remaining = rest.trim_start();
+                        } else {
+                            break; // no separator → only one object or done
+                        }
+                    }
+                    _ => break, // None (end of input) or Some(Err(_)) (malformed)
                 }
             }
         } else if s.starts_with('[') {
-            // Handle array format (like phi4: functools[{...}])
+            // Array format used by phi4 (functools[{...}]) and similar models.
+            // Parse as Vec<Box<RawValue>> to preserve each element's original byte
+            // span — serde_json::Value + to_string would reorder keys and strip
+            // whitespace, breaking append-only KV-cache prefix matching.
             if let Some(pos) = s.rfind(']') {
                 let candidate = &s[..=pos].trim();
-                // Keep only valid JSON arrays
-                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                    // For arrays, we need to extract the individual objects
-                    if let Ok(serde_json::Value::Array(arr)) =
-                        serde_json::from_str::<serde_json::Value>(candidate)
-                    {
-                        for item in arr {
-                            if let Ok(item_str) = serde_json::to_string(&item) {
-                                items.push(item_str);
-                            }
-                        }
+                if let Ok(arr) = serde_json::from_str::<Vec<Box<RawValue>>>(candidate) {
+                    for item in arr {
+                        items.push(item.get().to_string());
                     }
                 }
             }
         }
+        // Segments that start with neither '{' nor '[' are silently dropped.
+        // Note: a separate symptom of issue #8732 is that the model occasionally
+        // echoes back unfilled response-template text (e.g. "WinRM: [status]")
+        // after the start token instead of a tool call. That is a model-side
+        // behaviour (likely caused by an incorrect system prompt) and is tracked
+        // separately; it is not addressed by this parser change.
     }
     if items.is_empty() {
-        // If we found the start token but no valid JSON after it, return empty string
-        // to avoid leaking the invalid content (important for phi4 and similar models)
+        // Start token was found but no valid JSON followed it — return empty to
+        // avoid leaking the start token or invalid content into normal_text.
         return Some(String::new());
     }
     Some(format!("[{}]", items.join(",")))
@@ -286,9 +325,14 @@ pub fn try_tool_call_parse_basic_json(
                         // Single token case
                         let result = handle_single_token_tool_calls(&json, start_token);
                         if let Some(content) = result {
-                            // Check if we found a start token but got empty JSON back
-                            // This indicates the token was found but no valid JSON followed
-                            if content.is_empty() {
+                            // handle_single_token_tool_calls returns either:
+                            //   Some("[{...}, ...]") — one or more extracted calls
+                            //   Some("")             — start token found, no valid JSON followed
+                            // Only the "[..." form means extraction succeeded. Anything else
+                            // means the start token was present but produced no calls; set the
+                            // flag so the caller returns "" rather than leaking the start token
+                            // or the raw invalid content into normal_text.
+                            if !content.starts_with('[') {
                                 found_start_token_with_no_valid_json = true;
                             }
 
@@ -334,16 +378,19 @@ pub fn try_tool_call_parse_basic_json(
     }
     // Convert json (String) to &str
     let json = json.as_str();
-    // Anonymous function to attempt deserialization into a known representation
-    let parse = |name: String, args: HashMap<String, Value>| -> anyhow::Result<ToolCallResponse> {
-        // Preserve nested JSON strings intact; do not double-escape.
-        // serde_json::to_string on Value preserves required escapes only.
+    // Anonymous function to attempt deserialization into a known representation.
+    //
+    // We pass through the original byte span via `RawValue::get()` rather than
+    // re-serializing a parsed `HashMap` / `Value`. That keeps `arguments`
+    // byte-identical to what the model emitted, which is required for KV-cache
+    // append-only prefix matching across multi-step tool use.
+    let parse = |name: String, args: &RawValue| -> anyhow::Result<ToolCallResponse> {
         Ok(ToolCallResponse {
             id: format!("call-{}", Uuid::new_v4()),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name,
-                arguments: serde_json::to_string(&args)?,
+                arguments: args.get().to_string(),
             },
         })
     };
@@ -359,10 +406,9 @@ pub fn try_tool_call_parse_basic_json(
     // }
     if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(json) {
         return Ok((
-            vec![parse(single.name, single.parameters)?],
+            vec![parse(single.name, &single.parameters)?],
             Some(normal_text),
         ));
-        //parse(single.name, single.parameters).map(Some);
 
         // CalledFunctionArguments: Single { name, arguments }
         // Example:
@@ -375,7 +421,7 @@ pub fn try_tool_call_parse_basic_json(
         // }
     } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(json) {
         return Ok((
-            vec![parse(single.name, single.arguments)?],
+            vec![parse(single.name, &single.arguments)?],
             Some(normal_text),
         ));
 
@@ -385,17 +431,21 @@ pub fn try_tool_call_parse_basic_json(
     //   { "name": "lookup_user", "parameters": { "user_id": "123" } },
     //   { "name": "get_weather", "arguments": { "location": "SF", "units": "celsius" } }
     // ]
-    // Parse as generic array to handle both formats and malformed entries gracefully
-    // Note: Always return once we parse a valid array, even if empty or with malformed entries
-    } else if let Ok(array) = serde_json::from_str::<Vec<serde_json::Value>>(json) {
+    // Parse the array as `Vec<Box<RawValue>>` so each element retains its
+    // original byte span. Going through `Vec<serde_json::Value>` would
+    // already have mangled the inner `arguments` / `parameters` bytes by the
+    // time we tried to extract them.
+    } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(json) {
         let mut results = Vec::new();
         for item in array {
+            let item_str = item.get();
             // Try both CalledFunctionArguments and CalledFunctionParameters formats
-            if let Ok(func_args) = serde_json::from_value::<CalledFunctionArguments>(item.clone()) {
-                results.push(parse(func_args.name, func_args.arguments)?);
-            } else if let Ok(func_params) = serde_json::from_value::<CalledFunctionParameters>(item)
+            if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
+                results.push(parse(func_args.name, &func_args.arguments)?);
+            } else if let Ok(func_params) =
+                serde_json::from_str::<CalledFunctionParameters>(item_str)
             {
-                results.push(parse(func_params.name, func_params.parameters)?);
+                results.push(parse(func_params.name, &func_params.parameters)?);
             }
             // Skip malformed entries silently
         }
@@ -413,25 +463,24 @@ pub fn try_tool_call_parse_basic_json(
         let repaired = repaired.as_str();
         if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(repaired) {
             return Ok((
-                vec![parse(single.name, single.parameters)?],
+                vec![parse(single.name, &single.parameters)?],
                 Some(normal_text),
             ));
         } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(repaired) {
             return Ok((
-                vec![parse(single.name, single.arguments)?],
+                vec![parse(single.name, &single.arguments)?],
                 Some(normal_text),
             ));
-        } else if let Ok(array) = serde_json::from_str::<Vec<serde_json::Value>>(repaired) {
+        } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(repaired) {
             let mut results = Vec::new();
             for item in array {
-                if let Ok(func_args) =
-                    serde_json::from_value::<CalledFunctionArguments>(item.clone())
-                {
-                    results.push(parse(func_args.name, func_args.arguments)?);
+                let item_str = item.get();
+                if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
+                    results.push(parse(func_args.name, &func_args.arguments)?);
                 } else if let Ok(func_params) =
-                    serde_json::from_value::<CalledFunctionParameters>(item)
+                    serde_json::from_str::<CalledFunctionParameters>(item_str)
                 {
-                    results.push(parse(func_params.name, func_params.parameters)?);
+                    results.push(parse(func_params.name, &func_params.parameters)?);
                 }
             }
             if !results.is_empty() {

--- a/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -270,6 +270,7 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_calls_deepseek_v3_1_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -288,6 +289,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "New York"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -306,6 +308,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_1_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
@@ -318,6 +321,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -343,6 +347,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_tool_calls_deepseek_v3_1_with_invalid_json() {
         // Everything is normal text in case of invalid json
@@ -356,6 +361,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
@@ -369,6 +375,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_tool_calls_deepseek_v3_1_with_multiline_json() {
         let text = r#"I'll help you understand this codebase. Let me start by exploring the structure and key

--- a/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -274,6 +274,7 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_calls_deepseek_v3_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -298,6 +299,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -319,6 +321,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
@@ -334,6 +337,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -368,6 +372,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_tool_calls_deepseek_v3_with_invalid_json() {
         // Everything is normal text in case of invalid json
@@ -384,6 +389,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
@@ -406,6 +412,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_tool_calls_deepseek_v3_with_multiline_json() {
         let text = r#"I'll help you understand this Xiaohongshu codebase. Let me start by exploring the structure

--- a/parsers/src/tool_calling/json/mod.rs
+++ b/parsers/src/tool_calling/json/mod.rs
@@ -153,6 +153,7 @@ mod tests {
     // Recovery for missing outer </TOOLCALL> (max_tokens / EOS truncation):
     // when the inner JSON array is well-formed, treat EOF as the end token
     // and extract the call rather than silently dropping it.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — nemotron_deci
     fn test_parse_nemotron_deci_no_outer_close_recovers() {
         let config = JsonParserConfig {
@@ -177,6 +178,7 @@ mod tests {
     // but no parser-level test pinned it. This test makes the contract
     // visible at the per-parser surface so a JSON-family refactor can't
     // silently break parallel-call extraction without a per-parser failure.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — nemotron_deci
     fn test_parse_nemotron_deci_multiple_calls() {
         let config = JsonParserConfig {
@@ -198,6 +200,7 @@ mod tests {
     // `"city":"NYC` with no closing quote, brace, or array bracket). The
     // base parser balances unclosed strings/braces and retries the parse,
     // surfacing the call rather than silently dropping it.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — nemotron_deci
     fn test_parse_nemotron_deci_truncated_json_recovers() {
         let config = JsonParserConfig {
@@ -239,6 +242,7 @@ mod tests {
 
     /// PARSER.batch.6 — empty args. A no-arg call (`{}`) must still be returned
     /// with the function name intact.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — nemotron_deci
     fn test_parse_nemotron_deci_empty_args() {
         let config = nemotron_deci_config();

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -146,14 +146,15 @@ pub async fn detect_and_parse_tool_call_with_recovery(
         }
         ParserConfig::Xml(c) => {
             let mut c = c.clone();
-            c.allow_eof_recovery = true;
+            // Strict-match families opt out — flipping recovery here would
+            // contradict their per-spec strictness.
+            if !c.strict_match {
+                c.allow_eof_recovery = true;
+            }
             ParserConfig::Xml(c)
         }
-        ParserConfig::Glm47(c) => {
-            let mut c = c.clone();
-            c.allow_eof_recovery = true;
-            ParserConfig::Glm47(c)
-        }
+        // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
+        // (drop the call when </tool_call> is missing).
         // Other parsers don't have an EOF-recovery flag — pass through.
         other => other.clone(),
     };
@@ -560,6 +561,99 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
+    }
+
+    /// Hermes-style models emit `arguments` as compact JSON (no spaces) on the
+    /// wire. The parser must preserve those exact bytes so the next turn's
+    /// rendered prompt is byte-equivalent to [turn-N prompt + model output],
+    /// keeping KV-cache prefix matching intact across multi-step tool use.
+    /// See PR 9301 for the matching prompt-rendering fix.
+    #[tokio::test]
+    async fn parser_preserves_compact_arguments_byte_span() {
+        let input = r#"<tool_call>{"name": "get_weather", "arguments": {"location":"San Francisco, USA","unit":"celsius"}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].function.arguments, r#"{"location":"San Francisco, USA","unit":"celsius"}"#,
+            "arguments must be preserved byte-for-byte (no `, ` or `: ` injected)"
+        );
+    }
+
+    /// HashMap iteration order is randomized; key order in the output of a
+    /// `HashMap` round-trip would not match what the model emitted. With
+    /// RawValue passthrough, the order survives.
+    #[tokio::test]
+    async fn parser_preserves_argument_key_order() {
+        let input = r#"<tool_call>{"name":"f","arguments":{"z":1,"a":2,"m":3}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].function.arguments, r#"{"z":1,"a":2,"m":3}"#);
+    }
+
+    /// Numeric formatting (e.g. `1.0` vs `1`) must survive round-tripping;
+    /// `serde_json::Value` parses `1.0` as `Number::F64(1.0)` and may
+    /// serialize differently than what the model emitted.
+    #[tokio::test]
+    async fn parser_preserves_numeric_formatting() {
+        let input = r#"<tool_call>{"name":"f","arguments":{"x":1.0,"y":42}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].function.arguments, r#"{"x":1.0,"y":42}"#);
+    }
+
+    /// Parallel tool_calls each go through the array-deserialization path
+    /// (`Vec<Box<RawValue>>`); each element's byte span must be independent.
+    #[tokio::test]
+    async fn parser_preserves_byte_span_for_parallel_calls() {
+        let input = r#"<tool_call>{"name":"a","arguments":{"k":"v1"}}</tool_call>
+<tool_call>{"name":"b","arguments":{"k":"v2"}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].function.arguments, r#"{"k":"v1"}"#);
+        assert_eq!(result[1].function.arguments, r#"{"k":"v2"}"#);
+    }
+
+    /// Single-token-start parsers (`functools`, `[TOOL_CALLS]`,
+    /// `<|python_tag|>`) route arrays through
+    /// `handle_single_token_tool_calls`. That helper previously round-tripped
+    /// each element through `serde_json::Value` + `to_string`, which dropped
+    /// whitespace and reordered keys in `arguments` before the downstream
+    /// `Vec<Box<RawValue>>` parser ever saw them. The fix parses the array
+    /// directly as `Vec<Box<RawValue>>` so each element retains its original
+    /// byte span end-to-end.
+    #[tokio::test]
+    async fn single_token_array_preserves_argument_byte_span_phi4() {
+        let input = r#"functools[{"name":"f","arguments":{"z":1,"a":2,"unit":"celsius"}}]"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("phi4"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].function.arguments, r#"{"z":1,"a":2,"unit":"celsius"}"#,
+            "phi4/functools path must preserve key order and absent whitespace verbatim"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_token_array_preserves_argument_byte_span_mistral() {
+        let input = r#"[TOOL_CALLS] [{"name":"f","arguments":{"z":1,"a":2}}, {"name":"g","arguments":{"b":3.0}}]"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("mistral"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].function.arguments, r#"{"z":1,"a":2}"#);
+        assert_eq!(
+            result[1].function.arguments, r#"{"b":3.0}"#,
+            "numeric formatting (3.0 vs 3) must be preserved"
+        );
     }
 
     #[tokio::test]
@@ -1639,14 +1733,11 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_harmony_parser_basic() {
         let input = r#"
-        <|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}"#;
+        <|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (result, content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();
-        assert_eq!(
-            content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_current_weather");

--- a/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -262,6 +262,7 @@ mod tests {
         assert_eq!(matches.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_call_parse_pythonic_basic() {
         let message = "[foo(a=1, b=2), bar(x=3)]";
@@ -278,6 +279,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
@@ -294,6 +296,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8, PARSER.fmt.2
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
@@ -319,6 +322,7 @@ mod tests {
         assert_eq!(result.len(), 0)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2, PARSER.fmt.3
     fn test_parse_tool_call_parse_pythonic_with_python_tags() {
         let message = "<|python_start|>[foo(a=1, b=2), bar(x=3)]<|python_end|>";
@@ -335,6 +339,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_parse_pythonic_with_list_arg_values() {
         let message = "[foo(a=[1, 2, 3], b=2), bar(x=[3, 4, 5])]";
@@ -350,6 +355,7 @@ mod tests {
         assert_eq!(args["x"], json!([3, 4, 5]));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_parse_pythonic_with_dict_arg_values() {
         let message = "[foo(a={'a': 1, 'b': 2}, b=2), bar(x={'x': 3, 'y': {'e': 'f'}})]";

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -15,6 +15,29 @@ use super::super::ToolDefinition;
 use super::super::config::Glm47ParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
+/// Render a tool_call block snippet for logs. Bounded so a huge truncated
+/// argument body doesn't blow up the log line; control chars are escaped
+/// because raw newlines/tabs make the warning unreadable in grep/jq.
+fn truncate_for_log(s: &str) -> String {
+    const MAX: usize = 200;
+    let mut out = String::with_capacity(MAX.min(s.len()) + 16);
+    let mut bytes = 0usize;
+    for ch in s.chars() {
+        if bytes >= MAX {
+            out.push('…');
+            break;
+        }
+        match ch {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+        bytes += ch.len_utf8();
+    }
+    out
+}
+
 /// Check if a chunk contains the start of a GLM-4.7 tool call.
 /// Format: <tool_call>function_name<arg_key>...</arg_key><arg_value>...</arg_value></tool_call>
 pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> bool {
@@ -35,16 +58,39 @@ pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> 
     false
 }
 
-/// Find the end position of a GLM-4.7 tool call.
-/// Returns the position after </tool_call> or the length of the chunk if not found.
+/// Find the end position of all consecutive GLM-4.7 tool calls.
+/// When a model emits multiple parallel tool calls in one chunk
+/// (e.g. `<tool_call>A</tool_call><tool_call>B</tool_call>`), this
+/// function advances past every consecutive start→end pair so the
+/// entire group is captured as a single jailed region.  Returns the
+/// position after the last `</tool_call>` found, or the length of the
+/// chunk when no end token is present.
 pub fn find_tool_call_end_position_glm47(chunk: &str, config: &Glm47ParserConfig) -> usize {
+    let start_token = &config.tool_call_start;
     let end_token = &config.tool_call_end;
 
-    if let Some(pos) = chunk.find(end_token.as_str()) {
-        pos + end_token.len()
-    } else {
-        chunk.len()
+    let Some(first_end) = chunk.find(end_token.as_str()) else {
+        return chunk.len();
+    };
+
+    let mut cursor = first_end + end_token.len();
+
+    loop {
+        let rest = &chunk[cursor..];
+        let trimmed = rest.trim_start();
+        if !trimmed.starts_with(start_token.as_str()) {
+            break;
+        }
+        let trim_offset = rest.len() - trimmed.len();
+        let search_from = cursor + trim_offset + start_token.len();
+        if let Some(end_pos) = chunk[search_from..].find(end_token.as_str()) {
+            cursor = search_from + end_pos + end_token.len();
+        } else {
+            break;
+        }
     }
+
+    cursor
 }
 
 /// Try to parse GLM-4.7 formatted tool calls from a message.
@@ -84,21 +130,36 @@ fn extract_tool_calls(
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
 
-            // Add text before tool call to normal parts
-            normal_parts.push(&text[cursor..abs_start]);
+            // Only surface normal text that precedes the first parsed call.
+            // Text after any </tool_call> is not response content; matches the
+            // convention ported into the generic XML parser by PR #9350 and
+            // vLLM's glm47_moe_tool_parser.
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..abs_start]);
+            }
 
             // Find the corresponding end token
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
                 let abs_end = abs_start + end_pos + end_token.len();
                 let block = &text[abs_start..abs_end];
 
-                // Parse this tool call block; preserve unparseable blocks as
-                // normal text so model output is never silently dropped.
+                // Parse this tool call block. Unparseable blocks (malformed
+                // <tool_call>...</tool_call> markup the parser can't extract)
+                // are dropped — emitting the raw markup as normal_text leaks
+                // wire tags downstream. vLLM and SGLang both drop on this
+                // path; aligning Dynamo to that contract.
                 match parse_tool_call_block(block, config, tools) {
                     Ok(parsed_call) => calls.push(parsed_call),
                     Err(e) => {
-                        warn!("Failed to parse GLM-4.7 tool call block: {e}");
-                        normal_parts.push(block);
+                        warn!(
+                            reason = %e,
+                            why = "block has open + close fence but content failed to parse \
+                                   as a GLM-4.7 tool call (e.g. empty function name, \
+                                   missing <arg_key>, malformed args); dropping to avoid \
+                                   leaking wire tags through normal_text",
+                            dropped_block = %truncate_for_log(block),
+                            "GLM-4.7 parser dropping unparseable tool_call block"
+                        );
                     }
                 }
 
@@ -119,21 +180,55 @@ fn extract_tool_calls(
                             continue;
                         }
                         Err(e) => {
-                            warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
+                            warn!(
+                                reason = %e,
+                                why = "EOF recovery enabled and <arg_key> opener present, \
+                                       but parse_tool_call_block failed on the truncated \
+                                       tail; dropping to avoid leaking wire tags through \
+                                       normal_text",
+                                dropped_block = %truncate_for_log(block),
+                                "GLM-4.7 parser dropping truncated tool_call block (recovery attempt failed)"
+                            );
                         }
                     }
+                } else {
+                    // Either recovery disabled (production default for GLM-4.7)
+                    // or no <arg_key> in the tail (so this is plausibly not a
+                    // real tool call at all, just a stray <tool_call> token).
+                    let reason = if !config.allow_eof_recovery {
+                        "allow_eof_recovery=false (production default for GLM-4.7 to match \
+                         vLLM/SGLang on truncated tool calls)"
+                    } else {
+                        "no <arg_key> in the tail after the <tool_call> start fence, so the \
+                         block does not look like a structurally-real GLM-4.7 tool call"
+                    };
+                    warn!(
+                        why = %reason,
+                        dropped_block = %truncate_for_log(block),
+                        "GLM-4.7 parser dropping truncated tool_call block (no end fence)"
+                    );
                 }
-                normal_parts.push(&text[abs_start..]);
+                // Drop the truncated/unrecoverable tail. Emitting the raw
+                // <tool_call>...<arg_key>...<arg_value>... prefix as
+                // normal_text would leak wire tags into message.content; vLLM
+                // strips the same way on truncation.
                 break;
             }
         } else {
             // No more tool calls
-            normal_parts.push(&text[cursor..]);
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..]);
+            }
             break;
         }
     }
 
-    let normal_text = normal_parts.join("").trim().to_string();
+    let normal_text = normal_parts.join("");
+    let normal_text = if calls.is_empty() {
+        normal_text.trim().to_string()
+    } else {
+        normal_text
+    };
     Ok((normal_text, calls))
 }
 
@@ -328,6 +423,7 @@ mod tests {
         assert!(!detect_tool_call_start_glm47("Just normal text", &config));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let config = get_test_config();
@@ -347,6 +443,7 @@ mod tests {
         assert_eq!(normal_text, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_tool_call_with_multiple_args() {
         let config = get_test_config();
@@ -364,6 +461,7 @@ mod tests {
         assert_eq!(args.get("date").unwrap().as_str().unwrap(), "2026-03-15");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_with_json_value() {
         let config = get_test_config();
@@ -380,6 +478,7 @@ mod tests {
         assert!(filters.is_object());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = get_test_config();
@@ -392,6 +491,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let config = get_test_config();
@@ -403,10 +503,11 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(
             normal_text,
-            Some("I'll check the weather for you.".to_string())
+            Some("I'll check the weather for you. ".to_string())
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6
     fn test_parse_tool_call_no_args() {
         let config = get_test_config();
@@ -435,6 +536,75 @@ mod tests {
         );
     }
 
+    #[test] // helper — parallel calls: end position must advance past ALL blocks
+    fn test_find_tool_call_end_position_parallel() {
+        let config = get_test_config();
+        let chunk = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>SF</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>trailing";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            &chunk[..end_pos],
+            "<tool_call>get_weather<arg_key>location</arg_key><arg_value>SF</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
+            "Must advance past ALL consecutive tool call blocks"
+        );
+    }
+
+    #[test] // helper — parallel calls with whitespace between blocks
+    fn test_find_tool_call_end_position_parallel_with_whitespace() {
+        let config = get_test_config();
+        let chunk = "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call>\n<tool_call>b<arg_key>k</arg_key><arg_value>2</arg_value></tool_call>";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            end_pos,
+            chunk.len(),
+            "Must handle whitespace/newlines between consecutive blocks"
+        );
+    }
+
+    #[test] // helper — parallel calls: second block incomplete (streaming)
+    fn test_find_tool_call_end_position_parallel_second_incomplete() {
+        let config = get_test_config();
+        let chunk = "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call><tool_call>b<arg_key>k</arg_key><arg_value>2</arg_value>";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            &chunk[..end_pos],
+            "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call>",
+            "Must stop at first complete block when second is incomplete"
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
+    #[test] // PARSER.batch.2 + PARSER.batch.8 — bug report repro: text + parallel calls
+    fn test_parse_text_then_parallel_calls() {
+        let config = get_test_config();
+        let message = "I'll check the weather for both cities at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>San Francisco</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value></tool_call>";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+
+        assert_eq!(calls.len(), 2, "Both parallel calls must be extracted");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+
+        let args0: HashMap<String, Value> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: HashMap<String, Value> =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(
+            args0.get("location").unwrap().as_str().unwrap(),
+            "San Francisco"
+        );
+        assert_eq!(args1.get("location").unwrap().as_str().unwrap(), "New York");
+
+        let text = normal_text.unwrap();
+        assert_eq!(
+            text,
+            "I'll check the weather for both cities at the same time!"
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_multiline_arg_value() {
         let config = get_test_config();
@@ -456,6 +626,7 @@ mod tests {
         assert!(content.contains("print(\"Hello, World!\")"));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_malformed_tool_call() {
         let config = get_test_config();
@@ -473,6 +644,7 @@ mod tests {
     // when the inner arg pairs are well-formed, treat EOF as the end token
     // and extract the call. The arg_key opener gates recovery so plain text
     // that happens to start with `<tool_call>` is still preserved verbatim.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5
     fn test_parse_no_end_tag_complete_args_recovers() {
         let config = Glm47ParserConfig {
@@ -489,6 +661,7 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5
     fn test_parse_no_end_tag_multiple_calls_recovers() {
         let config = Glm47ParserConfig {
@@ -504,25 +677,35 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c, PARSER.batch.13 in tests/parity/parser/fixtures/glm47/PARSER.batch.13.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.4, PARSER.batch.8
-    fn test_unparseable_block_preserved_as_normal_text() {
+    fn test_unparseable_block_dropped_no_tag_leak() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
         }];
 
-        // Tool call block references a function not in the tools list
+        // Tool call block references a function not in the tools list — the
+        // whole block (including <tool_call>...<arg_key>...<arg_value>... wire
+        // markup) must be dropped, not leaked through normal_text.
         let message = "Here is the result: <tool_call>unknown_func<arg_key>x</arg_key><arg_value>1</arg_value></tool_call> done";
         let (calls, normal_text) =
             try_tool_call_parse_glm47(message, &config, Some(&tools)).unwrap();
 
         assert_eq!(calls.len(), 0);
-        // The unparseable block should be preserved in normal text, not dropped
         let text = normal_text.unwrap();
         assert!(
-            text.contains("unknown_func"),
-            "Unparseable block should be in normal text, got: {text}"
+            !text.contains("unknown_func"),
+            "Unparseable block must be dropped to avoid tag leakage, got: {text}"
+        );
+        assert!(
+            !text.contains("<tool_call>") && !text.contains("<arg_key>"),
+            "Wire-format tags must not leak into normal_text, got: {text}"
+        );
+        assert!(
+            text.contains("Here is the result:") && text.contains("done"),
+            "Surrounding prose must be preserved, got: {text}"
         );
     }
 
@@ -668,6 +851,7 @@ mod tests {
     /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_glm47_empty_and_whitespace_inputs() {
         let config = get_test_config();
@@ -690,6 +874,7 @@ mod tests {
     /// PARSER.batch.10 — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; pin parser-level behavior —
     /// both calls returned with distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_glm47_duplicate_calls_same_name() {
         let config = get_test_config();

--- a/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -152,6 +152,44 @@ fn find_section_end(
     best
 }
 
+/// True for prefix-only narration before a tool section where vLLM preserves
+/// the wrapper-adjacent trailing space (PARSER.batch.8.a).
+fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[&str]) -> bool {
+    let mut non_empty_parts = normal_parts
+        .iter()
+        .enumerate()
+        .filter(|(_, part)| !part.trim().is_empty());
+
+    matches!(
+        non_empty_parts.next(),
+        Some((0, part)) if part.chars().next_back().is_some_and(|ch| ch.is_whitespace())
+    ) && non_empty_parts.next().is_none()
+}
+
+/// True when the first visible normal text appears only after a parsed tool
+/// section, so the intermediate Kimi tool-call turn should expose no content
+/// (PARSER.batch.8.b).
+fn should_drop_post_tool_text_without_prefix(normal_parts: &[&str]) -> bool {
+    normal_parts
+        .iter()
+        .enumerate()
+        .find(|(_, part)| !part.trim().is_empty())
+        .is_some_and(|(idx, _)| idx != 0)
+}
+
+/// True when there is prefix narration before the first tool section plus
+/// post-wrapper or inter-wrapper narration that should be dropped for Kimi
+/// tool-call turns (PARSER.batch.2.c, 8.c, 8.d).
+fn should_drop_post_tool_text_after_prefix(normal_parts: &[&str]) -> bool {
+    normal_parts
+        .first()
+        .is_some_and(|prefix| !prefix.trim().is_empty())
+        && normal_parts
+            .iter()
+            .skip(1)
+            .any(|part| !part.trim().is_empty())
+}
+
 /// Extract tool calls and normal text from message.
 ///
 /// ## Difference from Moonshot's reference implementation
@@ -218,7 +256,31 @@ fn extract_tool_calls(
         }
     }
 
-    let normal_text = normal_parts.join("").trim().to_string();
+    let joined_normal_text = normal_parts.join("");
+    let normal_text =
+        if !calls.is_empty() && should_drop_post_tool_text_without_prefix(&normal_parts) {
+            // Kimi tool-call responses are intermediate assistant turns: the
+            // official API flow treats content as empty while tool_calls are
+            // emitted, then asks the client to execute tools before returning
+            // final user-facing content. Match vLLM/SGLang by not surfacing
+            // post-wrapper text when there is no prefix narration.
+            String::new()
+        } else if !calls.is_empty() && should_drop_post_tool_text_after_prefix(&normal_parts) {
+            // Kimi tool-call responses are intermediate assistant turns even
+            // when a single section contains multiple calls or a turn contains
+            // multiple sections. Preserve only the prefix emitted before the
+            // first tool section and drop post-wrapper/inter-wrapper text;
+            // final user-facing content should be produced after tool results.
+            normal_parts[0].trim_start().to_string()
+        } else if !calls.is_empty() && should_preserve_vllm_prefix_trailing_space(&normal_parts) {
+            // vLLM preserves wrapper-adjacent trailing whitespace when the
+            // response has only prefix narration before a Kimi tool section.
+            // Keep this compatibility path narrow to avoid changing Dynamo's
+            // existing handling of post-wrapper/inter-wrapper narration.
+            normal_parts[0].trim_start().to_string()
+        } else {
+            joined_normal_text.trim().to_string()
+        };
     Ok((normal_text, calls))
 }
 
@@ -347,6 +409,7 @@ mod tests {
         assert_eq!(pos, None, "should return None when section_end is missing");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let config = default_config();
@@ -361,6 +424,7 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_multiple_args() {
         let config = default_config();
@@ -375,6 +439,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = default_config();
@@ -392,20 +457,76 @@ mod tests {
         assert_eq!(args1["timezone"], "EST");
     }
 
-    #[test] // PARSER.batch.8
-    fn test_parse_with_normal_text() {
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml.
+    #[test] // PARSER.batch.8.c
+    fn test_parse_keeps_prefix_drops_post_tool_text() {
         let config = default_config();
         let input = r#"I'll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
 
         let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(
-            normal,
-            Some("I'll help you with that.  Let me check.".to_string())
-        );
+        assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
+    #[test] // PARSER.batch.8.a
+    fn test_parse_preserves_vllm_prefix_trailing_space() {
+        let config = default_config();
+        let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(normal, Some("I'll check the weather. ".to_string()));
+    }
+
+    #[test] // PARSER.batch.8.a
+    fn test_parse_prefix_only_ignores_post_wrapper_whitespace() {
+        let config = default_config();
+        let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>   "#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(normal, Some("I'll check the weather. ".to_string()));
+    }
+
+    #[test] // PARSER.batch.2.c
+    fn test_parse_parallel_calls_with_surrounding_text() {
+        let config = default_config();
+        let input = r#"I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|> Done."#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_time");
+        assert_eq!(normal, Some("I will check both. ".to_string()));
+    }
+
+    #[test] // PARSER.batch.8.d
+    fn test_parse_multiple_sections_drops_inter_wrapper_text() {
+        let config = default_config();
+        let input = r#"First check Dallas. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Then check NYC. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_eq!(normal, Some("First check Dallas. ".to_string()));
+    }
+
+    #[test] // PARSER.batch.8.b
+    fn test_parse_drops_post_tool_text_without_prefix() {
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
+
+        let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(normal, Some("".to_string()));
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6
     fn test_parse_no_arg_call() {
         let config = default_config();
@@ -440,6 +561,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1 (with declared `ToolDefinition` tools provided)
     fn test_parse_with_tool_validation() {
         let config = default_config();
@@ -467,6 +589,7 @@ mod tests {
     // `serde_json::from_str` falls back to raw-string arguments when the
     // payload doesn't parse, matching the behavior of the existing
     // `test_parse_invalid_json_falls_back_to_raw_string` case.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_truncated_json_inside_complete_fences_recovers() {
         let config = default_config();
@@ -479,6 +602,7 @@ mod tests {
         assert_eq!(calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 (PR #8208)
     fn test_parse_malformed_no_section_end() {
         let config = default_config();
@@ -496,6 +620,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.4, PARSER.batch.5
     fn test_parse_truncated_mid_argument_no_section_end() {
         let config = default_config();
@@ -515,6 +640,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.5
     fn test_parse_multiple_calls_no_section_end() {
         let config = default_config();
@@ -531,6 +657,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.4, PARSER.batch.5
     fn test_parse_complete_plus_truncated_no_section_end() {
         let config = default_config();
@@ -559,6 +686,7 @@ mod tests {
         assert_eq!(args["query"], "rust programming");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_complex_json_arguments() {
         let config = default_config();
@@ -573,6 +701,7 @@ mod tests {
         assert_eq!(args["config"]["nested"], true);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_deeply_nested_json_multiple_calls() {
         let config = default_config();
@@ -638,6 +767,7 @@ mod tests {
 
     // --- Tests inspired by vllm/sglang coverage gaps ---
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_invalid_json_falls_back_to_raw_string() {
         // vllm: test_extract_tool_calls_invalid_json
@@ -681,6 +811,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "valid");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — special characters in arg values
     fn test_parse_angle_brackets_in_json_arguments() {
         // vllm: angle_brackets_in_json
@@ -699,6 +830,7 @@ mod tests {
         assert_eq!(args["format"], "html");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — parallel calls, zero-spacing edge case
     fn test_parse_three_concatenated_calls_no_spacing() {
         // vllm: concatenated_tool_calls_bug_fix, three_concatenated_tool_calls
@@ -728,6 +860,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — newlines in arg values
     fn test_parse_newlines_in_json_arguments() {
         // vllm: newlines_in_json
@@ -794,6 +927,7 @@ mod tests {
     /// `<|tool_call_end|>` is missing and section fences are complete. Fix:
     /// anchor on the next `<|tool_call_begin|>` or `<|tool_calls_section_end|>`
     /// to terminate the args region. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_call_end_inside_complete_section_silent_drop() {
         let config = default_config();
@@ -816,6 +950,7 @@ mod tests {
     /// markup, and C is dropped — caller gets garbage args for B and
     /// never sees C. Fix: same anchor on `<|tool_call_begin|>` as the
     /// silent-drop case above. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.4
     fn test_parse_middle_call_missing_end_corrupts_next() {
         let config = default_config();
@@ -872,6 +1007,7 @@ mod tests {
     /// `PARSER.batch.9` — empty / null content variants. Empty section already
     /// covered by `test_parse_empty_tool_section`; this pins the
     /// truly-empty (zero bytes) and null-ish ("\n", whitespace-only) inputs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_empty_and_whitespace_inputs() {
         let config = default_config();
@@ -893,6 +1029,7 @@ mod tests {
 
     /// `PARSER.batch.10` — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; first parser to land coverage.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_duplicate_calls_same_name() {
         let config = default_config();

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -14,6 +14,20 @@ use super::super::ToolDefinition;
 use super::super::config::XmlParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
+/// Build a `<start>name>(body)<end>` regex pattern. When `strict` is false,
+/// missing `<end>` falls back to end-of-block so truncated input still parses
+/// best-effort. Strict mode requires both fences and returns no match without
+/// the close tag.
+fn build_block_pattern(start: &str, end: &str, strict: bool) -> String {
+    let start = regex::escape(start);
+    let end = regex::escape(end);
+    if strict {
+        format!(r"(?s){}([^>]+)>(.*?){}", start, end)
+    } else {
+        format!(r"(?s){}([^>]+)>(.*?)(?:{}|$)", start, end)
+    }
+}
+
 /// Strip surrounding quotes from a string if present
 fn strip_quotes(s: &str) -> &str {
     let trimmed = s.trim();
@@ -29,11 +43,12 @@ fn strip_quotes(s: &str) -> &str {
 /// Check if a chunk contains the start of a xml-style tool call.
 /// Format: `<tool_call><function=name><parameter=foo>...</parameter></function></tool_call>`
 pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool {
-    // Check for complete or partial start token.
     let start_token = &config.tool_call_start_token;
 
-    // Check if we have the complete start token.
-    if chunk.contains(start_token.as_str()) {
+    // Complete start token, or bare `<function=...>` in back-off mode (the
+    // batch path treats both as tool-call starts; the streaming jail must
+    // agree — see XmlParserConfig::is_bare_function_mode).
+    if chunk.contains(start_token.as_str()) || config.is_bare_function_mode(chunk) {
         return true;
     }
 
@@ -53,9 +68,17 @@ pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool
 /// advances past every consecutive start→end pair so the entire group is captured
 /// as a single jailed region.  Returns the position after the last `</tool_call>`
 /// found, or the length of the chunk when no end token is present.
+///
+/// In back-off mode (see XmlParserConfig::is_bare_function_mode) the
+/// function-level tokens act as the boundary so the jail releases at
+/// `</function>` instead of buffering to EOS waiting for a missing
+/// `</tool_call>`.
 pub fn find_tool_call_end_position_xml(chunk: &str, config: &XmlParserConfig) -> usize {
-    let start_token = &config.tool_call_start_token;
-    let end_token = &config.tool_call_end_token;
+    let (start_token, end_token) = if config.is_bare_function_mode(chunk) {
+        (&config.function_start_token, &config.function_end_token)
+    } else {
+        (&config.tool_call_start_token, &config.tool_call_end_token)
+    };
 
     // Find the first end token — if there isn't one, the call is incomplete.
     let Some(first_end) = chunk.find(end_token.as_str()) else {
@@ -94,6 +117,41 @@ pub fn try_tool_call_parse_xml(
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    // Qwen3-Coder-style passthrough: if the function-start token is absent
+    // anywhere in the input, the reference parser returns the raw input as
+    // content with no tool calls. Gated so it only fires for parsers that
+    // opt in (e.g. qwen3_coder, nemotron_nano); other XML-style families
+    // (minimax_m2, kimi_k2 alias paths) keep their stricter behavior.
+    if config.passthrough_when_no_function
+        && !message.contains(config.function_start_token.as_str())
+    {
+        return Ok((vec![], Some(message.to_string())));
+    }
+
+    // Qwen3-Coder-style back-off: outer wrapper missing but `<function=...>`
+    // tags are present — parse the whole input as a single tool-call block
+    // (mirrors `qwen3coder_tool_parser._get_function_calls`'s fallback).
+    //
+    // Gated on `function_end_token` being present OR `allow_eof_recovery` set,
+    // mirroring the wrapped path's recovery gate in `extract_tool_calls`. The
+    // lenient inner regex has a `|$` fallback that would otherwise match a
+    // partial `<function=...>` block mid-stream and cause `should_exit_jail_
+    // early` to release the jail before the closing tag arrives.
+    if config.is_bare_function_mode(message)
+        && (message.contains(config.function_end_token.as_str()) || config.allow_eof_recovery)
+    {
+        let calls = parse_tool_call_block(message, config, tools).unwrap_or_default();
+        if !calls.is_empty() {
+            // Preserve narration before the first `<function=...>` tag so
+            // streaming output isn't dropped on the back-off path.
+            let prefix = message
+                .split_once(config.function_start_token.as_str())
+                .map(|(p, _)| p.to_string())
+                .unwrap_or_default();
+            return Ok((calls, Some(prefix)));
+        }
+    }
+
     let (normal_text, tool_calls) = extract_tool_calls(message, config, tools)?;
 
     let normal_content = if normal_text.is_empty() {
@@ -152,6 +210,7 @@ fn extract_tool_calls(
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
                 if config.allow_eof_recovery
+                    && !config.strict_match
                     && block.contains(function_start.as_str())
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
@@ -189,20 +248,18 @@ fn parse_tool_call_block(
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<Vec<ToolCallResponse>> {
-    // Build regex patterns based on config
-    let function_start = regex::escape(&config.function_start_token);
-    let function_end = regex::escape(&config.function_end_token);
-    let parameter_start = regex::escape(&config.parameter_start_token);
-    let parameter_end = regex::escape(&config.parameter_end_token);
-
-    let function_pattern = format!(r"(?s){}([^>]+)>(.*?)(?:{}|$)", function_start, function_end);
-    let parameter_pattern = format!(
-        r"(?s){}([^>]+)>(.*?)(?:{}|$)",
-        parameter_start, parameter_end
-    );
-
-    let function_regex = Regex::new(&function_pattern)?;
-    let parameter_regex = Regex::new(&parameter_pattern)?;
+    // Strict-match families (e.g. minimax_m2) require paired fences; lenient
+    // families fall back to end-of-block when the close tag is missing.
+    let function_regex = Regex::new(&build_block_pattern(
+        &config.function_start_token,
+        &config.function_end_token,
+        config.strict_match,
+    ))?;
+    let parameter_regex = Regex::new(&build_block_pattern(
+        &config.parameter_start_token,
+        &config.parameter_end_token,
+        config.strict_match,
+    ))?;
 
     let mut results = Vec::new();
 
@@ -713,6 +770,7 @@ mod tests {
         assert_eq!(html_unescape(input), expected);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let input = r#"<tool_call>
@@ -733,6 +791,7 @@ pwd && ls
         assert_eq!(args["command"], "pwd && ls");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml, tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_multiple_parameters() {
         let input = r#"<tool_call>
@@ -759,6 +818,7 @@ fahrenheit
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"I'll help you with that. <tool_call>
@@ -776,6 +836,7 @@ Dallas
         assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<tool_call>
@@ -804,6 +865,7 @@ Orlando
         assert_eq!(args1["city"], "Orlando");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_json_parameter_value() {
         // With schema-aware parsing, we need to provide a schema to parse JSON objects
@@ -844,6 +906,7 @@ Orlando
         assert_eq!(normal, Some(input.to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_malformed_tool_call() {
         let input = r#"<tool_call>
@@ -857,6 +920,7 @@ value
         assert!(result.is_ok());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_parameter_closing_tag() {
         let input = r#"<tool_call>
@@ -874,6 +938,7 @@ ls -la
         assert_eq!(args["command"], "ls -la");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_function_closing_tag() {
         let input = r#"<tool_call>
@@ -891,6 +956,7 @@ Boston
         assert_eq!(args["city"], "Boston");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_both_closing_tags() {
         let input = r#"<tool_call>
@@ -908,6 +974,7 @@ SELECT * FROM users
         assert_eq!(args["sql"], "SELECT * FROM users\n</tool_call>");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_multiple_parameters_missing_closing_tags() {
         let input = r#"<tool_call>
@@ -933,6 +1000,7 @@ rust programming
     // token and extract the call. Recovery is gated on a function-start
     // opener in the trailing slice so plain text that happens to start with
     // `<tool_call>` is preserved verbatim.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — qwen3_coder
     fn test_parse_qwen3_no_outer_close_recovers() {
         let input = r#"<tool_call>
@@ -953,6 +1021,56 @@ NYC
         assert_eq!(args["city"], "NYC");
     }
 
+    // Streaming-jail symmetry: when `<function=...>` is partial (no
+    // `</function>` yet) and recovery is OFF, back-off must NOT fire — the
+    // lenient `|$` regex would otherwise match the truncated content and
+    // cause `should_exit_jail_early` to release the jail before the closing
+    // tag arrives, leaking the rest of the call as text. Recovery ON
+    // (finalize path) is still allowed to recover the truncated call.
+    #[test]
+    fn test_parse_qwen3_bare_function_partial_no_recovery_returns_no_calls() {
+        let input = "<function=get_weather>\n<parameter=city>\nNY";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            // allow_eof_recovery=false (streaming jail path)
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert!(
+            calls.is_empty(),
+            "back-off must not fire on partial input without recovery (streaming jail leak)",
+        );
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_complete_streaming_recovers() {
+        // Same scenario but `</function>` has arrived — back-off should fire
+        // even with recovery off (streaming-complete path).
+        let input = "<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_partial_with_recovery_recovers() {
+        // Finalize path: recovery ON allows truncated function block to
+        // surface a (potentially incomplete) call rather than being dropped.
+        let input = "<function=get_weather>\n<parameter=city>\nNY";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            allow_eof_recovery: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
     // Qwen3-Coder-style XML treats text after the first parsed tool call as
     // non-content, including after EOF recovery.
     #[test]
@@ -968,8 +1086,14 @@ NYC
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // PARSER.batch.5 — minimax_m2
-    fn test_parse_minimax_m2_no_outer_close_recovers() {
+    #[test] // PARSER.batch.5.a — minimax_m2 spec-strict
+    fn test_parse_minimax_m2_no_outer_close_drops_call() {
+        // MiniMax-M2's reference parser (huggingface.co/MiniMaxAI/MiniMax-M2)
+        // requires both outer fences — missing `</minimax:tool_call>` means
+        // the regex does not match and zero calls are recovered. Strict-match
+        // mode opts into that behavior even when `allow_eof_recovery=true`
+        // would otherwise apply (and the binding-layer override is also
+        // suppressed for strict configs).
         let config = XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
             tool_call_end_token: "</minimax:tool_call>".to_string(),
@@ -978,14 +1102,17 @@ NYC
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: true,
+            strict_match: true,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         };
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 
         let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "get_weather");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["city"], "NYC");
+        assert!(
+            calls.is_empty(),
+            "strict_match config must not recover when outer </minimax:tool_call> is absent"
+        );
     }
 
     #[test] // helper
@@ -1171,10 +1298,8 @@ NYC
     }
 
     /// Helper for the new corner-case tests below (PARSER.batch.6 / PIPELINE.finish_reason / PARSER.batch.9
-    /// / PARSER.batch.10) — `allow_eof_recovery: false` because none of these tests
-    /// rely on EOF recovery. The inline config in
-    /// `test_parse_minimax_m2_no_outer_close_recovers` keeps that flag `true`
-    /// because that test specifically exercises the recovery path.
+    /// / PARSER.batch.10) — matches the production `ToolCallConfig::minimax_m2()`
+    /// factory: strict-match per MiniMax's reference parser.
     fn minimax_m2_config() -> XmlParserConfig {
         XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -1184,11 +1309,15 @@ NYC
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: false,
+            strict_match: true,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         }
     }
 
     /// PARSER.batch.6 — empty args. A no-arg call (no `<parameter=...>` block)
     /// must still surface the function name with empty arguments.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — qwen3_coder
     fn test_parse_qwen3_empty_args() {
         let input = r#"<tool_call>
@@ -1203,6 +1332,7 @@ NYC
     }
 
     /// PARSER.batch.6 — empty args, minimax_m2 format.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — minimax_m2
     fn test_parse_minimax_m2_empty_args() {
         let config = minimax_m2_config();
@@ -1248,6 +1378,7 @@ NYC
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string. Tested under both qwen3_coder and
     /// minimax_m2 configs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — qwen3_coder
     fn test_parse_qwen3_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -1267,6 +1398,7 @@ NYC
         }
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — minimax_m2
     fn test_parse_minimax_m2_empty_and_whitespace_inputs() {
         let config = minimax_m2_config();
@@ -1289,6 +1421,7 @@ NYC
     /// PARSER.batch.10 — duplicate calls (same function name twice). qwen3_coder
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.10 — qwen3_coder
     fn test_parse_qwen3_duplicate_calls_same_name() {
         let input = r#"<tool_call>
@@ -1320,6 +1453,7 @@ LA
     /// PARSER.batch.10 — duplicate calls (same function name twice). minimax_m2
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
     #[test] // PARSER.batch.10 — minimax_m2
     fn test_parse_minimax_m2_duplicate_calls_same_name() {
         let config = minimax_m2_config();


### PR DESCRIPTION
## Summary

- Hourly `sync-check` workflow has been failing since `ai-dynamo/dynamo@main` advanced past our last-synced SHA (tracking issue #4).
- Pulls `lib/parsers/src/` from `ai-dynamo/dynamo@ad997e7` via `scripts/sync-from-dynamo.sh --apply`. 14 files updated.
- Enables `serde_json/raw_value` in `parsers/Cargo.toml` — required by upstream's new RawValue-based byte-span preservation in tool_call arguments. The sync script intentionally skips `Cargo.toml` (we maintain a standalone-publish-friendly copy), so this dep-feature flip is mirrored by hand.

### Notable upstream changes pulled in

- **RawValue byte-span preservation**: parsed `arguments` now match model bytes exactly (no `: `/`, ` injection, no key reordering, numeric formatting preserved). Keeps next-turn prompt byte-equivalent so KV-cache prefix matches across multi-step tool use.
- **GLM-4.7 strict matching**: GLM-4.7 + other strict-match XML families now opt out of `allow_eof_recovery` (matches vLLM/SGLang — drop incomplete tool calls instead of emitting partials).
- Updates across `harmony`, `gemma4`, `dsml`, `kimi_k2`, `glm47`, and base `xml`/`json` parsers (~1.4k inserted, ~350 deleted).
- `protocols/` and `tokenizers/` `src/` are still in sync — only their `Cargo.toml`/README differ, which is intentional (flagged as NOTE, not drift).

## Test plan

- [x] `cd parsers && cargo build` — clean
- [x] `cd parsers && cargo test` — 522 passed, 0 failed, 4 ignored
- [x] `cd protocols && cargo build` — clean
- [x] `cd tokenizers && cargo build` — clean
- [x] `cd examples/dynamo-demo-server && cargo build` — clean
- [ ] CI `sync-check` should go green once merged; tracking issue #4 auto-closes on next cron run

Closes #4