### PR TITLE
chore: sync from dynamo @ 7d7b1fb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,6 @@ name = "dynamo-parsers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dynamo-protocols",
  "num-traits",
  "openai-harmony",
  "regex",

--- a/examples/dynamo-demo-server/src/handlers/chat.rs
+++ b/examples/dynamo-demo-server/src/handlers/chat.rs
@@ -47,6 +47,7 @@ pub async fn handler(
                 .map(|t| dynamo_parsers::tool_calling::ToolDefinition {
                     name: t.function.name.clone(),
                     parameters: t.function.parameters.clone(),
+                    strict: None,
                 })
                 .collect();
             match dynamo_parsers::tool_calling::detect_and_parse_tool_call(

--- a/examples/dynamo-demo-server/src/handlers/tool_parse.rs
+++ b/examples/dynamo-demo-server/src/handlers/tool_parse.rs
@@ -59,6 +59,7 @@ pub async fn handler(Json(req): Json<ToolParseRequest>) -> Response {
             .map(|t| ToolDefinition {
                 name: t.name,
                 parameters: t.parameters,
+                strict: None,
             })
             .collect()
     });

--- a/parsers/Cargo.toml
+++ b/parsers/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["llm", "parser", "tool-calling", "reasoning", "inference"]
 
 [dependencies]
 anyhow.workspace = true
-dynamo-protocols.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true, features = ["full"] }

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -105,7 +105,20 @@ impl ReasoningParser for BasicReasoningParser {
 
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         let has_think_tag = text.contains(&self.think_start_token);
-        let in_reasoning = self._in_reasoning || has_think_tag;
+        // REASONING.batch.4: dangling end marker without an opener. Treat the
+        // prefix as reasoning.
+        // Models in this family normally emit `<think>...</think>final_answer`;
+        // when the opener is absent but a `</think>` is present, the natural
+        // reading is that the opener was implicit (chat template or tokenizer
+        // consumed it). Without this, the `</think>` markup leaks into
+        // normal_text. Matches vLLM's `partition()`-based behavior for the
+        // same input.
+        let supports_dangling_end_recovery =
+            self.think_start_token == "<think>" && self.think_end_token == "</think>";
+        let has_dangling_end = supports_dangling_end_recovery
+            && !has_think_tag
+            && text.contains(&self.think_end_token);
+        let in_reasoning = self._in_reasoning || has_think_tag || has_dangling_end;
         if !in_reasoning {
             return ParserResult {
                 normal_text: text.to_string(),
@@ -134,7 +147,11 @@ impl ReasoningParser for BasicReasoningParser {
         let mut reasoning_parts = Vec::new();
         let mut normal_parts = Vec::new();
         let mut cursor = 0;
-        let mut currently_reasoning = self._in_reasoning;
+        let mut exited_on_tool_start = false;
+        // Dangling-end case enters the loop already in reasoning so the prefix
+        // before `</think>` is captured (the loop's normal-text branch would
+        // otherwise treat it as plain text and re-leak the closer).
+        let mut currently_reasoning = self._in_reasoning || has_dangling_end;
 
         while cursor < text.len() {
             if currently_reasoning {
@@ -157,6 +174,7 @@ impl ReasoningParser for BasicReasoningParser {
                         normal_parts.push(&text[cursor + t..]);
                         cursor = text.len();
                         currently_reasoning = false;
+                        exited_on_tool_start = true;
                     }
                     (Some(e), _) => {
                         reasoning_parts.push(&text[cursor..cursor + e]);
@@ -169,6 +187,7 @@ impl ReasoningParser for BasicReasoningParser {
                         normal_parts.push(&text[cursor + t..]);
                         cursor = text.len();
                         currently_reasoning = false;
+                        exited_on_tool_start = true;
                     }
                     (None, None) => {
                         // No end token — rest is reasoning (truncated)
@@ -190,7 +209,12 @@ impl ReasoningParser for BasicReasoningParser {
             }
         }
 
-        let reasoning_text = reasoning_parts.join("").trim().to_string();
+        let joined_reasoning_text = reasoning_parts.join("");
+        let reasoning_text = if exited_on_tool_start {
+            joined_reasoning_text.trim_start().to_string()
+        } else {
+            joined_reasoning_text.trim().to_string()
+        };
         let normal_text = normal_parts.join("").trim().to_string();
 
         // Note: self._in_reasoning is intentionally NOT updated here. This method is
@@ -336,6 +360,25 @@ impl ReasoningParser for BasicReasoningParser {
         ParserResult {
             normal_text: accumulated_normal,
             reasoning_text: accumulated_reasoning,
+        }
+    }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self._buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self._buffer);
+        if self._in_reasoning {
+            ParserResult {
+                normal_text: String::new(),
+                reasoning_text: buffered,
+            }
+        } else {
+            ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            }
         }
     }
 }
@@ -541,7 +584,16 @@ mod tests {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("normal text</think> more normal", &[]);
-        assert_eq!(result.normal_text, "normal text</think> more normal");
+        assert_eq!(result.normal_text, "more normal");
+        assert_eq!(result.reasoning_text, "normal text");
+    }
+
+    #[test] // REASONING.batch.4 — Kimi Unicode delimiters keep stray closer as normal text.
+    fn test_kimi_unicode_stray_closing_tag_passes_through() {
+        let mut parser =
+            BasicReasoningParser::new("◁think▷".to_string(), "◁/think▷".to_string(), false, true);
+        let result = parser.detect_and_parse_reasoning("normal◁/think▷answer", &[]);
+        assert_eq!(result.normal_text, "normal◁/think▷answer");
         assert_eq!(result.reasoning_text, "");
     }
 
@@ -566,7 +618,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.2.e, PARSER.fmt.2
+    #[test] // REASONING.batch.2.e, TOOLCALLING.fmt.2
     fn test_whitespace_only_reasoning_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -1139,7 +1191,7 @@ mod tests {
     #[rstest] // REASONING.batch.3.b — Kimi K2 split
     #[case(
         "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
-        "thinking text",
+        "thinking text ",
         "<|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"
     )]
     #[case("r</think>a", "r", "a")]

--- a/parsers/src/reasoning/gemma4_parser.rs
+++ b/parsers/src/reasoning/gemma4_parser.rs
@@ -138,37 +138,8 @@ impl ReasoningParser for Gemma4ReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         // Non-streaming path: we have the complete text, so we can use plain
         // string operations.
-        let start_idx = text.find(START_TOKEN);
-        let end_idx = text.find(END_TOKEN);
-        match (start_idx, end_idx) {
-            (None, None) => {
-                // No reasoning markers visible at all (either model didn't
-                // emit them, or skip_special_tokens stripped them).
-                ParserResult {
-                    normal_text: text.to_string(),
-                    reasoning_text: String::new(),
-                }
-            }
-            (Some(s), end_opt) => {
-                let pre = &text[..s];
-                let rest = &text[s + START_TOKEN.len()..];
-                let (reasoning_raw, post) = match end_opt
-                    .filter(|e| *e > s + START_TOKEN.len())
-                    .map(|e| e - (s + START_TOKEN.len()))
-                {
-                    Some(end_rel) => (&rest[..end_rel], &rest[end_rel + END_TOKEN.len()..]),
-                    None => (rest, ""),
-                };
-                let reasoning = strip_thought_prefix(reasoning_raw).to_string();
-                let mut normal = String::with_capacity(pre.len() + post.len());
-                normal.push_str(pre);
-                normal.push_str(post);
-                ParserResult {
-                    normal_text: normal,
-                    reasoning_text: reasoning,
-                }
-            }
-            (None, Some(e)) => {
+        if !text.contains(START_TOKEN) {
+            if let Some(e) = text.find(END_TOKEN) {
                 // Dangling end marker without start marker — upstream's
                 // offline parser still treats text-before as reasoning. Mirror
                 // that so model emissions where the start tag was stripped
@@ -177,11 +148,45 @@ impl ReasoningParser for Gemma4ReasoningParser {
                 let reasoning_raw = &text[..e];
                 let post = &text[e + END_TOKEN.len()..];
                 let reasoning = strip_thought_prefix(reasoning_raw).to_string();
-                ParserResult {
+                return ParserResult {
                     normal_text: post.to_string(),
                     reasoning_text: reasoning,
-                }
+                };
             }
+
+            return ParserResult {
+                normal_text: text.to_string(),
+                reasoning_text: String::new(),
+            };
+        }
+
+        // We have at least one start marker. Extract reasoning spans iteratively until we run out of markers.
+        let mut normal = String::new();
+        let mut reasoning = String::new();
+        let mut cursor = 0;
+
+        while let Some(start_rel) = text[cursor..].find(START_TOKEN) {
+            let start = cursor + start_rel;
+            normal.push_str(&text[cursor..start]);
+
+            let reasoning_start = start + START_TOKEN.len();
+            let Some(end_rel) = text[reasoning_start..].find(END_TOKEN) else {
+                reasoning.push_str(strip_thought_prefix(&text[reasoning_start..]));
+                return ParserResult {
+                    normal_text: normal,
+                    reasoning_text: reasoning,
+                };
+            };
+
+            let end = reasoning_start + end_rel;
+            reasoning.push_str(strip_thought_prefix(&text[reasoning_start..end]));
+            cursor = end + END_TOKEN.len();
+        }
+
+        normal.push_str(&text[cursor..]);
+        ParserResult {
+            normal_text: normal,
+            reasoning_text: reasoning,
         }
     }
 
@@ -266,6 +271,34 @@ impl ReasoningParser for Gemma4ReasoningParser {
         ParserResult {
             normal_text: normal,
             reasoning_text: reasoning_emit,
+        }
+    }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self.buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self.buffer);
+        if !self.in_reasoning {
+            return ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            };
+        }
+
+        let reasoning_text = if self.prefix_resolved {
+            buffered
+        } else {
+            self.reasoning_accum.push_str(&buffered);
+            let (emit, resolved) = resolve_prefix(&self.reasoning_accum, &buffered);
+            self.prefix_resolved = resolved;
+            emit.to_string()
+        };
+        self.reset_span();
+        ParserResult {
+            normal_text: String::new(),
+            reasoning_text,
         }
     }
 }
@@ -444,7 +477,17 @@ mod tests {
         assert_eq!(r.normal_text, "plain text only");
     }
 
-    #[test] // REASONING.batch.6.a — multiple reasoning spans back-to-back
+    #[test] // REASONING.batch.6.a — multiple reasoning spans separated by normal text
+    fn detect_multiple_reasoning_spans() {
+        let mut p = Gemma4ReasoningParser::new();
+        let input =
+            "<|channel>thought\nfirst<channel|> middle <|channel>thought\nsecond<channel|> done";
+        let r = p.detect_and_parse_reasoning(input, &[]);
+        assert_eq!(r.reasoning_text, "firstsecond");
+        assert_eq!(r.normal_text, " middle  done");
+    }
+
+    #[test] // REASONING.stream.2.b — multiple reasoning spans in one stream chunk
     fn streaming_multiple_reasoning_spans() {
         let mut p = Gemma4ReasoningParser::new();
         let input =
@@ -475,15 +518,13 @@ mod tests {
         );
     }
 
-    // ----- Explicit N/A coverage notes (per lib/parsers/PARSER_CASES.md) -----
+    // ----- Explicit N/A coverage notes (per lib/parsers/TOOLCALLING_CASES.md) -----
     //
     // REASONING.batch.1.a/c/d — empty, whitespace-only, and null/missing
     //          input variants are not Gemma-specific.
     // FRONTEND.tool_choice, PIPELINE.finish_reason — `tool_choice` and `finish_reason`: tool-call concerns,
     //          N/A for reasoning. (Universal cross-parser gap regardless;
     //          see notes in `tool_calling/gemma4/parser.rs`.)
-    // REASONING.batch.6.* — Multi-span reasoning is covered by
-    //          `streaming_multiple_reasoning_spans`.
-    // PARSER.xml.1 / PARSER.xml.2 — XML-family only. N/A.
-    // PARSER.harmony.1 / PARSER.harmony.2 — Harmony only. N/A.
+    // TOOLCALLING.xml.1 / TOOLCALLING.xml.2 — XML-family only. N/A.
+    // TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 — Harmony only. N/A.
 }

--- a/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/parsers/src/reasoning/gpt_oss_parser.rs
@@ -7,8 +7,9 @@ use crate::ParserResult;
 use crate::ReasoningParser;
 
 use openai_harmony::StreamableParser;
-use openai_harmony::chat::TextContent;
+use openai_harmony::chat::{Content, Message, TextContent};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, chat::Role, load_harmony_encoding};
+use regex::Regex;
 
 ///// Static initialization of harmony encoder to not affect performance every time a parser is created
 /// This is because load_harmony_encoding downloads some tiktoken files into a directory and we don't want to do this every time we create a parser.
@@ -17,7 +18,17 @@ use std::sync::OnceLock;
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
 static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
+static HARMONY_ANALYSIS_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 const HARMONY_CALL_MARKER: &str = "<|call|>";
+const HARMONY_SPECIAL_TOKENS: &[&str] = &[
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+    "<|channel|>",
+    "<|constrain|>",
+    "<|message|>",
+    "<|call|>",
+];
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -36,6 +47,12 @@ fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
 
 pub struct GptOssReasoningParser {
     parser: StreamableParser,
+    pending_text: String,
+    pending_tool_call_text: String,
+    emitted_reasoning_text: bool,
+    insert_reasoning_separator: bool,
+    emitted_normal_text: bool,
+    insert_normal_separator: bool,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -64,7 +81,15 @@ impl GptOssReasoningParser {
                 return Err(anyhow::anyhow!("Failed to load Harmony encoding: {e}"));
             }
         };
-        Ok(Self { parser })
+        Ok(Self {
+            parser,
+            pending_text: String::new(),
+            pending_tool_call_text: String::new(),
+            emitted_reasoning_text: false,
+            insert_reasoning_separator: false,
+            emitted_normal_text: false,
+            insert_normal_separator: false,
+        })
     }
 }
 
@@ -100,6 +125,15 @@ fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
             .any(|window| window == marker_ids)
 }
 
+fn harmony_analysis_block_regex() -> &'static Regex {
+    HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis.*?<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
+        )
+            .expect("harmony analysis block regex")
+    })
+}
+
 fn input_contains_call_marker(
     text: &str,
     token_ids: &[u32],
@@ -126,18 +160,114 @@ fn raw_input_text_for_tool_parser(
     text.to_string()
 }
 
+fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
+    let hold_len = HARMONY_SPECIAL_TOKENS
+        .iter()
+        .flat_map(|token| (1..token.len()).map(|idx| &token[..idx]))
+        .filter(|prefix| text.ends_with(*prefix))
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+
+    text.split_at(text.len() - hold_len)
+}
+
+fn contains_directed_harmony_function_call(text: &str) -> bool {
+    text.contains("<|channel|>commentary to=functions.") && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn strip_analysis_blocks_for_tool_handoff(text: &str) -> String {
+    harmony_analysis_block_regex()
+        .replace_all(text, "")
+        .into_owned()
+}
+
+fn append_separated(target: &mut String, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    if !target.is_empty() {
+        target.push('\n');
+    }
+    target.push_str(text);
+}
+
+fn append_text_content(target: &mut String, content: &[Content]) {
+    for item in content {
+        if let Content::Text(TextContent { text }) = item {
+            append_separated(target, text);
+        }
+    }
+}
+
+fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
+    match msg.channel.as_deref() {
+        Some("analysis") => append_text_content(reasoning_text, &msg.content),
+        Some("final") => append_text_content(normal_text, &msg.content),
+        Some("commentary") if msg.recipient.is_none() => {
+            append_text_content(normal_text, &msg.content)
+        }
+        _ => {}
+    }
+}
+
+fn append_current_by_channel(
+    reasoning_text: &mut String,
+    normal_text: &mut String,
+    channel: Option<String>,
+    current: String,
+) {
+    match channel.as_deref() {
+        Some("analysis") => append_separated(reasoning_text, &current),
+        Some("final") => append_separated(normal_text, &current),
+        Some("commentary") => append_separated(normal_text, &current),
+        _ => {}
+    }
+}
+
+fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> bool {
+    matches!(channel, Some("final"))
+        || (matches!(channel, Some("commentary")) && recipient.is_none())
+}
+
+fn starts_directed_harmony_tool_call(text: &str) -> bool {
+    text.contains("<|channel|>commentary to=functions.")
+}
+
 impl ReasoningParser for GptOssReasoningParser {
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        self.pending_tool_call_text.clear();
+        let pending = std::mem::take(&mut self.pending_text);
+        if pending.is_empty() {
+            return ParserResult::default();
+        }
+
+        match self.parser.current_channel().as_deref() {
+            Some("analysis") => ParserResult {
+                normal_text: String::new(),
+                reasoning_text: pending,
+            },
+            Some("final") | Some("commentary") => ParserResult {
+                normal_text: pending,
+                reasoning_text: String::new(),
+            },
+            _ => ParserResult::default(),
+        }
+    }
+
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -160,70 +290,42 @@ impl ReasoningParser for GptOssReasoningParser {
         let output_msgs = parser.messages();
         tracing::debug!("Parser has {} output messages", output_msgs.len());
 
-        match output_msgs.len() {
-            0 => {
-                tracing::debug!("No output messages, using current content");
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: String::new(),
-                    reasoning_text: current,
-                }
-            }
-            1 => {
-                tracing::debug!("Single output message detected");
-                let mut reasoning_text = String::new();
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    output_msgs[0].content.first()
-                {
-                    reasoning_text.push_str(text);
-                    tracing::debug!("Extracted reasoning text length: {}", reasoning_text.len());
-                }
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: current,
-                    reasoning_text,
-                }
-            }
-            _ => {
-                tracing::debug!("Multiple output messages detected: {}", output_msgs.len());
-                let mut reasoning_text = String::new();
-                let mut normal_text = String::new();
+        let mut reasoning_text = String::new();
+        let mut normal_text = String::new();
+        for msg in output_msgs {
+            append_message_by_channel(&mut reasoning_text, &mut normal_text, msg);
+        }
 
-                // Loop until second last message
-                for (i, parse_msg) in output_msgs.iter().take(output_msgs.len() - 1).enumerate() {
-                    tracing::debug!("Processing reasoning message {}", i + 1);
-                    if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                        parse_msg.content.first()
-                    {
-                        reasoning_text.push_str(text);
-                        tracing::debug!("Added {} chars to reasoning text", text.len());
-                    }
-                }
+        let current = parser.current_content().unwrap_or_default();
+        let current_channel = parser.current_channel();
+        if current_channel.as_deref() != Some("commentary") || parser.current_recipient().is_none()
+        {
+            append_current_by_channel(
+                &mut reasoning_text,
+                &mut normal_text,
+                current_channel,
+                current,
+            );
+        }
 
-                let last_msg = &output_msgs[output_msgs.len() - 1];
-                tracing::debug!("Processing final message");
+        let raw_input_text =
+            raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
+        if contains_directed_harmony_function_call(&raw_input_text) {
+            // The serving pipeline feeds reasoning normal_text into the Harmony
+            // tool parser. Keep directed commentary envelopes intact so tool
+            // calls are not silently dropped.
+            normal_text = strip_analysis_blocks_for_tool_handoff(&raw_input_text);
+        }
 
-                // Handle the last message
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    last_msg.content.first()
-                {
-                    normal_text.push_str(text);
-                    tracing::debug!("Added {} chars to normal text", text.len());
-                }
+        tracing::debug!(
+            "Final result - normal_text: {} chars, reasoning_text: {} chars",
+            normal_text.len(),
+            reasoning_text.len()
+        );
 
-                tracing::debug!(
-                    "Final result - normal_text: {} chars, reasoning_text: {} chars",
-                    normal_text.len(),
-                    reasoning_text.len()
-                );
-
-                ParserResult {
-                    normal_text,
-                    reasoning_text,
-                }
-            }
+        ParserResult {
+            normal_text,
+            reasoning_text,
         }
     }
 
@@ -233,16 +335,33 @@ impl ReasoningParser for GptOssReasoningParser {
         token_ids: &[u32],
     ) -> ParserResult {
         let caller_supplied_token_ids = !token_ids.is_empty();
+        let text_to_process;
+        let text = if caller_supplied_token_ids {
+            text
+        } else {
+            self.pending_text.push_str(text);
+            let combined = std::mem::take(&mut self.pending_text);
+            let (ready, pending) = split_incomplete_harmony_suffix(&combined);
+            self.pending_text.push_str(pending);
+            text_to_process = ready.to_string();
+            text_to_process.as_str()
+        };
+
+        if text.is_empty() && token_ids.is_empty() {
+            return ParserResult::default();
+        }
+
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -258,31 +377,100 @@ impl ReasoningParser for GptOssReasoningParser {
                 token_ids.len(),
                 token_id
             );
+            let previous_channel = parser.current_channel();
+            let previous_recipient = parser.current_recipient();
             if let Err(e) = parser.process(*token_id) {
                 tracing::warn!("Harmony parse error for token_id {token_id}: {e}");
                 return ParserResult::default();
             }
+            let current_channel = parser.current_channel();
+            let current_recipient = parser.current_recipient();
+
+            if previous_channel.as_deref() != Some("analysis")
+                && current_channel.as_deref() == Some("analysis")
+                && self.emitted_reasoning_text
+            {
+                self.insert_reasoning_separator = true;
+            }
+
+            if is_visible_normal_channel(current_channel.as_deref(), current_recipient.as_deref())
+                && !is_visible_normal_channel(
+                    previous_channel.as_deref(),
+                    previous_recipient.as_deref(),
+                )
+                && self.emitted_normal_text
+            {
+                self.insert_normal_separator = true;
+            }
 
             if let (Some(delta), Some(channel)) = (
                 parser.last_content_delta().unwrap_or_default(),
-                parser.current_channel(),
+                current_channel,
             ) {
-                // `last_content_delta` only exposes the newest token slice, so we forward
-                // `final`/`analysis` chunks immediately; commentary is reconstructed in the
-                // fallback path below because it needs the stripped metadata.
+                // `last_content_delta` only exposes the newest token slice, so directed
+                // commentary still falls through to the raw handoff path for tool parsing.
                 match channel.as_str() {
-                    "final" => normal_delta.push_str(&delta),
-                    "analysis" => reasoning_delta.push_str(&delta),
-                    "commentary" => {}
+                    "final" => {
+                        if self.insert_normal_separator {
+                            normal_delta.push('\n');
+                            self.insert_normal_separator = false;
+                        }
+                        normal_delta.push_str(&delta);
+                        self.emitted_normal_text = true;
+                    }
+                    "analysis" => {
+                        if self.insert_reasoning_separator {
+                            reasoning_delta.push('\n');
+                            self.insert_reasoning_separator = false;
+                        }
+                        reasoning_delta.push_str(&delta);
+                        self.emitted_reasoning_text = true;
+                    }
+                    "commentary" => {
+                        if current_recipient.is_none() {
+                            if self.insert_normal_separator {
+                                normal_delta.push('\n');
+                                self.insert_normal_separator = false;
+                            }
+                            normal_delta.push_str(&delta);
+                            self.emitted_normal_text = true;
+                        }
+                    }
                     _ => {}
                 }
             }
         }
 
