### PR TITLE
chore: OSRB prep — DCO, attributions, NOTICE, SECURITY, SPDX headers

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -1,0 +1,68 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Third-Party Attributions
+
+This file lists third-party open-source code that has been incorporated into the crates in this repository, along with the upstream copyright and license terms required for redistribution.
+
+The attributions below are mandatory under the licenses of the upstream projects. They are reproduced here in addition to the inline attribution notices in the affected source files (see e.g. [`protocols/src/lib.rs`](protocols/src/lib.rs) and [`protocols/Cargo.toml`](protocols/Cargo.toml)).
+
+For all *transitive* third-party crates pulled in as `Cargo.toml` `[dependencies]` but not vendored into this repository, license metadata is published as part of each crate's release metadata on crates.io and the standard Cargo-ecosystem tools (`cargo about`, `cargo deny`, `cargo license`) can enumerate them locally. Only code physically present in this tree appears below.
+
+---
+
+## `dynamo-protocols` — based on `async-openai`
+
+The `dynamo-protocols` crate is a derivative work of [`async-openai`](https://github.com/64bit/async-openai) by Himanshu Neema. The OpenAI request/response type hierarchy in this crate originated from that project and has been extended and modified for inference-serving use cases.
+
+### Upstream Project
+
+- **Project**: `async-openai`
+- **Source**: https://github.com/64bit/async-openai
+- **Version originated from**: 0.34
+- **Original Copyright**: Copyright (c) 2022 Himanshu Neema
+- **License**: MIT
+
+### Upstream License Text
+
+```
+MIT License
+
+Copyright (c) 2022 Himanshu Neema
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### NVIDIA Modifications
+
+NVIDIA's modifications are licensed under the Apache License, Version 2.0. They include, but are not limited to:
+
+- Inference-serving extensions (`nvext` request/response fields, agent-context metadata, streaming control hooks).
+- Anthropic Messages API request/response types.
+- Additional impls for serialization, validation, and error handling tailored to multi-backend inference serving.
+
+The resulting `dynamo-protocols` crate is therefore distributed under the dual license **Apache-2.0 AND MIT** — Apache-2.0 covers the NVIDIA-authored modifications, and MIT covers the portions derived from `async-openai`.
+
+---
+
+## Other Crates
+
+`dynamo-tokenizers` and `dynamo-parsers` are NVIDIA-authored and contain no vendored third-party source. All third-party code consumed by these crates is loaded at build time as standard Cargo dependencies and is governed solely by those upstream crates' own licenses (recorded in each crate's `Cargo.toml` metadata).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contributing to frontend-crates
+
+Thank you for your interest in contributing to `frontend-crates`!
+
+This repository contains three independently published Rust crates — `dynamo-protocols`, `dynamo-tokenizers`, and `dynamo-parsers` — that can be adopted on their own to build OpenAI/Anthropic-compatible inference servers, plus a demo server wiring them together.
+
+## Source of Truth and Sync Direction
+
+The code under `protocols/`, `tokenizers/`, and `parsers/` currently mirrors `lib/{protocols,tokenizers,parsers}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The canonical sync direction is **dynamo → frontend-crates**, one-way and manual, driven by [`scripts/sync-from-dynamo.sh`](scripts/sync-from-dynamo.sh).
+
+What this means for contributors:
+
+- **Changes to crate source code (`protocols/src/**`, `tokenizers/src/**`, `parsers/src/**`)** should be opened as PRs against [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo) in the corresponding `lib/` directory. Once merged upstream, the sync script pulls them into this repository for the next published release.
+- **Changes to repository scaffolding** — crate `Cargo.toml` metadata, `examples/dynamo-demo-server/`, `scripts/`, `.github/`, docs in this repo, the sync tooling itself — should be opened as PRs here.
+
+If you're not sure where a change belongs, open the PR in either place and we'll route it.
+
+## How to Contribute
+
+Standard GitHub fork-and-PR workflow:
+
+1. Fork the repository ([this one](https://github.com/ai-dynamo/frontend-crates), or [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo) for crate source changes — see above).
+2. Create a topic branch from `main`.
+3. Make your changes; keep PRs focused (one logical change per PR).
+4. Run the local checks for each affected crate:
+
+   ```bash
+   cargo fmt
+   cargo clippy -- -D warnings
+   cargo test
+   ```
+
+5. Add tests for new parser families, new tokenizer code paths, and any new public surface.
+6. Make sure every new source file carries the SPDX header block (see [Source Headers](#source-headers) below).
+7. Sign off your commits (see [Signing Your Work](#signing-your-work) below).
+8. Open the PR. CI must pass.
+
+### Reporting Issues
+
+- **Bugs / unexpected behavior**: open a [GitHub issue](https://github.com/ai-dynamo/frontend-crates/issues) with a minimal repro and the crate version (`cargo pkgid`).
+- **Feature requests / new model parsers**: open a [GitHub issue](https://github.com/ai-dynamo/frontend-crates/issues) describing the use case. For new tool-calling or reasoning parsers, please include a representative sample of the model's raw output.
+- **Security disclosures**: do **not** open a public issue. See [`SECURITY.md`](SECURITY.md).
+
+### Community
+
+- [CNCF Slack `#ai-dynamo`](https://communityinviter.com/apps/cloud-native/cncf)
+- [Dynamo Discord](https://discord.gg/nvidia-dynamo)
+
+## Signing Your Work
+
+We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+
+- Any contribution which contains commits that are not Signed-Off will not be accepted.
+- To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
+
+  ```bash
+  $ git commit -s -m "Add cool feature."
+  ```
+
+  This will append the following to your commit message:
+
+  ```
+  Signed-off-by: Your Name <your@email.com>
+  ```
+
+- Full text of the DCO (https://developercertificate.org/):
+
+  ```
+  Developer Certificate of Origin
+  Version 1.1
+
+  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
+
+
+  Developer's Certificate of Origin 1.1
+
+  By making a contribution to this project, I certify that:
+
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+  ```
+
+## Source Headers
+
+All new source files must carry the SPDX header block. Use the form appropriate for the file type.
+
+**Rust / TypeScript / C-style comments:**
+
+```
+// SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+```
+
+**Shell / Python / YAML / TOML:**
+
+```
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+```
+
+If a file is derived from third-party code (as `dynamo-protocols` is from `async-openai`), include the upstream attribution beneath the SPDX block — see [`ATTRIBUTIONS-Rust.md`](ATTRIBUTIONS-Rust.md) and the existing headers in `protocols/src/lib.rs` and `protocols/Cargo.toml` for the canonical form.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the [Apache 2.0 license](LICENSE) of this project.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,29 @@
+frontend-crates
+Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This product is distributed under the Apache License, Version 2.0
+(see the LICENSE file for the full license text).
+
+================================================================================
+
+This product includes software developed by third parties:
+
+--------------------------------------------------------------------------------
+async-openai
+--------------------------------------------------------------------------------
+The `dynamo-protocols` crate in this repository is a derivative work of
+async-openai (https://github.com/64bit/async-openai), originally authored by
+Himanshu Neema and licensed under the MIT License.
+
+  Copyright (c) 2022 Himanshu Neema
+
+The full upstream MIT license text and a description of NVIDIA's modifications
+are reproduced in ATTRIBUTIONS-Rust.md.
+
+================================================================================
+
+For attribution and license information covering all third-party Rust crates
+consumed by this repository as Cargo dependencies (rather than vendored into
+the source tree), see each crate's published metadata on crates.io. Standard
+Cargo-ecosystem tooling (`cargo about`, `cargo deny`, `cargo license`) can be
+used to enumerate the full dependency-tree license set locally.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+NVIDIA takes the security of our software products seriously. If you believe you have found a security vulnerability in any of the crates in this repository (`dynamo-protocols`, `dynamo-tokenizers`, `dynamo-parsers`, or the bundled demo server), please report it through coordinated disclosure to the NVIDIA Product Security Incident Response Team (PSIRT).
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please report them by either:
+
+- Email: **psirt@nvidia.com**
+- Web form: [NVIDIA Security Vulnerability Submission Form](https://www.nvidia.com/en-us/security/psirt-vulnerability-submission/)
+
+For sensitive disclosures, NVIDIA's PGP key is available on the same page.
+
+When reporting, please include as much of the following as you can:
+
+- The affected crate(s) and version(s) (e.g. `dynamo-protocols 0.1.0`).
+- A description of the vulnerability and the impact.
+- Step-by-step reproduction instructions, or a minimal proof-of-concept.
+- Any known mitigations or workarounds.
+
+Once a report is received, the PSIRT team will coordinate with the maintainers of this repository on triage, fix development, and coordinated disclosure timing.
+
+## Supported Versions
+
+This repository is in active development; we generally support and accept security fixes against the latest published version of each crate on crates.io. Older versions are not supported.
+
+| Crate                | Supported     |
+|----------------------|---------------|
+| `dynamo-protocols`   | latest only   |
+| `dynamo-tokenizers`  | latest only   |
+| `dynamo-parsers`     | latest only   |
+
+## More Information
+
+- NVIDIA Product Security: <https://www.nvidia.com/en-us/security/>
+- NVIDIA PSIRT Policy: <https://www.nvidia.com/en-us/security/psirt-policies/>

--- a/examples/dynamo-demo-server/Cargo.toml
+++ b/examples/dynamo-demo-server/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "dynamo-demo-server"
 version = "0.1.0"

--- a/examples/dynamo-demo-server/src/echo.rs
+++ b/examples/dynamo-demo-server/src/echo.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Dummy echo backend -- the pluggable inference point.
 //!
 //! This module extracts text from incoming requests and echoes it back.

--- a/examples/dynamo-demo-server/src/engine.rs
+++ b/examples/dynamo-demo-server/src/engine.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared server state -- the integration point for the three Dynamo crates.
 //!
 //! Holds an optional tokenizer loaded at startup. Handlers use it for accurate

--- a/examples/dynamo-demo-server/src/handlers/anthropic.rs
+++ b/examples/dynamo-demo-server/src/handlers/anthropic.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/messages -- Anthropic Messages API
 //!
 //! Supports both streaming (SSE) and non-streaming responses.

--- a/examples/dynamo-demo-server/src/handlers/chat.rs
+++ b/examples/dynamo-demo-server/src/handlers/chat.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/chat/completions -- OpenAI Chat Completions API
 //!
 //! Supports both streaming (SSE) and non-streaming responses.

--- a/examples/dynamo-demo-server/src/handlers/completions.rs
+++ b/examples/dynamo-demo-server/src/handlers/completions.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/completions -- OpenAI Completions API
 //!
 //! Supports both streaming (SSE) and non-streaming responses.

--- a/examples/dynamo-demo-server/src/handlers/mod.rs
+++ b/examples/dynamo-demo-server/src/handlers/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod anthropic;
 pub mod chat;
 pub mod completions;

--- a/examples/dynamo-demo-server/src/handlers/reasoning_parse.rs
+++ b/examples/dynamo-demo-server/src/handlers/reasoning_parse.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/reasoning-parse -- dynamo-parsers reasoning demo endpoint
 //!
 //! Splits raw model output into reasoning vs normal text using one of the

--- a/examples/dynamo-demo-server/src/handlers/responses.rs
+++ b/examples/dynamo-demo-server/src/handlers/responses.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/responses -- OpenAI Responses API
 //!
 //! Non-streaming only for simplicity. Constructs the response via serde_json

--- a/examples/dynamo-demo-server/src/handlers/tokenize.rs
+++ b/examples/dynamo-demo-server/src/handlers/tokenize.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/tokenize, /v1/detokenize -- dynamo-tokenizers demo endpoints
 //!
 //! Round-trip text <-> token IDs using the tokenizer loaded at startup.

--- a/examples/dynamo-demo-server/src/handlers/tool_parse.rs
+++ b/examples/dynamo-demo-server/src/handlers/tool_parse.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! POST /v1/tool-parse -- Dedicated dynamo-parsers demo endpoint
 //!
 //! Accepts raw text + optional parser name + tool definitions, returns parsed tool calls.

--- a/examples/dynamo-demo-server/src/main.rs
+++ b/examples/dynamo-demo-server/src/main.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod echo;
 mod engine;
 mod handlers;

--- a/scripts/sync-from-dynamo.sh
+++ b/scripts/sync-from-dynamo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Check (or apply) a one-way sync from a local ai-dynamo/dynamo checkout into this repo.
 #
 # Sources:  $DYNAMO_SRC/lib/{protocols,tokenizers,parsers}/


### PR DESCRIPTION
## Summary

Stage `ai-dynamo/frontend-crates` for Open Source Review Board (OSRB) review and public release. No functional code changes.

### What's added

- **`CONTRIBUTING.md`** — canonical NVIDIA DCO sign-off block with the full DCO text inline (OSRB requires the canonical text verbatim, not just a link). Explains the upstream sync direction (`ai-dynamo/dynamo` → `frontend-crates`, one-way and manual) so contributors know to open crate source PRs in `ai-dynamo/dynamo` and scaffolding/example PRs here.
- **`ATTRIBUTIONS-Rust.md`** — fulfills the attribution referenced from `protocols/Cargo.toml` and `protocols/src/lib.rs`. Contains the upstream [`async-openai`](https://github.com/64bit/async-openai) MIT copyright and license text, plus a description of NVIDIA's modifications.
- **`NOTICE`** — Apache-2.0 NOTICE with a third-party derivative-work entry for `async-openai`. Required because `dynamo-protocols` is a derivative of MIT-licensed third-party source.
- **`SECURITY.md`** — points at `psirt@nvidia.com` per NVIDIA PSIRT policy, with per-crate supported-versions table.
- **SPDX headers** added to:
  - `scripts/sync-from-dynamo.sh`
  - `examples/dynamo-demo-server/Cargo.toml`
  - All 11 Rust source files under `examples/dynamo-demo-server/src/`

### Why now

Bernd Weber's OSRB technical checklist (per the pi-dynamo-provider review) flags these as the gating items for any Apache-2.0 NVIDIA-authored repo going public:

1. `LICENSE` Apache-2.0 — ✅ already present
2. `CONTRIBUTING.md` with DCO — added here
3. SPDX/NVIDIA copyright headers on every implementation file — completed here
4. `NOTICE` if any vendored or derivative third-party source — added here (for async-openai)
5. Consistent license metadata — Cargo.toml files already say `Apache-2.0` (or `Apache-2.0 AND MIT` for `dynamo-protocols`); no `package-lock.json` style mismatch issue applies to Cargo

### Test plan

- [ ] CI green
- [ ] Reviewer sanity-checks the SPDX header text matches the form in [Apache2 License guidance](https://nvidia.atlassian.net/wiki/spaces/OSS/pages/3205043483)
- [ ] Reviewer confirms `CONTRIBUTING.md` DCO block is the canonical text from [DCO requirements](https://nvidia.atlassian.net/wiki/spaces/OSS/pages/3293716536)
- [ ] Reviewer confirms `ATTRIBUTIONS-Rust.md` correctly captures the async-openai upstream

### What's next (separate work, not in this PR)

- File the OSRB NVBug for this repo (in flight in parallel with this PR).
- Get VP sign-off once Bernd's technical review completes (per the pi-dynamo-provider precedent).
- Flip repo from `INTERNAL` to public.
- `cargo publish` each of `dynamo-protocols`, `dynamo-tokenizers`, `dynamo-parsers` to crates.io.