### PR TITLE
chore: add Apache-2.0 SPDX headers to demo-server Makefile + smoke.sh

### DIFF
--- a/examples/dynamo-demo-server/Makefile
+++ b/examples/dynamo-demo-server/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # dynamo-demo-server -- build, run, test.
 
 MODEL ?= Qwen/Qwen2.5-0.5B-Instruct

--- a/examples/dynamo-demo-server/scripts/smoke.sh
+++ b/examples/dynamo-demo-server/scripts/smoke.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Smoke tests for dynamo-demo-server. Hits each endpoint and prints a one-line summary.
 # Usage: scripts/smoke.sh [http://127.0.0.1:3000]
 


### PR DESCRIPTION
Closes the one OSRB follow-up on [NVBug 6189641](https://nvbugspro.nvidia.com/bug/6189641). Bernd's check found two files in `examples/dynamo-demo-server/` without the Apache-2.0 SPDX/NVIDIA copyright header:

- `examples/dynamo-demo-server/Makefile`
- `examples/dynamo-demo-server/scripts/smoke.sh`

Add the standard header to both. For the shell script the `#!/usr/bin/env bash` shebang stays on line 1, SPDX block on lines 2-3, per the [OSRB header guidance](https://nvidia.atlassian.net/wiki/spaces/OSS/pages/3205043483).

```diff
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
```

Everything else in Bernd's review came back clean: `LICENSE`, `CONTRIBUTING.md` (DCO + sign-off), `NOTICE`, `ATTRIBUTIONS-Rust.md` (async-openai MIT derivative).

VP sign-off is in flight with Ujval. Once that lands the repo flips to public.

NVBug: 6189641