-        if input_contains_call_marker(text, token_ids, caller_supplied_token_ids) {
-            let raw_input_text =
-                raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
-            normal_delta.push_str(&raw_input_text);
+        let has_call_marker =
+            input_contains_call_marker(text, token_ids, caller_supplied_token_ids);
+        let raw_input_text = if has_call_marker
+            || !self.pending_tool_call_text.is_empty()
+            || starts_directed_harmony_tool_call(text)
+        {
+            Some(raw_input_text_for_tool_parser(
+                text,
+                token_ids,
+                caller_supplied_token_ids,
+            ))
+        } else {
+            None
+        };
+
+        if let Some(raw_input_text) = raw_input_text {
+            // Streaming currently feeds the downstream Harmony tool parser through
+            // `normal_text`. This is an internal handoff, not visible-content
+            // semantics: directed commentary tool payloads must become tool calls,
+            // not assistant `content`.
+            if !self.pending_tool_call_text.is_empty() {
+                self.pending_tool_call_text.push_str(&raw_input_text);
+                if has_call_marker {
+                    normal_delta.push_str(&std::mem::take(&mut self.pending_tool_call_text));
+                }
+            } else if starts_directed_harmony_tool_call(&raw_input_text) && !has_call_marker {
+                self.pending_tool_call_text.push_str(&raw_input_text);
+            } else if has_call_marker {
+                normal_delta.push_str(&raw_input_text);
+            }
         }
 
         if !normal_delta.is_empty() || !reasoning_delta.is_empty() {
@@ -365,7 +553,7 @@ impl ReasoningParser for GptOssReasoningParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.2.c, PARSER.harmony.1
+    #[test] // REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed.<|end|><|start|>assistant<|channel|>final<|message|>The capital of Brazil is Brasília.";
@@ -377,7 +565,57 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, PARSER.harmony.1
+    #[test] // REASONING.batch.4
+    fn test_gpt_oss_final_channel_without_analysis_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.detect_and_parse_reasoning("<|channel|>final<|message|>answer", &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test] // REASONING.batch.6.a
+    fn test_gpt_oss_multiple_analysis_spans_join_before_final() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "first\nsecond");
+        assert_eq!(result.normal_text, "done");
+    }
+
+    #[test]
+    fn test_gpt_oss_directed_commentary_is_tool_parser_handoff() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "think");
+        assert_eq!(
+            result.normal_text,
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
+    }
+
+    #[test]
+    fn test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "{\"q\":\"x\"}");
+        assert_eq!(
+            result.normal_text,
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
+    }
+
+    #[test]
+    fn test_gpt_oss_recipientless_commentary_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant<|channel|>final<|message|>Done.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "I will check that.\nDone.");
+    }
+
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let chunks = vec![
@@ -401,7 +639,107 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, PARSER.harmony.1
+    #[test] // REASONING.stream.3.b
+    fn test_gpt_oss_reasoning_parser_streaming_split_end_marker() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>thinking<|e",
+            "nd|><|start|>assistant<|channel|>final<|message|>answer",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "thinking");
+        assert_eq!(normal_text_incr, "answer");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_flushes_pending_suffix_on_finish() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.parse_reasoning_streaming_incremental(
+            "<|channel|>analysis<|message|>thinking<|e",
+            &[],
+        );
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.reasoning_text, "thinking");
+        assert_eq!(finish.reasoning_text, "<|e");
+        assert_eq!(finish.normal_text, "");
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(finish.reasoning_text, "");
+        assert_eq!(finish.normal_text, "");
+
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser
+            .parse_reasoning_streaming_incremental("<|channel|>final<|message|>answer<|e", &[]);
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.normal_text, "answer");
+        assert_eq!(finish.normal_text, "<|e");
+        assert_eq!(finish.reasoning_text, "");
+    }
+
+    #[test] // REASONING.stream.2.b
+    fn test_gpt_oss_reasoning_parser_streaming_multiple_analysis_spans() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>first<|end|><|start|>assistant",
+            "<|channel|>analysis<|message|>second<|end|><|start|>assistant",
+            "<|channel|>final<|message|>done",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "first\nsecond");
+        assert_eq!(normal_text_incr, "done");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_recipientless_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant",
+            "<|channel|>final<|message|>Done.",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(normal_text_incr, "I will check that.\nDone.");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_split_directed_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary to=functions.get_",
+            "weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(
+            normal_text_incr,
+            "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>"
+        );
+    }
+
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_chunked() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let enc = get_harmony_encoding()
@@ -430,7 +768,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.batch.3.a, PARSER.harmony.1
+    #[test] // REASONING.batch.3.a, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_variable_length_chunks() {
         let text = "<|channel|>analysis<|message|>User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>{}";
         let enc = get_harmony_encoding()

--- a/parsers/src/reasoning/granite_parser.rs
+++ b/parsers/src/reasoning/granite_parser.rs
@@ -176,6 +176,25 @@ impl ReasoningParser for GraniteReasoningParser {
             }
         }
     }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self.buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self.buffer);
+        if self.in_reasoning {
+            ParserResult {
+                normal_text: String::new(),
+                reasoning_text: buffered,
+            }
+        } else {
+            ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -192,7 +211,7 @@ mod tests {
         assert_eq!(result.normal_text, " The answer is 42.");
     }
 
-    #[test] // helper, PARSER.fmt.3
+    #[test] // helper, TOOLCALLING.fmt.3
     fn test_alternative_start_token() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here is my thought process: Different thinking here. Here is my response: Final answer.";
@@ -276,7 +295,7 @@ mod tests {
         assert_eq!(result.normal_text, " Direct answer.");
     }
 
-    #[test] // REASONING.batch.2.f, PARSER.fmt.2
+    #[test] // REASONING.batch.2.f, TOOLCALLING.fmt.2
     fn test_reasoning_with_whitespace() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n  Indented reasoning  \n  Here's my response:   Final result  ";
@@ -286,7 +305,7 @@ mod tests {
         assert_eq!(result.normal_text, "   Final result  ");
     }
 
-    #[test] // PARSER.fmt.1 — token case sensitivity
+    #[test] // TOOLCALLING.fmt.1 — token case sensitivity
     fn test_case_sensitive_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "here's my thought process: lowercase. here's my response: answer.";
@@ -320,7 +339,7 @@ mod tests {
         assert_eq!(result.normal_text, "The solution is clear.");
     }
 
-    #[test] // REASONING.batch.2.c, PARSER.fmt.3
+    #[test] // REASONING.batch.2.c, TOOLCALLING.fmt.3
     fn test_detect_and_parse_reasoning_alternative_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here is my thought process: Different reasoning approach. Here is my response: Final conclusion.";
@@ -360,7 +379,7 @@ mod tests {
         assert_eq!(result.normal_text, "");
     }
 
-    #[test] // REASONING.batch.2.f, PARSER.fmt.2
+    #[test] // REASONING.batch.2.f, TOOLCALLING.fmt.2
     fn test_detect_and_parse_reasoning_whitespace_handling() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n\tSpaced reasoning\n   Here's my response:  \n  Spaced response\n";
@@ -370,7 +389,7 @@ mod tests {
         assert_eq!(result.normal_text, "Spaced response");
     }
 
-    #[test] // REASONING.batch.2.f, PARSER.fmt.3
+    #[test] // REASONING.batch.2.f, TOOLCALLING.fmt.3
     fn test_detect_and_parse_reasoning_multiple_end_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: Thinking about Here's my response: in the middle. Here's my response: Real end.";
@@ -383,7 +402,7 @@ mod tests {
         );
     }
 
-    #[test] // PARSER.fmt.1
+    #[test] // TOOLCALLING.fmt.1
     fn test_detect_and_parse_reasoning_case_sensitivity() {
         let mut parser = GraniteReasoningParser::new();
         let text =
@@ -394,7 +413,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.2.c, PARSER.fmt.3
+    #[test] // REASONING.batch.2.c, TOOLCALLING.fmt.3
     fn test_detect_and_parse_reasoning_mixed_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: First reasoning. Here is my response: Mixed token response.";

--- a/parsers/src/reasoning/mod.rs
+++ b/parsers/src/reasoning/mod.rs
@@ -28,6 +28,14 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
     REASONING_PARSER_MAP.get_or_init(|| {
         let mut map = HashMap::new();
         map.insert("deepseek_r1", ReasoningParserType::DeepseekR1);
+        // DeepSeek V3.x thinking mode uses the same output shape as R1:
+        // reasoning text is already in progress and the completion emits
+        // `</think>` before the final answer. The V3.x tool-call parsers are
+        // distinct because their tool-call wire formats differ, but reasoning
+        // shares this forced think-tag parser.
+        map.insert("deepseek_v3", ReasoningParserType::DeepseekR1);
+        map.insert("deepseek_v3_1", ReasoningParserType::DeepseekR1);
+        map.insert("deepseek_v3_2", ReasoningParserType::DeepseekR1);
         map.insert("basic", ReasoningParserType::Basic);
         map.insert("gpt_oss", ReasoningParserType::GptOss);
         map.insert("qwen3", ReasoningParserType::Qwen);
@@ -117,6 +125,17 @@ pub trait ReasoningParser: Send + std::fmt::Debug {
         token_ids: &[u32],
     ) -> ParserResult;
 
+    /// Finalizes a stream after the last chunk, before parser state is dropped.
+    ///
+    /// Incremental parsing may buffer a partial delimiter prefix instead of
+    /// emitting it immediately because the next chunk could complete a marker
+    /// like `<think>` or `</think>`. At EOF, no next chunk is coming, so the
+    /// parser must flush the undecided bytes as normal or reasoning text based
+    /// on its current state.
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        ParserResult::default()
+    }
+
     /// Override the parser's initial reasoning state. When called with `true`, the parser
     /// starts in reasoning mode without waiting for the start token in the completion stream.
     /// Use this when the chat template already injected the start token (e.g., `<think>`)
@@ -170,6 +189,10 @@ impl ReasoningParser for ReasoningParserWrapper {
     ) -> ParserResult {
         self.parser
             .parse_reasoning_streaming_incremental(text, token_ids)
+    }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        self.parser.finish_reasoning_stream()
     }
 
     fn set_in_reasoning(&mut self, in_reasoning: bool) {
@@ -287,6 +310,9 @@ mod tests {
         // Update this list when adding a new parser
         let available_parsers = [
             "deepseek_r1",
+            "deepseek_v3",
+            "deepseek_v3_1",
+            "deepseek_v3_2",
             "basic",
             "gpt_oss",
             "qwen3",
@@ -462,7 +488,7 @@ mod tests {
         assert_eq!(result.normal_text, "answer");
     }
 
-    #[test] // PARSER.fmt.3 — token-spelling differences across model variants
+    #[test] // TOOLCALLING.fmt.3 — token-spelling differences across model variants
     fn test_kimi_vs_kimi_k25_different_tags() {
         // Kimi (original) uses ◁think▷/◁/think▷, KimiK25 uses <think>/</think>
         let mut kimi = ReasoningParserType::Kimi.get_reasoning_parser();

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::json::JsonParserType;
+use super::structural_tag::format::JsonSchemaStyle;
+use super::structural_tag::{
+    DsmlToolCallsConfig, StructuralTagBuilder, TOOL_NAME_PLACEHOLDER, TriggeredTagsConfig,
+};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParserConfig {
@@ -155,6 +159,11 @@ pub struct DsmlParserConfig {
     pub parameter_prefix: String,
     /// End token for parameter (e.g., "</｜DSML｜parameter>")
     pub parameter_end: String,
+
+    /// See [`JsonParserConfig::allow_eof_recovery`]. Streaming jails MUST
+    /// leave this `false`.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
 }
 
 impl Default for DsmlParserConfig {
@@ -166,6 +175,7 @@ impl Default for DsmlParserConfig {
             invoke_end: "</｜DSML｜invoke>".to_string(),
             parameter_prefix: "<｜DSML｜parameter name=".to_string(),
             parameter_end: "</｜DSML｜parameter>".to_string(),
+            allow_eof_recovery: false,
         }
     }
 }
@@ -315,12 +325,20 @@ impl ParserConfig {
 pub struct ToolCallConfig {
     /// Parser-specific configuration.
     pub parser_config: ParserConfig,
+
+    /// Structural tag builder for xgrammar guided decoding.
+    ///
+    /// When `Some`, the Dynamo preprocessor can generate structural tags that
+    /// constrain the backend into producing model-native tool call format.
+    #[serde(skip)]
+    pub structural_tag_builder: Option<StructuralTagBuilder>,
 }
 
 impl Default for ToolCallConfig {
     fn default() -> Self {
         Self {
             parser_config: ParserConfig::Json(JsonParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 }
@@ -335,6 +353,19 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</tool_call>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
+                TriggeredTagsConfig {
+                    begin_template: format!(
+                        "<tool_call>\n{{\"name\": \"{}\", \"arguments\": ",
+                        TOOL_NAME_PLACEHOLDER
+                    ),
+                    end_template: "}\n</tool_call>".to_string(),
+                    triggers: vec!["<tool_call>".to_string()],
+                    content_style: JsonSchemaStyle::Json,
+                    tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                    reasoning_end: Some("</think>".to_string()),
+                },
+            )),
         }
     }
 
@@ -347,6 +378,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -359,6 +391,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -369,6 +402,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["[/TOOL_CALLS]".to_string(), "".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -379,12 +413,14 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
     pub fn pythonic() -> Self {
         Self {
             parser_config: ParserConfig::Pythonic,
+            structural_tag_builder: None,
         }
     }
 
@@ -398,6 +434,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["<|call|>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -422,6 +459,7 @@ impl ToolCallConfig {
                 parser_type: JsonParserType::DeepseekV31,
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -437,6 +475,7 @@ impl ToolCallConfig {
                 parser_type: JsonParserType::DeepseekV3,
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -453,6 +492,16 @@ impl ToolCallConfig {
                 backoff_when_no_wrapper: true,
                 ..XmlParserConfig::default()
             }),
+            structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
+                TriggeredTagsConfig {
+                    begin_template: format!("<tool_call>\n<function={}>\n", TOOL_NAME_PLACEHOLDER),
+                    end_template: "\n</function>\n</tool_call>".to_string(),
+                    triggers: vec!["<tool_call>\n<function=".to_string()],
+                    content_style: JsonSchemaStyle::QwenXml,
+                    tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                    reasoning_end: Some("</think>".to_string()),
+                },
+            )),
         }
     }
 
@@ -463,16 +512,38 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</tool_calls>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
     fn deepseek_dsml(block_name: &str) -> Self {
+        let dsml_config = DsmlParserConfig {
+            block_start: format!("<｜DSML｜{}>", block_name),
+            block_end: format!("</｜DSML｜{}>", block_name),
+            ..Default::default()
+        };
+        let structural_tag = StructuralTagBuilder::DsmlToolCalls(DsmlToolCallsConfig {
+            trigger: dsml_config.block_start.clone(),
+            block_begin: format!("{}\n", dsml_config.block_start),
+            block_end: dsml_config.block_end.clone(),
+            invoke_begin_template: format!(
+                "{}\"{}\">\n",
+                dsml_config.invoke_start_prefix, TOOL_NAME_PLACEHOLDER
+            ),
+            // Keep the newline in invoke_end and separator empty so the model
+            // can either emit another invoke or close the DSML block.
+            invoke_end: format!("{}\n", dsml_config.invoke_end),
+            separator: "".to_string(),
+            // The DSML opening is several tokens (`<`, `｜DSML｜`, ...), so `tool_choice=none`
+            // cannot suppress the entire prefix, so we ban the `｜DSML｜` token.
+            // The model may still begin a tool block and hurt plain-text quality; prefer omitting tools
+            // from the prompt (default `--exclude-tools-when-tool-choice-none`) when that matters.
+            tool_call_ban_tokens: vec!["｜DSML｜".to_string()],
+            reasoning_end: Some("</think>".to_string()),
+        });
         Self {
-            parser_config: ParserConfig::Dsml(DsmlParserConfig {
-                block_start: format!("<｜DSML｜{}>", block_name),
-                block_end: format!("</｜DSML｜{}>", block_name),
-                ..Default::default()
-            }),
+            parser_config: ParserConfig::Dsml(dsml_config),
+            structural_tag_builder: Some(structural_tag),
         }
     }
 
@@ -524,6 +595,7 @@ impl ToolCallConfig {
                 passthrough_when_no_function: false,
                 backoff_when_no_wrapper: false,
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -533,6 +605,7 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja
         Self {
             parser_config: ParserConfig::Glm47(Glm47ParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 
@@ -544,6 +617,7 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
         Self {
             parser_config: ParserConfig::KimiK2(KimiK2ParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 
@@ -558,6 +632,7 @@ impl ToolCallConfig {
     pub fn gemma4() -> Self {
         Self {
             parser_config: ParserConfig::Gemma4,
+            structural_tag_builder: None,
         }
     }
 }

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -56,21 +56,6 @@ pub fn find_tool_call_end_position_dsml(chunk: &str, config: &DsmlParserConfig) 
     }
 }
 
-/// Build the regex that matches a complete DSML tool_calls / function_calls block.
-/// Shared by `extract_tool_calls_with_regex` and `try_tool_call_parse_dsml` so
-/// the two stay in lockstep on how a block is recognised.
-fn build_block_regex(config: &DsmlParserConfig) -> anyhow::Result<Regex> {
-    // Matches: <｜DSML｜function_calls> ... </｜DSML｜function_calls>
-    // Pattern: (?s) = dot matches newlines
-    //          \s*(.*?)\s* = capture content between start/end tags (non-greedy)
-    let block_pattern = format!(
-        r"(?s){}\s*(.*?)\s*{}",
-        regex::escape(&config.block_start),
-        regex::escape(&config.block_end)
-    );
-    Ok(Regex::new(&block_pattern)?)
-}
-
 /// Parse DSML formatted tool calls from a message.
 ///
 /// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
@@ -83,7 +68,7 @@ fn build_block_regex(config: &DsmlParserConfig) -> anyhow::Result<Regex> {
 ///
 /// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
 /// after the wrapper across XML-style families; this aligns Dynamo to that
-/// behavior. Cases: PARSER.batch.{2.b, 2.c, 8.b, 8.c, 8.d}.
+/// behavior. Cases: TOOLCALLING.batch.{2.b, 2.c, 8.b, 8.c, 8.d}.
 pub fn try_tool_call_parse_dsml(
     message: &str,
     config: &DsmlParserConfig,
@@ -101,9 +86,9 @@ pub fn try_tool_call_parse_dsml(
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Extract tool calls blocks
-    let block_regex = build_block_regex(config)?;
-    let tool_calls = extract_tool_calls_with_regex(trimmed, &block_regex, config)?;
+    // Extract tool calls blocks. Finalize paths can opt into EOF recovery so
+    // a missing outer block end still yields any complete inner invokes.
+    let tool_calls = extract_tool_calls(trimmed, config)?;
 
     // Whether or not invokes parsed, normal_text is the prefix before the
     // first block_start — mirrors vLLM's success path. On no-invokes the
@@ -155,22 +140,37 @@ pub fn try_tool_call_parse_dsml(
     Ok((tool_calls, Some(pre_block_text)))
 }
 
-/// Extract all tool calls matched by `block_regex` from the DSML formatted text.
-fn extract_tool_calls_with_regex(
+/// Extract all tool calls from DSML formatted text.
+fn extract_tool_calls(
     text: &str,
-    block_regex: &Regex,
     config: &DsmlParserConfig,
 ) -> anyhow::Result<Vec<ToolCallResponse>> {
     let mut tool_calls = Vec::new();
+    let mut cursor = 0;
 
-    for block_match in block_regex.captures_iter(text) {
-        if let Some(block_content) = block_match.get(1) {
-            let block = block_content.as_str();
+    while cursor < text.len() {
+        let Some(rel_start) = text[cursor..].find(config.block_start.as_str()) else {
+            break;
+        };
+        let block_content_start = cursor + rel_start + config.block_start.len();
+        let after_start = &text[block_content_start..];
 
-            // Extract individual invokes from this block
-            let invokes = extract_invokes(block, config)?;
-            tool_calls.extend(invokes);
-        }
+        let (block, next_cursor) =
+            if let Some(rel_end) = after_start.find(config.block_end.as_str()) {
+                (
+                    &after_start[..rel_end],
+                    block_content_start + rel_end + config.block_end.len(),
+                )
+            } else if config.allow_eof_recovery {
+                (&text[block_content_start..], text.len())
+            } else {
+                break;
+            };
+
+        let invokes = extract_invokes(block, config)?;
+        tool_calls.extend(invokes);
+
+        cursor = next_cursor;
     }
 
     Ok(tool_calls)
@@ -290,6 +290,13 @@ mod tests {
         }
     }
 
+    fn get_v4_recovery_test_config() -> DsmlParserConfig {
+        DsmlParserConfig {
+            allow_eof_recovery: true,
+            ..get_v4_test_config()
+        }
+    }
+
     #[test] // helper
     fn test_detect_tool_call_start() {
         let config = get_test_config();
@@ -308,30 +315,30 @@ mod tests {
     // -------------------------------------------------------------------
     // DEPRECATED(parser-fixture-duplicate): Legacy V4 coverage manifest.
     // The blackbox case mapping now lives in the YAML parser fixtures under
-    // tests/parity/parser/fixtures/deepseek_v4/ and the taxonomy in
-    // lib/parsers/PARSER_CASES.md; keep this temporarily as a pointer while
+    // tests/parity/toolcalling/fixtures/deepseek_v4/ and the taxonomy in
+    // lib/parsers/TOOLCALLING_CASES.md; keep this temporarily as a pointer while
     // the duplicate Rust tests are being retired.
     //
-    // DeepSeek V4 coverage (see lib/parsers/PARSER_CASES.md for PARSER.* taxonomy).
+    // DeepSeek V4 coverage (see lib/parsers/TOOLCALLING_CASES.md for TOOLCALLING.* taxonomy).
     //
     // Covered by the V4 tests below (or by a shared DSML generic test):
-    //   - PARSER.batch.1   single-call            (parsers.rs :: test_deepseek_v4_single_tool_call)
-    //   - PARSER.batch.2   multi-calls            (test_parse_deepseek_v4_multiple_tool_calls)
-    //   - PARSER.batch.3   no-call                (shared: test_parse_no_tool_calls)
-    //   - PARSER.batch.4   malformed-args         (test_parse_deepseek_v4_malformed_json_value_falls_back_to_string,
+    //   - TOOLCALLING.batch.1   single-call            (parsers.rs :: test_deepseek_v4_single_tool_call)
+    //   - TOOLCALLING.batch.2   multi-calls            (test_parse_deepseek_v4_multiple_tool_calls)
+    //   - TOOLCALLING.batch.3   no-call                (shared: test_parse_no_tool_calls)
+    //   - TOOLCALLING.batch.4   malformed-args         (test_parse_deepseek_v4_malformed_json_value_falls_back_to_string,
     //                                      test_parse_deepseek_v4_missing_invoke_close_drops_call)
-    //   - PARSER.batch.5   missing-end-token      (test_parse_deepseek_v4_missing_end_token{,_multiple_calls})
+    //   - TOOLCALLING.batch.5   missing-end-token      (test_parse_deepseek_v4_missing_end_token{,_multiple_calls})
     //                                      — PINNED AS BROKEN: parser drops the call. See TODO below.
-    //   - PARSER.batch.6   empty-args             (test_parse_deepseek_v4_no_parameters)
-    //   - PARSER.batch.7   complex-args           (shared: test_parse_mixed_types_realistic, test_parse_nested_object_parameter,
+    //   - TOOLCALLING.batch.6   empty-args             (test_parse_deepseek_v4_no_parameters)
+    //   - TOOLCALLING.batch.7   complex-args           (shared: test_parse_mixed_types_realistic, test_parse_nested_object_parameter,
     //                                      lib/llm/tests/test_streaming_tool_parsers :: ..._mixed_param_types_vllm,
     //                                      ..._special_chars_vllm)
-    //   - PARSER.stream.3   streaming              (test_detect_tool_call_start_v4, test_find_tool_call_end_position_v4,
+    //   - TOOLCALLING.stream.3   streaming              (test_detect_tool_call_start_v4, test_find_tool_call_end_position_v4,
     //                                      test_streaming_chunk_boundary_split_v4,
     //                                      lib/llm/tests/test_streaming_tool_parsers :: ..._fragmented_tokens_vllm)
-    //   - PARSER.batch.8   reasoning-plus-tool    (test_parse_reasoning_plus_tool_v4;
+    //   - TOOLCALLING.batch.8   reasoning-plus-tool    (test_parse_reasoning_plus_tool_v4;
     //                                      lib/llm/tests/test_streaming_tool_parsers :: ..._with_tools_vllm)
-    //   - PARSER.batch.3  reasoning-only         (test_parse_reasoning_only_no_tool_v4;
+    //   - TOOLCALLING.batch.3  reasoning-only         (test_parse_reasoning_only_no_tool_v4;
     //                                      reasoning/mod.rs :: test_deepseek_v4_detect_and_parse etc.)
     //   - FRONTEND.tool_choice  tool_choice            (lib/llm/tests/tool_choice.rs ::
     //                                      test_deepseek_v4_tool_choice_{auto,required_pins_current_behavior,
@@ -344,33 +351,42 @@ mod tests {
     //                                      cross-parser stop/tool_calls/length mapping is
     //                                      cross-parser finish_reason mapping work-item (tracked separately); lib/llm/tests/test_streaming_tool_parsers
     //                                      covers ToolCalls / Stop on E2E fixtures)
-    //   - PARSER.batch.8  interleaved-text       (test_parse_deepseek_v4_multiple_tool_calls prefix text;
+    //   - TOOLCALLING.batch.8  interleaved-text       (test_parse_deepseek_v4_multiple_tool_calls prefix text;
     //                                      lib/llm/tests/test_streaming_tool_parsers :: ..._content_before_tool_vllm)
-    //   - PARSER.batch.9  empty/null             (test_parse_empty_and_whitespace_inputs_v4)
-    //   - PARSER.batch.10  duplicate-calls        (test_parse_duplicate_invokes_same_name_v4)
+    //   - TOOLCALLING.batch.9  empty/null             (test_parse_empty_and_whitespace_inputs_v4)
+    //   - TOOLCALLING.batch.10  duplicate-calls        (test_parse_duplicate_invokes_same_name_v4)
     //
-    //   - PARSER.xml.1 / PARSER.xml.2  N/A — DSML carries per-parameter
+    //   - TOOLCALLING.xml.1 / TOOLCALLING.xml.2  N/A — DSML carries per-parameter
     //                  string="true|false" type hints, so XML entity decoding
     //                  and schema-aware coercion don't apply.
-    //   - PARSER.harmony.1 / PARSER.harmony.2 N/A — Harmony-only.
+    //   - TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 N/A — Harmony-only.
+    //
+    // EOF recovery:
+    //   - TOOLCALLING.stream.4.a  Stream finalization sets
+    //             `allow_eof_recovery=true` and recovers complete
+    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even when the
+    //             outer close fence is absent at EOS. Streaming early-exit and
+    //             batch/non-streaming aggregate paths keep recovery disabled so
+    //             they do not claim DSML calls before `</｜DSML｜tool_calls>`
+    //             actually arrives.
     //
     // TODO — bugs pinned, parser still needs to be fixed:
-    //   - PARSER.batch.5  BUG: parser drops all calls when </｜DSML｜tool_calls> is
+    //   - TOOLCALLING.batch.5  BUG: parser drops all calls when </｜DSML｜tool_calls> is
     //             absent (max_tokens / EOS before close). Same class as
     //             Kimi K2 pre-PR #8208. Fix: scan for complete
     //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even without the
     //             outer close fence (see kimi_k2_parser.rs for precedent).
     //             Pinning tests below assert the current silent-drop;
     //             flip them once the parser is fixed.
-    //   - (PARSER.batch.4 missing-parameter-close & middle-invoke-truncation now
+    //   - (TOOLCALLING.batch.4 missing-parameter-close & middle-invoke-truncation now
     //     pinned: see test_parse_deepseek_v4_missing_parameter_close_loses_param,
     //     test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next.)
     // No customer-incident regression tests yet — V4 is hours old
     // (2026-04-24) and no bugs have been filed against it.
     // -------------------------------------------------------------------
 
-    /// `PARSER.stream.3` — streaming start-token detection (V4 variant).
-    #[test] // helper, PARSER.fmt.3 — V4 token variant
+    /// `TOOLCALLING.stream.3` — streaming start-token detection (V4 variant).
+    #[test] // helper, TOOLCALLING.fmt.3 — V4 token variant
     fn test_detect_tool_call_start_v4() {
         let config = get_v4_test_config();
         assert!(detect_tool_call_start_dsml("<｜DSML｜tool_calls>", &config));
@@ -394,8 +410,8 @@ mod tests {
         assert_eq!(&text[pos..], "more");
     }
 
-    /// `PARSER.stream.3` — streaming end-position lookup (V4 variant).
-    #[test] // helper, PARSER.fmt.3 — V4 token variant
+    /// `TOOLCALLING.stream.3` — streaming end-position lookup (V4 variant).
+    #[test] // helper, TOOLCALLING.fmt.3 — V4 token variant
     fn test_find_tool_call_end_position_v4() {
         let config = get_v4_test_config();
         let text = "<｜DSML｜tool_calls><｜DSML｜invoke name=\"test\"></｜DSML｜invoke></｜DSML｜tool_calls>more";
@@ -403,8 +419,8 @@ mod tests {
         assert_eq!(&text[pos..], "more");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1
     fn test_parse_single_tool_call_string_param() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
@@ -432,8 +448,8 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1, TOOLCALLING.batch.7
     fn test_parse_single_tool_call_mixed_params() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="search">
@@ -452,8 +468,8 @@ mod tests {
         assert_eq!(args["topn"], 10);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
@@ -479,9 +495,9 @@ mod tests {
         assert_eq!(args2["location"], "Hangzhou");
     }
 
-    /// `PARSER.batch.2` multi-calls + `PARSER.batch.8` interleaved-text (prefix text before the block).
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2, PARSER.fmt.3 — V4 variant
+    /// `TOOLCALLING.batch.2` multi-calls + `TOOLCALLING.batch.8` interleaved-text (prefix text before the block).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_multiple_tool_calls() {
         let input = r#"Let's check this. <｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_favorite_tourist_spot">
@@ -513,9 +529,9 @@ mod tests {
         assert_eq!(args2["source"], "web");
     }
 
-    /// `PARSER.batch.6` — empty args (no-parameter invoke).
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6, PARSER.fmt.3 — V4 variant
+    /// `TOOLCALLING.batch.6` — empty args (no-parameter invoke).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6, TOOLCALLING.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_no_parameters() {
         let input = r#"<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_current_time">
@@ -532,8 +548,8 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"Here's the result: <｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -571,7 +587,7 @@ mod tests {
         assert_eq!(normal, "Let me check the forecast.\n\n");
     }
 
-    #[test] // PARSER.batch.3
+    #[test] // TOOLCALLING.batch.3
     fn test_parse_no_tool_calls() {
         let input = "This is just normal text without any tool calls.";
         let config = get_test_config();
@@ -580,8 +596,8 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_json_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="process">
@@ -599,8 +615,8 @@ mod tests {
         assert_eq!(args["config"]["count"], 42);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_array_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="process">
@@ -618,8 +634,8 @@ mod tests {
         assert_eq!(args["items"][2], 3);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_boolean_parameters() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="config">
@@ -637,8 +653,8 @@ mod tests {
         assert_eq!(args["disabled"], false);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_number_parameters() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="calculate">
@@ -658,8 +674,8 @@ mod tests {
         assert_eq!(args["negative"], -100);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_mixed_types_realistic() {
         // Realistic example based on test data
         let input = r#"<｜DSML｜function_calls>
@@ -681,8 +697,8 @@ mod tests {
         assert_eq!(args["source"], "web");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_nested_object_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="configure">
@@ -702,8 +718,8 @@ mod tests {
         assert_eq!(args["settings"]["endpoints"][0], "a");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_empty_string_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -877,8 +893,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a, PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.7, PARSER.batch.9
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a, TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.7, TOOLCALLING.batch.9
     fn test_parse_null_parameter() {
         let input = r#"<｜DSML｜function_calls>
 <｜DSML｜invoke name="test">
@@ -895,30 +911,17 @@ mod tests {
     }
 
     // Corner-case pinning tests. See the V4 coverage manifest above for the
-    // full mapping from PARSER.* → test. Each test's doc-comment names the
+    // full mapping from TOOLCALLING.* → test. Each test's doc-comment names the
     // specific CASE it pins.
 
-    /// `PARSER.batch.5` — missing end-token recovery.
-    /// **Pinned as broken** — parser drops the call; see the TODO block above.
+    /// `TOOLCALLING.batch.5` — missing end-token, streaming-safe path.
     ///
-    /// If a DeepSeek V4 stream is truncated before `</｜DSML｜tool_calls>`
-    /// arrives (max_tokens cut-off, EOS mid-generation, connection drop),
-    /// the block regex requires both fences and matches zero times. The
-    /// entire DSML-looking payload falls through as raw `normal_text`; no
-    /// tool calls are recovered.
-    ///
-    /// This is the same structural failure mode Kimi K2 had before its
-    /// parser gained end-token recovery; see
-    /// `kimi_k2_parser.rs::test_parse_malformed_no_section_end` for the
-    /// post-fix recovery pattern.
-    ///
-    /// Note: post-hardening, the parser no longer leaks raw DSML markup
-    /// into `normal_text` when block-start appears but no invokes parse —
-    /// it returns the pre-block text only (empty here, since the input
-    /// starts with the block-start fence). The call is still dropped.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5, PARSER.fmt.3 — V4 variant
-    fn test_parse_deepseek_v4_missing_end_token() {
+    /// Without EOF recovery, the parser must not claim a complete tool call
+    /// before `</｜DSML｜tool_calls>` arrives. Streaming early-exit uses this
+    /// path and keeps buffering until stream finalization.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5, TOOLCALLING.fmt.3 — V4 variant
+    fn test_parse_deepseek_v4_missing_end_token_without_recovery() {
         // Start fence + complete invoke, but no </｜DSML｜tool_calls>.
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"get_weather\">\n\
@@ -930,9 +933,8 @@ mod tests {
 
         assert!(
             calls.is_empty(),
-            "V4 DSML parser currently drops tool calls when \
-             </｜DSML｜tool_calls> is missing. \
-             If recovery is added, flip this assertion."
+            "Streaming-safe DSML parser must wait for </｜DSML｜tool_calls> \
+             instead of recovering early."
         );
         assert_eq!(
             normal_text.as_deref(),
@@ -942,14 +944,14 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.5` — multiple complete invokes, missing end fence.
+    /// `TOOLCALLING.batch.5` — multiple complete invokes, missing end fence.
     ///
     /// Even with multiple fully-formed invokes inside the start fence, the
     /// absence of the closing fence prevents the block regex from matching.
     /// All calls are dropped. If the parser ever gains partial-block
     /// recovery, this test will fail and force an intentional update.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.5, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a, TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.5, TOOLCALLING.fmt.3
     fn test_parse_deepseek_v4_missing_end_token_multiple_calls() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"a\">\n\
@@ -969,13 +971,58 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.4` — malformed JSON in a `string="false"` parameter value falls back
+    /// `TOOLCALLING.stream.4.a` — missing end-token recovery at stream finalize.
+    ///
+    /// Stream finalization flips `allow_eof_recovery=true`, treating an
+    /// unterminated outer block as extending to EOF and recovering complete
+    /// inner invokes. Batch/non-streaming aggregate parsing remains strict.
+    #[test] // TOOLCALLING.stream.4.a — V4 variant
+    fn test_parse_deepseek_v4_missing_end_token_with_recovery() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"city\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_recovery_test_config();
+        let (calls, normal_text) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(normal_text.as_deref(), Some(""));
+        let (name, args) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["city"], "NYC");
+    }
+
+    /// Stream-finalize recovery with multiple complete invokes and no outer end fence.
+    #[test]
+    fn test_parse_deepseek_v4_missing_end_token_multiple_calls_with_recovery() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"a\">\n\
+<｜DSML｜parameter name=\"x\" string=\"true\">1</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+<｜DSML｜invoke name=\"b\">\n\
+<｜DSML｜parameter name=\"y\" string=\"true\">2</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_recovery_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 2);
+        let (name1, args1) = extract_name_and_args(calls[0].clone());
+        let (name2, args2) = extract_name_and_args(calls[1].clone());
+        assert_eq!(name1, "a");
+        assert_eq!(args1["x"], "1");
+        assert_eq!(name2, "b");
+        assert_eq!(args2["y"], "2");
+    }
+
+    /// `TOOLCALLING.batch.4` — malformed JSON in a `string="false"` parameter value falls back
     /// to a string. `parse_parameters` explicitly swallows the serde error
     /// (unwrap_or_else → Value::String). Pin the fallback so removing it
     /// (which would cause the whole call to 500 on ragged-edge JSON) is a
     /// deliberate change.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.fmt.3
     fn test_parse_deepseek_v4_malformed_json_value_falls_back_to_string() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\
@@ -996,11 +1043,11 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.4` — malformed invoke (missing `</｜DSML｜invoke>` but block fences
+    /// `TOOLCALLING.batch.4` — malformed invoke (missing `</｜DSML｜invoke>` but block fences
     /// intact). The invoke regex requires its own close tag, so the call is
     /// silently dropped. Pin the behavior.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.fmt.3
     fn test_parse_deepseek_v4_missing_invoke_close_drops_call() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\
@@ -1016,16 +1063,16 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.4` — malformed invoke (missing `</｜DSML｜parameter>` close tag).
+    /// `TOOLCALLING.batch.4` — malformed invoke (missing `</｜DSML｜parameter>` close tag).
     /// The parameter regex requires its closing tag; if a parameter never
     /// closes before `</｜DSML｜invoke>`, the parameter is silently lost
     /// while the call itself still parses. Pin the partial behavior.
     ///
-    /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: parser silently loses the parameter
+    /// TODO(TOOLCALLING.batch.4) — BUG, NEEDS FIX: parser silently loses the parameter
     /// and ships an under-specified call to the user. The fix should keep
     /// the raw value up to `</｜DSML｜invoke>`. Flip this test once fixed.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.fmt.3
     fn test_parse_deepseek_v4_missing_parameter_close_loses_param() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\
@@ -1046,17 +1093,17 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.4` — middle-invoke truncation. If invoke A is missing its
+    /// `TOOLCALLING.batch.4` — middle-invoke truncation. If invoke A is missing its
     /// `</｜DSML｜invoke>` and invoke B follows inside the same outer block,
     /// A's body bleeds through into B (regex non-greedy match consumes B's
     /// markup). Pin the corruption.
     ///
-    /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: A swallows B's parameters and B is
+    /// TODO(TOOLCALLING.batch.4) — BUG, NEEDS FIX: A swallows B's parameters and B is
     /// silently dropped — caller receives wrong args for A and never sees
     /// B at all. Fix: anchor on `<｜DSML｜invoke name=` to re-sync between
     /// invokes. Flip this test once fixed.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.fmt.3
     fn test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"a\">\n\
@@ -1081,10 +1128,10 @@ mod tests {
         );
     }
 
-    /// `PARSER.stream.3` — streaming chunk-boundary split. Token-by-token assembly:
+    /// `TOOLCALLING.stream.3` — streaming chunk-boundary split. Token-by-token assembly:
     /// the start-token detector and end-position lookup must each tolerate
     /// the block boundary landing in the middle of a multi-byte fence.
-    #[test] // PARSER.stream.3
+    #[test] // TOOLCALLING.stream.3
     fn test_streaming_chunk_boundary_split_v4() {
         let config = get_v4_test_config();
         // Detector should fire on a partial start fence (one char short).
@@ -1101,12 +1148,12 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.8` — paired reasoning + tool in same response. DSv4 emits
+    /// `TOOLCALLING.batch.8` — paired reasoning + tool in same response. DSv4 emits
     /// `<think>...</think>` before the DSML block; the tool parser is
     /// concerned only with the DSML, but normal text must round-trip
     /// the reasoning markup verbatim for the reasoning parser to pick up.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_reasoning_plus_tool_v4() {
         let input = "<think>Let me check the weather.</think>\
 <｜DSML｜tool_calls>\n\
@@ -1127,9 +1174,9 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.3` — reasoning only (think tags, no tool call). Parser must
+    /// `TOOLCALLING.batch.3` — reasoning only (think tags, no tool call). Parser must
     /// return zero calls and pass the entire input through as normal text.
-    #[test] // PARSER.batch.3
+    #[test] // TOOLCALLING.batch.3
     fn test_parse_reasoning_only_no_tool_v4() {
         let input = "<think>Just thinking out loud, no tools needed.</think>";
         let config = get_v4_test_config();
@@ -1175,10 +1222,10 @@ mod tests {
         assert_eq!(calls.len(), 1);
     }
 
-    /// `PARSER.batch.9` — empty / null content variants. Pin behavior on truly
+    /// `TOOLCALLING.batch.9` — empty / null content variants. Pin behavior on truly
     /// empty bytes and whitespace-only inputs.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9
     fn test_parse_empty_and_whitespace_inputs_v4() {
         let config = get_v4_test_config();
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -1199,10 +1246,10 @@ mod tests {
         }
     }
 
-    /// `PARSER.batch.10` — duplicate calls (same invoke name twice in one block).
+    /// `TOOLCALLING.batch.10` — duplicate calls (same invoke name twice in one block).
     /// Universal gap noted in the test taxonomy; first DSML coverage.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.10
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.10
     fn test_parse_duplicate_invokes_same_name_v4() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"get_weather\">\n\

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -80,7 +80,7 @@ pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
 ///
 /// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
 /// after the wrapper across XML-style families; this aligns Dynamo to that
-/// behavior. Cases: PARSER.batch.{2.c, 8.b, 8.c, 8.d}.
+/// behavior. Cases: TOOLCALLING.batch.{2.c, 8.b, 8.c, 8.d}.
 ///
 /// The `}<tool_call|>` adjacency requirement in the regex means embedded
 /// `<tool_call|>` literals inside string-typed args (e.g. a `description`
@@ -143,7 +143,7 @@ pub fn try_tool_call_parse_gemma4(
     //     exception-fallback (which echoes raw bytes) so tool-call markup
     //     never leaks into normal_text on malformed / truncated / orphan-
     //     close / no-body inputs. Cases flagged by the parity table's `↯`:
-    //     PARSER.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
+    //     TOOLCALLING.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
     //   - Plain-text path (zero calls AND no markup): return the message
     //     as-is.
     let has_markup = message.contains(TOOL_CALL_START)
@@ -476,8 +476,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1 — single string argument
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1 — single string argument
     fn parse_single_string_argument() {
         let input = r#"<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>"#;
         let (name, args) = extract_first(input);
@@ -485,8 +485,8 @@ mod tests {
         assert_eq!(args["location"], "Tokyo");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml, tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1, PARSER.batch.7 — multiple typed arguments
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1, TOOLCALLING.batch.7 — multiple typed arguments
     fn parse_multiple_typed_arguments() {
         let input = r#"<|tool_call>call:f{loc:<|"|>San Francisco, CA<|"|>,unit:<|"|>celsius<|"|>,count:42,flag:true,nope:null}<tool_call|>"#;
         let (name, args) = extract_first(input);
@@ -498,8 +498,8 @@ mod tests {
         assert_eq!(args["nope"], Value::Null);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6 — empty argument object
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6 — empty argument object
     fn parse_no_arg_call() {
         let input = "<|tool_call>call:get_time{}<tool_call|>";
         let (name, args) = extract_first(input);
@@ -507,8 +507,8 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — nested object value
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — nested object value
     fn parse_nested_object_value() {
         let input = r#"<|tool_call>call:f{cfg:{ssl:true,pool:{min:5,max:20}}}<tool_call|>"#;
         let (_name, args) = extract_first(input);
@@ -517,16 +517,16 @@ mod tests {
         assert_eq!(args["cfg"]["pool"]["max"], 20);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — array of strings
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — array of strings
     fn parse_array_of_strings() {
         let input = r#"<|tool_call>call:f{tags:[<|"|>a<|"|>,<|"|>b<|"|>,<|"|>c<|"|>]}<tool_call|>"#;
         let (_name, args) = extract_first(input);
         assert_eq!(args["tags"], serde_json::json!(["a", "b", "c"]));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — array of mixed primitives
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — array of mixed primitives
     fn parse_array_of_mixed_primitives() {
         let input = "<|tool_call>call:f{xs:[1,2,3.5,true,false,null]}<tool_call|>";
         let (_name, args) = extract_first(input);
@@ -538,8 +538,8 @@ mod tests {
         assert_eq!(args["xs"][5], Value::Null);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2 — multiple parallel calls, zero spacing
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2 — multiple parallel calls, zero spacing
     fn parse_multiple_parallel_calls() {
         let input = concat!(
             "<|tool_call>call:a{x:1}<tool_call|>",
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    #[test] // PARSER.batch.8.c — prefix narration preserved, trailing dropped (matches vLLM)
+    #[test] // TOOLCALLING.batch.8.c — prefix narration preserved, trailing dropped (matches vLLM)
     fn parse_with_surrounding_text() {
         let input = r#"Sure thing. <|tool_call>call:f{x:1}<tool_call|> All set."#;
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -562,15 +562,15 @@ mod tests {
         assert_eq!(normal, Some("Sure thing.".to_string()));
     }
 
-    #[test] // PARSER.batch.3 — no tool calls at all
+    #[test] // TOOLCALLING.batch.3 — no tool calls at all
     fn parse_no_tool_calls() {
         let (calls, normal) = try_tool_call_parse_gemma4("just plain prose here", None).unwrap();
         assert_eq!(calls.len(), 0);
         assert_eq!(normal, Some("just plain prose here".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5 — complete prior call survives; truncated tail dropped (matches vLLM)
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.c in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5 — complete prior call survives; truncated tail dropped (matches vLLM)
     fn truncated_tail_dropped_complete_prior_survives() {
         let input = concat!(
             "<|tool_call>call:complete{x:1}<tool_call|>",
@@ -585,8 +585,8 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4 — malformed args body falls back to empty object, call still emitted
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4 — malformed args body falls back to empty object, call still emitted
     fn malformed_args_falls_back_to_empty_object() {
         let input = "<|tool_call>call:f{garbage no colons here}<tool_call|>";
         let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -596,7 +596,7 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
-    #[test] // PARSER.fmt.1 — function names with hyphens, dots, underscores
+    #[test] // TOOLCALLING.fmt.1 — function names with hyphens, dots, underscores
     fn parse_function_names_with_special_chars() {
         for (input, expected_name) in [
             (
@@ -618,23 +618,23 @@ mod tests {
         }
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — angle brackets / HTML inside string values
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — angle brackets / HTML inside string values
     fn parse_html_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><div class="x"><h1>Hi</h1></div><|"|>}<tool_call|>"#;
         let (_name, args) = extract_first(input);
         assert_eq!(args["html"], "<div class=\"x\"><h1>Hi</h1></div>");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — newlines inside string values
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — newlines inside string values
     fn parse_newlines_in_string_value() {
         let input = "<|tool_call>call:f{body:<|\"|>line1\nline2\nline3<|\"|>}<tool_call|>";
         let (_name, args) = extract_first(input);
         assert_eq!(args["body"], "line1\nline2\nline3");
     }
 
-    #[test] // PARSER.fmt.2 — whitespace tolerance inside args
+    #[test] // TOOLCALLING.fmt.2 — whitespace tolerance inside args
     fn parse_with_internal_whitespace() {
         let input = r#"<|tool_call>call:f{ x : 1 , y : <|"|>z<|"|> }<tool_call|>"#;
         let (_name, args) = extract_first(input);
@@ -642,8 +642,8 @@ mod tests {
         assert_eq!(args["y"], "z");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — negative numbers and floats
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — negative numbers and floats
     fn parse_signed_numbers_and_floats() {
         let input = "<|tool_call>call:f{a:-1,b:-2.5,c:0,d:0.0}<tool_call|>";
         let (_name, args) = extract_first(input);
@@ -653,19 +653,20 @@ mod tests {
         assert!((args["d"].as_f64().unwrap()).abs() < 1e-9);
     }
 
-    #[test] // PARSER.fmt.1 — tool validation warns but doesn't drop
+    #[test] // TOOLCALLING.fmt.1 — tool validation warns but doesn't drop
     fn parse_with_tool_validation() {
         let input = r#"<|tool_call>call:get_weather{x:1}<tool_call|>"#;
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
+            strict: None,
         }];
         let (calls, _) = try_tool_call_parse_gemma4(input, Some(&tools)).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test] // PARSER.fmt.4 — empty wrapper between calls
+    #[test] // TOOLCALLING.fmt.4 — empty wrapper between calls
     fn parse_empty_text_between_calls() {
         let input = concat!(
             "<|tool_call>call:a{}<tool_call|>",
@@ -678,32 +679,32 @@ mod tests {
 
     // Argument-grammar unit tests (parse_args_object directly)
 
-    #[test] // PARSER.batch.6 — empty args at the grammar entry point
+    #[test] // TOOLCALLING.batch.6 — empty args at the grammar entry point
     fn args_grammar_empty() {
         let v = parse_args_object("").unwrap();
         assert_eq!(v, serde_json::json!({}));
     }
 
-    #[test] // PARSER.batch.7 — string with comma/colon/brace literals
+    #[test] // TOOLCALLING.batch.7 — string with comma/colon/brace literals
     fn args_grammar_string_with_special_chars() {
         let v = parse_args_object(r#"x:<|"|>has,comma:and{brace}<|"|>"#).unwrap();
         assert_eq!(v["x"], "has,comma:and{brace}");
     }
 
-    #[test] // PARSER.batch.7 — deeply nested object value
+    #[test] // TOOLCALLING.batch.7 — deeply nested object value
     fn args_grammar_deeply_nested() {
         let v = parse_args_object("a:{b:{c:{d:{e:1}}}}").unwrap();
         assert_eq!(v["a"]["b"]["c"]["d"]["e"], 1);
     }
 
-    #[test] // PARSER.batch.7 — array of objects
+    #[test] // TOOLCALLING.batch.7 — array of objects
     fn args_grammar_array_of_objects() {
         let v = parse_args_object(r#"items:[{n:<|"|>x<|"|>},{n:<|"|>y<|"|>}]"#).unwrap();
         assert_eq!(v["items"][0]["n"], "x");
         assert_eq!(v["items"][1]["n"], "y");
     }
 
-    #[test] // PARSER.batch.4, PARSER.batch.5 — truncated string-arg recovery (mirrors upstream)
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.batch.5 — truncated string-arg recovery (mirrors upstream)
     fn args_grammar_unterminated_string_takes_remainder() {
         // Upstream Gemma 4 parser: when the closing <|"|> is missing,
         // everything after the opening delimiter becomes the value. We mirror
@@ -713,21 +714,21 @@ mod tests {
         assert_eq!(v["x"], "oops");
     }
 
-    #[test] // PARSER.batch.4 — empty value mid-args (upstream test_empty_value)
+    #[test] // TOOLCALLING.batch.4 — empty value mid-args (upstream test_empty_value)
     fn args_grammar_empty_value_yields_empty_string() {
         let v = parse_args_object("x:,y:1").unwrap();
         assert_eq!(v["x"], "");
         assert_eq!(v["y"], 1);
     }
 
-    #[test] // PARSER.batch.4 — empty value at end-of-args (upstream test_empty_value)
+    #[test] // TOOLCALLING.batch.4 — empty value at end-of-args (upstream test_empty_value)
     fn args_grammar_trailing_empty_value() {
         let v = parse_args_object("x:1,y:").unwrap();
         assert_eq!(v["x"], 1);
         assert_eq!(v["y"], "");
     }
 
-    #[test] // PARSER.batch.7 — typed-value null variants, case-insensitive (upstream `value_str.lower() in (...)`)
+    #[test] // TOOLCALLING.batch.7 — typed-value null variants, case-insensitive (upstream `value_str.lower() in (...)`)
     fn args_grammar_null_aliases_case_insensitive() {
         for variant in [
             "null", "NULL", "Null", "none", "NONE", "None", "nil", "NIL", "Nil",
@@ -738,14 +739,14 @@ mod tests {
         }
     }
 
-    #[test] // PARSER.batch.4 — keyword-prefix must not partial-match (`nullable` vs `null`)
+    #[test] // TOOLCALLING.batch.4 — keyword-prefix must not partial-match (`nullable` vs `null`)
     fn args_grammar_keyword_prefix_not_consumed() {
         // `nullable` must not be parsed as `null` + leftover `able`.
         let _ = parse_args_object("x:nullable").unwrap_err();
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5 — missing end-marker, markup suppressed (no-leak contract)
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.c in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5 — missing end-marker, markup suppressed (no-leak contract)
     fn incomplete_tool_call_suppresses_markup() {
         let input = "<|tool_call>call:foo{x:1";
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -757,10 +758,10 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    #[test] // PARSER.batch.7 — `<tool_call|>` literal inside a string-typed argument
+    #[test] // TOOLCALLING.batch.7 — `<tool_call|>` literal inside a string-typed argument
     // must not truncate the call. The extraction regex requires
     // `}<tool_call|>` adjacency, so a bare embedded marker is safe.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.7.yaml.
     fn embedded_tool_call_marker_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><tool_call|> example<|"|>}<tool_call|>"#;
         let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -778,11 +779,11 @@ mod tests {
         assert_eq!(&input[pos..], " trailing");
     }
 
-    #[test] // PARSER.batch.8 — paired reasoning span + tool call in the same emission
+    #[test] // TOOLCALLING.batch.8 — paired reasoning span + tool call in the same emission
     // (in production the reasoning parser runs first and strips `<|channel>`,
     // but the tool-call parser must remain correct if it sees the full
     // emission, e.g. when reasoning parsing is disabled).
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.8.yaml.
     fn paired_reasoning_and_tool_call_in_same_emission() {
         let input = concat!(
             "<|channel>thought\nthinking about the request<channel|>",
@@ -798,16 +799,16 @@ mod tests {
         assert!(normal.unwrap().contains("<|channel>thought"));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9 — empty input, no tool calls
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9 — empty input, no tool calls
     fn empty_input_yields_zero_calls_empty_content() {
         let (calls, normal) = try_tool_call_parse_gemma4("", None).unwrap();
         assert_eq!(calls.len(), 0);
         assert_eq!(normal, Some(String::new()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9 — `null` argument values round-trip as JSON null
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9 — `null` argument values round-trip as JSON null
     fn null_argument_values_preserved() {
         let input = "<|tool_call>call:f{x:null,y:none,z:nil}<tool_call|>";
         let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -818,10 +819,10 @@ mod tests {
         assert_eq!(args["z"], Value::Null);
     }
 
-    #[test] // PARSER.batch.10 — duplicate calls to the same function name. Both must
+    #[test] // TOOLCALLING.batch.10 — duplicate calls to the same function name. Both must
     // appear with distinct IDs; client decides whether duplicate invocation
     // is intended.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.yaml.
     fn duplicate_tool_call_same_name() {
         let input = concat!(
             "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",
@@ -841,9 +842,9 @@ mod tests {
         assert_eq!(args1["location"], "NYC");
     }
 
-    // ----- Explicit N/A coverage notes (per lib/parsers/PARSER_CASES.md) -----
+    // ----- Explicit N/A coverage notes (per lib/parsers/TOOLCALLING_CASES.md) -----
     //
-    // PARSER.stream.3  — Streaming token-by-token assembly: indirect. The Gemma 4
+    // TOOLCALLING.stream.3  — Streaming token-by-token assembly: indirect. The Gemma 4
     //           parser exposes only the synchronous extraction path; the
     //           streaming jail (`tools.rs::try_tool_call_parse_stream`) drives
     //           it via `detect_tool_call_start_gemma4` and
@@ -857,7 +858,7 @@ mod tests {
     // PIPELINE.finish_reason — `finish_reason` semantics: same universal gap; lives in
     //           `lib/llm/tests/tool_choice_finish_reasons.rs`, hermes-only
     //           today.
-    // PARSER.xml.1 / PARSER.xml.2 — XML-family only. N/A — Gemma 4 uses a custom
+    // TOOLCALLING.xml.1 / TOOLCALLING.xml.2 — XML-family only. N/A — Gemma 4 uses a custom
     //           non-JSON, non-XML grammar.
-    // PARSER.harmony.1 / PARSER.harmony.2 — Harmony only. N/A.
+    // TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 — Harmony only. N/A.
 }

--- a/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -503,8 +503,8 @@ mod tests {
         (call.function.name, args)
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
-    #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.1, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
         let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -518,8 +518,8 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
-    #[tokio::test] // PARSER.batch.4, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.harmony.2
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -530,8 +530,8 @@ mod tests {
         assert_eq!(tool_calls.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
-    #[tokio::test] // PARSER.batch.7, PARSER.batch.8, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.7, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -546,8 +546,8 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
-    #[tokio::test] // PARSER.batch.8, PARSER.batch.8, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.8, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
@@ -561,7 +561,7 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
     async fn test_parse_harmony_bare_text_without_final_message_is_dropped() {
         let text = "Hello, how can I help you today?";
         let (tool_calls, normal_content) =
@@ -572,7 +572,7 @@ mod tests {
         assert_eq!(normal_content, Some("".to_string()));
     }
 
-    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
     async fn test_parse_harmony_final_message_returns_normal_text() {
         let text = r#"<|channel|>final<|message|>Hello, how can I help you today?<|return|>"#;
         let (tool_calls, normal_content) =
@@ -634,8 +634,8 @@ mod tests {
     // Harmony's strict tokenizer rejects two back-to-back commentary
     // blocks, so EOF recovery falls back to regex extraction and pins that
     // both calls are surfaced without leaking the raw envelopes.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml.
-    #[tokio::test] // PARSER.batch.2 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.2.yaml.
+    #[tokio::test] // TOOLCALLING.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
         let (tool_calls, _normal) =
@@ -651,8 +651,8 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
-    #[tokio::test] // PARSER.batch.4 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
     async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
         let (tool_calls, _normal) =
@@ -664,8 +664,8 @@ mod tests {
         assert_eq!(tool_calls[0].function.arguments, "not json at all");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
-    #[tokio::test] // PARSER.batch.4 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
     async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
@@ -683,11 +683,11 @@ mod tests {
         assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
-    // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
+    // Bare-envelope TOOLCALLING.batch.5: no preceding `analysis` block, no `<|call|>`
     // at the end. Harmony requires the explicit call stop token, so fallback
     // must not accept EOS as a synthetic close.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml.
-    #[tokio::test] // PARSER.batch.5 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml.
+    #[tokio::test] // TOOLCALLING.batch.5 — gpt-oss
     async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
         let (tool_calls, normal) = parse_tool_calls_harmony_complete(
@@ -791,8 +791,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
-    #[tokio::test] // PARSER.batch.4, PARSER.batch.5, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.batch.5, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
         let (tool_calls, normal_content) =
@@ -818,10 +818,10 @@ mod tests {
         assert_eq!(tool_calls.len(), 1);
     }
 
-    /// PARSER.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
+    /// TOOLCALLING.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
     /// the function name.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml.
-    #[tokio::test] // PARSER.batch.6 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.6.yaml.
+    #[tokio::test] // TOOLCALLING.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
         let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
@@ -833,13 +833,13 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls. Unlike the
     /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
     /// harmony parser passes the input verbatim through to normal_text —
     /// pin that distinction here.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
-    #[tokio::test] // PARSER.batch.9 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.9 — gpt-oss
     async fn test_parse_harmony_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
             let (tool_calls, normal) =
@@ -860,12 +860,12 @@ mod tests {
         }
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice). Two
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice). Two
     /// back-to-back commentary blocks for the same function. Pin
     /// parser-level behavior — both calls returned with distinct ids
     /// and distinct args.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
-    #[tokio::test] // PARSER.batch.10 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.10 — gpt-oss
     async fn test_parse_harmony_duplicate_calls_same_name() {
         let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
@@ -919,7 +919,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn test_detect_tool_call_start_harmony_partial_tokens() {
         // Test partial token detection for streaming scenarios
         let config = JsonParserConfig {

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -594,7 +594,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.batch.8
+    #[test] // helper, TOOLCALLING.batch.8
     fn detect_tool_call_start_basic_json_chunk_without_tool_call_start_token_with_normal_text() {
         let text = r#"Here it is {"name": "#;
         let config = JsonParserConfig {
@@ -681,7 +681,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_fun() {
         // Test the streaming scenario where "fun" arrives first
         let text = r#"fun"#;
@@ -697,7 +697,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_func() {
         let text = r#"func"#;
         let config = JsonParserConfig {
@@ -712,7 +712,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_f() {
         let text = r#"f"#;
         let config = JsonParserConfig {
@@ -727,7 +727,7 @@ mod detect_parser_tests {
         );
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn detect_tool_call_start_basic_json_chunk_phi4_partial_with_prefix() {
         // Test case where text ends with a partial token (more realistic streaming scenario)
         let text = r#"Hello fun"#;

--- a/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -117,6 +117,28 @@ fn parse_single_tool_call_v3_1(
     None
 }
 
+fn normal_text_before_wrapper_start(message: &str, config: &JsonParserConfig) -> String {
+    wrapper_start_index(message, config)
+        .map(|idx| message[..idx].to_string())
+        .unwrap_or_default()
+}
+
+fn wrapper_start_index(message: &str, config: &JsonParserConfig) -> Option<usize> {
+    config
+        .tool_call_start_tokens
+        .iter()
+        .filter(|token| !token.is_empty())
+        .filter_map(|token| message.find(token))
+        .min()
+}
+
+fn has_complete_wrapper_end(message: &str, config: &JsonParserConfig) -> bool {
+    config
+        .tool_call_end_tokens
+        .iter()
+        .any(|token| !token.is_empty() && message.contains(token.as_str()))
+}
+
 pub fn parse_tool_calls_deepseek_v3_1(
     message: &str,
     config: &JsonParserConfig,
@@ -131,24 +153,6 @@ pub fn parse_tool_calls_deepseek_v3_1(
         return Ok((vec![], Some(String::new())));
     }
 
-    // For DeepSeek_v3_1, we consider the tool call block to be
-    // <｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜> and only start parsing
-    // if seeing <｜tool▁calls▁begin｜>, even though the individual calls are
-    // parsed by <｜tool▁call▁begin｜>...<｜tool▁call▁end｜>.
-    // This is because if we start parsing by considering all call(s) tokens,
-    // we are not properly grouping the tool calls and results in groups:
-    // 1. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>...<｜tool▁call▁end｜>
-    // 2. <｜tool▁calls▁end｜>
-    // where 2. will not be recognized as part of the tool call block due
-    // to missing start token and will not be consumed.
-    let has_end_token = config
-        .tool_call_end_tokens
-        .iter()
-        .any(|token| !token.is_empty() && trimmed.contains(token));
-    if !has_end_token {
-        return Ok((vec![], Some(trimmed.to_string())));
-    }
-
     let mut tool_call_start_tokens = config.tool_call_start_tokens.clone();
     tool_call_start_tokens.extend(vec!["<｜tool▁call▁begin｜>".to_string()]);
     let mut tool_call_end_tokens = config.tool_call_end_tokens.clone();
@@ -160,43 +164,30 @@ pub fn parse_tool_calls_deepseek_v3_1(
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Check if tool call start token is present
-    if !detect_tool_call_start_deepseek_v3_1(trimmed, config) {
+    // Batch parsing requires a complete outer wrapper start; the public
+    // detector also accepts partial prefixes for streaming chunk detection.
+    if wrapper_start_index(trimmed, config).is_none() {
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Extract normal text (content before the first wrapper start token)
-    // Look for wrapper tokens like <｜tool▁calls▁begin｜> (note: "calls" not "call")
-    let wrapper_tokens: Vec<&String> = tool_call_start_tokens
-        .iter()
-        .filter(|t| t.contains("tool_calls_begin") || t.contains("tool▁calls▁begin"))
-        .collect();
+    let normal_text = normal_text_before_wrapper_start(trimmed, config);
 
-    let normal_text = if !wrapper_tokens.is_empty() {
-        wrapper_tokens
-            .iter()
-            .find_map(|token| {
-                trimmed
-                    .find(token.as_str())
-                    .map(|idx| trimmed[..idx].to_string())
-            })
-            .unwrap_or_else(String::new)
-    } else {
-        // Fallback to first individual call token if no wrapper found
-        tool_call_start_tokens
-            .iter()
-            .filter(|token| !token.is_empty())
-            .find_map(|token| trimmed.find(token).map(|idx| trimmed[..idx].to_string()))
-            .unwrap_or_else(String::new)
-    };
+    // Missing outer end-token recovery is finalize-only. Streaming jail paths
+    // leave allow_eof_recovery=false so they do not release before later calls
+    // or the wrapper end token arrive.
+    if !has_complete_wrapper_end(trimmed, config) && !config.allow_eof_recovery {
+        return Ok((vec![], Some(normal_text)));
+    }
 
     // Extract individual tool call blocks
     let blocks =
         extract_tool_call_blocks_v3_1(trimmed, &tool_call_start_tokens, &tool_call_end_tokens);
 
     if blocks.is_empty() {
-        // Found start token but no valid blocks
-        return Ok((vec![], Some(trimmed.to_string())));
+        // Found a wrapper start token but no complete individual call. Strip
+        // the malformed/truncated tool-call block instead of leaking protocol
+        // markers into message content.
+        return Ok((vec![], Some(normal_text)));
     }
 
     // Parse each block to extract function name and arguments
@@ -216,9 +207,10 @@ pub fn parse_tool_calls_deepseek_v3_1(
         }
     }
 
-    // If no valid tool calls were parsed, return everything as normal text
+    // If no valid tool calls were parsed, strip the wrapper and keep only the
+    // prefix before it.
     if tool_calls.is_empty() {
-        return Ok((vec![], Some(trimmed.to_string())));
+        return Ok((vec![], Some(normal_text)));
     }
 
     Ok((tool_calls, Some(normal_text)))
@@ -270,8 +262,8 @@ mod tests {
         (call.function.name, args)
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_tool_calls_deepseek_v3_1_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -289,8 +281,8 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "New York"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -308,8 +300,57 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4 — recovery from missing start
+    #[test]
+    fn test_parse_tool_calls_deepseek_v3_1_partial_wrapper_prefix_is_normal_text() {
+        let text = "This is normal text <";
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
+
+        assert_eq!(content, Some(text.to_string()));
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_tool_calls_deepseek_v3_1_missing_wrapper_end_requires_eof_recovery() {
+        let text = r#"prefix <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜>"#;
+        let mut config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
+        assert_eq!(content, Some("prefix ".to_string()));
+        assert_eq!(result.len(), 0);
+
+        config.allow_eof_recovery = true;
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
+        assert_eq!(content, Some("prefix ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_current_weather");
+        assert_eq!(args["location"], "Tokyo");
+    }
+
+    #[test]
+    fn test_normal_text_before_wrapper_start_uses_earliest_token() {
+        let mut config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+        config.tool_call_start_tokens = vec!["<later>".to_string(), "<early>".to_string()];
+
+        assert_eq!(
+            normal_text_before_wrapper_start("prefix <early> body <later>", &config),
+            "prefix "
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_1_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -321,8 +362,8 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.7
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
@@ -347,36 +388,39 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_tool_calls_deepseek_v3_1_with_invalid_json() {
-        // Everything is normal text in case of invalid json
+        // Malformed wrapper content is stripped instead of leaked as normal text.
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.trim().to_string()));
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_normal_text() {
-        // Everything is normal text in case of invalid json
+        // Malformed wrapper content is stripped while preserving prefix text.
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast宽带}{location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality宽带}{location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.trim().to_string()));
+        assert_eq!(
+            content,
+            Some("The following tool calls retrieve weather information: ".to_string())
+        );
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7, PARSER.fmt.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7, TOOLCALLING.fmt.2
     fn test_parse_tool_calls_deepseek_v3_1_with_multiline_json() {
         let text = r#"I'll help you understand this codebase. Let me start by exploring the structure and key
   files to provide you with a comprehensive
@@ -474,7 +518,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn test_detect_tool_call_start_deepseek_v3_1_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
         let config = match ToolCallConfig::deepseek_v3_1().parser_config {

--- a/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -88,20 +88,21 @@ fn parse_single_tool_call_v3(block: &str, separator_tokens: &[String]) -> Option
                 continue;
             }
 
-            // Extract JSON arguments from code block
-            let args_str = if let Some(json_start) = args_block.find("```json") {
-                let after_fence = &args_block[json_start + "```json".len()..];
-                let after_newline = after_fence
-                    .strip_prefix("\r\n")
-                    .or_else(|| after_fence.strip_prefix('\n'))
-                    .unwrap_or(after_fence);
-                if let Some(json_end) = after_newline.find("```") {
-                    after_newline[..json_end].trim()
-                } else {
-                    after_newline.trim()
-                }
+            // DeepSeek V3's documented shape requires a fenced JSON argument
+            // block. Treat an unfenced body as malformed rather than parsing it
+            // as a call and diverging from upstream recovery behavior.
+            let Some(json_start) = args_block.find("```json") else {
+                continue;
+            };
+            let after_fence = &args_block[json_start + "```json".len()..];
+            let after_newline = after_fence
+                .strip_prefix("\r\n")
+                .or_else(|| after_fence.strip_prefix('\n'))
+                .unwrap_or(after_fence);
+            let args_str = if let Some(json_end) = after_newline.find("```") {
+                after_newline[..json_end].trim()
             } else {
-                args_block.trim()
+                after_newline.trim()
             };
 
             // Try to parse arguments as JSON
@@ -127,6 +128,28 @@ fn parse_single_tool_call_v3(block: &str, separator_tokens: &[String]) -> Option
     None
 }
 
+fn normal_text_before_wrapper_start(message: &str, config: &JsonParserConfig) -> String {
+    wrapper_start_index(message, config)
+        .map(|idx| message[..idx].to_string())
+        .unwrap_or_default()
+}
+
+fn wrapper_start_index(message: &str, config: &JsonParserConfig) -> Option<usize> {
+    config
+        .tool_call_start_tokens
+        .iter()
+        .filter(|token| !token.is_empty())
+        .filter_map(|token| message.find(token))
+        .min()
+}
+
+fn has_complete_wrapper_end(message: &str, config: &JsonParserConfig) -> bool {
+    config
+        .tool_call_end_tokens
+        .iter()
+        .any(|token| !token.is_empty() && message.contains(token.as_str()))
+}
+
 pub fn parse_tool_calls_deepseek_v3(
     message: &str,
     config: &JsonParserConfig,
@@ -141,18 +164,6 @@ pub fn parse_tool_calls_deepseek_v3(
         return Ok((vec![], Some(String::new())));
     }
 
-    // For DeepSeek_v3, we consider the tool call block to be
-    // <｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜> and only start parsing
-    // if seeing <｜tool▁calls▁begin｜>, even though the individual calls are
-    // parsed by <｜tool▁call▁begin｜>...<｜tool▁call▁end｜>.
-    let has_end_token = config
-        .tool_call_end_tokens
-        .iter()
-        .any(|token| !token.is_empty() && trimmed.contains(token));
-    if !has_end_token {
-        return Ok((vec![], Some(trimmed.to_string())));
-    }
-
     let mut tool_call_start_tokens = config.tool_call_start_tokens.clone();
     tool_call_start_tokens.extend(vec!["<｜tool▁call▁begin｜>".to_string()]);
     let mut tool_call_end_tokens = config.tool_call_end_tokens.clone();
@@ -164,43 +175,30 @@ pub fn parse_tool_calls_deepseek_v3(
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Check if tool call start token is present
-    if !detect_tool_call_start_deepseek_v3(trimmed, config) {
+    // Batch parsing requires a complete outer wrapper start; the public
+    // detector also accepts partial prefixes for streaming chunk detection.
+    if wrapper_start_index(trimmed, config).is_none() {
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Extract normal text (content before the first wrapper start token)
-    // Look for wrapper tokens like <｜tool▁calls▁begin｜> (note: "calls" not "call")
-    let wrapper_tokens: Vec<&String> = tool_call_start_tokens
-        .iter()
-        .filter(|t| t.contains("tool_calls_begin") || t.contains("tool▁calls▁begin"))
-        .collect();
+    let normal_text = normal_text_before_wrapper_start(trimmed, config);
 
-    let normal_text = if !wrapper_tokens.is_empty() {
-        wrapper_tokens
-            .iter()
-            .find_map(|token| {
-                trimmed
-                    .find(token.as_str())
-                    .map(|idx| trimmed[..idx].to_string())
-            })
-            .unwrap_or_else(String::new)
-    } else {
-        // Fallback to first individual call token if no wrapper found
-        tool_call_start_tokens
-            .iter()
-            .filter(|token| !token.is_empty())
-            .find_map(|token| trimmed.find(token).map(|idx| trimmed[..idx].to_string()))
-            .unwrap_or_else(String::new)
-    };
+    // Missing outer end-token recovery is finalize-only. Streaming jail paths
+    // leave allow_eof_recovery=false so they do not release before later calls
+    // or the wrapper end token arrive.
+    if !has_complete_wrapper_end(trimmed, config) && !config.allow_eof_recovery {
+        return Ok((vec![], Some(normal_text)));
+    }
 
     // Extract individual tool call blocks
     let blocks =
         extract_tool_call_blocks_v3(trimmed, &tool_call_start_tokens, &tool_call_end_tokens);
 
     if blocks.is_empty() {
-        // Found start token but no valid blocks
-        return Ok((vec![], Some(trimmed.to_string())));
+        // Found a wrapper start token but no complete individual call. Strip
+        // the malformed/truncated tool-call block instead of leaking protocol
+        // markers into message content.
+        return Ok((vec![], Some(normal_text)));
     }
 
     // Parse each block to extract function name and arguments
@@ -220,9 +218,10 @@ pub fn parse_tool_calls_deepseek_v3(
         }
     }
 
-    // If no valid tool calls were parsed, return everything as normal text
+    // If no valid tool calls were parsed, strip the wrapper and keep only the
+    // prefix before it.
     if tool_calls.is_empty() {
-        return Ok((vec![], Some(trimmed.to_string())));
+        return Ok((vec![], Some(normal_text)));
     }
 
     Ok((tool_calls, Some(normal_text)))
@@ -274,8 +273,8 @@ mod tests {
         (call.function.name, args)
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_tool_calls_deepseek_v3_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -299,8 +298,8 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -321,8 +320,60 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4 — recovery from missing start
+    #[test]
+    fn test_parse_tool_calls_deepseek_v3_partial_wrapper_prefix_is_normal_text() {
+        let text = "This is normal text <";
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
+
+        assert_eq!(content, Some(text.to_string()));
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_tool_calls_deepseek_v3_missing_wrapper_end_requires_eof_recovery() {
+        let text = r#"prefix <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
+```json
+{"location": "HongKong"}
+```<｜tool▁call▁end｜>"#;
+        let mut config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
+        assert_eq!(content, Some("prefix ".to_string()));
+        assert_eq!(result.len(), 0);
+
+        config.allow_eof_recovery = true;
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
+        assert_eq!(content, Some("prefix ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_current_weather");
+        assert_eq!(args["location"], "HongKong");
+    }
+
+    #[test]
+    fn test_normal_text_before_wrapper_start_uses_earliest_token() {
+        let mut config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+        config.tool_call_start_tokens = vec!["<later>".to_string(), "<early>".to_string()];
+
+        assert_eq!(
+            normal_text_before_wrapper_start("prefix <early> body <later>", &config),
+            "prefix "
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
 ```json
@@ -337,8 +388,8 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.7
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
@@ -372,10 +423,10 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_tool_calls_deepseek_v3_with_invalid_json() {
-        // Everything is normal text in case of invalid json
+        // Malformed wrapper content is stripped instead of leaked as normal text.
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather}{location": "HongKong"}
 ```json
 }
@@ -385,14 +436,14 @@ mod tests {
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.trim().to_string()));
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_normal_text() {
-        // Everything is normal text in case of invalid json
+        // Malformed wrapper content is stripped while preserving prefix text.
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
 ```json
 }
@@ -408,12 +459,15 @@ mod tests {
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.trim().to_string()));
+        assert_eq!(
+            content,
+            Some("The following tool calls retrieve weather information: ".to_string())
+        );
         assert_eq!(result.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7, PARSER.fmt.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7, TOOLCALLING.fmt.2
     fn test_parse_tool_calls_deepseek_v3_with_multiline_json() {
         let text = r#"I'll help you understand this Xiaohongshu codebase. Let me start by exploring the structure
   and key files to provide you with a comprehensive
@@ -514,7 +568,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[test] // helper, TOOLCALLING.stream.3
     fn test_detect_tool_call_start_deepseek_v3_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
         let config = match ToolCallConfig::deepseek_v3().parser_config {

--- a/parsers/src/tool_calling/json/mod.rs
+++ b/parsers/src/tool_calling/json/mod.rs
@@ -101,7 +101,7 @@ mod tests {
     /// all be captured by find_tool_call_end_position_json so that the jail passes the
     /// entire group to the parser rather than emitting the second (and later) calls
     /// as raw trailing text.
-    #[test] // PARSER.batch.2, helper
+    #[test] // TOOLCALLING.batch.2, helper
     fn test_find_tool_call_end_position_parallel_calls() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<tool_call>".to_string()],
@@ -153,8 +153,8 @@ mod tests {
     // Recovery for missing outer </TOOLCALL> (max_tokens / EOS truncation):
     // when the inner JSON array is well-formed, treat EOF as the end token
     // and extract the call rather than silently dropping it.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5 — nemotron_deci
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5 — nemotron_deci
     fn test_parse_nemotron_deci_no_outer_close_recovers() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
@@ -178,8 +178,8 @@ mod tests {
     // but no parser-level test pinned it. This test makes the contract
     // visible at the per-parser surface so a JSON-family refactor can't
     // silently break parallel-call extraction without a per-parser failure.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2 — nemotron_deci
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a in tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2 — nemotron_deci
     fn test_parse_nemotron_deci_multiple_calls() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
@@ -200,8 +200,8 @@ mod tests {
     // `"city":"NYC` with no closing quote, brace, or array bracket). The
     // base parser balances unclosed strings/braces and retries the parse,
     // surfacing the call rather than silently dropping it.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4 — nemotron_deci
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4 — nemotron_deci
     fn test_parse_nemotron_deci_truncated_json_recovers() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
@@ -240,10 +240,10 @@ mod tests {
         assert_eq!(calls.len(), 1);
     }
 
-    /// PARSER.batch.6 — empty args. A no-arg call (`{}`) must still be returned
+    /// TOOLCALLING.batch.6 — empty args. A no-arg call (`{}`) must still be returned
     /// with the function name intact.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6 — nemotron_deci
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6 — nemotron_deci
     fn test_parse_nemotron_deci_empty_args() {
         let config = nemotron_deci_config();
         let input = r#"<TOOLCALL>[{"name":"current_time","arguments":{}}]</TOOLCALL>"#;
@@ -254,10 +254,10 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string.
-    #[test] // PARSER.batch.9 — nemotron_deci
+    #[test] // TOOLCALLING.batch.9 — nemotron_deci
     fn test_parse_nemotron_deci_empty_and_whitespace_inputs() {
         let config = nemotron_deci_config();
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -276,10 +276,10 @@ mod tests {
         }
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice in one section).
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice in one section).
     /// JSON-array form pin parser-level behavior — both calls returned with
     /// distinct ids.
-    #[test] // PARSER.batch.10 — nemotron_deci
+    #[test] // TOOLCALLING.batch.10 — nemotron_deci
     fn test_parse_nemotron_deci_duplicate_calls_same_name() {
         let config = nemotron_deci_config();
         let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}},{"name":"get_weather","arguments":{"city":"LA"}}]</TOOLCALL>"#;

--- a/parsers/src/tool_calling/mod.rs
+++ b/parsers/src/tool_calling/mod.rs
@@ -11,6 +11,7 @@ pub mod json;
 pub mod parsers;
 pub mod pythonic;
 pub mod response;
+pub mod structural_tag;
 #[cfg(test)]
 pub mod tests;
 pub mod tools;
@@ -21,6 +22,16 @@ pub mod xml;
 pub struct ToolDefinition {
     pub name: String,
     pub parameters: Option<Value>,
+    pub strict: Option<bool>,
+}
+
+/// Tool choice policy used by parser-side tool-call helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoice {
+    None,
+    Auto,
+    Required,
+    Named(String),
 }
 
 // Re-export main types and functions for convenience
@@ -36,10 +47,16 @@ pub use parsers::{
     try_tool_call_parse,
 };
 pub use pythonic::try_tool_call_parse_pythonic;
-pub use response::{CalledFunction, ToolCallResponse, ToolCallType};
+pub use response::{
+    CalledFunction, CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+};
+pub use structural_tag::{
+    DsmlToolCallsConfig, StructuralTagBuilder, StructuralTagSchemaMode, TOOL_NAME_PLACEHOLDER,
+    ToolCallFormatBuildContext, TriggeredTagsConfig,
+};
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
-    try_tool_call_parse_stream,
+    try_tool_call_parse_aggregate_stream_finalize, try_tool_call_parse_stream,
 };
 pub use xml::try_tool_call_parse_kimi_k2;
 pub use xml::try_tool_call_parse_xml;

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -116,8 +116,8 @@ pub async fn try_tool_call_parse(
 }
 
 /// Same as [`detect_and_parse_tool_call`] but flips `allow_eof_recovery=true`
-/// on the JSON / XML / GLM-4.7 configs so finalize / non-streaming aggregate
-/// paths recover from missing-end-token / truncated-JSON instead of silently
+/// on the JSON / XML configs so finalize / non-streaming aggregate paths
+/// recover from missing-end-token / truncated-JSON instead of silently
 /// dropping the call. Streaming jails MUST keep using the non-recovery
 /// variant — otherwise `should_exit_jail_early` fires before the end-token
 /// has actually arrived (see jail.rs).
@@ -125,6 +125,29 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, false).await
+}
+
+/// Stream-end finalize variant of [`detect_and_parse_tool_call_with_recovery`].
+///
+/// DeepSeek V4's vLLM streaming parser emits a tool call once a complete
+/// `<｜DSML｜invoke>...</｜DSML｜invoke>` arrives, even if the outer
+/// `</｜DSML｜tool_calls>` wrapper never appears before EOS. Keep that recovery
+/// scoped to stream finalization so batch/non-streaming parity remains strict.
+pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, true).await
+}
+
+async fn detect_and_parse_tool_call_with_recovery_options(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+    recover_dsml_eof: bool,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let parser_map = get_tool_parser_map();
     let parser_key = match parser_str {
@@ -153,6 +176,11 @@ pub async fn detect_and_parse_tool_call_with_recovery(
             }
             ParserConfig::Xml(c)
         }
+        ParserConfig::Dsml(c) if recover_dsml_eof => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::Dsml(c)
+        }
         // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
         // (drop the call when </tool_call> is missing).
         // Other parsers don't have an EOF-recovery flag — pass through.
@@ -160,6 +188,7 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     };
     let cfg = ToolCallConfig {
         parser_config: recovery_config,
+        structural_tag_builder: None,
     };
     try_tool_call_parse(message, &cfg, tools).await
 }
@@ -412,6 +441,7 @@ mod tests {
                     tool_call_end_tokens: vec!["".to_string()],
                     ..Default::default()
                 }),
+                structural_tag_builder: None,
             },
             None,
         )
@@ -760,6 +790,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
                 arguments_keys: vec!["arguments".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         };
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1208,6 +1239,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
                 arguments_keys: vec!["arguments".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         };
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1881,7 +1913,47 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
     }
-    /// Alias registration: verifies `deepseek-v4` and `deepseekv4` route to the same parser as `deepseek_v4`. Not a PARSER.*; covers registry plumbing.
+    #[tokio::test]
+    async fn test_deepseek_v4_common_recovery_stays_strict_without_outer_close() {
+        let input = r#"<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_datetime">
+<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
+</｜DSML｜invoke>"#;
+
+        let (tool_calls, normal_text) =
+            detect_and_parse_tool_call_with_recovery(input, Some("deepseek_v4"), None)
+                .await
+                .expect("Failed to parse");
+
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal_text, Some("".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_v4_stream_finalize_recovery_recovers_without_outer_close() {
+        let input = r#"<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_datetime">
+<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
+</｜DSML｜invoke>"#;
+
+        let (tool_calls, normal_text) = detect_and_parse_tool_call_with_stream_finalize_recovery(
+            input,
+            Some("deepseek_v4"),
+            None,
+        )
+        .await
+        .expect("Failed to parse");
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_datetime");
+        assert_eq!(normal_text, Some("".to_string()));
+
+        let args: serde_json::Value =
+            serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
+        assert_eq!(args["timezone"], "Asia/Shanghai");
+    }
+
+    /// Alias registration: verifies `deepseek-v4` and `deepseekv4` route to the same parser as `deepseek_v4`. Not a TOOLCALLING.*; covers registry plumbing.
     #[tokio::test]
     async fn test_deepseek_v4_compatibility_aliases() {
         let input = r#"<｜DSML｜tool_calls>
@@ -2051,7 +2123,7 @@ mod parallel_tool_calling_tests {
     }
 
     // =============================================================================
-    // 1. NEMOTRON/DECI TOOL PARSER FORMAT (JSON Array in XML tags)
+    // 1. NEMOTRON/DECI TOOL-CALL FORMAT (JSON Array in XML tags)
     // =============================================================================
 
     #[tokio::test]
@@ -2107,7 +2179,7 @@ mod parallel_tool_calling_tests {
     }
 
     // =================================================
-    // 2. QWEN3CODER TOOL PARSER FORMAT (XML-style tags)
+    // 2. QWEN3CODER TOOL-CALL FORMAT (XML-style tags)
     // =================================================
 
     #[tokio::test]
@@ -2148,7 +2220,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 3. xLAM TOOL PARSER FORMAT (Pure JSON Array) - Testing via mistral parser
+    // 3. xLAM TOOL-CALL FORMAT (Pure JSON Array) - Testing via mistral parser
     // =============================================================================
 
     #[tokio::test]
@@ -2179,7 +2251,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 4. MINIMAX TOOL PARSER FORMAT (Multi-line JSON in XML tags)
+    // 4. MINIMAX TOOL-CALL FORMAT (Multi-line JSON in XML tags)
     // =============================================================================
 
     #[tokio::test]
@@ -2206,7 +2278,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 5. HARMONY TOOL PARSER FORMAT (Multiple Tool Calls with Harmony Encoding)
+    // 5. HARMONY TOOL-CALL FORMAT (Multiple Tool Calls with Harmony Encoding)
     // =============================================================================
 
     #[tokio::test]
@@ -3063,6 +3135,7 @@ fahrenheit
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, content) =
             detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
@@ -3101,6 +3174,7 @@ true
                     "enabled": {"type": "bool"},
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
@@ -3223,6 +3297,7 @@ weather forecasting
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, content) =
             detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
@@ -3279,6 +3354,7 @@ weather forecasting
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
@@ -3330,6 +3406,7 @@ weather forecasting
                     "query_list": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await
@@ -3422,6 +3499,7 @@ weather forecasting
                     "enabled": {"type": "boolean"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await
@@ -3448,6 +3526,7 @@ weather forecasting
                     "items": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await

--- a/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(matches[0], "[foo(a=1, b=2), bar(x= 3)]");
     }
 
-    #[test] // helper, PARSER.batch.7
+    #[test] // helper, TOOLCALLING.batch.7
     fn test_get_regex_matches_new_line_in_arg_and_value() {
         // New Line in Arg and value
         let message = "Hey \n yo ! [foo(a=1,b=2), \n bar(x=3)] Hey yo";
@@ -262,8 +262,8 @@ mod tests {
         assert_eq!(matches.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_tool_call_parse_pythonic_basic() {
         let message = "[foo(a=1, b=2), bar(x=3)]";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -279,8 +279,8 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.c in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.8
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -296,8 +296,8 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.8, PARSER.fmt.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.c in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.8, TOOLCALLING.fmt.2
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -313,7 +313,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    #[test] // PARSER.batch.3
+    #[test] // TOOLCALLING.batch.3
     fn test_parse_tool_call_parse_pythonic_with_no_calls() {
         let message = "Hey \n yo !";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -322,8 +322,8 @@ mod tests {
         assert_eq!(result.len(), 0)
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2, PARSER.fmt.3
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.fmt.3
     fn test_parse_tool_call_parse_pythonic_with_python_tags() {
         let message = "<|python_start|>[foo(a=1, b=2), bar(x=3)]<|python_end|>";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -339,8 +339,8 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.a in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_tool_call_parse_pythonic_with_list_arg_values() {
         let message = "[foo(a=[1, 2, 3], b=2), bar(x=[3, 4, 5])]";
         let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();
@@ -355,8 +355,8 @@ mod tests {
         assert_eq!(args["x"], json!([3, 4, 5]));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/pythonic/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_tool_call_parse_pythonic_with_dict_arg_values() {
         let message = "[foo(a={'a': 1, 'b': 2}, b=2), bar(x={'x': 3, 'y': {'e': 'f'}})]";
         let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();

--- a/parsers/src/tool_calling/response.rs
+++ b/parsers/src/tool_calling/response.rs
@@ -26,3 +26,25 @@ pub struct ToolCallResponse {
     pub tp: ToolCallType,
     pub function: CalledFunction,
 }
+
+/// Streaming (delta) variant of a parsed tool call.
+///
+/// Mirrors the field shape of a streaming tool-call chunk so consumers can map
+/// it onto their own wire types without `dynamo-parsers` depending on those
+/// types. Field semantics match the unary [`ToolCallResponse`]: `name` and
+/// `arguments` live under `function`, and `index` orders parallel calls.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ToolCallResponseChunk {
+    pub index: u32,
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub tp: Option<ToolCallType>,
+    pub function: Option<CalledFunctionStream>,
+}
+
+/// Streaming variant of [`CalledFunction`] where both fields are optional.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CalledFunctionStream {
+    pub name: Option<String>,
+    pub arguments: Option<String>,
+}

--- a/parsers/src/tool_calling/structural_tag/builder.rs
+++ b/parsers/src/tool_calling/structural_tag/builder.rs
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public structural tag builder API used by the Dynamo preprocessor.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::tool_calling::{ToolChoice, ToolDefinition};
+
+use super::dsml::{self, DsmlToolCallsConfig};
+use super::format::{
+    AnyTextFormat, AnyTokensFormat, Format, SequenceFormat, StructuralTag, TagFormat,
+};
+use super::triggered_tags::{self, TriggeredTagsConfig};
+
+/// Controls whether tools get their real parameter schema or an
+/// unconstrained one inside structural tags.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuralTagSchemaMode {
+    /// Real schema only for tools with `strict: true`; others get an
+    /// unconstrained schema (`true` in xgrammar).
+    #[default]
+    Auto,
+    /// Real parameter schema for all tools regardless of `strict` flag.
+    Strict,
+}
+
+/// Request-scoped inputs for building a tool-call structural tag.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolCallFormatBuildContext<'a> {
+    /// Resolved `tool_choice` from the request.
+    pub tool_choice: &'a ToolChoice,
+    /// All tools from the request.
+    pub tools: &'a [ToolDefinition],
+    /// From the request; `Some(false)` sets `stop_after_first` in the tag.
+    pub parallel_tool_calls: Option<bool>,
+    /// Schema strictness mode for tool arguments.
+    pub schema_mode: StructuralTagSchemaMode,
+    /// Whether generation starts inside an already-opened reasoning block.
+    pub starts_in_reasoning: bool,
+}
+
+impl ToolCallFormatBuildContext<'_> {
+    /// Whether we should stop after the first matched tool-call tag.
+    pub(crate) fn stop_after_first(&self) -> bool {
+        self.parallel_tool_calls.is_some_and(|v| !v)
+    }
+
+    /// Whether all tools should use their request-provided parameter schema.
+    pub(crate) fn strict_schema(&self) -> bool {
+        self.schema_mode == StructuralTagSchemaMode::Strict
+    }
+}
+
+/// Select tools for `tool_choice` and whether at least one call is required.
+pub(crate) fn resolve_tools_to_include<'a>(
+    ctx: &ToolCallFormatBuildContext<'a>,
+) -> anyhow::Result<(Vec<&'a ToolDefinition>, bool)> {
+    match ctx.tool_choice {
+        ToolChoice::None => Ok((vec![], false)),
+        ToolChoice::Auto => Ok((ctx.tools.iter().collect(), false)),
+        ToolChoice::Required => {
+            anyhow::ensure!(
+                !ctx.tools.is_empty(),
+                "tool_choice is \"required\" but tools is empty"
+            );
+            Ok((ctx.tools.iter().collect(), true))
+        }
+        ToolChoice::Named(name) => {
+            let tool = ctx.tools.iter().find(|t| t.name == *name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "tool named \"{}\" in tool_choice is not present in tools",
+                    name
+                )
+            })?;
+            Ok((vec![tool], true))
+        }
+    }
+}
+
+/// Resolve one tool's argument schema for structural tag generation.
+pub(crate) fn resolve_tool_schema(tool: &ToolDefinition, strict_schema: bool) -> Value {
+    // xgrammar uses `true` for syntactically valid but schema-unconstrained JSON.
+    let default_schema = json!(true);
+
+    let use_tool_schema = strict_schema || tool.strict.unwrap_or(false);
+    if use_tool_schema {
+        tool.parameters.clone().unwrap_or(default_schema)
+    } else {
+        default_schema
+    }
+}
+
+/// Builder for model-family-specific tool-call structural tags.
+#[derive(Debug, Clone)]
+pub enum StructuralTagBuilder {
+    /// Simple `triggered_tags` format with one tag template per tool.
+    TriggeredTags(TriggeredTagsConfig),
+
+    /// DeepSeek DSML format with a `triggered_tags` wrapper and invoke list.
+    DsmlToolCalls(DsmlToolCallsConfig),
+}
+
+impl StructuralTagBuilder {
+    /// Build the structural tag for the given request context.
+    ///
+    /// Returns `Ok(None)` when `tool_choice="none"` (use
+    /// [`build_tool_call_ban`](Self::build_tool_call_ban) for that case)
+    /// or when the tools list is empty for `tool_choice="auto"`.
+    ///
+    /// Returns `Err` when the request is invalid (e.g. named tool not found
+    /// in the tools list, or empty tools for `tool_choice="required"`).
+    pub fn build_tool_call_format(
+        &self,
+        ctx: &ToolCallFormatBuildContext<'_>,
+    ) -> anyhow::Result<Option<Value>> {
+        let structural_tag = match self {
+            Self::TriggeredTags(config) => triggered_tags::build_triggered_tags(config, ctx)?,
+            Self::DsmlToolCalls(config) => dsml::build_dsml_tool_calls(config, ctx)?,
+        };
+
+        structural_tag
+            .map(|tag| self.wrap_reasoning_prefix_if_needed(ctx, tag))
+            .transpose()?
+            .map(|tag| serde_json::to_value(tag).map_err(Into::into))
+            .transpose()
+    }
+
+    fn wrap_reasoning_prefix_if_needed(
+        &self,
+        ctx: &ToolCallFormatBuildContext<'_>,
+        suffix: StructuralTag,
+    ) -> anyhow::Result<StructuralTag> {
+        let should_wrap_with_reasoning_tag = ctx.starts_in_reasoning
+            && matches!(ctx.tool_choice, ToolChoice::Required | ToolChoice::Named(_));
+        if !should_wrap_with_reasoning_tag {
+            return Ok(suffix);
+        }
+
+        let reasoning_end = self.reasoning_end().ok_or_else(|| {
+            anyhow::anyhow!("reasoning end tag is not configured for structural tag")
+        })?;
+        let reasoning_prefix = Format::Tag(TagFormat {
+            begin: String::new(),
+            content: Box::new(Format::AnyText(AnyTextFormat { excludes: vec![] })),
+            end: reasoning_end.to_string(),
+        });
+
+        Ok(StructuralTag {
+            format: Format::Sequence(SequenceFormat {
+                elements: vec![reasoning_prefix, suffix.format],
+            }),
+        })
+    }
+
+    /// Build a structural tag that prevents tool-call generation for
+    /// `tool_choice="none"`.
+    ///
+    /// Returns `Ok(None)` when no ban tokens are configured.
+    pub fn build_tool_call_ban(&self) -> anyhow::Result<Option<Value>> {
+        let tokens = self.ban_tokens();
+        if tokens.is_empty() {
+            return Ok(None);
+        }
+
+        let content = Format::AnyTokens(AnyTokensFormat {
+            exclude_tokens: tokens.to_vec(),
+        });
+
+        let tag = StructuralTag {
+            format: Format::Tag(TagFormat {
+                begin: String::new(),
+                content: Box::new(content),
+                end: String::new(),
+            }),
+        };
+
+        serde_json::to_value(tag).map(Some).map_err(Into::into)
+    }
+
+    /// Returns the tokens to ban for `tool_choice="none"`.
+    pub fn ban_tokens(&self) -> &[String] {
+        match self {
+            Self::TriggeredTags(config) => &config.tool_call_ban_tokens,
+            Self::DsmlToolCalls(config) => &config.tool_call_ban_tokens,
+        }
+    }
+
+    fn reasoning_end(&self) -> Option<&str> {
+        match self {
+            Self::TriggeredTags(config) => config.reasoning_end.as_deref(),
+            Self::DsmlToolCalls(config) => config.reasoning_end.as_deref(),
+        }
+    }
+}

--- a/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`StructuralTagBuilder::DsmlToolCalls`] implementation.
+//!
+//! DSML uses two structural tag levels: an outer `triggered_tags` block and
+//! an inner `tags_with_separator` list of per-tool invoke tags.
+
+use serde::{Deserialize, Serialize};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{ToolCallFormatBuildContext, resolve_tool_schema, resolve_tools_to_include};
+use super::format::{
+    Format, JsonSchemaFormat, JsonSchemaStyle, StructuralTag, TagFormat, TagsWithSeparatorFormat,
+    TriggeredTagsFormat,
+};
+
+/// Configuration for the nested DSML tool-call structural tag.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DsmlToolCallsConfig {
+    /// Trigger for the outer DSML block.
+    pub trigger: String,
+
+    /// Begin string for the outer block tag.
+    pub block_begin: String,
+
+    /// End string for the outer block tag.
+    pub block_end: String,
+
+    /// Invoke begin template; [`TOOL_NAME_PLACEHOLDER`] is replaced per tool.
+    pub invoke_begin_template: String,
+
+    /// End string for each invoke tag.
+    pub invoke_end: String,
+
+    /// Separator between consecutive invoke tags.
+    pub separator: String,
+
+    /// Tokens to ban when `tool_choice="none"`.
+    #[serde(default)]
+    pub tool_call_ban_tokens: Vec<String>,
+
+    /// Closing tag for prompt-injected reasoning, if this parser supports it.
+    #[serde(default)]
+    pub reasoning_end: Option<String>,
+}
+
+/// Build a DSML tool-calls structural tag from config and request context.
+pub(crate) fn build_dsml_tool_calls(
+    config: &DsmlToolCallsConfig,
+    ctx: &ToolCallFormatBuildContext<'_>,
+) -> anyhow::Result<Option<StructuralTag>> {
+    let (tools_to_include, outer_at_least_one) = resolve_tools_to_include(ctx)?;
+
+    if tools_to_include.is_empty() {
+        return Ok(None);
+    }
+
+    // Per-tool invoke tags inside the DSML block.
+    let invoke_tags: Vec<TagFormat> = tools_to_include
+        .iter()
+        .map(|tool| {
+            // function name validated by validate_tools() in the request handler
+            let begin = config
+                .invoke_begin_template
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.name);
+
+            TagFormat {
+                begin,
+                content: Box::new(Format::JsonSchema(JsonSchemaFormat {
+                    json_schema: resolve_tool_schema(tool, ctx.strict_schema()),
+                    style: JsonSchemaStyle::DeepseekXml,
+                })),
+                end: config.invoke_end.clone(),
+            }
+        })
+        .collect();
+
+    // Inner list of invokes.
+    let inner_content = Format::TagsWithSeparator(TagsWithSeparatorFormat {
+        tags: invoke_tags,
+        separator: config.separator.clone(),
+        at_least_one: true,
+        stop_after_first: ctx.stop_after_first(),
+    });
+
+    // Outer trigger that opens the DSML block.
+    let block_tag = TagFormat {
+        begin: config.block_begin.clone(),
+        content: Box::new(inner_content),
+        end: config.block_end.clone(),
+    };
+
+    Ok(Some(StructuralTag {
+        format: Format::TriggeredTags(TriggeredTagsFormat {
+            triggers: vec![config.trigger.clone()],
+            tags: vec![block_tag],
+            at_least_one: outer_at_least_one,
+            stop_after_first: ctx.stop_after_first(),
+        }),
+    }))
+}

--- a/parsers/src/tool_calling/structural_tag/format.rs
+++ b/parsers/src/tool_calling/structural_tag/format.rs
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed representations of xgrammar structural tag formats.
+//!
+//! This module models the subset of the
+//! [xgrammar structural tag API](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html)
+//! used by Dynamo for tool-call guided decoding. The types serialize to the JSON
+//! shape expected by xgrammar backends.
+
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::Value;
+
+/// Top-level structural tag wrapper.
+///
+/// Serializes to `{"type": "structural_tag", "format": ...}`.
+#[derive(Debug, Clone)]
+pub struct StructuralTag {
+    pub format: Format,
+}
+
+impl Serialize for StructuralTag {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "structural_tag")?;
+        map.serialize_entry("format", &self.format)?;
+        map.end()
+    }
+}
+
+/// A format node inside a structural tag.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Format {
+    /// `{"type": "tag", "begin": ..., "content": ..., "end": ...}`
+    Tag(TagFormat),
+    /// `{"type": "triggered_tags", "triggers": [...], "tags": [...], ...}`
+    TriggeredTags(TriggeredTagsFormat),
+    /// `{"type": "tags_with_separator", "tags": [...], "separator": ..., ...}`
+    TagsWithSeparator(TagsWithSeparatorFormat),
+    /// `{"type": "sequence", "elements": [...]}`
+    Sequence(SequenceFormat),
+    /// `{"type": "json_schema", "json_schema": ..., "style": ...}`
+    JsonSchema(JsonSchemaFormat),
+    /// `{"type": "any_tokens", "exclude_tokens": [...]}`
+    AnyTokens(AnyTokensFormat),
+    /// `{"type": "any_text", "excludes": [...]}`
+    AnyText(AnyTextFormat),
+}
+
+/// `tag` format: `begin + content + end`.
+///
+/// Always serializes with `"type": "tag"` so it is valid both as a
+/// standalone format node and inside `TriggeredTagsFormat.tags`.
+#[derive(Debug, Clone)]
+pub struct TagFormat {
+    pub begin: String,
+    pub content: Box<Format>,
+    pub end: String,
+}
+
+impl Serialize for TagFormat {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("type", "tag")?;
+        map.serialize_entry("begin", &self.begin)?;
+        map.serialize_entry("content", &self.content)?;
+        map.serialize_entry("end", &self.end)?;
+        map.end()
+    }
+}
+
+/// `triggered_tags`: free text until a trigger, then one of the configured tags.
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggeredTagsFormat {
+    pub triggers: Vec<String>,
+    pub tags: Vec<TagFormat>,
+    pub at_least_one: bool,
+    pub stop_after_first: bool,
+}
+
+/// `tags_with_separator`: a tag sequence with fixed separators and no free text.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagsWithSeparatorFormat {
+    pub tags: Vec<TagFormat>,
+    pub separator: String,
+    pub at_least_one: bool,
+    pub stop_after_first: bool,
+}
+
+/// `sequence`: a fixed sequence of format nodes.
+#[derive(Debug, Clone, Serialize)]
+pub struct SequenceFormat {
+    pub elements: Vec<Format>,
+}
+
+/// Content style for `json_schema` format nodes.
+///
+/// Controls how xgrammar renders tool arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonSchemaStyle {
+    /// Standard JSON output.
+    #[default]
+    Json,
+    /// Qwen-style XML: `<parameter=name>value</parameter>`.
+    QwenXml,
+    /// MiniMax-style XML: `<parameter name="name">value</parameter>`.
+    MinimaxXml,
+    /// DeepSeek DSML XML parameter format.
+    DeepseekXml,
+}
+
+/// `json_schema` content format.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonSchemaFormat {
+    /// Full schema object, or `true` for unconstrained JSON.
+    pub json_schema: Value,
+
+    /// Output style for generated arguments.
+    pub style: JsonSchemaStyle,
+}
+
+/// `any_tokens` format: match zero or more tokens, excluding specific ones.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnyTokensFormat {
+    pub exclude_tokens: Vec<String>,
+}
+
+/// `any_text` format: match zero or more tokens, excluding arbitrary text.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnyTextFormat {
+    pub excludes: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn structural_tag_serializes_correctly() {
+        let tag = StructuralTag {
+            format: Format::Tag(TagFormat {
+                begin: "<think>".to_string(),
+                content: Box::new(Format::AnyTokens(AnyTokensFormat {
+                    exclude_tokens: vec!["<eos>".to_string()],
+                })),
+                end: "</think>".to_string(),
+            }),
+        };
+
+        let value = serde_json::to_value(&tag).unwrap();
+        assert_eq!(value["type"], "structural_tag");
+        assert_eq!(value["format"]["type"], "tag");
+        assert_eq!(value["format"]["begin"], "<think>");
+        assert_eq!(value["format"]["content"]["type"], "any_tokens");
+    }
+
+    #[test]
+    fn any_text_serializes_correctly() {
+        let format = Format::AnyText(AnyTextFormat {
+            excludes: vec!["<tool_call>\n<function=".to_string()],
+        });
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["type"], "any_text");
+        assert_eq!(value["excludes"][0], "<tool_call>\n<function=");
+    }
+
+    #[test]
+    fn sequence_serializes_correctly() {
+        let format = Format::Sequence(SequenceFormat {
+            elements: vec![Format::AnyText(AnyTextFormat { excludes: vec![] })],
+        });
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["type"], "sequence");
+        assert_eq!(value["elements"][0]["type"], "any_text");
+    }
+
+    #[test]
+    fn triggered_tags_serializes_at_least_one_when_false() {
+        let format = TriggeredTagsFormat {
+            triggers: vec!["<fn=".to_string()],
+            tags: vec![],
+            at_least_one: false,
+            stop_after_first: false,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["at_least_one"], false);
+    }
+
+    #[test]
+    fn triggered_tags_includes_at_least_one_when_true() {
+        let format = TriggeredTagsFormat {
+            triggers: vec!["<fn=".to_string()],
+            tags: vec![],
+            at_least_one: true,
+            stop_after_first: false,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["at_least_one"], true);
+    }
+
+    #[test]
+    fn json_schema_serializes_default_style() {
+        let format = JsonSchemaFormat {
+            json_schema: json!(true),
+            style: JsonSchemaStyle::Json,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["style"], "json");
+    }
+
+    #[test]
+    fn json_schema_serializes_non_default_style() {
+        let format = JsonSchemaFormat {
+            json_schema: json!(true),
+            style: JsonSchemaStyle::QwenXml,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["style"], "qwen_xml");
+    }
+}

--- a/parsers/src/tool_calling/structural_tag/mod.rs
+++ b/parsers/src/tool_calling/structural_tag/mod.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural tag builder for guided decoding with tool calls.
+//!
+//! Parsers with a [`StructuralTagBuilder`] can generate xgrammar structural
+//! tags that constrain guided decoding to a model-specific tool-call format.
+//!
+//! # Module layout
+//!
+//! - [`format`] — typed representations of xgrammar format nodes
+//! - [`builder`] — public builder API used by the preprocessor
+//! - [`triggered_tags`] — `triggered_tags` format implementation
+//! - [`dsml`] — DeepSeek V3.2+ DSML tool-call format implementation
+
+pub mod builder;
+pub mod dsml;
+pub mod format;
+pub mod triggered_tags;
+
+/// Placeholder in structural tag templates that is replaced with the tool
+/// function name at request time.
+pub const TOOL_NAME_PLACEHOLDER: &str = "{name}";
+
+pub use builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext};
+pub use dsml::DsmlToolCallsConfig;
+pub use triggered_tags::TriggeredTagsConfig;
+
+#[cfg(test)]
+mod tests;

--- a/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/parsers/src/tool_calling/structural_tag/tests.rs
@@ -1,0 +1,590 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::{Value, json};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext};
+use super::dsml::DsmlToolCallsConfig;
+use super::format::JsonSchemaStyle;
+use super::triggered_tags::TriggeredTagsConfig;
+use crate::tool_calling::{ToolCallConfig, ToolChoice, ToolDefinition};
+
+fn sample_config() -> TriggeredTagsConfig {
+    TriggeredTagsConfig {
+        begin_template: format!("<function={}>", TOOL_NAME_PLACEHOLDER),
+        end_template: "</function>".to_string(),
+        triggers: vec!["<function=".to_string()],
+        content_style: JsonSchemaStyle::Json,
+        tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+        reasoning_end: Some("</think>".to_string()),
+    }
+}
+
+fn sample_tools() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: "add_numbers".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            })),
+            strict: None,
+        },
+        ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            })),
+            strict: None,
+        },
+    ]
+}
+
+fn builder() -> StructuralTagBuilder {
+    StructuralTagBuilder::TriggeredTags(sample_config())
+}
+
+fn ctx<'a>(
+    tool_choice: &'a ToolChoice,
+    tools: &'a [ToolDefinition],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> ToolCallFormatBuildContext<'a> {
+    ToolCallFormatBuildContext {
+        tool_choice,
+        tools,
+        parallel_tool_calls,
+        schema_mode,
+        starts_in_reasoning: false,
+    }
+}
+
+fn ctx_starting_in_reasoning<'a>(
+    tool_choice: &'a ToolChoice,
+    tools: &'a [ToolDefinition],
+) -> ToolCallFormatBuildContext<'a> {
+    ToolCallFormatBuildContext {
+        tool_choice,
+        tools,
+        parallel_tool_calls: None,
+        schema_mode: StructuralTagSchemaMode::Auto,
+        starts_in_reasoning: true,
+    }
+}
+
+/// Helper: build and unwrap both Result and Option layers.
+fn build_unwrap(
+    builder: &StructuralTagBuilder,
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> Value {
+    let c = ctx(tool_choice, tools, parallel_tool_calls, schema_mode);
+    builder
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some")
+}
+
+#[test]
+fn required_builds_all_tools_with_at_least_one() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["type"], "structural_tag");
+    assert_eq!(parsed["format"]["type"], "triggered_tags");
+    assert_eq!(parsed["format"]["at_least_one"], true);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 2);
+    // Each tag element must have "type": "tag" per xgrammar spec.
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[0]["begin"], "<function=add_numbers>");
+    assert_eq!(tags[1]["type"], "tag");
+    assert_eq!(tags[1]["begin"], "<function=get_weather>");
+    assert_eq!(tags[0]["end"], "</function>");
+}
+
+#[test]
+fn auto_builds_all_tools_without_at_least_one() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Auto,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], false);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 2);
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[1]["type"], "tag");
+}
+
+#[test]
+fn named_builds_single_tool() {
+    let tools = sample_tools();
+    let named = ToolChoice::Named("get_weather".to_string());
+    let parsed = build_unwrap(
+        &builder(),
+        &named,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], true);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[0]["begin"], "<function=get_weather>");
+}
+
+#[test]
+fn named_unknown_tool_returns_error() {
+    let tools = sample_tools();
+    let named = ToolChoice::Named("nonexistent".to_string());
+    let c = ctx(&named, &tools, None, StructuralTagSchemaMode::Auto);
+    let err = builder()
+        .build_tool_call_format(&c)
+        .expect_err("should error for unknown tool");
+    assert!(
+        err.to_string().contains("nonexistent"),
+        "error should mention the missing tool name: {err}"
+    );
+}
+
+#[test]
+fn required_with_empty_tools_returns_error() {
+    let c = ctx(
+        &ToolChoice::Required,
+        &[],
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let err = builder()
+        .build_tool_call_format(&c)
+        .expect_err("should error for empty tools");
+    assert!(
+        err.to_string().contains("empty"),
+        "error should mention empty tools: {err}"
+    );
+}
+
+#[test]
+fn none_returns_ok_none() {
+    let tools = sample_tools();
+    let c = ctx(
+        &ToolChoice::None,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let result = builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn auto_with_empty_tools_returns_ok_none() {
+    let c = ctx(&ToolChoice::Auto, &[], None, StructuralTagSchemaMode::Auto);
+    let result = builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn parallel_false_sets_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        Some(false),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], true);
+}
+
+#[test]
+fn parallel_true_does_not_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        Some(true),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], false);
+}
+
+#[test]
+fn non_strict_tools_get_unconstrained_schema() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags[0]["content"]["json_schema"], json!(true));
+}
+
+#[test]
+fn strict_tool_uses_own_schema() {
+    let mut tools = sample_tools();
+    tools[0].strict = Some(true);
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert!(tags[0]["content"]["json_schema"]["properties"]["a"].is_object());
+    assert_eq!(tags[1]["content"]["json_schema"], json!(true));
+}
+
+#[test]
+fn strict_schema_mode_uses_real_schema_for_all() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Strict,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert!(tags[0]["content"]["json_schema"]["properties"]["a"].is_object());
+    assert!(tags[1]["content"]["json_schema"]["properties"]["location"].is_object());
+}
+
+#[test]
+fn tool_call_ban_tag_bans_tokens() {
+    let result = builder()
+        .build_tool_call_ban()
+        .expect("should serialize")
+        .expect("should build");
+
+    assert_eq!(result["type"], "structural_tag");
+    assert_eq!(result["format"]["type"], "tag");
+    assert_eq!(result["format"]["content"]["type"], "any_tokens");
+    assert_eq!(
+        result["format"]["content"]["exclude_tokens"][0],
+        "<tool_call>"
+    );
+}
+
+#[test]
+fn tool_call_ban_empty_tokens_returns_none() {
+    let mut config = sample_config();
+    config.tool_call_ban_tokens = vec![];
+    let b = StructuralTagBuilder::TriggeredTags(config);
+    assert!(b.build_tool_call_ban().expect("should serialize").is_none());
+}
+
+#[test]
+fn required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ToolChoice::Required, &tools);
+
+    let parsed = builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "sequence");
+    assert_eq!(parsed["format"]["elements"][0]["type"], "tag");
+    assert_eq!(parsed["format"]["elements"][0]["begin"], "");
+    assert_eq!(
+        parsed["format"]["elements"][0]["content"]["type"],
+        "any_text"
+    );
+    assert_eq!(parsed["format"]["elements"][0]["end"], "</think>");
+    assert_eq!(parsed["format"]["elements"][1]["type"], "triggered_tags");
+}
+
+#[test]
+fn auto_starting_in_reasoning_keeps_plain_tool_call_format() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ToolChoice::Auto, &tools);
+
+    let parsed = builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "triggered_tags");
+}
+
+// ---- DSML builder tests ----
+
+fn dsml_config() -> DsmlToolCallsConfig {
+    DsmlToolCallsConfig {
+        trigger: "<｜DSML｜function_calls>".to_string(),
+        block_begin: "<｜DSML｜function_calls>\n".to_string(),
+        block_end: "</｜DSML｜function_calls>".to_string(),
+        invoke_begin_template: format!("<｜DSML｜invoke name=\"{}\">\n", TOOL_NAME_PLACEHOLDER),
+        invoke_end: "</｜DSML｜invoke>\n".to_string(),
+        separator: "".to_string(),
+        tool_call_ban_tokens: vec![],
+        reasoning_end: Some("</think>".to_string()),
+    }
+}
+
+fn dsml_builder() -> StructuralTagBuilder {
+    StructuralTagBuilder::DsmlToolCalls(dsml_config())
+}
+
+fn dsml_build_unwrap(
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> Value {
+    let c = ctx(tool_choice, tools, parallel_tool_calls, schema_mode);
+    dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some")
+}
+
+#[test]
+fn dsml_required_builds_nested_structure() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    // Top level: structural_tag
+    assert_eq!(parsed["type"], "structural_tag");
+
+    // Outer: triggered_tags with one block tag
+    let fmt = &parsed["format"];
+    assert_eq!(fmt["type"], "triggered_tags");
+    assert_eq!(fmt["triggers"][0], "<｜DSML｜function_calls>");
+    assert_eq!(fmt["at_least_one"], true);
+    assert_eq!(fmt["stop_after_first"], false);
+    assert!(fmt.get("excludes").is_none());
+
+    let outer_tags = fmt["tags"].as_array().unwrap();
+    assert_eq!(outer_tags.len(), 1);
+
+    // Block tag wrapping the invokes
+    let block = &outer_tags[0];
+    assert_eq!(block["type"], "tag");
+    assert_eq!(block["begin"], "<｜DSML｜function_calls>\n");
+    assert_eq!(block["end"], "</｜DSML｜function_calls>");
+
+    // Inner: tags_with_separator
+    let inner = &block["content"];
+    assert_eq!(inner["type"], "tags_with_separator");
+    assert_eq!(inner["separator"], "");
+    assert_eq!(inner["at_least_one"], true);
+    assert_eq!(inner["stop_after_first"], false);
+
+    // Per-tool invoke tags
+    let invoke_tags = inner["tags"].as_array().unwrap();
+    assert_eq!(invoke_tags.len(), 2);
+    assert_eq!(invoke_tags[0]["type"], "tag");
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"add_numbers\">\n"
+    );
+    assert_eq!(invoke_tags[0]["end"], "</｜DSML｜invoke>\n");
+    assert_eq!(invoke_tags[0]["content"]["type"], "json_schema");
+    assert_eq!(invoke_tags[0]["content"]["style"], "deepseek_xml");
+
+    assert_eq!(
+        invoke_tags[1]["begin"],
+        "<｜DSML｜invoke name=\"get_weather\">\n"
+    );
+}
+
+#[test]
+fn dsml_auto_sets_inner_at_least_one() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ToolChoice::Auto,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], false);
+    assert_eq!(parsed["format"]["stop_after_first"], false);
+    let inner = &parsed["format"]["tags"][0]["content"];
+    assert_eq!(inner["at_least_one"], true);
+}
+
+#[test]
+fn dsml_named_builds_single_invoke() {
+    let tools = sample_tools();
+    let named = ToolChoice::Named("get_weather".to_string());
+    let parsed = dsml_build_unwrap(&named, &tools, None, StructuralTagSchemaMode::Auto);
+
+    let invoke_tags = parsed["format"]["tags"][0]["content"]["tags"]
+        .as_array()
+        .unwrap();
+    assert_eq!(invoke_tags.len(), 1);
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"get_weather\">\n"
+    );
+}
+
+#[test]
+fn dsml_parallel_false_sets_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ToolChoice::Required,
+        &tools,
+        Some(false),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], true);
+    let inner = &parsed["format"]["tags"][0]["content"];
+    assert_eq!(inner["stop_after_first"], true);
+}
+
+#[test]
+fn dsml_none_returns_ok_none() {
+    let tools = sample_tools();
+    let c = ctx(
+        &ToolChoice::None,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let result = dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn dsml_required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ToolChoice::Required, &tools);
+
+    let parsed = dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "sequence");
+    assert_eq!(parsed["format"]["elements"][0]["end"], "</think>");
+    assert_eq!(parsed["format"]["elements"][1]["type"], "triggered_tags");
+    assert_eq!(
+        parsed["format"]["elements"][1]["triggers"][0],
+        "<｜DSML｜function_calls>"
+    );
+}
+
+#[test]
+fn deepseek_v4_config_builds_tool_calls_block() {
+    let tools = sample_tools();
+    let config = ToolCallConfig::deepseek_v4();
+    let builder = config
+        .structural_tag_builder
+        .as_ref()
+        .expect("deepseek_v4 should provide a structural tag builder");
+    let c = ctx(
+        &ToolChoice::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let parsed = builder
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    let fmt = &parsed["format"];
+    assert_eq!(fmt["type"], "triggered_tags");
+    assert_eq!(fmt["triggers"][0], "<｜DSML｜tool_calls>");
+    assert_eq!(fmt["at_least_one"], true);
+    assert!(fmt.get("excludes").is_none());
+
+    let block = &fmt["tags"][0];
+    assert_eq!(block["type"], "tag");
+    assert_eq!(block["begin"], "<｜DSML｜tool_calls>\n");
+    assert_eq!(block["end"], "</｜DSML｜tool_calls>");
+
+    let inner = &block["content"];
+    assert_eq!(inner["type"], "tags_with_separator");
+    assert_eq!(inner["at_least_one"], true);
+    assert_eq!(inner["separator"], "");
+
+    let invoke_tags = inner["tags"].as_array().unwrap();
+    assert_eq!(invoke_tags.len(), 2);
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"add_numbers\">\n"
+    );
+    assert_eq!(invoke_tags[0]["end"], "</｜DSML｜invoke>\n");
+    assert_eq!(invoke_tags[0]["content"]["style"], "deepseek_xml");
+}
+
+/// Round-trip every supported parser through the real parser map.
+#[test]
+fn parser_map_structural_tag_smoke() {
+    let map = crate::tool_calling::parsers::get_tool_parser_map();
+    let tools = sample_tools();
+    let names = ["hermes", "qwen3_coder", "deepseek_v3_2", "deepseek_v4"];
+
+    for name in names {
+        let builder = map
+            .get(name)
+            .unwrap_or_else(|| panic!("'{name}' not in parser map"))
+            .structural_tag_builder
+            .as_ref()
+            .unwrap_or_else(|| panic!("'{name}' has no structural_tag_builder"));
+
+        let c = ctx(
+            &ToolChoice::Required,
+            &tools,
+            None,
+            StructuralTagSchemaMode::Auto,
+        );
+        let tag = builder
+            .build_tool_call_format(&c)
+            .unwrap_or_else(|e| panic!("'{name}' failed: {e}"))
+            .unwrap_or_else(|| panic!("'{name}' returned None for Required"));
+
+        assert_eq!(tag["type"], "structural_tag", "'{name}'");
+    }
+}

--- a/parsers/src/tool_calling/structural_tag/triggered_tags.rs
+++ b/parsers/src/tool_calling/structural_tag/triggered_tags.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`StructuralTagBuilder::TriggeredTags`] implementation.
+//!
+//! Builds xgrammar `triggered_tags` tool-call formats.
+
+use serde::{Deserialize, Serialize};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{ToolCallFormatBuildContext, resolve_tool_schema, resolve_tools_to_include};
+use super::format::{
+    Format, JsonSchemaFormat, JsonSchemaStyle, StructuralTag, TagFormat, TriggeredTagsFormat,
+};
+
+/// Configuration for `triggered_tags` formats where each tool is a tag.
+///
+/// The model can emit free text until a trigger is encountered, then guided
+/// decoding constrains the output to the matching tool call structure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TriggeredTagsConfig {
+    /// Begin tag template; [`TOOL_NAME_PLACEHOLDER`] is replaced per tool.
+    pub begin_template: String,
+
+    /// End tag appended after each tool call's content.
+    pub end_template: String,
+
+    /// Trigger patterns that signal the start of a tool call in the output.
+    pub triggers: Vec<String>,
+
+    /// Content style passed to xgrammar.
+    #[serde(default)]
+    pub content_style: JsonSchemaStyle,
+
+    /// Tokens to ban when `tool_choice="none"`.
+    #[serde(default)]
+    pub tool_call_ban_tokens: Vec<String>,
+
+    /// Closing tag for prompt-injected reasoning, if this parser supports it.
+    #[serde(default)]
+    pub reasoning_end: Option<String>,
+}
+
+/// Build a `triggered_tags` structural tag from config and request context.
+pub(crate) fn build_triggered_tags(
+    config: &TriggeredTagsConfig,
+    ctx: &ToolCallFormatBuildContext<'_>,
+) -> anyhow::Result<Option<StructuralTag>> {
+    let (tools_to_include, at_least_one) = resolve_tools_to_include(ctx)?;
+
+    if tools_to_include.is_empty() {
+        return Ok(None);
+    }
+
+    let strict_schema = ctx.strict_schema();
+
+    let tags: Vec<TagFormat> = tools_to_include
+        .iter()
+        .map(|tool| {
+            // function name validated by validate_tools() in the request handler
+            let begin = config
+                .begin_template
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.name);
+
+            TagFormat {
+                begin,
+                content: Box::new(Format::JsonSchema(JsonSchemaFormat {
+                    json_schema: resolve_tool_schema(tool, strict_schema),
+                    style: config.content_style,
+                })),
+                end: config.end_template.clone(),
+            }
+        })
+        .collect();
+
+    Ok(Some(StructuralTag {
+        format: Format::TriggeredTags(TriggeredTagsFormat {
+            triggers: config.triggers.clone(),
+            tags,
+            at_least_one,
+            stop_after_first: ctx.stop_after_first(),
+        }),
+    }))
+}

--- a/parsers/src/tool_calling/tools.rs
+++ b/parsers/src/tool_calling/tools.rs
@@ -2,11 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
-pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
+pub use super::parsers::{
+    detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery,
+    detect_and_parse_tool_call_with_stream_finalize_recovery,
+};
+pub use super::response::{
+    CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+};
 
 /// Try parsing a string as a structured tool call, for aggregation usage.
 ///
-/// If successful, returns a `ChatCompletionMessageToolCall`.
+/// If successful, returns the parser-native [`ToolCallResponse`] values.
+/// Consumers that need protocol/wire types map these locally.
 ///
 /// Streaming jail callers (`should_exit_jail_early`, mid-stream early-exit
 /// confirmation) MUST keep using this function — `allow_eof_recovery` stays
@@ -16,10 +23,7 @@ pub async fn try_tool_call_parse_aggregate(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     if parser_str.is_none() {
         tracing::debug!("No tool parser provided. Trying parsing with default parser.");
     } else {
@@ -29,70 +33,56 @@ pub async fn try_tool_call_parse_aggregate(
     if parsed.is_empty() {
         return Ok((vec![], content));
     }
-    Ok((
-        parsed
-            .into_iter()
-            .map(
-                |parsed| dynamo_protocols::types::ChatCompletionMessageToolCall {
-                    id: parsed.id,
-                    r#type: dynamo_protocols::types::FunctionType::Function,
-                    function: dynamo_protocols::types::FunctionCall {
-                        name: parsed.function.name,
-                        arguments: parsed.function.arguments,
-                    },
-                },
-            )
-            .collect(),
-        content,
-    ))
+    Ok((parsed, content))
 }
 
 /// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
-/// EOF recovery (missing outer end-token, truncated JSON args). Use this from
-/// stream-end / non-streaming aggregator paths only — never from streaming
-/// jail early-exit logic.
+/// the common EOF recovery paths (missing outer end-token, truncated JSON args).
+/// Use this from non-streaming aggregator paths — never from streaming jail
+/// early-exit logic. Stream-end jail finalization uses
+/// [`try_tool_call_parse_aggregate_stream_finalize`] so DSML can salvage
+/// completed invokes without changing batch/non-streaming behavior.
 pub async fn try_tool_call_parse_aggregate_finalize(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let (parsed, content) =
         detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }
-    Ok((
-        parsed
-            .into_iter()
-            .map(
-                |parsed| dynamo_protocols::types::ChatCompletionMessageToolCall {
-                    id: parsed.id,
-                    r#type: dynamo_protocols::types::FunctionType::Function,
-                    function: dynamo_protocols::types::FunctionCall {
-                        name: parsed.function.name,
-                        arguments: parsed.function.arguments,
-                    },
-                },
-            )
-            .collect(),
-        content,
-    ))
+    Ok((parsed, content))
+}
+
+/// Stream-end variant of [`try_tool_call_parse_aggregate_finalize`].
+///
+/// It keeps the normal finalize recovery for JSON/XML and additionally lets
+/// DSML recover complete invokes from an unterminated outer wrapper. This is
+/// intentionally not used by batch/non-streaming aggregate paths.
+pub async fn try_tool_call_parse_aggregate_stream_finalize(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let (parsed, content) =
+        detect_and_parse_tool_call_with_stream_finalize_recovery(message, parser_str, tools)
+            .await?;
+    if parsed.is_empty() {
+        return Ok((vec![], content));
+    }
+    Ok((parsed, content))
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.
 ///
-/// If successful, returns a `ChatCompletionMessageToolCallChunk`.
+/// If successful, returns parser-native [`ToolCallResponseChunk`] values.
+/// Consumers that need protocol/wire types map these locally.
 pub async fn try_tool_call_parse_stream(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCallChunk>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponseChunk>, Option<String>)> {
     let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
@@ -101,19 +91,157 @@ pub async fn try_tool_call_parse_stream(
         parsed
             .into_iter()
             .enumerate()
-            .map(
-                |(idx, parsed)| dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
-                    index: idx as u32,
-                    id: Some(parsed.id),
-                    r#type: Some(dynamo_protocols::types::FunctionType::Function),
-                    function: Some(dynamo_protocols::types::FunctionCallStream {
-                        name: Some(parsed.function.name),
-                        arguments: Some(parsed.function.arguments),
-                    }),
-                    // Add other fields as needed if required by the struct definition
-                },
-            )
+            .map(|(idx, parsed)| ToolCallResponseChunk {
+                index: idx as u32,
+                id: Some(parsed.id),
+                tp: Some(ToolCallType::Function),
+                function: Some(CalledFunctionStream {
+                    name: Some(parsed.function.name),
+                    arguments: Some(parsed.function.arguments),
+                }),
+            })
             .collect(),
         content,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Hermes-style single tool call.
+    const SINGLE: &str = r#"<tool_call>{"name":"get_weather","arguments":{"location":"San Francisco, CA","unit":"celsius"}}</tool_call>"#;
+
+    // Two parallel hermes-style tool calls.
+    const PARALLEL: &str = r#"<tool_call>{"name":"a","arguments":{"k":"v1"}}</tool_call>
+<tool_call>{"name":"b","arguments":{"k":"v2"}}</tool_call>"#;
+
+    // Tool call with empty arguments object.
+    const EMPTY_ARGS: &str = r#"<tool_call>{"name":"ping","arguments":{}}</tool_call>"#;
+
+    /// `try_tool_call_parse_aggregate` returns native `ToolCallResponse`
+    /// values with the parsed id/type/name/arguments.
+    #[tokio::test]
+    async fn aggregate_returns_native_tool_call_response() {
+        let (calls, _content): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(!calls[0].id.is_empty());
+        assert!(matches!(calls[0].tp, ToolCallType::Function));
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"location":"San Francisco, CA","unit":"celsius"}"#
+        );
+    }
+
+    /// Parallel calls preserve ordering and per-call argument byte spans.
+    #[tokio::test]
+    async fn aggregate_returns_native_for_parallel_calls() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(PARALLEL, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "a");
+        assert_eq!(calls[0].function.arguments, r#"{"k":"v1"}"#);
+        assert_eq!(calls[1].function.name, "b");
+        assert_eq!(calls[1].function.arguments, r#"{"k":"v2"}"#);
+    }
+
+    /// The finalize variant also returns native `ToolCallResponse`.
+    #[tokio::test]
+    async fn aggregate_finalize_returns_native_tool_call_response() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate_finalize(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"location":"San Francisco, CA","unit":"celsius"}"#
+        );
+    }
+
+    /// `try_tool_call_parse_stream` returns native `ToolCallResponseChunk`
+    /// values populating index/id/type and the nested `CalledFunctionStream`.
+    #[tokio::test]
+    async fn stream_returns_native_tool_call_response_chunk() {
+        let (chunks, _content): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk = &chunks[0];
+        assert_eq!(chunk.index, 0);
+        assert!(chunk.id.as_deref().is_some_and(|id| !id.is_empty()));
+        assert!(matches!(chunk.tp, Some(ToolCallType::Function)));
+        let func = chunk.function.as_ref().expect("function present");
+        assert_eq!(func.name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            func.arguments.as_deref(),
+            Some(r#"{"location":"San Francisco, CA","unit":"celsius"}"#)
+        );
+    }
+
+    /// Streaming chunks are indexed sequentially for parallel calls.
+    #[tokio::test]
+    async fn stream_indexes_parallel_calls_sequentially() {
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(PARALLEL, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].index, 0);
+        assert_eq!(chunks[1].index, 1);
+        assert_eq!(
+            chunks[0].function.as_ref().unwrap().name.as_deref(),
+            Some("a")
+        );
+        assert_eq!(
+            chunks[1].function.as_ref().unwrap().name.as_deref(),
+            Some("b")
+        );
+    }
+
+    /// Empty arguments objects survive as `{}` through both entrypoints.
+    #[tokio::test]
+    async fn empty_arguments_preserved() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(EMPTY_ARGS, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "ping");
+        assert_eq!(calls[0].function.arguments, "{}");
+
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(EMPTY_ARGS, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(
+            chunks[0].function.as_ref().unwrap().arguments.as_deref(),
+            Some("{}")
+        );
+    }
+
+    /// No tool call -> empty result, content passed through.
+    #[tokio::test]
+    async fn no_tool_call_returns_empty() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate("just some prose", Some("hermes"), None)
+                .await
+                .unwrap();
+        assert!(calls.is_empty());
+
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream("just some prose", Some("hermes"), None)
+                .await
+                .unwrap();
+        assert!(chunks.is_empty());
+    }
 }

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -423,8 +423,8 @@ mod tests {
         assert!(!detect_tool_call_start_glm47("Just normal text", &config));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1
     fn test_parse_simple_tool_call() {
         let config = get_test_config();
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>San Francisco</arg_value></tool_call>";
@@ -443,8 +443,8 @@ mod tests {
         assert_eq!(normal_text, Some("".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1, TOOLCALLING.batch.7
     fn test_parse_tool_call_with_multiple_args() {
         let config = get_test_config();
         let message = "<tool_call>book_flight<arg_key>from</arg_key><arg_value>NYC</arg_value><arg_key>to</arg_key><arg_value>LAX</arg_value><arg_key>date</arg_key><arg_value>2026-03-15</arg_value></tool_call>";
@@ -461,8 +461,8 @@ mod tests {
         assert_eq!(args.get("date").unwrap().as_str().unwrap(), "2026-03-15");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_tool_call_with_json_value() {
         let config = get_test_config();
         let message = r#"<tool_call>search<arg_key>filters</arg_key><arg_value>{"category": "books", "price_max": 50}</arg_value></tool_call>"#;
@@ -478,8 +478,8 @@ mod tests {
         assert!(filters.is_object());
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = get_test_config();
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>";
@@ -491,8 +491,8 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_with_normal_text() {
         let config = get_test_config();
         let message = "I'll check the weather for you. <tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call>";
@@ -507,8 +507,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6
     fn test_parse_tool_call_no_args() {
         let config = get_test_config();
         let message = "<tool_call>get_current_time</tool_call>";
@@ -575,8 +575,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.2 + PARSER.batch.8 — bug report repro: text + parallel calls
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.c, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.2 + TOOLCALLING.batch.8 — bug report repro: text + parallel calls
     fn test_parse_text_then_parallel_calls() {
         let config = get_test_config();
         let message = "I'll check the weather for both cities at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>San Francisco</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value></tool_call>";
@@ -604,8 +604,8 @@ mod tests {
         );
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7, PARSER.fmt.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7, TOOLCALLING.fmt.2
     fn test_parse_multiline_arg_value() {
         let config = get_test_config();
         let message = "<tool_call>write_file<arg_key>path</arg_key><arg_value>/tmp/hello.py</arg_value><arg_key>content</arg_key><arg_value>#!/usr/bin/env python3\nprint(\"Hello, World!\")\n</arg_value></tool_call>";
@@ -626,8 +626,8 @@ mod tests {
         assert!(content.contains("print(\"Hello, World!\")"));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_malformed_tool_call() {
         let config = get_test_config();
 
@@ -644,8 +644,8 @@ mod tests {
     // when the inner arg pairs are well-formed, treat EOF as the end token
     // and extract the call. The arg_key opener gates recovery so plain text
     // that happens to start with `<tool_call>` is still preserved verbatim.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5
     fn test_parse_no_end_tag_complete_args_recovers() {
         let config = Glm47ParserConfig {
             allow_eof_recovery: true,
@@ -661,8 +661,8 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b, TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5
     fn test_parse_no_end_tag_multiple_calls_recovers() {
         let config = Glm47ParserConfig {
             allow_eof_recovery: true,
@@ -677,13 +677,14 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c, PARSER.batch.13 in tests/parity/parser/fixtures/glm47/PARSER.batch.13.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.4, PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.c, TOOLCALLING.batch.13 in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.13.yaml, tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.batch.8
     fn test_unparseable_block_dropped_no_tag_leak() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
+            strict: None,
         }];
 
         // Tool call block references a function not in the tools list — the
@@ -739,6 +740,7 @@ mod tests {
                     "label": {"type": "string"}
                 }
             })),
+            strict: None,
         }];
 
         let message = "<tool_call>set_temperature<arg_key>degrees</arg_key><arg_value>72.5</arg_value><arg_key>enabled</arg_key><arg_value>true</arg_value><arg_key>count</arg_key><arg_value>3</arg_value><arg_key>label</arg_key><arg_value>warm</arg_value></tool_call>";
@@ -770,6 +772,7 @@ mod tests {
                     "tags": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
 
         // Model emits comma-separated values without JSON brackets
@@ -796,6 +799,7 @@ mod tests {
                     "ids": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
 
         // Model emits proper JSON array
@@ -820,6 +824,7 @@ mod tests {
                     "count": {"type": "integer"}
                 }
             })),
+            strict: None,
         }];
 
         // "not_a_number" can't be parsed as integer — should fall back to string
@@ -848,11 +853,11 @@ mod tests {
         assert_eq!(calls.len(), 1);
     }
 
-    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9
     fn test_parse_glm47_empty_and_whitespace_inputs() {
         let config = get_test_config();
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -871,11 +876,11 @@ mod tests {
         }
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice in one section).
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; pin parser-level behavior —
     /// both calls returned with distinct ids.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
-    #[test] // PARSER.batch.10
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.10
     fn test_parse_glm47_duplicate_calls_same_name() {
         let config = get_test_config();
         let input = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>";

--- a/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -153,7 +153,7 @@ fn find_section_end(
 }
 
 /// True for prefix-only narration before a tool section where vLLM preserves
-/// the wrapper-adjacent trailing space (PARSER.batch.8.a).
+/// the wrapper-adjacent trailing space (TOOLCALLING.batch.8.a).
 fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[&str]) -> bool {
     let mut non_empty_parts = normal_parts
         .iter()
@@ -168,7 +168,7 @@ fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[&str]) -> bool {
 
 /// True when the first visible normal text appears only after a parsed tool
 /// section, so the intermediate Kimi tool-call turn should expose no content
-/// (PARSER.batch.8.b).
+/// (TOOLCALLING.batch.8.b).
 fn should_drop_post_tool_text_without_prefix(normal_parts: &[&str]) -> bool {
     normal_parts
         .iter()
@@ -179,7 +179,7 @@ fn should_drop_post_tool_text_without_prefix(normal_parts: &[&str]) -> bool {
 
 /// True when there is prefix narration before the first tool section plus
 /// post-wrapper or inter-wrapper narration that should be dropped for Kimi
-/// tool-call turns (PARSER.batch.2.c, 8.c, 8.d).
+/// tool-call turns (TOOLCALLING.batch.2.c, 8.c, 8.d).
 fn should_drop_post_tool_text_after_prefix(normal_parts: &[&str]) -> bool {
     normal_parts
         .first()
@@ -409,8 +409,8 @@ mod tests {
         assert_eq!(pos, None, "should return None when section_end is missing");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1
     fn test_parse_simple_tool_call() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -424,8 +424,8 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1, TOOLCALLING.batch.7
     fn test_parse_multiple_args() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"San Francisco, CA","unit":"fahrenheit"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -439,8 +439,8 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -457,8 +457,8 @@ mod tests {
         assert_eq!(args1["timezone"], "EST");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8.c
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.c in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8.c
     fn test_parse_keeps_prefix_drops_post_tool_text() {
         let config = default_config();
         let input = r#"I'll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
@@ -469,7 +469,7 @@ mod tests {
         assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
-    #[test] // PARSER.batch.8.a
+    #[test] // TOOLCALLING.batch.8.a
     fn test_parse_preserves_vllm_prefix_trailing_space() {
         let config = default_config();
         let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -480,7 +480,7 @@ mod tests {
         assert_eq!(normal, Some("I'll check the weather. ".to_string()));
     }
 
-    #[test] // PARSER.batch.8.a
+    #[test] // TOOLCALLING.batch.8.a
     fn test_parse_prefix_only_ignores_post_wrapper_whitespace() {
         let config = default_config();
         let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>   "#;
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(normal, Some("I'll check the weather. ".to_string()));
     }
 
-    #[test] // PARSER.batch.2.c
+    #[test] // TOOLCALLING.batch.2.c
     fn test_parse_parallel_calls_with_surrounding_text() {
         let config = default_config();
         let input = r#"I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|> Done."#;
@@ -503,7 +503,7 @@ mod tests {
         assert_eq!(normal, Some("I will check both. ".to_string()));
     }
 
-    #[test] // PARSER.batch.8.d
+    #[test] // TOOLCALLING.batch.8.d
     fn test_parse_multiple_sections_drops_inter_wrapper_text() {
         let config = default_config();
         let input = r#"First check Dallas. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Then check NYC. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -515,7 +515,7 @@ mod tests {
         assert_eq!(normal, Some("First check Dallas. ".to_string()));
     }
 
-    #[test] // PARSER.batch.8.b
+    #[test] // TOOLCALLING.batch.8.b
     fn test_parse_drops_post_tool_text_without_prefix() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
@@ -526,8 +526,8 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6
     fn test_parse_no_arg_call() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_current_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -540,7 +540,7 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
-    #[test] // PARSER.batch.3
+    #[test] // TOOLCALLING.batch.3
     fn test_parse_no_tool_calls() {
         let config = default_config();
         let input = "This is just normal text without any tool calls.";
@@ -550,7 +550,7 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    #[test] // PARSER.fmt.1 — function-name conventions (`functions.X` vs bare `X`)
+    #[test] // TOOLCALLING.fmt.1 — function-name conventions (`functions.X` vs bare `X`)
     fn test_parse_without_functions_prefix() {
         let config = default_config();
         // Some models may emit without the "functions." prefix
@@ -561,8 +561,8 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1 (with declared `ToolDefinition` tools provided)
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1 (with declared `ToolDefinition` tools provided)
     fn test_parse_with_tool_validation() {
         let config = default_config();
         let tools = vec![ToolDefinition {
@@ -573,6 +573,7 @@ mod tests {
                     "location": {"type": "string"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -589,8 +590,8 @@ mod tests {
     // `serde_json::from_str` falls back to raw-string arguments when the
     // payload doesn't parse, matching the behavior of the existing
     // `test_parse_invalid_json_falls_back_to_raw_string` case.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_truncated_json_inside_complete_fences_recovers() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -602,8 +603,8 @@ mod tests {
         assert_eq!(calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5 (PR #8208)
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5 (PR #8208)
     fn test_parse_malformed_no_section_end() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>"#;
@@ -620,8 +621,8 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.4, PARSER.batch.5
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b, TOOLCALLING.batch.5.c in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.4, TOOLCALLING.batch.5
     fn test_parse_truncated_mid_argument_no_section_end() {
         let config = default_config();
         // Model hit max_tokens mid-argument — no call_end, no section_end.
@@ -640,8 +641,8 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.5
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a, TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.5
     fn test_parse_multiple_calls_no_section_end() {
         let config = default_config();
         // Two complete individual tool calls, but model stopped before section_end.
@@ -657,8 +658,8 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.4, PARSER.batch.5
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b, TOOLCALLING.batch.4.b, TOOLCALLING.batch.5.c in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.4, TOOLCALLING.batch.5
     fn test_parse_complete_plus_truncated_no_section_end() {
         let config = default_config();
         // First call is complete, second is truncated mid-argument.
@@ -673,7 +674,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    #[test] // PARSER.fmt.2 — whitespace tolerance
+    #[test] // TOOLCALLING.fmt.2 — whitespace tolerance
     fn test_parse_with_whitespace() {
         let config = default_config();
         let input = "<|tool_calls_section_begin|>\n<|tool_call_begin|> functions.search:0 <|tool_call_argument_begin|> {\"query\":\"rust programming\"} <|tool_call_end|>\n<|tool_calls_section_end|>";
@@ -686,8 +687,8 @@ mod tests {
         assert_eq!(args["query"], "rust programming");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_complex_json_arguments() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -701,8 +702,8 @@ mod tests {
         assert_eq!(args["config"]["nested"], true);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.a, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.7
     fn test_parse_deeply_nested_json_multiple_calls() {
         let config = default_config();
         // Multiple tool calls with deeply nested JSON - stress test for regex backtracking
@@ -729,7 +730,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // helper, PARSER.fmt.3 — detection helper, singular section-token variant
+    #[test] // helper, TOOLCALLING.fmt.3 — detection helper, singular section-token variant
     fn test_detect_singular_section_start() {
         let config = default_config();
         // Singular variant: <|tool_call_section_begin|> (without 's')
@@ -744,7 +745,7 @@ mod tests {
         ));
     }
 
-    #[test] // PARSER.fmt.3 — singular section-token variant
+    #[test] // TOOLCALLING.fmt.3 — singular section-token variant
     fn test_parse_with_singular_section_tokens() {
         let config = default_config();
         // Use singular form: tool_call_section_begin/end (without 's')
@@ -756,7 +757,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // helper, PARSER.fmt.3 — detection helper, singular section-token variant
+    #[test] // helper, TOOLCALLING.fmt.3 — detection helper, singular section-token variant
     fn test_find_end_position_singular_variant() {
         let config = default_config();
         // Singular variant end token
@@ -767,8 +768,8 @@ mod tests {
 
     // --- Tests inspired by vllm/sglang coverage gaps ---
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_invalid_json_falls_back_to_raw_string() {
         // vllm: test_extract_tool_calls_invalid_json
         // Invalid JSON in arguments should fall back to raw string, not panic
@@ -782,7 +783,7 @@ mod tests {
         assert_eq!(calls[0].function.arguments, "{invalid json here}");
     }
 
-    #[test] // PARSER.fmt.1 — function-name conventions (ID regex validation)
+    #[test] // TOOLCALLING.fmt.1 — function-name conventions (ID regex validation)
     fn test_parse_invalid_function_id_rejected_by_regex() {
         // vllm: test_extract_tool_calls_invalid_funcall
         // sglang: test_invalid_tool_call
@@ -811,8 +812,8 @@ mod tests {
         assert_eq!(calls[0].function.name, "valid");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — special characters in arg values
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — special characters in arg values
     fn test_parse_angle_brackets_in_json_arguments() {
         // vllm: angle_brackets_in_json
         // JSON values containing <tag> constructs should not confuse the parser,
@@ -830,8 +831,8 @@ mod tests {
         assert_eq!(args["format"], "html");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2 — parallel calls, zero-spacing edge case
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2 — parallel calls, zero-spacing edge case
     fn test_parse_three_concatenated_calls_no_spacing() {
         // vllm: concatenated_tool_calls_bug_fix, three_concatenated_tool_calls
         // Three tool calls concatenated with zero whitespace between them
@@ -860,8 +861,8 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7 — newlines in arg values
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7 — newlines in arg values
     fn test_parse_newlines_in_json_arguments() {
         // vllm: newlines_in_json
         // Multi-line formatted JSON arguments (model may emit pretty-printed JSON)
@@ -878,7 +879,7 @@ mod tests {
         assert_eq!(args["tags"], serde_json::json!(["admin", "active"]));
     }
 
-    #[test] // PARSER.fmt.4 — empty wrapper (start+end with no calls between)
+    #[test] // TOOLCALLING.fmt.4 — empty wrapper (start+end with no calls between)
     fn test_parse_empty_tool_section() {
         // vllm: test_empty_tool_section
         // Section begin immediately followed by section end, no tool calls inside
@@ -894,7 +895,7 @@ mod tests {
         );
     }
 
-    #[rstest] // PARSER.fmt.1 — function-name conventions (hyphens, double-underscores)
+    #[rstest] // TOOLCALLING.fmt.1 — function-name conventions (hyphens, double-underscores)
     #[case(
         r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.list-tasklists:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>"#,
         "list-tasklists",
@@ -918,17 +919,17 @@ mod tests {
         assert_eq!(calls[0].id, id);
     }
 
-    /// `PARSER.batch.4` — call missing its `<|tool_call_end|>` while the outer
+    /// `TOOLCALLING.batch.4` — call missing its `<|tool_call_end|>` while the outer
     /// `<|tool_calls_section_end|>` IS present. Per-call delimiter is the
     /// regex anchor; without it the call cannot be matched even though
     /// the block fences are intact. Pin the silent-drop.
     ///
-    /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: a real call is silently dropped when
+    /// TODO(TOOLCALLING.batch.4) — BUG, NEEDS FIX: a real call is silently dropped when
     /// `<|tool_call_end|>` is missing and section fences are complete. Fix:
     /// anchor on the next `<|tool_call_begin|>` or `<|tool_calls_section_end|>`
     /// to terminate the args region. Flip this test once fixed.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_missing_call_end_inside_complete_section_silent_drop() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_calls_section_end|>"#;
@@ -942,16 +943,16 @@ mod tests {
         );
     }
 
-    /// `PARSER.batch.4` — middle-call truncation. Three calls A, B, C inside a
+    /// `TOOLCALLING.batch.4` — middle-call truncation. Three calls A, B, C inside a
     /// complete section; B is missing its `<|tool_call_end|>`. Does B's
     /// body bleed into C, or are both lost? Pin whichever today does.
     ///
-    /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: B's args swallow all of C's raw
+    /// TODO(TOOLCALLING.batch.4) — BUG, NEEDS FIX: B's args swallow all of C's raw
     /// markup, and C is dropped — caller gets garbage args for B and
     /// never sees C. Fix: same anchor on `<|tool_call_begin|>` as the
     /// silent-drop case above. Flip this test once fixed.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.2, PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b, TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.2, TOOLCALLING.batch.4
     fn test_parse_middle_call_missing_end_corrupts_next() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.a:0<|tool_call_argument_begin|>{"x":"1"}<|tool_call_end|><|tool_call_begin|>functions.b:1<|tool_call_argument_begin|>{"y":"2"}<|tool_call_begin|>functions.c:2<|tool_call_argument_begin|>{"z":"3"}<|tool_call_end|><|tool_calls_section_end|>"#;
@@ -1004,11 +1005,11 @@ mod tests {
         assert_eq!(calls_stop.len(), 1);
     }
 
-    /// `PARSER.batch.9` — empty / null content variants. Empty section already
+    /// `TOOLCALLING.batch.9` — empty / null content variants. Empty section already
     /// covered by `test_parse_empty_tool_section`; this pins the
     /// truly-empty (zero bytes) and null-ish ("\n", whitespace-only) inputs.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9
     fn test_parse_empty_and_whitespace_inputs() {
         let config = default_config();
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -1027,10 +1028,10 @@ mod tests {
         }
     }
 
-    /// `PARSER.batch.10` — duplicate calls (same function name twice in one section).
+    /// `TOOLCALLING.batch.10` — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; first parser to land coverage.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.10
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.10
     fn test_parse_duplicate_calls_same_name() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>"#;

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -123,6 +123,11 @@ pub fn find_tool_call_end_position_xml(chunk: &str, config: &XmlParserConfig) ->
     loop {
         let rest = &chunk[cursor..];
         let trimmed = rest.trim_start();
+        if config.is_bare_function_mode(chunk) && trimmed.starts_with(end_token.as_str()) {
+            let trim_offset = rest.len() - trimmed.len();
+            cursor += trim_offset + end_token.len();
+            continue;
+        }
         if !trimmed.starts_with(start_token.as_str()) {
             break;
         }
@@ -754,7 +759,7 @@ mod tests {
     /// all be captured by find_tool_call_end_position_xml so that the jail passes the
     /// entire group to extract_tool_calls rather than emitting the second (and later)
     /// calls as raw trailing text.
-    #[test] // PARSER.batch.2, helper
+    #[test] // TOOLCALLING.batch.2, helper
     fn test_find_tool_call_end_position_parallel_calls() {
         let config = XmlParserConfig::default();
 
@@ -812,6 +817,7 @@ mod tests {
                     "precise_count": {"type": "number"}
                 }
             })),
+            strict: None,
         }];
 
         let (calls, normal) =
@@ -851,8 +857,8 @@ mod tests {
         assert_eq!(html_unescape(input), expected);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1
     fn test_parse_simple_tool_call() {
         let input = r#"<tool_call>
 <function=execute_bash>
@@ -872,8 +878,8 @@ pwd && ls
         assert_eq!(args["command"], "pwd && ls");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml, tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
-    #[test] // PARSER.batch.1, PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.1, TOOLCALLING.batch.7
     fn test_parse_multiple_parameters() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -899,8 +905,8 @@ fahrenheit
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml.
-    #[test] // PARSER.batch.8
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.c in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.8.yaml.
+    #[test] // TOOLCALLING.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"I'll help you with that. <tool_call>
 <function=get_weather>
@@ -917,8 +923,8 @@ Dallas
         assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml.
-    #[test] // PARSER.batch.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml.
+    #[test] // TOOLCALLING.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -946,8 +952,8 @@ Orlando
         assert_eq!(args1["city"], "Orlando");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml.
-    #[test] // PARSER.batch.7
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.7.yaml.
+    #[test] // TOOLCALLING.batch.7
     fn test_parse_json_parameter_value() {
         // With schema-aware parsing, we need to provide a schema to parse JSON objects
         let tools = vec![ToolDefinition {
@@ -958,6 +964,7 @@ Orlando
                     "config": {"type": "object"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -978,7 +985,7 @@ Orlando
         assert_eq!(args["config"]["count"], 42);
     }
 
-    #[test] // PARSER.batch.3
+    #[test] // TOOLCALLING.batch.3
     fn test_parse_no_tool_calls() {
         let input = "This is just normal text without any tool calls.";
         let (calls, normal) =
@@ -987,8 +994,8 @@ Orlando
         assert_eq!(normal, Some(input.to_string()));
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_malformed_tool_call() {
         let input = r#"<tool_call>
 <function=incomplete>
@@ -1001,8 +1008,8 @@ value
         assert!(result.is_ok());
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_missing_parameter_closing_tag() {
         let input = r#"<tool_call>
 <function=execute_bash>
@@ -1019,8 +1026,8 @@ ls -la
         assert_eq!(args["command"], "ls -la");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_missing_function_closing_tag() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -1037,8 +1044,8 @@ Boston
         assert_eq!(args["city"], "Boston");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_missing_both_closing_tags() {
         let input = r#"<tool_call>
 <function=run_query>
@@ -1055,8 +1062,8 @@ SELECT * FROM users
         assert_eq!(args["sql"], "SELECT * FROM users\n</tool_call>");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
-    #[test] // PARSER.batch.4
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml.
+    #[test] // TOOLCALLING.batch.4
     fn test_parse_multiple_parameters_missing_closing_tags() {
         let input = r#"<tool_call>
 <function=search>
@@ -1081,8 +1088,8 @@ rust programming
     // token and extract the call. Recovery is gated on a function-start
     // opener in the trailing slice so plain text that happens to start with
     // `<tool_call>` is preserved verbatim.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml.
-    #[test] // PARSER.batch.5 — qwen3_coder
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml.
+    #[test] // TOOLCALLING.batch.5 — qwen3_coder
     fn test_parse_qwen3_no_outer_close_recovers() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -1167,7 +1174,7 @@ NYC
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // PARSER.batch.5.a — minimax_m2 spec-strict
+    #[test] // TOOLCALLING.batch.5.a — minimax_m2 spec-strict
     fn test_parse_minimax_m2_no_outer_close_drops_call() {
         // MiniMax-M2's reference parser (huggingface.co/MiniMaxAI/MiniMax-M2)
         // requires both outer fences — missing `</minimax:tool_call>` means
@@ -1216,6 +1223,7 @@ NYC
                 },
                 "required": ["param1", "param2", "param3", "param4", "param5", "param6", "param7", "param8"]
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1279,6 +1287,7 @@ NYC
                     "bool_param": {"type": "boolean"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1332,6 +1341,7 @@ NYC
                     }
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1378,8 +1388,8 @@ NYC
         assert_eq!(args["param3"], "hello");
     }
 
-    /// Helper for the new corner-case tests below (PARSER.batch.6 / PIPELINE.finish_reason / PARSER.batch.9
-    /// / PARSER.batch.10) — matches the production `ToolCallConfig::minimax_m2()`
+    /// Helper for the new corner-case tests below (TOOLCALLING.batch.6 / PIPELINE.finish_reason / TOOLCALLING.batch.9
+    /// / TOOLCALLING.batch.10) — matches the production `ToolCallConfig::minimax_m2()`
     /// factory: strict-match per MiniMax's reference parser.
     fn minimax_m2_config() -> XmlParserConfig {
         XmlParserConfig {
@@ -1396,10 +1406,10 @@ NYC
         }
     }
 
-    /// PARSER.batch.6 — empty args. A no-arg call (no `<parameter=...>` block)
+    /// TOOLCALLING.batch.6 — empty args. A no-arg call (no `<parameter=...>` block)
     /// must still surface the function name with empty arguments.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6 — qwen3_coder
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6 — qwen3_coder
     fn test_parse_qwen3_empty_args() {
         let input = r#"<tool_call>
 <function=current_time>
@@ -1412,9 +1422,9 @@ NYC
         assert_eq!(args, serde_json::json!({}));
     }
 
-    /// PARSER.batch.6 — empty args, minimax_m2 format.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml.
-    #[test] // PARSER.batch.6 — minimax_m2
+    /// TOOLCALLING.batch.6 — empty args, minimax_m2 format.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.6.yaml.
+    #[test] // TOOLCALLING.batch.6 — minimax_m2
     fn test_parse_minimax_m2_empty_args() {
         let config = minimax_m2_config();
         let input =
@@ -1455,12 +1465,12 @@ NYC
         assert_eq!(calls.len(), 1);
     }
 
-    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string. Tested under both qwen3_coder and
     /// minimax_m2 configs.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9 — qwen3_coder
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9 — qwen3_coder
     fn test_parse_qwen3_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
             let (calls, normal) =
@@ -1479,8 +1489,8 @@ NYC
         }
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.9 — minimax_m2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.9 — minimax_m2
     fn test_parse_minimax_m2_empty_and_whitespace_inputs() {
         let config = minimax_m2_config();
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -1499,11 +1509,11 @@ NYC
         }
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice). qwen3_coder
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice). qwen3_coder
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
-    #[test] // PARSER.batch.10 — qwen3_coder
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.10 — qwen3_coder
     fn test_parse_qwen3_duplicate_calls_same_name() {
         let input = r#"<tool_call>
 <function=get_weather>
@@ -1531,11 +1541,11 @@ LA
         assert_eq!(args1["city"], "LA");
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice). minimax_m2
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice). minimax_m2
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
-    #[test] // PARSER.batch.10 — minimax_m2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.yaml.
+    #[test] // TOOLCALLING.batch.10 — minimax_m2
     fn test_parse_minimax_m2_duplicate_calls_same_name() {
         let config = minimax_m2_config();
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke><invoke name="get_weather"><parameter name="city">LA</parameter></invoke></minimax:tool_call>"#;

--- a/protocols/src/types/anthropic.rs
+++ b/protocols/src/types/anthropic.rs
@@ -214,6 +214,9 @@ pub struct AnthropicMessage {
 pub enum AnthropicRole {
     User,
     Assistant,
+    /// Compatibility for clients that place system instructions in `messages[]`
+    /// instead of the top-level `system` field.
+    System,
 }
 
 /// Message content -- either a plain string or an array of content blocks.
@@ -807,6 +810,7 @@ impl AnthropicCountTokensRequest {
             total_len += match msg.role {
                 AnthropicRole::User => 4,
                 AnthropicRole::Assistant => 9,
+                AnthropicRole::System => 6,
             };
             // Count content
             match &msg.content {

--- a/protocols/src/types/embeddings.rs
+++ b/protocols/src/types/embeddings.rs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Based on https://github.com/64bit/async-openai/ by Himanshu Neema
+// Original Copyright (c) 2022 Himanshu Neema
+// Licensed under MIT License (see ATTRIBUTIONS-Rust.md)
+//
+// Modifications Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
+// Licensed under Apache 2.0
+
+//! Dynamo-owned overrides of the upstream `async-openai` embedding response
+//! types.
+//!
+//! Upstream's `Embedding.embedding` is typed `Vec<f32>`, which can't
+//! represent the `encoding_format=base64` shape from the OpenAI spec
+//! (where each per-input embedding is a base64-encoded little-endian
+//! f32 byte string). We own the narrowest subtree -- [`Embedding`] and
+//! [`CreateEmbeddingResponse`] -- so the wire-level value can be either a
+//! JSON array of floats or a JSON string.
+//!
+//! Everything else (request, [`EmbeddingInput`], [`EmbeddingUsage`],
+//! [`EncodingFormat`], the builder types, the base64-specific upstream
+//! types like `Base64Embedding`) is re-exported via the glob below;
+//! the local [`Embedding`] and [`CreateEmbeddingResponse`] shadow their
+//! upstream namesakes. This preserves the previous full re-export
+//! surface for downstream crates that may have been importing those
+//! other symbols.
+
+use serde::{Deserialize, Serialize};
+
+#[allow(unused_imports)]
+pub use async_openai::types::embeddings::*;
+
+/// Per-input embedding payload.
+///
+/// The OpenAI `/v1/embeddings` spec returns either a vector of floats
+/// (`encoding_format="float"`, the default) or a base64 string encoding
+/// raw little-endian `f32` bytes (`encoding_format="base64"`).
+///
+/// Serializes as an untagged union: a JSON array for [`Float`] and a JSON
+/// string for [`Base64`], matching the OpenAI wire format.
+///
+/// [`Float`]: EmbeddingVector::Float
+/// [`Base64`]: EmbeddingVector::Base64
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum EmbeddingVector {
+    Float(Vec<f32>),
+    Base64(String),
+}
+
+impl EmbeddingVector {
+    /// Number of float dimensions if this is the `Float` variant. Returns
+    /// `None` for `Base64` -- the count is encoded in the byte length and
+    /// only resolved on decode.
+    pub fn dim(&self) -> Option<usize> {
+        match self {
+            EmbeddingVector::Float(v) => Some(v.len()),
+            EmbeddingVector::Base64(_) => None,
+        }
+    }
+}
+
+impl From<Vec<f32>> for EmbeddingVector {
+    fn from(v: Vec<f32>) -> Self {
+        EmbeddingVector::Float(v)
+    }
+}
+
+/// A single embedding object inside an embeddings response.
+///
+/// Mirrors `async_openai::types::embeddings::Embedding` except for the
+/// `embedding` field, which is widened to [`EmbeddingVector`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Embedding {
+    pub index: u32,
+    pub object: String,
+    pub embedding: EmbeddingVector,
+}
+
+/// Top-level `/v1/embeddings` response.
+///
+/// Mirrors `async_openai::types::embeddings::CreateEmbeddingResponse`
+/// except the `data` field carries the Dynamo-owned [`Embedding`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct CreateEmbeddingResponse {
+    pub object: String,
+    pub model: String,
+    pub data: Vec<Embedding>,
+    pub usage: EmbeddingUsage,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_variant_serializes_as_array() {
+        let v = EmbeddingVector::Float(vec![0.1, 0.2, 0.3]);
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, "[0.1,0.2,0.3]");
+    }
+
+    #[test]
+    fn base64_variant_serializes_as_string() {
+        let v = EmbeddingVector::Base64("AAACOQ==".to_string());
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, "\"AAACOQ==\"");
+    }
+
+    #[test]
+    fn deserializes_array_as_float() {
+        let v: EmbeddingVector = serde_json::from_str("[0.1, 0.2, 0.3]").unwrap();
+        assert_eq!(v, EmbeddingVector::Float(vec![0.1, 0.2, 0.3]));
+    }
+
+    #[test]
+    fn deserializes_string_as_base64() {
+        let v: EmbeddingVector = serde_json::from_str("\"AAACOQ==\"").unwrap();
+        assert_eq!(v, EmbeddingVector::Base64("AAACOQ==".to_string()));
+    }
+
+    #[test]
+    fn round_trips_via_embedding_struct() {
+        let e = Embedding {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: EmbeddingVector::Float(vec![1.0, 2.0]),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let parsed: Embedding = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, parsed);
+
+        let e = Embedding {
+            index: 1,
+            object: "embedding".to_string(),
+            embedding: EmbeddingVector::Base64("AAACOQ==".to_string()),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let parsed: Embedding = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, parsed);
+    }
+}

--- a/protocols/src/types/mod.rs
+++ b/protocols/src/types/mod.rs
@@ -10,6 +10,7 @@
 pub mod anthropic;
 mod chat;
 mod completion;
+mod embeddings;
 pub mod realtime;
 pub mod responses;
 
@@ -17,12 +18,14 @@ pub mod responses;
 pub use chat::*;
 pub use completion::*;
 
-// --- Upstream re-exports (types-only, no HTTP client) ---
+// Embeddings: `Embedding` and `CreateEmbeddingResponse` are owned
+// locally (in the `embeddings` submodule) so a per-input embedding
+// can be either a float vector or a base64 string per the OpenAI
+// `encoding_format` spec. Every other embedding type is still
+// re-exported from `async_openai::types::embeddings::*`.
+pub use embeddings::*;
 
-// Embeddings (full re-export)
-pub use async_openai::types::embeddings::*;
-
-// Images
+// Images: re-exported wholesale from async-openai (no Dynamo overrides).
 pub use async_openai::types::images::*;
 
 // --- Convenience impls for locally-defined types ---


### PR DESCRIPTION
Restores the one-way mirror of dynamo `lib/{protocols,tokenizers,parsers}` up to dynamo `main` @ `7d7b1fb`.

## Synced code (verbatim from upstream)
- **protocols**: new `types/embeddings.rs`; updates to `types/anthropic.rs`, `types/mod.rs`.
- **parsers**: new `tool_calling/structural_tag/` module (builder, dsml, format, triggered_tags + tests); updates across reasoning parsers and tool_calling parsers (config, response, tools, json/xml/pythonic/harmony/gemma4/dsml).

## Local-owned fixes (to keep it building standalone)
- `ToolDefinition` gained a `strict: Option<bool>` field upstream → added `strict: None` to the two initializers in `examples/dynamo-demo-server` (`handlers/chat.rs`, `handlers/tool_parse.rs`).
- Upstream `tools.rs` refactor dropped all `dynamo_protocols` usage from the parsers crate (now uses parser-native `ToolCallResponse` types). `dynamo-protocols` is no longer a dependency in dynamo's `parsers/Cargo.toml` either, and `cargo machete` flagged it as unused → removed `dynamo-protocols.workspace = true` from the diverged `parsers/Cargo.toml` and updated `Cargo.lock`.

## CI gate (all green locally)
fmt ✓ · clippy `-D warnings` ✓ · check `--locked` ✓ · test (587+ pass) ✓ · cargo-deny bans+licenses ✓ · cargo-machete ✓ · sync-check exits 0 ✓