### PR TITLE
feat: add dynamo-renderer crate, wire sync + demo server

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -1,7 +1,7 @@
 name: sync-check
 
 # Runs the dry-run sync against ai-dynamo/dynamo main and fails if dynamo's
-# lib/{protocols,tokenizers,parsers}/{src,tests} have drifted from this repo's
+# lib/{protocols,tokenizers,parsers,renderer}/{src,tests} have drifted from this repo's
 # copies.
 #
 # On the hourly cron schedule, drift also opens a tracking issue (and the

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 /protocols/Cargo.lock
 /tokenizers/Cargo.lock
 /parsers/Cargo.lock
+/renderer/Cargo.lock
 /examples/*/Cargo.lock
 
 # rustfmt backups

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "clap",
  "dynamo-parsers",
  "dynamo-protocols",
+ "dynamo-renderer",
  "dynamo-tokenizers",
  "futures",
  "hf-hub",
@@ -915,6 +916,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-renderer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dynamo-protocols",
+ "dynamo-tokenizers",
+ "either",
+ "minijinja",
+ "minijinja-contrib",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-tokenizers"
 version = "0.1.0"
 dependencies = [
@@ -939,6 +957,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1994,6 +2015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2034,26 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99df5123c54391e2a228014c1dbbd85a3dab08a25e776c810526f2f47542b3de"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "protocols",
     "parsers",
+    "renderer",
     "tokenizers",
     "examples/dynamo-demo-server",
 ]
@@ -20,15 +21,26 @@ async-stream = "0.3"
 axum = "0.8"
 base64 = "0.22"
 blake3 = "1"
+chrono = { version = "0.4", default-features = false, features = [
+    "alloc",
+    "std",
+    "clock",
+    "now",
+    "serde",
+] }
 clap = "4"
 dashmap = "6.1"
 derive_builder = "0.20"
 dynamo-parsers = { path = "parsers", version = "0.1.0" }
 dynamo-protocols = { path = "protocols", version = "0.1.0" }
+dynamo-renderer = { path = "renderer", version = "0.1.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "0.1.0" }
+either = { version = "1.13", features = ["serde"] }
 fastokens = "0.1.0"
 futures = "0.3"
 hf-hub = { version = "0.4", default-features = false }
+minijinja = { version = "2.20.0" }
+minijinja-contrib = { version = "2.20.0" }
 num-traits = "0.2"
 openai-harmony = "0.0.3"
 rayon = "1"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # frontend-crates
 
-Three standalone Rust crates for building OpenAI/Anthropic-compatible inference servers, plus a small demo wiring them together.
+Standalone Rust crates for building OpenAI/Anthropic-compatible inference servers, plus a small demo wiring them together.
 
 | Crate | What it does |
 | -- | -- |
 | [`dynamo-protocols`](./protocols/)   | Request/response types for OpenAI Chat / Completions / Responses + Anthropic Messages. Built on `async-openai` v0.34 with inference-serving extensions. |
 | [`dynamo-tokenizers`](./tokenizers/) | HuggingFace + tiktoken + FastTokenizer wrappers with fast incremental detokenization and prefix-caching for shared-prefix workloads. |
-| [`dynamo-parsers`](./parsers/)       | Reasoning + tool-calling parsers across 18+ model families (DeepSeek R1/V4, Qwen3, GPT-OSS, Kimi K2, Gemma 4, Llama, Hermes, ...). Streaming-first. |
+| [`dynamo-parsers`](./parsers/)       | Reasoning + tool-calling parsers across 18+ model families (DeepSeek R1/V4, Qwen3, GPT-OSS, Kimi K2, Gemma 4, Llama, Hermes, ...). Streaming-first. The *decode* side. |
+| [`dynamo-renderer`](./renderer/)     | Chat-template / prompt rendering: OpenAI chat requests → model-ready prompt strings via HF `chat_template` (minijinja), plus native DeepSeek formatters. The *encode* side. |
 
-Each crate is independently published to crates.io and can be adopted on its own. `dynamo-parsers` depends on `dynamo-protocols`; the other two have no internal deps. The repository itself is a Cargo workspace so shared dependency versions, CI checks, and the demo build stay consistent.
+Each crate is independently published to crates.io and can be adopted on its own. `dynamo-parsers` and `dynamo-renderer` depend on `dynamo-protocols` (`dynamo-renderer` also re-exports `dynamo-tokenizers` for convenience); the leaf crates have no internal deps. The repository itself is a Cargo workspace so shared dependency versions, CI checks, and the demo build stay consistent.
 
 ## Layout
 
@@ -17,8 +18,9 @@ frontend-crates/
 ├── protocols/              # dynamo-protocols
 ├── tokenizers/             # dynamo-tokenizers
 ├── parsers/                # dynamo-parsers (deps protocols)
+├── renderer/               # dynamo-renderer (deps protocols, tokenizers)
 ├── examples/
-│   └── dynamo-demo-server/ # axum server wiring all three together
+│   └── dynamo-demo-server/ # axum server wiring them together
 └── scripts/
     └── sync-from-dynamo.sh # check / pull changes from ai-dynamo/dynamo
 ```
@@ -42,6 +44,7 @@ Each crate can still be built or tested directly:
 cargo build -p dynamo-protocols
 cargo build -p dynamo-tokenizers
 cargo build -p dynamo-parsers
+cargo build -p dynamo-renderer
 cargo build -p dynamo-demo-server --release
 ```
 
@@ -55,6 +58,6 @@ cargo deny --all-features check bans licenses
 
 ## Where the code lives
 
-These crates currently mirror `lib/{protocols,tokenizers,parsers}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The sync is **one-way (dynamo → frontend-crates) and manual** for now — see [`scripts/sync-from-dynamo.sh`](./scripts/sync-from-dynamo.sh) to check for upstream changes.
+These crates currently mirror `lib/{protocols,tokenizers,parsers,renderer}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The sync is **one-way (dynamo → frontend-crates) and manual** for now — see [`scripts/sync-from-dynamo.sh`](./scripts/sync-from-dynamo.sh) to check for upstream changes. (`renderer` lands upstream with [dynamo#9946](https://github.com/ai-dynamo/dynamo/pull/9946); until that merges the sync check skips it.)
 
 > **Heads up:** this mirroring is temporary. Over the next few weeks we plan to **remove the sync entirely and make this repository the source of truth** for these crates — dynamo will then depend on the published crates rather than the other way around. Until that cutover lands, treat dynamo as upstream and land crate changes there first.

--- a/examples/dynamo-demo-server/Cargo.toml
+++ b/examples/dynamo-demo-server/Cargo.toml
@@ -9,9 +9,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-# Three sibling crates from this repo.
+# Sibling crates from this repo.
 dynamo-protocols.workspace = true
 dynamo-parsers.workspace = true
+dynamo-renderer.workspace = true
 dynamo-tokenizers.workspace = true
 
 # Web framework

--- a/examples/dynamo-demo-server/README.md
+++ b/examples/dynamo-demo-server/README.md
@@ -1,6 +1,6 @@
 # dynamo-demo-server
 
-A working OpenAI/Anthropic-compatible server in ~600 lines of Rust, wiring together the three sibling crates (`dynamo-protocols`, `dynamo-tokenizers`, `dynamo-parsers`). The backend is a dummy echo — swap `src/echo.rs` for your scheduler / forward pass and you have a real server.
+A working OpenAI/Anthropic-compatible server in ~600 lines of Rust, wiring together the sibling crates (`dynamo-protocols`, `dynamo-tokenizers`, `dynamo-parsers`, `dynamo-renderer`). The backend is a dummy echo — swap `src/echo.rs` for your scheduler / forward pass and you have a real server.
 
 ## Build
 
@@ -9,25 +9,28 @@ cd examples/dynamo-demo-server
 cargo build --release
 ```
 
-This picks up the three sibling crates via path deps (`../../protocols`, `../../tokenizers`, `../../parsers`) — no separate clone.
+This picks up the sibling crates via path deps (`../../protocols`, `../../tokenizers`, `../../parsers`, `../../renderer`) — no separate clone.
 
 ## Run
 
 ```bash
-# Pass any HuggingFace repo id; tokenizer.json is fetched on startup.
+# Pass any HuggingFace repo id; tokenizer.json + tokenizer_config.json are
+# fetched on startup. The chat_template in tokenizer_config.json powers /v1/render.
 cargo run --release -- --model Qwen/Qwen2.5-0.5B-Instruct
 
-# Or point at a local tokenizer.json:
-cargo run --release -- --tokenizer /path/to/tokenizer.json
+# Or point at a local tokenizer.json (optionally a local chat-template config):
+cargo run --release -- --tokenizer /path/to/tokenizer.json \
+  --chat-template-config /path/to/tokenizer_config.json
 ```
 
 Flags:
 
 ```
---model <MODEL>       HuggingFace repo id (fetches tokenizer.json)
---tokenizer <PATH>    local tokenizer.json (alternative to --model)
---host <HOST>         default 0.0.0.0
---http-port <PORT>    default 3000
+--model <MODEL>                  HuggingFace repo id (fetches tokenizer.json + tokenizer_config.json)
+--tokenizer <PATH>               local tokenizer.json (alternative to --model)
+--chat-template-config <PATH>    local tokenizer_config.json for /v1/render (else fetched via --model)
+--host <HOST>                    default 0.0.0.0
+--http-port <PORT>               default 3000
 ```
 
 ## Test
@@ -53,14 +56,15 @@ Exits non-zero if any endpoint fails.
 | `POST /v1/detokenize`       | token ids → text                     | tokenizers                     |
 | `POST /v1/tool-parse`       | tool-call parser (15+ formats)       | parsers                        |
 | `POST /v1/reasoning-parse`  | reasoning parser                     | parsers                        |
+| `POST /v1/render`           | chat request → rendered prompt       | renderer (protocols)           |
 | `GET /health`               | —                                    | —                              |
 
 ## Layout
 
 ```
 src/
-  main.rs                 axum router + CLI + HF Hub tokenizer fetch
-  engine.rs               AppState — holds the loaded Tokenizer
+  main.rs                 axum router + CLI + HF Hub tokenizer / config fetch
+  engine.rs               AppState — holds the loaded Tokenizer + chat-template renderer
   echo.rs                 dummy backend (extracts text from request bodies)
   handlers/
     chat.rs               /v1/chat/completions  (streaming + tool parsing)
@@ -70,4 +74,5 @@ src/
     tokenize.rs           /v1/tokenize, /v1/detokenize
     tool_parse.rs         /v1/tool-parse
     reasoning_parse.rs    /v1/reasoning-parse
+    render.rs             /v1/render            (chat template → prompt)
 ```

--- a/examples/dynamo-demo-server/scripts/smoke.sh
+++ b/examples/dynamo-demo-server/scripts/smoke.sh
@@ -51,6 +51,19 @@ check "tool-parse (hermes)" -H 'Content-Type: application/json' -X POST "$BASE/v
 check "reasoning-parse (deepseek_r1)" -H 'Content-Type: application/json' -X POST "$BASE/v1/reasoning-parse" \
   -d '{"text":"<think>let me think</think>the answer is 42","parser":"deepseek_r1"}'
 
+# /v1/render needs a chat template (server started with --model or
+# --chat-template-config). A 503 "no chat template loaded" means the route is
+# wired but unconfigured -- treat it as a soft skip, not a failure, so the smoke
+# run is meaningful whether or not a model was provided.
+render_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Content-Type: application/json' -X POST "$BASE/v1/render" \
+  -d '{"model":"echo","messages":[{"role":"user","content":"hello"}]}')
+case "$render_code" in
+  200) echo "  PASS  render"; PASS=$((PASS+1)) ;;
+  503) echo "  SKIP  render (no chat template; start with --model)" ;;
+  *)   echo "  FAIL  render (HTTP $render_code)"; FAIL=$((FAIL+1)) ;;
+esac
+
 echo
 echo "== $PASS passed, $FAIL failed =="
 [ "$FAIL" -eq 0 ]

--- a/examples/dynamo-demo-server/src/engine.rs
+++ b/examples/dynamo-demo-server/src/engine.rs
@@ -1,22 +1,30 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared server state -- the integration point for the three Dynamo crates.
+//! Shared server state -- the integration point for the Dynamo crates.
 //!
 //! Holds an optional tokenizer loaded at startup. Handlers use it for accurate
 //! token usage counts and the `/v1/tokenize` + `/v1/detokenize` endpoints.
+//! Optionally also holds a [`PromptFormatter`] built from a model's
+//! `tokenizer_config.json`, used by the `/v1/render` endpoint to showcase
+//! dynamo-renderer's chat-template rendering.
 
 use std::sync::Arc;
 
+use dynamo_renderer::{ChatTemplate, ContextMixins, PromptFormatter};
 use dynamo_tokenizers::Tokenizer;
 
 #[derive(Clone)]
 pub struct AppState {
     pub tokenizer: Option<Arc<Tokenizer>>,
+    /// Chat-template renderer, present when a `tokenizer_config.json` carrying a
+    /// `chat_template` was loaded at startup. `PromptFormatter` is itself an
+    /// `Arc`-backed handle, so cloning `AppState` per request is cheap.
+    pub formatter: Option<PromptFormatter>,
 }
 
 impl AppState {
-    pub fn new(tokenizer_path: Option<&str>) -> Self {
+    pub fn new(tokenizer_path: Option<&str>, chat_template_config_path: Option<&str>) -> Self {
         let tokenizer = tokenizer_path.and_then(|path| match Tokenizer::from_file(path) {
             Ok(tk) => {
                 tracing::info!(path, "loaded tokenizer");
@@ -27,7 +35,11 @@ impl AppState {
                 None
             }
         });
-        Self { tokenizer }
+        let formatter = chat_template_config_path.and_then(load_formatter);
+        Self {
+            tokenizer,
+            formatter,
+        }
     }
 
     /// Count tokens in a string. Falls back to len/4 heuristic when no tokenizer is loaded.
@@ -53,5 +65,43 @@ impl AppState {
             .as_ref()
             .and_then(|tk| tk.decode(ids, skip_special).ok())
             .map(String::from)
+    }
+}
+
+/// Parse a `tokenizer_config.json` and build a chat-template [`PromptFormatter`]
+/// from its `chat_template`. Returns `None` (with a warning) if the file can't
+/// be read, parsed, or carries no `chat_template` -- the server then runs
+/// without `/v1/render` support rather than failing to start.
+fn load_formatter(path: &str) -> Option<PromptFormatter> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(path, error = %e, "failed to read tokenizer_config.json; /v1/render disabled");
+            return None;
+        }
+    };
+    let config: ChatTemplate = match serde_json::from_str(&raw) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(path, error = %e, "failed to parse tokenizer_config.json; /v1/render disabled");
+            return None;
+        }
+    };
+    if config.chat_template.is_none() {
+        tracing::warn!(
+            path,
+            "tokenizer_config.json has no chat_template; /v1/render disabled"
+        );
+        return None;
+    }
+    match PromptFormatter::from_parts(config, ContextMixins::default(), false) {
+        Ok(f) => {
+            tracing::info!(path, "loaded chat-template renderer");
+            Some(f)
+        }
+        Err(e) => {
+            tracing::warn!(path, error = %e, "failed to build renderer; /v1/render disabled");
+            None
+        }
     }
 }

--- a/examples/dynamo-demo-server/src/handlers/mod.rs
+++ b/examples/dynamo-demo-server/src/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod anthropic;
 pub mod chat;
 pub mod completions;
 pub mod reasoning_parse;
+pub mod render;
 pub mod responses;
 pub mod tokenize;
 pub mod tool_parse;

--- a/examples/dynamo-demo-server/src/handlers/render.rs
+++ b/examples/dynamo-demo-server/src/handlers/render.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! POST /v1/render -- Dedicated dynamo-renderer demo endpoint
+//!
+//! Accepts a standard OpenAI chat-completion request body and returns the
+//! prompt string produced by applying the model's chat template to it. This is
+//! NOT part of any standard API -- it exists to showcase dynamo-renderer's
+//! `apply_chat_template` rendering (the *encode* side of serving).
+//!
+//! Requires the server to have been started with a `tokenizer_config.json`
+//! carrying a `chat_template` (via `--model`, or `--chat-template-config`).
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use dynamo_protocols::types::CreateChatCompletionRequest;
+use dynamo_renderer::PromptFormatter;
+
+use crate::engine::AppState;
+
+#[derive(Serialize)]
+pub struct RenderResponse {
+    /// The fully-rendered prompt string ready to feed a tokenizer / engine.
+    pub prompt: String,
+    pub model: String,
+}
+
+pub async fn handler(
+    State(state): State<AppState>,
+    Json(req): Json<CreateChatCompletionRequest>,
+) -> Response {
+    let Some(PromptFormatter::OAI(formatter)) = state.formatter else {
+        let body = serde_json::json!({
+            "error": "no chat template loaded; start the server with --model or \
+                      --chat-template-config pointing at a tokenizer_config.json \
+                      that carries a chat_template",
+        });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+    };
+
+    let model = req.model.clone();
+    match formatter.render(&req) {
+        Ok(prompt) => Json(RenderResponse { prompt, model }).into_response(),
+        Err(e) => {
+            let body = serde_json::json!({ "error": e.to_string() });
+            (StatusCode::BAD_REQUEST, Json(body)).into_response()
+        }
+    }
+}

--- a/examples/dynamo-demo-server/src/main.rs
+++ b/examples/dynamo-demo-server/src/main.rs
@@ -16,12 +16,12 @@ use clap::Parser;
 use crate::engine::AppState;
 
 /// dynamo-demo-server -- minimal OpenAI/Anthropic-compatible server showcasing
-/// dynamo-protocols + dynamo-parsers + dynamo-tokenizers.
+/// dynamo-protocols + dynamo-parsers + dynamo-renderer + dynamo-tokenizers.
 #[derive(Parser, Debug)]
 #[command(version, about)]
 struct Cli {
-    /// HuggingFace repo id to fetch tokenizer.json from (e.g. "Qwen/Qwen2.5-7B-Instruct").
-    /// Mutually exclusive with --tokenizer.
+    /// HuggingFace repo id to fetch tokenizer.json + tokenizer_config.json from
+    /// (e.g. "Qwen/Qwen2.5-7B-Instruct"). Mutually exclusive with --tokenizer.
     #[arg(long, env = "MODEL")]
     model: Option<String>,
 
@@ -32,6 +32,12 @@ struct Cli {
     /// Path to a local tokenizer.json (or .model / .tiktoken). Mutually exclusive with --model.
     #[arg(long, env = "TOKENIZER_PATH")]
     tokenizer: Option<PathBuf>,
+
+    /// Path to a local tokenizer_config.json carrying a `chat_template`, used by
+    /// the `/v1/render` endpoint. When --model is used this is fetched from HF
+    /// automatically; pass this to point at a local file instead.
+    #[arg(long, env = "CHAT_TEMPLATE_CONFIG")]
+    chat_template_config: Option<PathBuf>,
 
     /// Host to bind.
     #[arg(long, env = "HOST", default_value = "0.0.0.0")]
@@ -61,8 +67,24 @@ async fn main() -> anyhow::Result<()> {
         _ => None,
     };
 
-    let state = AppState::new(tokenizer_path.as_deref().and_then(|p| p.to_str()));
+    // Resolve a tokenizer_config.json for chat-template rendering: an explicit
+    // --chat-template-config wins; otherwise fetch it alongside the tokenizer
+    // when --model is given. A missing/optional file is fine -- /v1/render just
+    // stays disabled.
+    let chat_template_config_path = match (&cli.chat_template_config, &cli.model) {
+        (Some(path), _) => Some(path.clone()),
+        (None, Some(repo)) => fetch_hf_tokenizer_config(repo, &cli.revision).await,
+        _ => None,
+    };
+
+    let state = AppState::new(
+        tokenizer_path.as_deref().and_then(|p| p.to_str()),
+        chat_template_config_path
+            .as_deref()
+            .and_then(|p| p.to_str()),
+    );
     let has_tk = state.tokenizer.is_some();
+    let has_renderer = state.formatter.is_some();
 
     let app = Router::new()
         .route("/v1/chat/completions", post(handlers::chat::handler))
@@ -76,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
             "/v1/reasoning-parse",
             post(handlers::reasoning_parse::handler),
         )
+        .route("/v1/render", post(handlers::render::handler))
         .route("/health", get(|| async { "ok" }))
         .with_state(state);
 
@@ -83,7 +106,8 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(
         addr = %addr,
         tokenizer = has_tk,
-        "dynamo-demo-server: protocols + parsers + tokenizers"
+        renderer = has_renderer,
+        "dynamo-demo-server: protocols + parsers + renderer + tokenizers"
     );
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app).await?;
@@ -108,4 +132,33 @@ async fn fetch_hf_tokenizer(repo_id: &str, revision: &str) -> anyhow::Result<Pat
     let path = repo.get("tokenizer.json").await?;
     tracing::info!(path = %path.display(), "tokenizer cached");
     Ok(path)
+}
+
+/// Download `tokenizer_config.json` from HF Hub and return the cached path.
+/// Returns `None` (with a warning) if the repo doesn't ship one -- rendering is
+/// optional, so this never aborts startup.
+async fn fetch_hf_tokenizer_config(repo_id: &str, revision: &str) -> Option<PathBuf> {
+    use hf_hub::{Repo, RepoType, api::tokio::ApiBuilder};
+
+    tracing::info!(
+        repo = repo_id,
+        revision,
+        "fetching tokenizer_config.json from HF Hub"
+    );
+    let api = ApiBuilder::new().with_progress(true).build().ok()?;
+    let repo = api.repo(Repo::with_revision(
+        repo_id.to_string(),
+        RepoType::Model,
+        revision.to_string(),
+    ));
+    match repo.get("tokenizer_config.json").await {
+        Ok(path) => {
+            tracing::info!(path = %path.display(), "tokenizer_config cached");
+            Some(path)
+        }
+        Err(e) => {
+            tracing::warn!(repo = repo_id, error = %e, "no tokenizer_config.json; /v1/render disabled");
+            None
+        }
+    }
 }

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-renderer"
+readme = "README.md"
+version = "0.1.0"
+edition.workspace = true
+description = "Standalone OpenAI chat-template / prompt formatting (HF chat_template via minijinja)."
+authors.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+keywords = ["llm", "chat-template", "prompt", "jinja", "inference"]
+
+[dependencies]
+# The chat-template engine bridges OpenAI request types (dynamo-protocols) with
+# the HF chat_template jinja engine (minijinja). It does NOT depend on tokenizer
+# internals; `dynamo-tokenizers` is re-exported only as a one-import convenience
+# for consumers that want tokenize + templating together.
+dynamo-protocols = { workspace = true }
+dynamo-tokenizers = { workspace = true }
+
+anyhow = { workspace = true }
+chrono = { workspace = true }
+either = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order", "raw_value"] }
+tracing = { workspace = true }
+
+minijinja = { workspace = true, features = ["loader", "loop_controls"] }
+minijinja-contrib = { workspace = true, features = ["pycompat"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -1,0 +1,44 @@
+# Renderer
+
+## Introduction
+`dynamo-renderer` turns OpenAI-style chat requests into model-ready prompt strings. It is the *encode* side of inference serving: messages + tools + generation settings in, a fully-rendered prompt out. It is standalone, so an external OpenAI frontend can reuse Dynamo's prompt formatting without pulling in the Dynamo runtime.
+
+It renders HuggingFace `chat_template` jinja2 (via `minijinja` + `minijinja-contrib` pycompat) and also ships native Rust formatters for DeepSeek families whose repos ship no usable template. The crate is a *bridge* between OpenAI request types (`dynamo-protocols`) and the template engine; it does **not** depend on tokenizer internals, though it re-exports `dynamo-tokenizers` for one-import convenience.
+
+## Features
+- **HF chat templates**: faithful `apply_chat_template` rendering, including tool-use and generation-prompt handling.
+- **Native DeepSeek formatters**: Rust formatters for V4 / V3.2 families (under `deepseek`).
+- **Bring-your-own request type**: implement `OAIChatLikeRequest` for any request type, or use the ready-made impl for `dynamo-protocols`' OpenAI chat request.
+- **Self-contained**: no async runtime, no networking, no tokenizer dependency on the rendering path.
+
+## Quick Start
+
+```rust
+use dynamo_renderer::{ChatTemplate, ContextMixins, PromptFormatter};
+use dynamo_protocols::types::CreateChatCompletionRequest;
+
+// `config` is parsed from a model's `tokenizer_config.json`.
+let config: ChatTemplate = serde_json::from_str(tokenizer_config_json)?;
+let PromptFormatter::OAI(formatter) =
+    PromptFormatter::from_parts(config, ContextMixins::default(), /* exclude_tools_when_tool_choice_none */ false)?
+else {
+    unreachable!("from_parts always builds an OAI formatter")
+};
+
+// Any type implementing `OAIChatLikeRequest` can be rendered; the standard
+// OpenAI chat request works out of the box.
+let request: CreateChatCompletionRequest = serde_json::from_str(request_json)?;
+let prompt: String = formatter.render(&request)?;
+```
+
+## Relationship to other crates
+- `dynamo-protocols` — OpenAI/wire request types this crate renders from.
+- `dynamo-tokenizers` — tokenization (the *next* step after rendering); re-exported here for convenience.
+- `dynamo-parsers` — the *decode* side (parsing model output back into reasoning / tool calls).
+
+## Provenance
+
+This crate is a one-way mirror of `lib/renderer` from
+[ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). `src/` is synced
+verbatim; `Cargo.toml` and this README are inlined for standalone publishing.
+See the repo root `scripts/sync-from-dynamo.sh`.

--- a/renderer/src/deepseek/common.rs
+++ b/renderer/src/deepseek/common.rs
@@ -1,0 +1,624 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared DeepSeek native prompt-formatting helpers.
+
+use anyhow::{Context, Result};
+use serde_json::Value as JsonValue;
+
+/// Special tokens for DeepSeek prompt formatting.
+pub mod tokens {
+    pub const BOS: &str = "<｜begin▁of▁sentence｜>";
+    pub const EOS: &str = "<｜end▁of▁sentence｜>";
+    pub const THINKING_START: &str = "<think>";
+    pub const THINKING_END: &str = "</think>";
+    pub const DSML_TOKEN: &str = "｜DSML｜";
+    pub const USER_START: &str = "<｜User｜>";
+    pub const ASSISTANT_START: &str = "<｜Assistant｜>";
+    pub const LATEST_REMINDER: &str = "<｜latest_reminder｜>";
+
+    // Quick-instruction task tokens
+    pub const TASK_ACTION: &str = "<｜action｜>";
+    pub const TASK_QUERY: &str = "<｜query｜>";
+    pub const TASK_AUTHORITY: &str = "<｜authority｜>";
+    pub const TASK_DOMAIN: &str = "<｜domain｜>";
+    pub const TASK_TITLE: &str = "<｜title｜>";
+    pub const TASK_READ_URL: &str = "<｜read_url｜>";
+}
+
+pub(crate) const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
+
+pub(crate) const RESPONSE_FORMAT_TEMPLATE: &str =
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}";
+
+pub(crate) const TOOLS_TEMPLATE: &str = r#"## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"#;
+
+/// System message template for tools.
+pub(crate) const TOOLS_SYSTEM_TEMPLATE: &str = r#"## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
+<{dsml_token}function_calls>
+<{dsml_token}invoke name="$FUNCTION_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$FUNCTION_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{dsml_token}function_calls>
+...
+</{dsml_token}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{thinking_start_token}...thinking about results{thinking_end_token}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"#;
+
+pub(crate) const TOOL_CALL_TEMPLATE: &str =
+    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>";
+
+pub(crate) const TOOL_OUTPUT_TEMPLATE: &str = "\n<result>{content}</result>";
+
+pub(crate) const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+
+/// Thinking mode for the model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingMode {
+    Chat,
+    Thinking,
+}
+
+impl ThinkingMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ThinkingMode::Chat => "chat",
+            ThinkingMode::Thinking => "thinking",
+        }
+    }
+}
+
+/// Reasoning effort level. `None` conveyed as `Option<ReasoningEffort>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    Max,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NormalizeNonText {
+    SerializeJson,
+    LeaveUntouched,
+}
+
+// Serialize a JSON value to match Python's `json.dumps(ensure_ascii=False)` spacing.
+// Python's default separators are `(', ', ': ')`; we use a custom `Formatter`
+// so escape sequences inside strings can't confuse state tracking.
+pub(crate) fn to_json(value: &JsonValue) -> String {
+    use serde::Serialize;
+    use serde_json::ser::Formatter;
+    use std::io;
+
+    struct PythonFormatter;
+
+    impl Formatter for PythonFormatter {
+        fn begin_array_value<W: ?Sized + io::Write>(
+            &mut self,
+            writer: &mut W,
+            first: bool,
+        ) -> io::Result<()> {
+            if first {
+                Ok(())
+            } else {
+                writer.write_all(b", ")
+            }
+        }
+
+        fn begin_object_key<W: ?Sized + io::Write>(
+            &mut self,
+            writer: &mut W,
+            first: bool,
+        ) -> io::Result<()> {
+            if first {
+                Ok(())
+            } else {
+                writer.write_all(b", ")
+            }
+        }
+
+        fn begin_object_value<W: ?Sized + io::Write>(&mut self, writer: &mut W) -> io::Result<()> {
+            writer.write_all(b": ")
+        }
+    }
+
+    // Serializing a JsonValue into Vec<u8> is infallible; the output is always UTF-8.
+    let mut buf = Vec::with_capacity(64);
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter);
+    value
+        .serialize(&mut ser)
+        .expect("JsonValue serialization to Vec<u8> is infallible");
+    String::from_utf8(buf).expect("serde_json output is always valid UTF-8")
+}
+
+pub(crate) fn render_tools(template: &str, tools: &[JsonValue]) -> String {
+    let tools_json: Vec<String> = tools
+        .iter()
+        .filter_map(|tool| tool.get("function"))
+        .map(to_json)
+        .collect();
+
+    // Always do the tool_schemas last because they are user controlled.
+    // See test_render_tools_preserves_placeholder_text_inside_tool_schema.
+    template
+        .replace("{dsml_token}", tokens::DSML_TOKEN)
+        .replace("{thinking_start_token}", tokens::THINKING_START)
+        .replace("{thinking_end_token}", tokens::THINKING_END)
+        .replace("{tool_schemas}", &tools_json.join("\n"))
+}
+
+pub(crate) fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, msg)| {
+            msg.get("role")
+                .and_then(|r| r.as_str())
+                .map(|r| r == "user" || r == "developer")
+                .unwrap_or(false)
+        })
+        .map(|(idx, _)| idx)
+}
+
+pub(crate) fn extract_visible_text(content: &JsonValue) -> String {
+    match content {
+        JsonValue::String(text) => text.clone(),
+        JsonValue::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                if let Some(text) = item.as_str() {
+                    return Some(text.to_string());
+                }
+                let item_type = item.get("type").and_then(|v| v.as_str());
+                if item_type == Some("text") {
+                    return item
+                        .get("text")
+                        .and_then(|v| v.as_str())
+                        .map(|text| text.to_string());
+                }
+                tracing::warn!(
+                    chunk_type = item_type.unwrap_or("unknown"),
+                    "DeepSeek formatter dropped non-text content chunk while normalizing message content",
+                );
+                None
+            })
+            .collect::<String>(),
+        _ => to_json(content),
+    }
+}
+
+pub(crate) fn normalize_message_contents(messages: &mut [JsonValue], non_text: NormalizeNonText) {
+    for msg in messages {
+        let Some(content) = msg.get("content") else {
+            continue;
+        };
+        if !content.is_string()
+            && !content.is_array()
+            && non_text == NormalizeNonText::LeaveUntouched
+        {
+            continue;
+        }
+        let normalized = extract_visible_text(content);
+        if let Some(obj) = msg.as_object_mut() {
+            obj.insert("content".to_string(), JsonValue::String(normalized));
+        }
+    }
+}
+
+pub(crate) fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
+    let arguments_str = tool_call
+        .get("arguments")
+        .and_then(|a| a.as_str())
+        .context("Missing or invalid 'arguments' field")?;
+
+    // Python falls back to `{"arguments": raw_string}` on parse failure.
+    let arguments: JsonValue = match serde_json::from_str(arguments_str) {
+        Ok(v) => v,
+        Err(_) => serde_json::json!({ "arguments": arguments_str }),
+    };
+
+    let arguments_obj = arguments
+        .as_object()
+        .context("Arguments must be a JSON object")?;
+
+    let mut params = Vec::new();
+    for (key, value) in arguments_obj {
+        let value_str = if let Some(vs) = value.as_str() {
+            vs.to_string()
+        } else {
+            to_json(value)
+        };
+        params.push(format!(
+            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
+            tokens::DSML_TOKEN,
+            key,
+            if value.is_string() { "true" } else { "false" },
+            value_str,
+            tokens::DSML_TOKEN
+        ));
+    }
+
+    Ok(params.join("\n"))
+}
+
+pub(crate) fn task_token(task: &str) -> Option<&'static str> {
+    match task {
+        "action" => Some(tokens::TASK_ACTION),
+        "query" => Some(tokens::TASK_QUERY),
+        "authority" => Some(tokens::TASK_AUTHORITY),
+        "domain" => Some(tokens::TASK_DOMAIN),
+        "title" => Some(tokens::TASK_TITLE),
+        "read_url" => Some(tokens::TASK_READ_URL),
+        _ => None,
+    }
+}
+
+const USER_FIELDS_TO_PRESERVE: [&str; 3] = ["task", "wo_eos", "mask"];
+
+fn preserve_user_fields(target: &mut JsonValue, source: &JsonValue) {
+    if let Some(obj) = target.as_object_mut() {
+        for key in USER_FIELDS_TO_PRESERVE {
+            if let Some(v) = source.get(key) {
+                obj.insert(key.to_string(), v.clone());
+            }
+        }
+    }
+}
+
+// Merge `tool` role messages into preceding user `content_blocks` and collapse
+// consecutive user turns, matching Python's `merge_tool_messages`.
+pub(crate) fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
+    let mut merged: Vec<JsonValue> = Vec::with_capacity(messages.len());
+
+    for msg in messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+
+        if role == "tool" {
+            let tool_block = serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id").cloned().unwrap_or_else(|| JsonValue::String(String::new())),
+                "content": msg.get("content").cloned().unwrap_or_else(|| JsonValue::String(String::new())),
+            });
+
+            let can_merge = merged
+                .last()
+                .map(|m| {
+                    m.get("role").and_then(|r| r.as_str()) == Some("user")
+                        && m.get("content_blocks").is_some()
+                })
+                .unwrap_or(false);
+
+            if can_merge {
+                let last = merged.last_mut().unwrap();
+                if let Some(blocks) = last
+                    .as_object_mut()
+                    .and_then(|o| o.get_mut("content_blocks"))
+                    .and_then(|v| v.as_array_mut())
+                {
+                    blocks.push(tool_block);
+                }
+            } else {
+                merged.push(serde_json::json!({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                }));
+            }
+        } else if role == "user" {
+            let text = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            let text_block = serde_json::json!({ "type": "text", "text": text });
+
+            let can_merge = merged
+                .last()
+                .map(|m| {
+                    m.get("role").and_then(|r| r.as_str()) == Some("user")
+                        && m.get("content_blocks").is_some()
+                        && m.get("task").map(|v| v.is_null()).unwrap_or(true)
+                })
+                .unwrap_or(false);
+
+            if can_merge {
+                let last = merged.last_mut().unwrap();
+                let appended = last
+                    .as_object_mut()
+                    .and_then(|o| o.get_mut("content_blocks"))
+                    .and_then(|v| v.as_array_mut())
+                    .map(|blocks| {
+                        blocks.push(text_block);
+                    })
+                    .is_some();
+                if appended {
+                    preserve_user_fields(last, msg);
+                }
+            } else {
+                let mut new_msg = serde_json::json!({
+                    "role": "user",
+                    "content": text,
+                    "content_blocks": [text_block],
+                });
+                preserve_user_fields(&mut new_msg, msg);
+                merged.push(new_msg);
+            }
+        } else {
+            merged.push(msg.clone());
+        }
+    }
+
+    merged
+}
+
+// Sort `tool_result` blocks within user messages by the `tool_calls[].id` order
+// of the preceding assistant message.
+pub(crate) fn sort_tool_results_by_call_order(mut messages: Vec<JsonValue>) -> Vec<JsonValue> {
+    use std::collections::HashMap;
+    let mut last_order: HashMap<String, usize> = HashMap::new();
+
+    for msg in &mut messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if role == "assistant" {
+            if let Some(tcs) = msg.get("tool_calls").and_then(|t| t.as_array()) {
+                last_order.clear();
+                for (idx, tc) in tcs.iter().enumerate() {
+                    let id = tc
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| {
+                            tc.get("function")
+                                .and_then(|f| f.get("id"))
+                                .and_then(|v| v.as_str())
+                        })
+                        .unwrap_or("");
+                    if !id.is_empty() {
+                        last_order.insert(id.to_string(), idx);
+                    }
+                }
+            }
+        } else if role == "user" && !last_order.is_empty() {
+            let Some(blocks) = msg
+                .as_object_mut()
+                .and_then(|o| o.get_mut("content_blocks"))
+                .and_then(|v| v.as_array_mut())
+            else {
+                continue;
+            };
+
+            // Collect tool_result blocks with their positions.
+            let tool_positions: Vec<usize> = blocks
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| b.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+                .map(|(i, _)| i)
+                .collect();
+
+            if tool_positions.len() > 1 {
+                let start = *tool_positions
+                    .first()
+                    .expect("tool_positions has length > 1");
+                let end = *tool_positions
+                    .last()
+                    .expect("tool_positions has length > 1");
+                let is_contiguous = end - start + 1 == tool_positions.len();
+
+                if is_contiguous {
+                    // Fast path: sort the contiguous slice in place
+                    blocks[start..=end].sort_by_key(|b| {
+                        let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
+                        *last_order.get(id).unwrap_or(&0)
+                    });
+                } else {
+                    // Fallback: extract, sort, and replace for non-contiguous blocks
+                    let mut tool_blocks: Vec<JsonValue> = tool_positions
+                        .iter()
+                        .map(|&i| std::mem::take(&mut blocks[i]))
+                        .collect();
+
+                    tool_blocks.sort_by_key(|b| {
+                        let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
+                        *last_order.get(id).unwrap_or(&0)
+                    });
+
+                    for (sorted_idx, &pos) in tool_positions.iter().enumerate() {
+                        blocks[pos] = std::mem::take(&mut tool_blocks[sorted_idx]);
+                    }
+                }
+            }
+        }
+    }
+
+    messages
+}
+
+// Drop reasoning and non-essential messages before the last user message.
+pub(crate) fn drop_thinking_messages(messages: Vec<JsonValue>) -> Vec<JsonValue> {
+    let last_user_idx = find_last_user_index(&messages);
+    let mut out = Vec::with_capacity(messages.len());
+    const KEEP: &[&str] = &[
+        "user",
+        "system",
+        "tool",
+        "latest_reminder",
+        "direct_search_results",
+    ];
+
+    for (idx, mut msg) in messages.into_iter().enumerate() {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if KEEP.contains(&role) || last_user_idx.is_none_or(|u| idx >= u) {
+            out.push(msg);
+        } else if role == "assistant" {
+            if let Some(obj) = msg.as_object_mut() {
+                obj.remove("reasoning_content");
+            }
+            out.push(msg);
+        }
+        // developer and other roles before last_user_idx are dropped.
+    }
+    out
+}
+
+pub(crate) fn resolve_thinking_mode(
+    args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    default_mode: ThinkingMode,
+) -> ThinkingMode {
+    if let Some(enabled) = crate::thinking_bool_from_args(args) {
+        return if enabled {
+            ThinkingMode::Thinking
+        } else {
+            ThinkingMode::Chat
+        };
+    }
+    if let Some(args) = args
+        && let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str())
+    {
+        match mode {
+            "chat" => return ThinkingMode::Chat,
+            "thinking" => return ThinkingMode::Thinking,
+            _ => {}
+        }
+    }
+    default_mode
+}
+
+pub(crate) fn inject_tools_and_response_format(
+    messages_array: &mut Vec<JsonValue>,
+    req: &dyn crate::OAIChatLikeRequest,
+) -> Result<()> {
+    let tools_json = req
+        .tools()
+        .map(|t| serde_json::to_value(&t))
+        .transpose()
+        .context("Failed to convert tools to JSON")?;
+
+    let response_format_json = req
+        .response_format()
+        .map(|rf| serde_json::to_value(&rf))
+        .transpose()
+        .context("Failed to convert response_format to JSON")?;
+
+    if tools_json.is_some() || response_format_json.is_some() {
+        let system_idx = messages_array
+            .iter()
+            .position(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"));
+
+        if let Some(idx) = system_idx {
+            if let Some(msg) = messages_array.get_mut(idx)
+                && let Some(obj) = msg.as_object_mut()
+            {
+                if let Some(tools) = tools_json {
+                    obj.insert("tools".to_string(), tools);
+                }
+                if let Some(rf) = response_format_json {
+                    obj.insert("response_format".to_string(), rf);
+                }
+            }
+        } else {
+            let mut system_msg = serde_json::json!({
+                "role": "system",
+                "content": ""
+            });
+            if let Some(obj) = system_msg.as_object_mut() {
+                if let Some(tools) = tools_json {
+                    obj.insert("tools".to_string(), tools);
+                }
+                if let Some(rf) = response_format_json {
+                    obj.insert("response_format".to_string(), rf);
+                }
+            }
+            messages_array.insert(0, system_msg);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_extract_visible_text_from_content_array() {
+        let content = json!([
+            {"type": "text", "text": "who "},
+            {"type": "text", "text": "are "},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+            {"type": "text", "text": "you?"}
+        ]);
+        assert_eq!(extract_visible_text(&content), "who are you?");
+    }
+
+    #[test]
+    fn test_render_tools_preserves_placeholder_text_inside_tool_schema() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "placeholder_tool",
+                "description": "literal {dsml_token} {thinking_start_token} {thinking_end_token}",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        }]);
+        let rendered = render_tools(
+            "static {dsml_token} {thinking_start_token} {thinking_end_token}\n{tool_schemas}",
+            tools.as_array().unwrap(),
+        );
+
+        assert!(rendered.starts_with(&format!(
+            "static {} {} {}\n",
+            tokens::DSML_TOKEN,
+            tokens::THINKING_START,
+            tokens::THINKING_END
+        )));
+        assert!(
+            rendered.contains("literal {dsml_token} {thinking_start_token} {thinking_end_token}")
+        );
+    }
+}

--- a/renderer/src/deepseek/mod.rs
+++ b/renderer/src/deepseek/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native (non-jinja) prompt formatters for DeepSeek model families.
+//!
+//! DeepSeek's HF repos ship no usable `chat_template`, so these render the
+//! prompt in Rust instead. [`common`] holds the shared thinking-mode /
+//! tool-injection logic; [`v4`] and [`v32`] are the per-family formatters.
+
+pub mod common;
+pub mod v32;
+pub mod v4;

--- a/renderer/src/deepseek/v32.rs
+++ b/renderer/src/deepseek/v32.rs
@@ -1,0 +1,1060 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! DeepSeek V3.2 native prompt formatting
+//!
+//! This module provides native Rust implementation of DeepSeek V3.2's chat template,
+//! based on their official Python code: encoding_dsv32.py
+//!
+//! Reference: https://huggingface.co/deepseek-ai/DeepSeek-V3.2/tree/main/encoding
+
+use anyhow::{Context, Result};
+use serde_json::Value as JsonValue;
+
+use super::common::{
+    NormalizeNonText, RESPONSE_FORMAT_TEMPLATE, TOOL_CALL_TEMPLATE, TOOL_OUTPUT_TEMPLATE,
+    TOOLS_SYSTEM_TEMPLATE, encode_arguments_to_dsml, find_last_user_index,
+    normalize_message_contents, render_tools, to_json,
+};
+
+pub use super::common::{ThinkingMode, tokens};
+
+/// Render a single message
+fn render_message(
+    index: usize,
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    last_user_idx: Option<usize>,
+) -> Result<String> {
+    let msg = &messages[index];
+    let role = msg
+        .get("role")
+        .and_then(|r| r.as_str())
+        .context("Missing 'role' field")?;
+
+    let mut prompt = String::new();
+
+    match role {
+        "system" => {
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            prompt.push_str(content);
+
+            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
+                prompt.push_str("\n\n");
+                prompt.push_str(&render_tools(TOOLS_SYSTEM_TEMPLATE, tools));
+            }
+
+            if let Some(response_format) = msg.get("response_format") {
+                prompt.push_str("\n\n");
+                prompt.push_str(
+                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
+                );
+            }
+        }
+
+        "user" => {
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            prompt.push_str(tokens::USER_START);
+            prompt.push_str(content);
+            prompt.push_str(tokens::ASSISTANT_START);
+
+            if Some(index) == last_user_idx && thinking_mode == ThinkingMode::Thinking {
+                prompt.push_str(tokens::THINKING_START);
+            } else {
+                prompt.push_str(tokens::THINKING_END);
+            }
+        }
+
+        "developer" => {
+            let content = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .context("Developer role requires content")?;
+
+            let mut content_developer = String::new();
+
+            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(&render_tools(TOOLS_SYSTEM_TEMPLATE, tools));
+            }
+
+            if let Some(response_format) = msg.get("response_format") {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(
+                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
+                );
+            }
+
+            content_developer.push_str(&format!("\n\n# The user's message is: {}", content));
+
+            prompt.push_str(tokens::USER_START);
+            prompt.push_str(&content_developer);
+            prompt.push_str(tokens::ASSISTANT_START);
+
+            if Some(index) == last_user_idx && thinking_mode == ThinkingMode::Thinking {
+                prompt.push_str(tokens::THINKING_START);
+            } else {
+                prompt.push_str(tokens::THINKING_END);
+            }
+        }
+
+        "assistant" => {
+            // Handle reasoning content
+            // NOTE: If this assistant comes after last user message, the opening <think>
+            // was already added in the user message. We only need to add content and closing tag.
+            //
+            // Handle reasoning_content which may be a plain string or an array of segments.
+            // DeepSeek V3.2 always places its <think> block before all tool calls, so
+            // joining segments produces the correct flat form here.
+            if thinking_mode == ThinkingMode::Thinking
+                && last_user_idx.is_some_and(|idx| index > idx)
+            {
+                let reasoning = msg.get("reasoning_content").and_then(|v| match v {
+                    serde_json::Value::String(s) => {
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(s.clone())
+                        }
+                    }
+                    serde_json::Value::Array(arr) => {
+                        let joined = arr
+                            .iter()
+                            .filter_map(|v| v.as_str())
+                            .filter(|s| !s.is_empty())
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if joined.is_empty() {
+                            None
+                        } else {
+                            Some(joined)
+                        }
+                    }
+                    _ => None,
+                });
+
+                if let Some(reasoning) = reasoning {
+                    // DON'T add THINKING_START - it was already added in user message
+                    prompt.push_str(&reasoning);
+                    prompt.push_str(tokens::THINKING_END);
+                }
+            }
+
+            // Handle content
+            if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
+                prompt.push_str(content);
+            }
+
+            // Handle tool calls
+            if let Some(tool_calls) = msg.get("tool_calls").and_then(|t| t.as_array())
+                && !tool_calls.is_empty()
+            {
+                prompt.push_str("\n\n");
+                prompt.push_str(&format!("<{}function_calls>\n", tokens::DSML_TOKEN));
+
+                for tool_call in tool_calls {
+                    let name = tool_call
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str())
+                        .context("Missing tool call name")?;
+
+                    let arguments = encode_arguments_to_dsml(
+                        tool_call.get("function").context("Missing function")?,
+                    )?;
+
+                    let invoke = TOOL_CALL_TEMPLATE
+                        .replace("{dsml_token}", tokens::DSML_TOKEN)
+                        .replace("{name}", name)
+                        .replace("{arguments}", &arguments);
+
+                    prompt.push_str(&invoke);
+                    prompt.push('\n');
+                }
+
+                prompt.push_str(&format!("</{}function_calls>", tokens::DSML_TOKEN));
+            }
+
+            prompt.push_str(tokens::EOS);
+        }
+
+        "tool" => {
+            // Find the previous assistant message
+            let mut prev_assistant_idx = None;
+            let mut tool_count = 0;
+
+            for i in (0..index).rev() {
+                let prev_role = messages[i].get("role").and_then(|r| r.as_str());
+                if prev_role == Some("tool") {
+                    tool_count += 1;
+                } else if prev_role == Some("assistant") {
+                    prev_assistant_idx = Some(i);
+                    break;
+                }
+            }
+
+            let tool_call_order = tool_count + 1;
+
+            // Add opening tag for first tool result
+            if tool_call_order == 1 {
+                prompt.push_str("\n\n<function_results>");
+            }
+
+            // Add result
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            prompt.push_str(&TOOL_OUTPUT_TEMPLATE.replace("{content}", content));
+
+            // Check if this is the last tool result
+            if let Some(prev_idx) = prev_assistant_idx {
+                let tool_calls_count = messages[prev_idx]
+                    .get("tool_calls")
+                    .and_then(|t| t.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+
+                if tool_call_order == tool_calls_count {
+                    prompt.push_str("\n</function_results>");
+
+                    if last_user_idx.is_some_and(|idx| index >= idx)
+                        && thinking_mode == ThinkingMode::Thinking
+                    {
+                        prompt.push_str("\n\n");
+                        prompt.push_str(tokens::THINKING_START);
+                    } else {
+                        prompt.push_str("\n\n");
+                        prompt.push_str(tokens::THINKING_END);
+                    }
+                }
+            }
+        }
+
+        _ => anyhow::bail!("Unknown role: {}", role),
+    }
+
+    Ok(prompt)
+}
+
+/// Encode messages to prompt string
+///
+/// # Arguments
+/// * `messages` - Array of messages in OpenAI format
+/// * `thinking_mode` - Whether to use thinking mode
+/// * `add_bos_token` - Whether to add BOS token at start
+///
+/// # Returns
+/// Formatted prompt string ready for tokenization
+pub fn encode_messages(
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    add_bos_token: bool,
+) -> Result<String> {
+    let mut prompt = String::new();
+
+    if add_bos_token {
+        prompt.push_str(tokens::BOS);
+    }
+
+    let last_user_idx = find_last_user_index(messages);
+
+    for (index, _) in messages.iter().enumerate() {
+        let msg_prompt = render_message(index, messages, thinking_mode, last_user_idx)?;
+        prompt.push_str(&msg_prompt);
+    }
+
+    Ok(prompt)
+}
+
+/// DeepSeek V3.2 Prompt Formatter
+///
+/// Implements OAIPromptFormatter for DeepSeek V3.2 models using native Rust implementation
+#[derive(Debug)]
+pub struct DeepSeekV32Formatter {
+    thinking_mode: ThinkingMode,
+}
+
+impl DeepSeekV32Formatter {
+    pub fn new(thinking_mode: ThinkingMode) -> Self {
+        Self { thinking_mode }
+    }
+
+    /// Create formatter with thinking mode enabled (default for DSV3.2)
+    pub fn new_thinking() -> Self {
+        Self::new(ThinkingMode::Thinking)
+    }
+
+    /// Create formatter with chat mode
+    pub fn new_chat() -> Self {
+        Self::new(ThinkingMode::Chat)
+    }
+}
+
+impl crate::OAIPromptFormatter for DeepSeekV32Formatter {
+    fn supports_add_generation_prompt(&self) -> bool {
+        true
+    }
+
+    fn render(&self, req: &dyn crate::OAIChatLikeRequest) -> Result<String> {
+        let thinking_mode =
+            super::common::resolve_thinking_mode(req.chat_template_args(), self.thinking_mode);
+
+        // Get messages from request
+        let messages_value = req.messages();
+
+        // Convert minijinja Value to serde_json Value
+        let messages_json =
+            serde_json::to_value(&messages_value).context("Failed to convert messages to JSON")?;
+
+        let mut messages_array = messages_json
+            .as_array()
+            .context("Messages is not an array")?
+            .clone();
+
+        // DeepSeek V3.2 native formatter expects text content in each message.
+        // Normalize OpenAI content arrays (e.g. [{type: "text", text: "..."}]) to strings.
+        normalize_message_contents(&mut messages_array, NormalizeNonText::SerializeJson);
+
+        // Inject tools and response_format from request into the first system message
+        // DeepSeek V3.2 expects these to be part of the system message for prompt rendering
+        super::common::inject_tools_and_response_format(&mut messages_array, req)?;
+
+        // Encode with native implementation
+        encode_messages(
+            &messages_array,
+            thinking_mode,
+            true, // always add BOS token
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_simple_conversation() {
+        let messages = json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]);
+
+        let result =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+
+        assert!(result.starts_with(tokens::BOS));
+        assert!(result.contains("You are a helpful assistant."));
+        assert!(result.contains(tokens::USER_START));
+        assert!(result.contains("Hello!"));
+        assert!(result.contains(tokens::ASSISTANT_START));
+        assert!(result.contains(tokens::THINKING_START));
+    }
+
+    #[test]
+    fn test_formatter_handles_user_content_array() {
+        use crate::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "user", "content": [
+                {"type": "text", "text": "who are you?"}
+            ]}
+        ]));
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(result.contains("who are you?"));
+        assert!(result.contains(tokens::USER_START));
+        assert!(result.contains(tokens::ASSISTANT_START));
+    }
+
+    #[test]
+    fn test_formatter_serializes_non_text_content() {
+        use crate::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "user", "content": {"foo": "bar"}}
+        ]));
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(result.contains(r#"{"foo": "bar"}"#));
+    }
+
+    #[test]
+    fn test_tools_rendering() {
+        let messages = json!([
+            {
+                "role": "system",
+                "content": "You are helpful.",
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "location": {"type": "string"}
+                            }
+                        }
+                    }
+                }]
+            },
+            {"role": "user", "content": "What's the weather?"}
+        ]);
+
+        let result =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+
+        assert!(result.contains("## Tools"));
+        assert!(result.contains("get_weather"));
+        assert!(result.contains("<functions>"));
+    }
+
+    // Mock request for testing OAIPromptFormatter implementation
+    struct MockRequest {
+        messages: JsonValue,
+        tools: Option<JsonValue>,
+        response_format: Option<JsonValue>,
+        chat_template_args: Option<std::collections::HashMap<String, JsonValue>>,
+    }
+
+    impl MockRequest {
+        fn new(messages: JsonValue) -> Self {
+            Self {
+                messages,
+                tools: None,
+                response_format: None,
+                chat_template_args: None,
+            }
+        }
+
+        fn with_tools(mut self, tools: JsonValue) -> Self {
+            self.tools = Some(tools);
+            self
+        }
+
+        fn with_response_format(mut self, response_format: JsonValue) -> Self {
+            self.response_format = Some(response_format);
+            self
+        }
+
+        fn with_chat_template_args(
+            mut self,
+            args: std::collections::HashMap<String, JsonValue>,
+        ) -> Self {
+            self.chat_template_args = Some(args);
+            self
+        }
+    }
+
+    impl crate::OAIChatLikeRequest for MockRequest {
+        fn model(&self) -> String {
+            "deepseek-v3.2".to_string()
+        }
+
+        fn messages(&self) -> minijinja::value::Value {
+            minijinja::value::Value::from_serialize(&self.messages)
+        }
+
+        fn tools(&self) -> Option<minijinja::value::Value> {
+            self.tools
+                .as_ref()
+                .map(minijinja::value::Value::from_serialize)
+        }
+
+        fn response_format(&self) -> Option<minijinja::value::Value> {
+            self.response_format
+                .as_ref()
+                .map(minijinja::value::Value::from_serialize)
+        }
+
+        fn should_add_generation_prompt(&self) -> bool {
+            true
+        }
+
+        fn chat_template_args(
+            &self,
+        ) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
+            self.chat_template_args.as_ref()
+        }
+    }
+
+    #[test]
+    fn test_formatter_injects_tools_into_existing_system_message() {
+        use crate::OAIPromptFormatter;
+
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string", "description": "City name"},
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                    },
+                    "required": ["location"]
+                }
+            }
+        }]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What's the weather in Moscow?"}
+        ]))
+        .with_tools(tools);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify tools were injected into the prompt
+        assert!(
+            result.contains("## Tools"),
+            "Should contain Tools section header"
+        );
+        assert!(
+            result.contains("get_weather"),
+            "Should contain function name"
+        );
+        assert!(
+            result.contains("<functions>"),
+            "Should contain functions block"
+        );
+        assert!(
+            result.contains("</functions>"),
+            "Should contain closing functions tag"
+        );
+        assert!(
+            result.contains("You are a helpful assistant."),
+            "Should preserve original system content"
+        );
+        assert!(
+            result.contains(&format!("<{}function_calls>", tokens::DSML_TOKEN)),
+            "Should contain DSML format instructions"
+        );
+    }
+
+    #[test]
+    fn test_formatter_creates_system_message_for_tools_when_missing() {
+        use crate::OAIPromptFormatter;
+
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "get_current_time",
+                "description": "Get current time in a timezone",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "timezone": {"type": "string"}
+                    },
+                    "required": ["timezone"]
+                }
+            }
+        }]);
+
+        // Request without system message
+        let request = MockRequest::new(json!([
+            {"role": "user", "content": "What time is it in Tokyo?"}
+        ]))
+        .with_tools(tools);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify tools were injected via auto-created system message
+        assert!(
+            result.contains("## Tools"),
+            "Should contain Tools section even without explicit system message"
+        );
+        assert!(
+            result.contains("get_current_time"),
+            "Should contain function name"
+        );
+        assert!(
+            result.contains("<functions>"),
+            "Should contain functions block"
+        );
+    }
+
+    #[test]
+    fn test_formatter_without_tools_does_not_add_tools_section() {
+        use crate::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]));
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify no tools section was added
+        assert!(
+            !result.contains("## Tools"),
+            "Should not contain Tools section when no tools provided"
+        );
+        assert!(
+            !result.contains("<functions>"),
+            "Should not contain functions block when no tools provided"
+        );
+        assert!(
+            result.contains("You are a helpful assistant."),
+            "Should preserve system content"
+        );
+    }
+
+    #[test]
+    fn test_formatter_with_multiple_tools() {
+        use crate::OAIPromptFormatter;
+
+        let tools = json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string"}
+                        }
+                    }
+                }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_time",
+                    "description": "Get current time",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "timezone": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        ]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Weather and time in Moscow?"}
+        ]))
+        .with_tools(tools);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify both tools are present
+        assert!(
+            result.contains("get_weather"),
+            "Should contain first function"
+        );
+        assert!(
+            result.contains("get_current_time"),
+            "Should contain second function"
+        );
+    }
+
+    // ==================== Structured Output Tests ====================
+
+    #[test]
+    fn test_formatter_injects_response_format_into_existing_system_message() {
+        use crate::OAIPromptFormatter;
+
+        let response_format = json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "city_info",
+                "strict": true,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "country": {"type": "string"},
+                        "population": {"type": "number"}
+                    },
+                    "required": ["city", "country", "population"]
+                }
+            }
+        });
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Tell me about Moscow."}
+        ]))
+        .with_response_format(response_format);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify response format was injected into the prompt
+        assert!(
+            result.contains("## Response Format:"),
+            "Should contain Response Format section header"
+        );
+        assert!(
+            result.contains("json_schema"),
+            "Should contain json_schema type"
+        );
+        assert!(result.contains("city_info"), "Should contain schema name");
+        assert!(
+            result.contains("You are a helpful assistant."),
+            "Should preserve original system content"
+        );
+    }
+
+    #[test]
+    fn test_formatter_creates_system_message_for_response_format_when_missing() {
+        use crate::OAIPromptFormatter;
+
+        let response_format = json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather_response",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "temperature": {"type": "number"},
+                        "conditions": {"type": "string"}
+                    }
+                }
+            }
+        });
+
+        // Request without system message
+        let request = MockRequest::new(json!([
+            {"role": "user", "content": "What's the weather?"}
+        ]))
+        .with_response_format(response_format);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify response format was injected via auto-created system message
+        assert!(
+            result.contains("## Response Format:"),
+            "Should contain Response Format section even without explicit system message"
+        );
+        assert!(
+            result.contains("weather_response"),
+            "Should contain schema name"
+        );
+    }
+
+    #[test]
+    fn test_formatter_with_both_tools_and_response_format() {
+        use crate::OAIPromptFormatter;
+
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "search_database",
+                "description": "Search the database",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"}
+                    }
+                }
+            }
+        }]);
+
+        let response_format = json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "search_result",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "results": {"type": "array"},
+                        "total_count": {"type": "number"}
+                    }
+                }
+            }
+        });
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a search assistant."},
+            {"role": "user", "content": "Find documents about Rust."}
+        ]))
+        .with_tools(tools)
+        .with_response_format(response_format);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify both tools and response format are present
+        assert!(result.contains("## Tools"), "Should contain Tools section");
+        assert!(
+            result.contains("search_database"),
+            "Should contain function name"
+        );
+        assert!(
+            result.contains("## Response Format:"),
+            "Should contain Response Format section"
+        );
+        assert!(
+            result.contains("search_result"),
+            "Should contain schema name"
+        );
+        assert!(
+            result.contains("You are a search assistant."),
+            "Should preserve original system content"
+        );
+    }
+
+    #[test]
+    fn test_formatter_without_response_format_does_not_add_response_format_section() {
+        use crate::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]));
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // Verify no response format section was added
+        assert!(
+            !result.contains("## Response Format:"),
+            "Should not contain Response Format section when not provided"
+        );
+    }
+
+    // ==================== Thinking Mode Override Tests ====================
+
+    #[test]
+    fn test_chat_mode_via_thinking_false() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([("thinking".to_string(), json!(false))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // In chat mode, the last user message should be followed by </think> (closing tag)
+        // rather than <think> (opening tag)
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END
+            )),
+            "Chat mode should end with </think> after Assistant token, got: ...{}",
+            &result[result.len().saturating_sub(80)..],
+        );
+        assert!(
+            !result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_START
+            )),
+            "Chat mode should NOT end with <think>",
+        );
+    }
+
+    #[test]
+    fn test_explicit_thinking_true_via_args() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([("thinking".to_string(), json!(true))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_START
+            )),
+            "Thinking mode should end with <think> after Assistant token",
+        );
+    }
+
+    #[test]
+    fn test_chat_mode_via_thinking_mode_string() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([("thinking_mode".to_string(), json!("chat"))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END
+            )),
+            "thinking_mode='chat' should produce chat mode (ends with </think>)",
+        );
+    }
+
+    #[test]
+    fn test_thinking_mode_string_thinking() {
+        use crate::OAIPromptFormatter;
+
+        let args =
+            std::collections::HashMap::from([("thinking_mode".to_string(), json!("thinking"))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_START
+            )),
+            "thinking_mode='thinking' should produce thinking mode (ends with <think>)",
+        );
+    }
+
+    #[test]
+    fn test_default_thinking_mode_without_args() {
+        use crate::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]));
+
+        // No chat_template_args — should default to formatter's thinking mode
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_START
+            )),
+            "Default (new_thinking) should produce thinking mode",
+        );
+
+        // Verify new_chat() default also works
+        let formatter_chat = DeepSeekV32Formatter::new_chat();
+        let result_chat = formatter_chat.render(&request).unwrap();
+
+        assert!(
+            result_chat.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END
+            )),
+            "Default (new_chat) should produce chat mode",
+        );
+    }
+
+    #[test]
+    fn test_thinking_false_overrides_default_thinking() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([("thinking".to_string(), json!(false))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        // Formatter defaults to thinking, but request overrides to chat
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END
+            )),
+            "Per-request thinking=false should override new_thinking() default",
+        );
+    }
+
+    #[test]
+    fn test_thinking_true_overrides_default_chat() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([("thinking".to_string(), json!(true))]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        // Formatter defaults to chat, but request overrides to thinking
+        let formatter = DeepSeekV32Formatter::new_chat();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_START
+            )),
+            "Per-request thinking=true should override new_chat() default",
+        );
+    }
+
+    #[test]
+    fn test_thinking_bool_takes_precedence_over_thinking_mode_string() {
+        use crate::OAIPromptFormatter;
+
+        let args = std::collections::HashMap::from([
+            ("thinking".to_string(), json!(false)),
+            ("thinking_mode".to_string(), json!("thinking")),
+        ]);
+
+        let request = MockRequest::new(json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        // "thinking": false should win over "thinking_mode": "thinking"
+        assert!(
+            result.ends_with(&format!(
+                "{}{}",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END
+            )),
+            "Boolean 'thinking' key should take precedence over 'thinking_mode' string",
+        );
+    }
+}

--- a/renderer/src/deepseek/v4.rs
+++ b/renderer/src/deepseek/v4.rs
@@ -1,0 +1,792 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! DeepSeek V4 native prompt formatting
+//!
+//! Native Rust port of DeepSeek V4's chat encoding (encoding_dsv4.py).
+//!
+//! Reference: DeepSeek-V4-Pro/encoding/encoding_dsv4.py
+
+use anyhow::{Context, Result};
+use serde_json::Value as JsonValue;
+
+use super::common::{
+    NormalizeNonText, REASONING_EFFORT_MAX, RESPONSE_FORMAT_TEMPLATE, TOOL_CALLS_BLOCK_NAME,
+    TOOLS_TEMPLATE, drop_thinking_messages, encode_arguments_to_dsml, find_last_user_index,
+    merge_tool_messages, normalize_message_contents, render_tools, sort_tool_results_by_call_order,
+    task_token, to_json,
+};
+pub use super::common::{ReasoningEffort, ThinkingMode, tokens};
+
+/// Render a single message at the given index.
+fn render_message(
+    index: usize,
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    drop_thinking: bool,
+    reasoning_effort: Option<ReasoningEffort>,
+    last_user_idx: Option<usize>,
+) -> Result<String> {
+    let msg = &messages[index];
+
+    let role = msg
+        .get("role")
+        .and_then(|r| r.as_str())
+        .context("Missing 'role' field")?;
+
+    let mut prompt = String::new();
+
+    // Reasoning effort prefix (only at index 0 in thinking mode with max effort).
+    if index == 0
+        && thinking_mode == ThinkingMode::Thinking
+        && reasoning_effort == Some(ReasoningEffort::Max)
+    {
+        prompt.push_str(REASONING_EFFORT_MAX);
+    }
+
+    match role {
+        "system" => {
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            prompt.push_str(content);
+            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
+                prompt.push_str("\n\n");
+                prompt.push_str(&render_tools(TOOLS_TEMPLATE, tools));
+            }
+            if let Some(response_format) = msg.get("response_format") {
+                prompt.push_str("\n\n");
+                prompt.push_str(
+                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
+                );
+            }
+        }
+
+        "developer" => {
+            let content = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .filter(|s| !s.is_empty())
+                .context("Developer role requires content")?;
+
+            let mut content_developer = String::from(tokens::USER_START);
+            content_developer.push_str(content);
+
+            if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(&render_tools(TOOLS_TEMPLATE, tools));
+            }
+            if let Some(response_format) = msg.get("response_format") {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(
+                    &RESPONSE_FORMAT_TEMPLATE.replace("{schema}", &to_json(response_format)),
+                );
+            }
+            prompt.push_str(&content_developer);
+        }
+
+        "user" => {
+            prompt.push_str(tokens::USER_START);
+            if let Some(blocks) = msg.get("content_blocks").and_then(|b| b.as_array()) {
+                let mut parts: Vec<String> = Vec::with_capacity(blocks.len());
+                for block in blocks {
+                    let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    match block_type {
+                        "text" => {
+                            let text = block.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                            parts.push(text.to_string());
+                        }
+                        "tool_result" => {
+                            let rendered = render_tool_result_content(
+                                block.get("content").unwrap_or(&JsonValue::Null),
+                            );
+                            parts.push(format!("<tool_result>{}</tool_result>", rendered));
+                        }
+                        other => {
+                            parts.push(format!("[Unsupported {}]", other));
+                        }
+                    }
+                }
+                prompt.push_str(&parts.join("\n\n"));
+            } else {
+                let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                prompt.push_str(content);
+            }
+        }
+
+        "latest_reminder" => {
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            prompt.push_str(tokens::LATEST_REMINDER);
+            prompt.push_str(content);
+        }
+
+        "tool" => {
+            anyhow::bail!(
+                "deepseek_v4 merges tool messages into user; preprocess with merge_tool_messages()"
+            );
+        }
+
+        "assistant" => {
+            let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            let reasoning = msg
+                .get("reasoning_content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            let wo_eos = msg.get("wo_eos").and_then(|v| v.as_bool()).unwrap_or(false);
+
+            let prev_has_task = index > 0
+                && messages[index - 1]
+                    .get("task")
+                    .map(|v| !v.is_null())
+                    .unwrap_or(false);
+
+            let mut thinking_part = String::new();
+            if thinking_mode == ThinkingMode::Thinking && !prev_has_task {
+                let render_thinking = !drop_thinking || last_user_idx.is_none_or(|u| index > u);
+                if render_thinking {
+                    thinking_part.push_str(reasoning);
+                    thinking_part.push_str(tokens::THINKING_END);
+                }
+            }
+
+            prompt.push_str(&thinking_part);
+            prompt.push_str(content);
+
+            if let Some(tool_calls) = msg.get("tool_calls").and_then(|t| t.as_array())
+                && !tool_calls.is_empty()
+            {
+                prompt.push_str("\n\n");
+                prompt.push_str(&format!(
+                    "<{}{}>\n",
+                    tokens::DSML_TOKEN,
+                    TOOL_CALLS_BLOCK_NAME
+                ));
+
+                let mut invocations = Vec::with_capacity(tool_calls.len());
+                for tc in tool_calls {
+                    // Accept both OpenAI-format (nested `function`) and internal
+                    // `{name, arguments}` shape, matching Python's `tool_calls_from_openai_format`.
+                    let fn_obj = tc.get("function").unwrap_or(tc);
+                    let name = fn_obj
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .context("Missing tool call name")?;
+                    let arguments = encode_arguments_to_dsml(fn_obj)?;
+                    invocations.push(format!(
+                        "<{}invoke name=\"{}\">\n{}\n</{}invoke>",
+                        tokens::DSML_TOKEN,
+                        name,
+                        arguments,
+                        tokens::DSML_TOKEN
+                    ));
+                }
+                prompt.push_str(&invocations.join("\n"));
+                prompt.push_str(&format!(
+                    "\n</{}{}>",
+                    tokens::DSML_TOKEN,
+                    TOOL_CALLS_BLOCK_NAME
+                ));
+            }
+
+            if !wo_eos {
+                prompt.push_str(tokens::EOS);
+            }
+        }
+
+        other => anyhow::bail!("Unknown role: {}", other),
+    }
+
+    // Early return if the next message is not assistant/latest_reminder — no transition appended.
+    if index + 1 < messages.len() {
+        let next_role = messages[index + 1].get("role").and_then(|r| r.as_str());
+        if !matches!(next_role, Some("assistant") | Some("latest_reminder")) {
+            return Ok(prompt);
+        }
+    }
+
+    // Transition tokens based on task field and role.
+    let task = msg.get("task").and_then(|v| v.as_str());
+    if let Some(task) = task {
+        let sp = task_token(task).with_context(|| format!("Invalid task: '{}'", task))?;
+        if task != "action" {
+            prompt.push_str(sp);
+        } else {
+            prompt.push_str(tokens::ASSISTANT_START);
+            prompt.push_str(if thinking_mode != ThinkingMode::Thinking {
+                tokens::THINKING_END
+            } else {
+                tokens::THINKING_START
+            });
+            prompt.push_str(sp);
+        }
+    } else if matches!(role, "user" | "developer") {
+        prompt.push_str(tokens::ASSISTANT_START);
+        let seed_thinking = thinking_mode == ThinkingMode::Thinking
+            && (!drop_thinking || last_user_idx.is_none_or(|u| index >= u));
+        prompt.push_str(if seed_thinking {
+            tokens::THINKING_START
+        } else {
+            tokens::THINKING_END
+        });
+    }
+
+    Ok(prompt)
+}
+
+/// Render a tool_result `content` payload (string or content-block list).
+fn render_tool_result_content(content: &JsonValue) -> String {
+    match content {
+        JsonValue::String(s) => s.clone(),
+        JsonValue::Array(items) => {
+            let mut parts: Vec<String> = Vec::with_capacity(items.len());
+            for item in items {
+                let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if item_type == "text" {
+                    parts.push(
+                        item.get("text")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                } else {
+                    parts.push(format!("[Unsupported {}]", item_type));
+                }
+            }
+            parts.join("\n\n")
+        }
+        JsonValue::Null => String::new(),
+        _ => to_json(content),
+    }
+}
+
+/// Encode messages to prompt string with default options.
+///
+/// Equivalent to `encode_messages_with_options(.., drop_thinking=true, reasoning_effort=None)`.
+pub fn encode_messages(
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    add_bos_token: bool,
+) -> Result<String> {
+    encode_messages_with_options(messages, thinking_mode, add_bos_token, true, None)
+}
+
+/// Encode messages to prompt string.
+///
+/// # Arguments
+/// * `messages` - Array of messages in OpenAI format
+/// * `thinking_mode` - Chat or Thinking
+/// * `add_bos_token` - Whether to prepend BOS token
+/// * `drop_thinking` - Drop reasoning_content from earlier turns (auto-disabled if tools present)
+/// * `reasoning_effort` - Optional reasoning effort level (Max prepends a verbatim block)
+pub fn encode_messages_with_options(
+    messages: &[JsonValue],
+    thinking_mode: ThinkingMode,
+    add_bos_token: bool,
+    drop_thinking: bool,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Result<String> {
+    let merged = merge_tool_messages(messages);
+    let mut full = sort_tool_results_by_call_order(merged);
+
+    let mut prompt = String::new();
+    if add_bos_token {
+        prompt.push_str(tokens::BOS);
+    }
+
+    // Auto-disable drop_thinking when any message carries a `tools` field.
+    let has_tools = full.iter().any(|m| {
+        m.get("tools")
+            .map(|v| match v {
+                JsonValue::Array(a) => !a.is_empty(),
+                JsonValue::Null => false,
+                _ => true,
+            })
+            .unwrap_or(false)
+    });
+    let effective_drop_thinking = drop_thinking && !has_tools;
+
+    if thinking_mode == ThinkingMode::Thinking && effective_drop_thinking {
+        full = drop_thinking_messages(full);
+    }
+
+    let last_user_idx = find_last_user_index(&full);
+    for idx in 0..full.len() {
+        let part = render_message(
+            idx,
+            &full,
+            thinking_mode,
+            effective_drop_thinking,
+            reasoning_effort,
+            last_user_idx,
+        )?;
+        prompt.push_str(&part);
+    }
+
+    Ok(prompt)
+}
+
+/// DeepSeek V4 Prompt Formatter
+#[derive(Debug)]
+pub struct DeepSeekV4Formatter {
+    thinking_mode: ThinkingMode,
+}
+
+impl DeepSeekV4Formatter {
+    pub fn new(thinking_mode: ThinkingMode) -> Self {
+        Self { thinking_mode }
+    }
+
+    /// Create formatter with thinking mode enabled (default for DSV4)
+    pub fn new_thinking() -> Self {
+        Self::new(ThinkingMode::Thinking)
+    }
+
+    /// Create formatter with chat mode
+    pub fn new_chat() -> Self {
+        Self::new(ThinkingMode::Chat)
+    }
+
+    fn resolve_reasoning_effort(
+        args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> Option<ReasoningEffort> {
+        let args = args?;
+        let v = args.get("reasoning_effort")?;
+        match v.as_str() {
+            Some("max") => Some(ReasoningEffort::Max),
+            Some("high") => Some(ReasoningEffort::High),
+            _ => {
+                tracing::warn!(
+                    value = ?v,
+                    "chat_template_args.reasoning_effort must be a string of \"max\" or \"high\"; ignoring and using default (none)"
+                );
+                None
+            }
+        }
+    }
+
+    fn resolve_drop_thinking(
+        args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> bool {
+        let Some(args) = args else { return true };
+        let Some(v) = args.get("drop_thinking") else {
+            return true;
+        };
+        if let Some(b) = v.as_bool() {
+            return b;
+        }
+        tracing::warn!(
+            value = ?v,
+            "chat_template_args.drop_thinking must be a bool; ignoring and using default (true)"
+        );
+        true
+    }
+}
+
+impl crate::OAIPromptFormatter for DeepSeekV4Formatter {
+    fn supports_add_generation_prompt(&self) -> bool {
+        true
+    }
+
+    fn render(&self, req: &dyn crate::OAIChatLikeRequest) -> Result<String> {
+        let args = req.chat_template_args();
+        let thinking_mode = super::common::resolve_thinking_mode(args, self.thinking_mode);
+        let reasoning_effort = Self::resolve_reasoning_effort(args);
+        let drop_thinking = Self::resolve_drop_thinking(args);
+
+        let messages_value = req.messages();
+        let messages_json =
+            serde_json::to_value(&messages_value).context("Failed to convert messages to JSON")?;
+
+        let mut messages_array = messages_json
+            .as_array()
+            .context("Messages is not an array")?
+            .clone();
+
+        normalize_message_contents(&mut messages_array, NormalizeNonText::LeaveUntouched);
+
+        super::common::inject_tools_and_response_format(&mut messages_array, req)?;
+
+        encode_messages_with_options(
+            &messages_array,
+            thinking_mode,
+            true,
+            drop_thinking,
+            reasoning_effort,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_simple_conversation() {
+        let messages = json!([
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "reasoning_content": "greet", "content": "Hi!"},
+            {"role": "user", "content": "What is 2+2?"}
+        ]);
+        let out =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+        assert!(out.starts_with(tokens::BOS));
+        assert!(out.ends_with(&format!(
+            "{}{}",
+            tokens::ASSISTANT_START,
+            tokens::THINKING_START
+        )));
+        // drop_thinking default true → earlier reasoning stripped
+        assert!(!out.contains("greet"));
+    }
+
+    #[test]
+    fn test_reasoning_effort_max_prefix() {
+        let messages = json!([
+            {"role": "system", "content": "hi"},
+            {"role": "user", "content": "hello"}
+        ]);
+        let out = encode_messages_with_options(
+            messages.as_array().unwrap(),
+            ThinkingMode::Thinking,
+            true,
+            true,
+            Some(ReasoningEffort::Max),
+        )
+        .unwrap();
+        assert!(out.contains("Reasoning Effort: Absolute maximum"));
+        // Prefix comes between BOS and system content.
+        let after_bos = &out[tokens::BOS.len()..];
+        assert!(after_bos.starts_with("Reasoning Effort:"));
+
+        // High and None do not emit the prefix.
+        let out2 = encode_messages_with_options(
+            messages.as_array().unwrap(),
+            ThinkingMode::Thinking,
+            true,
+            true,
+            Some(ReasoningEffort::High),
+        )
+        .unwrap();
+        assert!(!out2.contains("Reasoning Effort: Absolute maximum"));
+    }
+
+    #[test]
+    fn test_content_blocks_with_tool_result() {
+        // `merge_tool_messages` turns a `tool` role followed by a plain user text
+        // into a single user turn whose `content_blocks` interleave the tool result
+        // with the text, joined by "\n\n" at render time. Users don't construct
+        // `content_blocks` directly — both the Python reference and this port
+        // overwrite any user-supplied `content_blocks` with a single text block.
+        let messages = json!([
+            {"role": "user", "content": "call tool"},
+            {"role": "assistant", "content": "", "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "f", "arguments": "{}"}
+            }]},
+            {"role": "tool", "tool_call_id": "c1", "content": "RESULT"},
+            {"role": "user", "content": "thanks"}
+        ]);
+        let out = encode_messages(messages.as_array().unwrap(), ThinkingMode::Chat, true).unwrap();
+        assert!(
+            out.contains("<tool_result>RESULT</tool_result>\n\nthanks"),
+            "expected tool_result block followed by 'thanks' in the merged user turn, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_user_task_preserved_when_merged_after_tool_result() {
+        let messages = json!([
+            {"role": "assistant", "content": "", "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "search", "arguments": "{}"}
+            }]},
+            {"role": "tool", "tool_call_id": "c1", "content": "RESULT"},
+            {"role": "user", "content": "Search", "task": "action"},
+            {"role": "assistant", "content": "OK"}
+        ]);
+
+        let out = encode_messages(messages.as_array().unwrap(), ThinkingMode::Chat, true).unwrap();
+        assert!(
+            out.contains(&format!(
+                "{}Search{}{}{}OK",
+                "<tool_result>RESULT</tool_result>\n\n",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END,
+                tokens::TASK_ACTION
+            )),
+            "expected merged user text to keep the action task transition, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_drop_thinking_auto_disable_when_tools_present() {
+        let messages = json!([
+            {"role": "system", "content": "s", "tools": [{
+                "type": "function",
+                "function": {"name": "f", "description": "", "parameters": {"type": "object", "properties": {}}}
+            }]},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "reasoning_content": "PRIOR_REASONING", "content": "reply"},
+            {"role": "user", "content": "again"}
+        ]);
+        let out =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+        // Tools present → drop_thinking auto-disabled → earlier reasoning preserved.
+        assert!(out.contains("PRIOR_REASONING"));
+    }
+
+    // ---- Regression tests for known divergences from the Python reference ----
+
+    /// Bug: `last_user_idx = None` (no user/developer in history) should behave
+    /// like Python's `-1` sentinel — `index >= -1` / `idx >= -1` always true, so
+    /// earlier reasoning is preserved and the assistant's reasoning block is
+    /// rendered. Rust defaulting `None` to `usize::MAX` / `is_some_and` silently
+    /// stripped reasoning instead.
+    ///
+    /// Byte-equivalent to Python reference with the same input:
+    /// `<BOS>sysREASONING_BLOCK</think>hello<EOS>`
+    #[test]
+    fn test_assistant_reasoning_preserved_when_no_user_in_history() {
+        let messages = json!([
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "hello", "reasoning_content": "REASONING_BLOCK"}
+        ]);
+        let out =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+        assert_eq!(
+            out, "<｜begin▁of▁sentence｜>sysREASONING_BLOCK</think>hello<｜end▁of▁sentence｜>",
+            "Output must match Python reference byte-for-byte when no user/developer in history"
+        );
+    }
+
+    /// Bug: `to_json` tracks in-string state via `prev_char != '\\'` which
+    /// mis-handles consecutive backslashes. A value containing `\\` (one literal
+    /// backslash in JSON) makes the helper think the closing `"` is escaped,
+    /// so it stops inserting Python-compatible spaces after subsequent `:`/`,`.
+    ///
+    /// Python `json.dumps({"path": "\\", "count": 5}, ensure_ascii=False)`
+    /// emits `{"path": "\\", "count": 5}` — space after every `:` and `,`.
+    #[test]
+    fn test_to_json_preserves_spacing_past_escaped_backslash() {
+        let v = json!({"path": "\\", "count": 5});
+        let got = to_json(&v);
+        assert_eq!(
+            got, r#"{"path": "\\", "count": 5}"#,
+            "to_json must match Python's json.dumps formatting past an escaped backslash"
+        );
+    }
+
+    #[test]
+    fn test_resolve_drop_thinking_warns_on_malformed_value() {
+        use std::collections::HashMap;
+        // String "false" where a bool is expected → fall back to default (true) and warn.
+        let mut args = HashMap::new();
+        args.insert(
+            "drop_thinking".to_string(),
+            serde_json::Value::String("false".to_string()),
+        );
+        assert!(DeepSeekV4Formatter::resolve_drop_thinking(Some(&args)));
+        // Malformed reasoning_effort falls back to None.
+        let mut args2 = HashMap::new();
+        args2.insert(
+            "reasoning_effort".to_string(),
+            serde_json::Value::String("HIGH".to_string()),
+        );
+        assert_eq!(
+            DeepSeekV4Formatter::resolve_reasoning_effort(Some(&args2)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_thinking_mode_honors_enable_thinking() {
+        use std::collections::HashMap;
+        let mut args = HashMap::new();
+        args.insert(
+            "enable_thinking".to_string(),
+            serde_json::Value::Bool(false),
+        );
+        assert_eq!(
+            super::super::common::resolve_thinking_mode(Some(&args), ThinkingMode::Thinking),
+            ThinkingMode::Chat
+        );
+        args.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
+        assert_eq!(
+            super::super::common::resolve_thinking_mode(Some(&args), ThinkingMode::Thinking),
+            ThinkingMode::Thinking
+        );
+    }
+
+    struct MockRequest {
+        messages: JsonValue,
+        chat_template_args: Option<std::collections::HashMap<String, JsonValue>>,
+    }
+
+    impl MockRequest {
+        fn new(messages: JsonValue) -> Self {
+            Self {
+                messages,
+                chat_template_args: None,
+            }
+        }
+
+        fn with_chat_template_args(
+            mut self,
+            args: std::collections::HashMap<String, JsonValue>,
+        ) -> Self {
+            self.chat_template_args = Some(args);
+            self
+        }
+    }
+
+    impl crate::OAIChatLikeRequest for MockRequest {
+        fn model(&self) -> String {
+            "deepseek-v4".to_string()
+        }
+
+        fn messages(&self) -> minijinja::value::Value {
+            minijinja::value::Value::from_serialize(&self.messages)
+        }
+
+        fn should_add_generation_prompt(&self) -> bool {
+            true
+        }
+
+        fn chat_template_args(
+            &self,
+        ) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
+            self.chat_template_args.as_ref()
+        }
+    }
+
+    #[test]
+    fn test_render_leaves_null_assistant_tool_content_empty() {
+        use crate::OAIPromptFormatter;
+
+        let req = MockRequest::new(json!([
+            {"role": "user", "content": "call tool"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "f", "arguments": "{}"}
+            }]}
+        ]));
+
+        let formatter = DeepSeekV4Formatter::new_chat();
+        let out = formatter.render(&req).unwrap();
+
+        assert!(out.contains(&format!(
+            "<{}{}>",
+            tokens::DSML_TOKEN,
+            TOOL_CALLS_BLOCK_NAME
+        )));
+        assert!(!out.contains("null"));
+    }
+
+    #[test]
+    fn test_render_wires_reasoning_effort_max_from_chat_template_args() {
+        use crate::OAIPromptFormatter;
+        use std::collections::HashMap;
+
+        let mut args = HashMap::new();
+        args.insert("reasoning_effort".to_string(), json!("max"));
+
+        let req = MockRequest::new(json!([
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"}
+        ]))
+        .with_chat_template_args(args);
+
+        let formatter = DeepSeekV4Formatter::new_thinking();
+        let out = formatter.render(&req).unwrap();
+
+        assert!(out.starts_with(tokens::BOS));
+        let after_bos = &out[tokens::BOS.len()..];
+        assert!(
+            after_bos.starts_with("Reasoning Effort:"),
+            "REASONING_EFFORT_MAX preamble should appear at start (after BOS), got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_render_drop_thinking_override_from_chat_template_args() {
+        use crate::OAIPromptFormatter;
+        use std::collections::HashMap;
+
+        let messages = json!([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "reasoning_content": "PRIOR", "content": "reply"},
+            {"role": "user", "content": "again"}
+        ]);
+
+        // Default (drop_thinking=true): prior reasoning stripped.
+        let req_default = MockRequest::new(messages.clone());
+        let formatter = DeepSeekV4Formatter::new_thinking();
+        let out_default = formatter.render(&req_default).unwrap();
+        assert!(
+            !out_default.contains("PRIOR"),
+            "default drop_thinking=true should strip prior reasoning, got:\n{}",
+            out_default
+        );
+
+        // drop_thinking=false override: prior reasoning survives.
+        let mut args = HashMap::new();
+        args.insert("drop_thinking".to_string(), json!(false));
+        let req_keep = MockRequest::new(messages).with_chat_template_args(args);
+        let out_keep = formatter.render(&req_keep).unwrap();
+        assert!(
+            out_keep.contains("PRIOR"),
+            "drop_thinking=false override should preserve prior reasoning, got:\n{}",
+            out_keep
+        );
+    }
+
+    // N4: developer-role interactions with drop_thinking.
+    // find_last_user_index returns the index of user OR developer messages; the
+    // drop_thinking reasoning cutoff and the thinking-seed insertion treat
+    // user and developer identically.
+
+    #[test]
+    fn test_developer_only_conversation_renders_developer_content() {
+        let messages = json!([
+            {"role": "system", "content": "sys"},
+            {"role": "developer", "content": "x"},
+            {"role": "assistant", "reasoning_content": "R", "content": "ok"}
+        ]);
+        let out =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+        assert!(
+            out.contains("x"),
+            "developer content should appear in output, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_developer_as_last_user_index_controls_reasoning_cutoff() {
+        // Indices: 0=user, 1=assistant(FIRST), 2=developer(y), 3=assistant(SECOND).
+        // find_last_user_index = 2 (developer). With drop_thinking=true:
+        //   - assistant idx=1 < 2  → reasoning_content stripped.
+        //   - assistant idx=3 >= 2 → reasoning_content preserved.
+        let messages = json!([
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "reasoning_content": "FIRST", "content": "r1"},
+            {"role": "developer", "content": "y"},
+            {"role": "assistant", "reasoning_content": "SECOND", "content": "r2"}
+        ]);
+        let out =
+            encode_messages(messages.as_array().unwrap(), ThinkingMode::Thinking, true).unwrap();
+        assert!(
+            !out.contains("FIRST"),
+            "reasoning before last user/developer (idx 1 < 2) should be stripped, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("SECOND"),
+            "reasoning at/after last user/developer (idx 3 > 2) should survive, got:\n{}",
+            out
+        );
+    }
+}

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Prompt Formatting
+//!
+//! Standalone, runtime-free chat-template / prompt formatting for
+//! OpenAI-compatible inference frontends. Renders HuggingFace `chat_template`
+//! jinja2 (via `minijinja` + `minijinja-contrib` pycompat), handles tool
+//! usage formatting and generation-prompt handling.
+//!
+//! Consumers implement [`OAIChatLikeRequest`] for their request type (or use
+//! the ready-made impl for `dynamo-protocols`' OpenAI chat request) and render
+//! with a [`PromptFormatter`] built from a HuggingFace `tokenizer_config.json`
+//! ([`ChatTemplate`]).
+//!
+//! This crate is a *bridge* between OpenAI request types ([`dynamo_protocols`])
+//! and the HF chat-template engine ([`minijinja`]); it does not depend on
+//! tokenizer internals. `dynamo-tokenizers` is re-exported for convenience.
+
+// TODO:
+// 1. Query if `add_generation_prompt` is present in the prompt template
+// 2. Support for models with add_generation_prompt:
+//    - PALS (Prefix-Assisted Language Sampling)
+//    - Continuation - Detected on user turns, where we can return
+//      partial assistant responses without add_generation_prompt
+
+use anyhow::Result;
+use minijinja::value::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Re-export of `dynamo-tokenizers` as a one-import convenience: consumers that
+/// want both tokenization and chat templating can reach the tokenizer types via
+/// `dynamo_renderer::dynamo_tokenizers::*` without adding a second dependency.
+/// This crate does not otherwise use the tokenizer internals.
+pub use dynamo_tokenizers;
+
+pub mod deepseek;
+mod template;
+
+pub use template::{
+    ChatTemplate, ChatTemplateValue, ContextMixins, deepseek_formatter_for, may_be_fix_tool_schema,
+};
+
+/// Selects which context-mixin behaviors a template renders with.
+///
+/// Carried on the model deployment card (`prompt_context`) and consumed by the
+/// chat-template renderer via [`ContextMixins`].
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptContextMixin {
+    /// Support OAI Chat Messages and Tools
+    OaiChat,
+
+    /// Enables templates with `{{datetime}}` to be rendered with the current date and time.
+    Llama3DateTime,
+}
+
+/// Shared helper: extract a boolean thinking toggle from `chat_template_args`.
+///
+/// Reads the two equivalent keys (`thinking`, `enable_thinking` — vLLM's
+/// canonical kwarg) in order and returns the first bool value found, or `None`
+/// if neither key is present (or neither carries a bool). Used by the V4
+/// formatter's `resolve_thinking_mode` and by reasoning-parser gating in
+/// consumers so both paths agree on the signal interpretation.
+pub fn thinking_bool_from_args(args: Option<&HashMap<String, serde_json::Value>>) -> Option<bool> {
+    let args = args?;
+    for key in ["thinking", "enable_thinking"] {
+        if let Some(v) = args.get(key).and_then(|x| x.as_bool()) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
+pub enum TokenInput {
+    Single(Vec<u32>),
+    Batch(Vec<Vec<u32>>),
+}
+
+#[derive(Debug)]
+pub enum TextInput {
+    Single(String),
+    Batch(Vec<String>),
+}
+
+#[derive(Debug)]
+pub enum PromptInput {
+    Tokens(TokenInput),
+    Text(TextInput),
+}
+
+/// Trait that defines a request that can map to an OpenAI-like request.
+///
+/// Implement this for your request type to render it through a
+/// [`PromptFormatter`]. Media/multimodal IO config is intentionally *not* part
+/// of this trait — it is a preprocessing concern owned by the consumer, kept
+/// off the rendering surface so this crate stays runtime-free.
+pub trait OAIChatLikeRequest {
+    fn model(&self) -> String;
+    fn messages(&self) -> Value;
+    fn typed_messages(&self) -> Option<&[dynamo_protocols::types::ChatCompletionRequestMessage]> {
+        None
+    }
+    fn tools(&self) -> Option<Value> {
+        None
+    }
+    fn tool_choice(&self) -> Option<Value> {
+        None
+    }
+    fn response_format(&self) -> Option<Value> {
+        None
+    }
+
+    fn should_add_generation_prompt(&self) -> bool;
+
+    /// Optional additional args to merge into the chat template context
+    fn chat_template_args(&self) -> Option<&HashMap<String, serde_json::Value>> {
+        None
+    }
+
+    /// Returns the type of input for the prompt. Default is Text.
+    fn prompt_input_type(&self) -> PromptInput {
+        PromptInput::Text(TextInput::Single(String::new()))
+    }
+
+    /// Extract tokens if the input is pre-tokenized
+    fn extract_tokens(&self) -> Option<TokenInput> {
+        None
+    }
+
+    fn extract_text(&self) -> Option<TextInput> {
+        None
+    }
+
+    fn mm_processor_kwargs(&self) -> Option<&serde_json::Value> {
+        None
+    }
+}
+
+pub trait OAIPromptFormatter: Send + Sync + 'static {
+    fn supports_add_generation_prompt(&self) -> bool;
+    fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String>;
+
+    /// Per-family image-placeholder template used when the chat template
+    /// requires string content and the request contains images. `{n}` in
+    /// the template is the 1-based image index. `None` when the
+    /// formatter has no flatten strategy — MM-aware routing falls back
+    /// to text-prefix routing for those families.
+    fn image_placeholder_template(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+#[derive(Clone)]
+pub enum PromptFormatter {
+    OAI(Arc<dyn OAIPromptFormatter>),
+}
+
+// No-op formatter: used for models without chat_template
+#[derive(Debug, Default)]
+pub struct NoOpFormatter;
+
+impl OAIPromptFormatter for NoOpFormatter {
+    fn supports_add_generation_prompt(&self) -> bool {
+        false
+    }
+
+    fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String> {
+        let messages = req.messages();
+
+        let first_message = messages
+            .get_item_by_index(0)
+            .map_err(|_| anyhow::Error::msg("No message at index 0 or messages array is empty"))?;
+
+        let content = first_message
+            .get_attr("content")
+            .map_err(|_| anyhow::Error::msg("First message has no 'content' field"))?;
+
+        let content_str = content
+            .as_str()
+            .ok_or_else(|| anyhow::Error::msg("Message content is not a string"))?
+            .to_string();
+        Ok(content_str)
+    }
+}
+
+impl PromptFormatter {
+    pub fn no_op() -> Self {
+        Self::OAI(Arc::new(NoOpFormatter))
+    }
+}

--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, sync::Arc};
+
+use anyhow::{Ok, Result};
+use minijinja::Environment;
+
+use super::PromptContextMixin;
+
+mod context;
+mod formatters;
+mod oai;
+mod tokcfg;
+
+use super::{OAIPromptFormatter, PromptFormatter};
+pub use oai::may_be_fix_tool_schema;
+pub use tokcfg::{ChatTemplate, ChatTemplateValue};
+
+/// If the model is a DeepSeek family whose HF repo doesn't ship a Jinja
+/// `chat_template`, return the native Rust formatter for it. Returns `None`
+/// for everything else (the caller then loads the HF `tokenizer_config.json`
+/// template via [`PromptFormatter::from_parts`]).
+///
+/// `model_type_lower` is the lowercased `config.json` `model_type` (authoritative,
+/// survives `--served-model-name` renames); `display_name_lower` is the
+/// lowercased served name, used only as a fallback when `model_type` is absent.
+pub fn deepseek_formatter_for(
+    model_type_lower: &Option<String>,
+    display_name_lower: &str,
+) -> Option<PromptFormatter> {
+    if is_deepseek_v4(model_type_lower, display_name_lower) {
+        tracing::info!(
+            model_type = ?model_type_lower,
+            display_name = %display_name_lower,
+            "Detected DeepSeek V4 model, using native Rust formatter",
+        );
+        return Some(PromptFormatter::OAI(Arc::new(
+            super::deepseek::v4::DeepSeekV4Formatter::new_thinking(),
+        )));
+    }
+    if is_deepseek_v3_2_non_exp(model_type_lower, display_name_lower) {
+        tracing::info!("Detected DeepSeek V3.2 model (non-Exp), using native Rust formatter");
+        return Some(PromptFormatter::OAI(Arc::new(
+            super::deepseek::v32::DeepSeekV32Formatter::new_thinking(),
+        )));
+    }
+    None
+}
+
+impl PromptFormatter {
+    pub fn from_parts(
+        config: ChatTemplate,
+        context: ContextMixins,
+        exclude_tools_when_tool_choice_none: bool,
+    ) -> Result<PromptFormatter> {
+        let formatter = HfTokenizerConfigJsonFormatter::with_options(
+            config,
+            context,
+            exclude_tools_when_tool_choice_none,
+        )?;
+        Ok(Self::OAI(Arc::new(formatter)))
+    }
+}
+
+/// Chat Template Jinja Renderer
+///
+/// Manages a Jinja environment with registered templates for chat formatting.
+/// Handles two types of ChatTemplateValue templates:
+///
+/// 1. String template: Registered as the 'default' template
+/// 2. Map template: Contains 'tool_use' and/or 'default' templates
+///    - tool_use: Template for tool-based interactions
+///    - default: Template for standard chat interactions
+///
+///   If the map contains both keys, the `tool_use` template is registered as the `tool_use` template
+///   and the `default` template is registered as the `default` template.
+struct JinjaEnvironment {
+    env: Environment<'static>,
+}
+
+/// Formatter for HuggingFace tokenizer config JSON templates
+///
+/// Implements chat template rendering based on HuggingFace's tokenizer_config.json format.
+/// Supports:
+/// - Tool usage templates
+/// - Generation prompts
+/// - Context mixins for template customization
+#[derive(Debug)]
+struct HfTokenizerConfigJsonFormatter {
+    env: Environment<'static>,
+    config: ChatTemplate,
+    mixins: Arc<ContextMixins>,
+    supports_add_generation_prompt: bool,
+    requires_content_arrays: bool,
+    /// When true, strip tool definitions from the chat template when tool_choice is "none".
+    /// This prevents models from generating raw XML tool calls in the content field.
+    exclude_tools_when_tool_choice_none: bool,
+    /// True if the chat template natively references `reasoning_content`.
+    /// When true, skip injection — the template handles it.
+    template_handles_reasoning: bool,
+    /// Per-family placeholder template for image content parts when flattening
+    /// mixed text+image content arrays into a single string (`preserve_arrays`
+    /// = false path). `{n}` in the template is substituted with the 1-based
+    /// image index. `None` when the model's chat template handles content
+    /// arrays natively (Qwen-VL family) or when we have no flatten strategy
+    /// for it (no MM-aware routing benefit either way).
+    image_placeholder_template: Option<&'static str>,
+    /// True if the `default` template branches on `tool_call.arguments is string`
+    /// (Qwen3, Hermes, etc.). When true and rendering through `default`, skip
+    /// pre-parsing the JSON-string `tool_calls[].function.arguments` into an
+    /// object — the template wants the raw string verbatim. Pre-parsing forces
+    /// the `tojson`-with-object branch and re-emits with minijinja's compact
+    /// separators, which breaks append-only prefix matching across multi-step
+    /// tool-use turns. Tracked separately for `default` and `tool_use` because
+    /// HF configs may register different sources for each, and because
+    /// `arguments is string` is tool_calls-specific — legacy
+    /// `function_call.arguments` lives outside that branch and is still
+    /// normalized unconditionally.
+    default_template_handles_tool_calls_arguments_string: bool,
+    /// True if the `tool_use` template branches on `tool_call.arguments is string`.
+    /// See `default_template_handles_tool_calls_arguments_string` for rationale.
+    tool_use_template_handles_tool_calls_arguments_string: bool,
+}
+
+// /// OpenAI Standard Prompt Formatter
+// pub trait StandardPromptFormatter {
+//     fn render(&self, context: &impl StandardPromptContext) -> Result<String>;
+// }
+
+// pub trait StandardPromptContext {
+//     fn messages(&self) -> Value;
+//     fn tools(&self) -> Option<Value>;
+// }
+
+#[derive(Debug, Clone, Default)]
+pub struct ContextMixins {
+    context_mixins: HashSet<PromptContextMixin>,
+}
+
+/// Decides whether to activate the DeepSeek-V4 native formatter.
+///
+/// Primary signal: config.json `model_type`. DeepSeek-V4-Pro and V4-Flash both
+/// ship `"model_type": "deepseek_v4"`, set by the model author — this survives
+/// any `--served-model-name` rename.
+///
+/// Fallback: `display_name`, tight-matched against
+/// `^deepseek(?:[-_.])?v4(?:[-_.]|$)`. Only consulted when config.json is
+/// absent (tokenizer-only MDCs) or unreadable; a concrete config.json value
+/// that is *not* `deepseek_v4` is authoritative and suppresses the fallback.
+fn is_deepseek_v4(model_type_lower: &Option<String>, display_name_lower: &str) -> bool {
+    match model_type_lower.as_deref() {
+        Some("deepseek_v4") => true,
+        Some(_) => false, // config.json says something else — trust it
+        None => is_deepseek_v4_name(display_name_lower),
+    }
+}
+
+/// Decides whether to activate the DeepSeek-V3.2 (non-Exp) native formatter.
+/// Same config-primary / name-fallback rule as V4.
+fn is_deepseek_v3_2_non_exp(model_type_lower: &Option<String>, display_name_lower: &str) -> bool {
+    let name_match = display_name_lower.contains("deepseek")
+        && display_name_lower.contains("v3.2")
+        && !display_name_lower.contains("exp");
+    match model_type_lower.as_deref() {
+        Some("deepseek_v3_2") => !display_name_lower.contains("exp"),
+        Some(_) => false,
+        None => name_match,
+    }
+}
+
+/// Tight, anchored match for DeepSeek-V4 display names. Equivalent to the
+/// regex `^deepseek(?:[-_.])?v4(?:[-_.]|$)` over an already-lowercased string.
+/// Written with string ops to avoid pulling in the `regex` crate.
+///
+/// Rejects composite names that previously short-circuited the V4 branch:
+/// - `deepseek-v3.2-v4-foo` (the `v3.2` variant is the real one)
+/// - `deepseek-v40` / `deepseek-v4pro` (no separator after `v4`)
+/// - `my-deepseek-v4` (prefix must be at the start)
+fn is_deepseek_v4_name(name_lower: &str) -> bool {
+    let Some(rest) = name_lower.strip_prefix("deepseek") else {
+        return false;
+    };
+    // Optional single separator between "deepseek" and "v4".
+    let rest = rest
+        .strip_prefix(|c: char| matches!(c, '-' | '_' | '.'))
+        .unwrap_or(rest);
+    let Some(after_v4) = rest.strip_prefix("v4") else {
+        return false;
+    };
+    // `v4` must end the name or be followed by a separator — anything else
+    // (e.g. `v40`, `v4pro`) is a different model family.
+    after_v4.is_empty() || after_v4.starts_with(['-', '_', '.'])
+}
+
+#[cfg(test)]
+mod detection_tests {
+    use super::{is_deepseek_v3_2_non_exp, is_deepseek_v4, is_deepseek_v4_name};
+
+    #[test]
+    fn v4_name_matches_canonical_variants() {
+        for name in [
+            "deepseek-v4",
+            "deepseek_v4",
+            "deepseek.v4",
+            "deepseekv4",
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "deepseek-v4-flash-2507",
+            "deepseek-v4.1",
+            "deepseek_v4_thinking",
+        ] {
+            assert!(is_deepseek_v4_name(name), "expected {name} to match V4");
+        }
+    }
+
+    #[test]
+    fn v4_name_rejects_non_v4() {
+        // Composite names that previously short-circuited to V4 before the
+        // V3.2 branch — now correctly rejected.
+        for name in [
+            "deepseek-v3.2-v4-foo",
+            "my-deepseek-v4",
+            "deepseek-v40",
+            "deepseek-v4pro",
+            "deepseekv40",
+            "deepseek-v3",
+            "deepseek-v3.2",
+            "deepseek-r1",
+            "qwen3-v4", // only deepseek-prefixed names qualify
+            "dsflash",
+            "",
+        ] {
+            assert!(
+                !is_deepseek_v4_name(name),
+                "expected {name} to NOT match V4",
+            );
+        }
+    }
+
+    #[test]
+    fn v4_detection_prefers_config_model_type() {
+        // config.json `model_type = "deepseek_v4"` wins regardless of what
+        // the operator calls the model via --served-model-name.
+        let v4 = Some("deepseek_v4".to_string());
+        for display in ["dsflash", "my-pet-model", "llama-3-8b", ""] {
+            assert!(
+                is_deepseek_v4(&v4, display),
+                "config says deepseek_v4, display {display:?} — expected V4",
+            );
+        }
+
+        // A concrete non-V4 config.json suppresses the display-name fallback.
+        // Even if the operator names the served model "deepseek-v4", a model
+        // with `model_type = "llama"` is NOT DeepSeek-V4.
+        let llama = Some("llama".to_string());
+        for display in ["deepseek-v4", "deepseek-v4-flash", "anything"] {
+            assert!(
+                !is_deepseek_v4(&llama, display),
+                "config says llama, display {display:?} — expected NOT V4",
+            );
+        }
+
+        // No config.json — fall back to display-name match.
+        assert!(is_deepseek_v4(&None, "deepseek-v4-flash"));
+        assert!(!is_deepseek_v4(&None, "dsflash"));
+
+        // A config.json with `"model_type": ""` is treated as "no signal" at
+        // the call site (normalized to None before is_deepseek_v4 is called),
+        // so the display-name fallback still runs — pin that contract.
+        let empty: Option<String> = None;
+        assert!(is_deepseek_v4(&empty, "deepseek-v4-flash"));
+        assert!(!is_deepseek_v4(&empty, "dsflash"));
+    }
+
+    #[test]
+    fn v3_2_detection_prefers_config_model_type() {
+        // config says deepseek_v3_2, any non-"exp" display name triggers.
+        let v3_2 = Some("deepseek_v3_2".to_string());
+        assert!(is_deepseek_v3_2_non_exp(&v3_2, "whatever"));
+        assert!(is_deepseek_v3_2_non_exp(&v3_2, "deepseek-v3.2"));
+        // V3.2-Exp is a separate model family; suppress even via config.
+        assert!(!is_deepseek_v3_2_non_exp(&v3_2, "deepseek-v3.2-exp"));
+
+        // Other config types lose regardless of display name.
+        let other = Some("deepseek_v4".to_string());
+        assert!(!is_deepseek_v3_2_non_exp(&other, "deepseek-v3.2"));
+
+        // No config — fall back to the original display-name heuristic.
+        assert!(is_deepseek_v3_2_non_exp(&None, "deepseek-v3.2-pro"));
+        assert!(!is_deepseek_v3_2_non_exp(&None, "deepseek-v3.2-exp"));
+        assert!(!is_deepseek_v3_2_non_exp(&None, "deepseek-v4"));
+    }
+}

--- a/renderer/src/template/context.rs
+++ b/renderer/src/template/context.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ContextMixins, PromptContextMixin};
+
+use chrono::{DateTime, Utc};
+use minijinja::value::{Object, Value};
+use std::sync::Arc;
+
+impl Object for ContextMixins {
+    fn get_value(self: &Arc<Self>, field: &Value) -> Option<Value> {
+        match field.as_str()? {
+            "datetime" => self.datetime(),
+            _ => None,
+        }
+    }
+}
+
+impl ContextMixins {
+    pub fn new(allowed_mixins: &[PromptContextMixin]) -> Self {
+        ContextMixins {
+            context_mixins: allowed_mixins.iter().cloned().collect(),
+        }
+    }
+
+    /// Implements the `datetime` context mixin.
+    /// Different mixins can be implemented here for the same key.
+    /// We need to valiate that multiple mixins do not conflict with each other.
+    fn datetime(&self) -> Option<Value> {
+        if self
+            .context_mixins
+            .contains(&PromptContextMixin::Llama3DateTime)
+        {
+            let now = chrono::Utc::now();
+            Some(Value::from(llama3_datetime(now)))
+        } else {
+            None
+        }
+    }
+}
+
+fn llama3_datetime(datetime: DateTime<Utc>) -> String {
+    datetime.format("%d, %B, %Y").to_string()
+}

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use super::tokcfg::{ChatTemplate, raise_exception, strftime_now, tojson};
+use super::{ContextMixins, HfTokenizerConfigJsonFormatter, JinjaEnvironment};
+use either::Either;
+use minijinja::{Environment, Value, context};
+use serde_json::json;
+
+/// Detects if a template requires content as arrays (multimodal) vs strings (text-only).
+/// Returns true if the template only works with array format.
+fn detect_content_array_usage(env: &Environment) -> bool {
+    // Test with array format
+    let array_msg = context! {
+        messages => json!([{"role": "user", "content": [{"type": "text", "text": "template_test"}]}]),
+        add_generation_prompt => false,
+    };
+
+    // Test with string format
+    let string_msg = context! {
+        messages => json!([{"role": "user", "content": "template_test"}]),
+        add_generation_prompt => false,
+    };
+
+    let out_array = env
+        .get_template("default")
+        .and_then(|t| t.render(&array_msg))
+        .unwrap_or_default();
+    let out_string = env
+        .get_template("default")
+        .and_then(|t| t.render(&string_msg))
+        .unwrap_or_default();
+
+    // If array works but string doesn't, template requires arrays
+    out_array.contains("template_test") && !out_string.contains("template_test")
+}
+
+/// Picks an image-placeholder template by sniffing the chat template source
+/// for distinctive role/end markers.
+///
+/// Returned string is a format with `{n}` standing in for the 1-based image
+/// index (numbered Phi-3 placeholders) or just a static placeholder (LLaVA).
+/// Returns `None` when we don't know a flatten strategy for this template —
+/// callers leave the mixed-content array untouched in that case.
+///
+/// The detection is intentionally narrow: only families whose chat templates
+/// concatenate `message.content` with strings (and therefore can't render a
+/// content array) need this. Qwen-VL / LLaVA-NeXT iterate `content` natively
+/// and don't reach the flatten path at all.
+fn detect_image_placeholder_template(env: &Environment) -> Option<&'static str> {
+    let src = env
+        .get_template("default")
+        .ok()
+        .map(|t| t.source().to_string())
+        .unwrap_or_default();
+    // Phi-3-vision template constructs `<|user|>` at runtime via
+    // `'<|' + message['role'] + '|>'`, so the literal `<|user|>` never
+    // appears in the source. The literals that ARE in the source are
+    // `<|end|>` (end-of-turn) and `<|assistant|>` (generation prompt).
+    if src.contains("<|end|>") && src.contains("<|assistant|>") {
+        return Some("<|image_{n}|>");
+    }
+    // LLaVA-1.5: USER:/ASSISTANT: convention with `+ message['content']`.
+    if src.contains("USER:") && src.contains("ASSISTANT:") {
+        return Some("<image>");
+    }
+    None
+}
+
+/// Remove known non-standard Jinja2 tags from chat templates
+///
+/// Some models use custom Jinja2 extensions that minijinja doesn't recognize. These tags
+/// are typically metadata markers that don't affect the rendered output. For example:
+/// - {% generation %} / {% endgeneration %}: Used by vLLM's AssistantTracker to mark
+///   assistant-generated content. The tags themselves don't produce output.
+///
+/// By removing these tags before validation, we allow templates with backend-specific
+/// extensions to work with minijinja while maintaining correct output semantics.
+///
+/// Note: This follows the same approach as Mistral.rs, which also strips these tags
+/// for compatibility: https://github.com/EricLBuehler/mistral.rs/blob/2bcf0e9/mistralrs-core/src/pipeline/chat_template.rs#L318-L322
+fn remove_known_non_jinja2_tags(template: &str) -> String {
+    template
+        .replace("{% generation %}", "")
+        .replace("{% endgeneration %}", "")
+}
+
+impl JinjaEnvironment {
+    fn env(self) -> Environment<'static> {
+        self.env
+    }
+}
+
+impl Default for JinjaEnvironment {
+    fn default() -> Self {
+        let mut env = Environment::new();
+
+        env.set_lstrip_blocks(true);
+        env.set_trim_blocks(true);
+
+        JinjaEnvironment { env }
+    }
+}
+
+impl HfTokenizerConfigJsonFormatter {
+    #[cfg(test)]
+    pub fn new(config: ChatTemplate, mixins: ContextMixins) -> anyhow::Result<Self> {
+        Self::with_options(config, mixins, true)
+    }
+
+    pub fn with_options(
+        config: ChatTemplate,
+        mixins: ContextMixins,
+        exclude_tools_when_tool_choice_none: bool,
+    ) -> anyhow::Result<Self> {
+        let mut env = JinjaEnvironment::default().env();
+
+        let chat_template = config.chat_template.as_ref().ok_or(anyhow::anyhow!(
+            "chat_template field is required in the tokenizer_config.json file"
+        ))?;
+
+        // Safely handle chat templates that check the length of arguments like `tools` even
+        // when `tools=None` when rendered through minijinja. For example:
+        // https://github.com/vllm-project/vllm/blob/d95d0f4b985f28ea381e301490f9d479b34d8980/examples/tool_chat_template_hermes.jinja#L36
+        env.add_filter("length", |value: Value| -> usize {
+            use minijinja::value::ValueKind;
+            match value.kind() {
+                ValueKind::Undefined | ValueKind::None => 0,
+                _ => value.len().unwrap_or(0),
+            }
+        });
+
+        // add pycompat
+        // todo: should we use this: minijinja_contrib::add_to_environment(&mut env);
+        env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+
+        env.add_filter("tojson", tojson);
+
+        env.add_function("raise_exception", raise_exception);
+        env.add_function("strftime_now", strftime_now);
+
+        let mut supports_add_generation_prompt = None;
+
+        match &chat_template.0 {
+            Either::Left(x) => {
+                if x.contains("add_generation_prompt") {
+                    tracing::debug!(
+                        "Chat template contains `add_generation_prompt` key. This model supports add_generation_prompt."
+                    );
+                    supports_add_generation_prompt = Some(true);
+                }
+                // Remove known non-standard tags before validation (they don't affect output)
+                let template_cleaned = remove_known_non_jinja2_tags(x);
+                env.add_template_owned("default", template_cleaned.clone())?;
+                env.add_template_owned("tool_use", template_cleaned)?;
+            }
+            Either::Right(map) => {
+                for t in map {
+                    for (k, v) in t.iter() {
+                        if v.contains("add_generation_prompt") {
+                            match supports_add_generation_prompt {
+                                Some(true) | None => {
+                                    tracing::debug!(
+                                        "Chat template contains `add_generation_prompt` key. This model supports add_generation_prompt."
+                                    );
+                                    supports_add_generation_prompt = Some(true);
+                                }
+                                Some(false) => {
+                                    tracing::warn!(
+                                        "Not all templates contain `add_generation_prompt` key. This model does not support add_generation_prompt."
+                                    );
+                                }
+                            }
+                        } else {
+                            supports_add_generation_prompt = Some(false);
+                        }
+                        // Remove known non-standard tags before validation (they don't affect output)
+                        let template_cleaned = remove_known_non_jinja2_tags(v);
+                        env.add_template_owned(k.to_string(), template_cleaned)?;
+                    }
+                }
+                if env.templates().count() == 0 {
+                    anyhow::bail!(
+                        "Chat template does not contain a `tool_use` or `default` key. Please ensure it contains at least a `default` key, although `tool_use` should be specified for using tools."
+                    );
+                }
+            }
+        }
+
+        // Detect at model load time whether this template requires content arrays
+        let requires_content_arrays = detect_content_array_usage(&env);
+
+        // Pick a per-family placeholder for the mixed-content → string flatten
+        // path. `None` is the safe default — the existing behavior in
+        // `may_be_fix_msg_content` leaves mixed arrays untouched.
+        let image_placeholder_template = if requires_content_arrays {
+            None
+        } else {
+            detect_image_placeholder_template(&env)
+        };
+
+        // Detect if the template natively handles reasoning_content (e.g. Nemotron, Qwen3).
+        // If so, we must NOT inject <think> blocks — the template does it itself.
+        let template_handles_reasoning = env
+            .templates()
+            .any(|(_, tmpl)| tmpl.source().contains("reasoning_content"));
+
+        // Detect if a given template branches on `tool_call.arguments is string` (Qwen3, Hermes).
+        // Such templates render a JSON-string `arguments` field verbatim; if we pre-parse
+        // it into an object, the `tojson` branch fires instead and emits compact JSON,
+        // breaking byte-level append-only across multi-step tool-use turns. The check is
+        // per-template (default vs tool_use) because in HF configs they can differ — and
+        // because `arguments is string` only appears inside tool-call iteration, the flag
+        // is naturally tied to the `tool_use` template in practice. It is also
+        // tool_calls-specific: legacy `function_call.arguments` lives outside this branch
+        // and must still be normalized.
+        let template_handles_args_string = |name: &str| -> bool {
+            env.templates()
+                .find(|(n, _)| *n == name)
+                .map(|(_, tmpl)| tmpl.source().contains("arguments is string"))
+                .unwrap_or(false)
+        };
+        let default_template_handles_tool_calls_arguments_string =
+            template_handles_args_string("default");
+        let tool_use_template_handles_tool_calls_arguments_string =
+            template_handles_args_string("tool_use");
+
+        Ok(HfTokenizerConfigJsonFormatter {
+            env,
+            config,
+            mixins: Arc::new(mixins),
+            supports_add_generation_prompt: supports_add_generation_prompt.unwrap_or(false),
+            requires_content_arrays,
+            exclude_tools_when_tool_choice_none,
+            template_handles_reasoning,
+            image_placeholder_template,
+            default_template_handles_tool_calls_arguments_string,
+            tool_use_template_handles_tool_calls_arguments_string,
+        })
+    }
+}
+
+// impl JinjaEnvironment {
+//     /// Renders the template with the provided messages.
+//     /// This function reuses the pre-compiled template for efficiency.
+//     pub fn render(&self, template_id: &str, ctx: &dyn erased_serde::Serialize) -> Result<String> {
+//         let tmpl = self.env.get_template(template_id)?;
+//         Ok(tmpl.render(ctx)?)
+//     }
+
+//     // fn apply_tool_template()
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_known_non_jinja2_tags() {
+        let template =
+            "USER: {{ message }} ASSISTANT: {% generation %}Reply here{% endgeneration %}";
+        let result = remove_known_non_jinja2_tags(template);
+        assert_eq!(result, "USER: {{ message }} ASSISTANT: Reply here");
+    }
+
+    #[test]
+    fn test_remove_known_non_jinja2_tags_preserves_standard_tags() {
+        let template = "{% for item in items %}{{ item }}{% endfor %}";
+        let result = remove_known_non_jinja2_tags(template);
+        assert_eq!(result, template);
+    }
+
+    #[test]
+    fn test_remove_known_non_jinja2_tags_multiple() {
+        let template = "Start {% generation %}Part 1{% endgeneration %} middle {% generation %}Part 2{% endgeneration %}";
+        let result = remove_known_non_jinja2_tags(template);
+        assert_eq!(result, "Start Part 1 middle Part 2");
+    }
+
+    #[test]
+    fn test_minijinja_parses_midchain_dotted_integer_lookup() {
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": r#"{{ m.content.0.type }} {{ "1.5.10" }}"#,
+        }))
+        .unwrap();
+
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        let result = formatter
+            .env
+            .get_template("default")
+            .unwrap()
+            .render(context! {
+                m => json!({
+                    "content": [
+                        {
+                            "type": "tool_reference"
+                        }
+                    ]
+                })
+            })
+            .unwrap();
+
+        assert_eq!(result, "tool_reference 1.5.10");
+    }
+}

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -1,0 +1,2105 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+use crate::{OAIChatLikeRequest, TextInput};
+use minijinja::{context, value::Value};
+use std::result::Result::Ok;
+
+/// Fix a tool schema that is missing `type`/`properties`. `pub` so consumers
+/// can normalize their own `tools` value when implementing
+/// [`crate::OAIChatLikeRequest::tools`].
+pub fn may_be_fix_tool_schema(tools: serde_json::Value) -> Option<Value> {
+    // No need to validate or enforce other schema checks as the basic Named function schema is already validated while creating the request.
+    // Empty parameters is allowed by OpenAI at request level. Need to enforce it at template level.
+    // Whenever parameters is empty, insert "type": "object" and "properties": {}
+    let mut updated_tools = Vec::new();
+    if let Some(arr) = tools.as_array() {
+        for tool in arr {
+            let mut tool = tool.clone();
+            if let Some(function) = tool.get_mut("function")
+                && let Some(parameters) = function.get_mut("parameters")
+            {
+                // Only operate if parameters is an object
+                if parameters.is_object() {
+                    let mut needs_type = false;
+                    let mut needs_properties = false;
+                    let is_empty = parameters
+                        .as_object()
+                        .map(|o| o.is_empty())
+                        .unwrap_or(false);
+
+                    // If empty, we need to insert both
+                    if is_empty {
+                        needs_type = true;
+                        needs_properties = true;
+                    } else {
+                        // If not empty, check if type/properties are missing
+                        if let Some(obj) = parameters.as_object() {
+                            if !obj.contains_key("type") {
+                                needs_type = true;
+                            }
+                            if !obj.contains_key("properties") {
+                                needs_properties = true;
+                            }
+                        }
+                    }
+
+                    if (needs_type || needs_properties)
+                        && let Some(obj) = parameters.as_object_mut()
+                    {
+                        if needs_type {
+                            obj.insert(
+                                "type".to_string(),
+                                serde_json::Value::String("object".to_string()),
+                            );
+                        }
+                        if needs_properties {
+                            obj.insert(
+                                "properties".to_string(),
+                                serde_json::Value::Object(Default::default()),
+                            );
+                        }
+                    }
+                }
+            }
+            updated_tools.push(tool);
+        }
+    }
+    Some(Value::from_serialize(&updated_tools))
+}
+
+/// Default media type conversions for multimodal content.
+/// Maps source types (e.g., "image_url") to target placeholder types (e.g., "image").
+const DEFAULT_MEDIA_TYPE_CONVERSIONS: &[(&str, &str)] = &[
+    ("image_url", "image"),
+    ("video_url", "video"),
+    ("audio_url", "audio"),
+];
+
+/// Convert media URL content parts to empty placeholder types.
+fn convert_media_url_to_placeholder(
+    content_array: &[serde_json::Value],
+    conversions: &[(&str, &str)],
+) -> Vec<serde_json::Value> {
+    content_array
+        .iter()
+        .map(|part| {
+            let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+            if let Some((_, target_type)) = conversions.iter().find(|(src, _)| *src == part_type) {
+                serde_json::json!({"type": target_type})
+            } else {
+                part.clone()
+            }
+        })
+        .collect()
+}
+
+fn may_be_fix_msg_content(
+    messages: serde_json::Value,
+    preserve_arrays: bool,
+    image_placeholder_template: Option<&str>,
+) -> Value {
+    // preserve_arrays=true: strings → arrays (multimodal)
+    // preserve_arrays=false: text-only arrays → strings (standard)
+    // image_placeholder_template: when `preserve_arrays=false` and the array
+    // mixes text + image parts, this template (e.g. `<|image_{n}|>`) lets us
+    // flatten by substituting image parts with model-family placeholders
+    // instead of leaving the raw array for the template, which would crash
+    // string-content templates like Phi-3-vision's `'+' message.content`.
+
+    let Some(arr) = messages.as_array() else {
+        return Value::from_serialize(&messages);
+    };
+
+    let updated_messages: Vec<_> = arr
+        .iter()
+        .map(|msg| {
+            match msg.get("content") {
+                // Case 1: String to Array (for multimodal templates)
+                Some(serde_json::Value::String(text)) if preserve_arrays => {
+                    let mut modified_msg = msg.clone();
+                    if let Some(msg_object) = modified_msg.as_object_mut() {
+                        let content_array = serde_json::json!([{
+                            "type": "text",
+                            "text": text
+                        }]);
+                        msg_object.insert("content".to_string(), content_array);
+                    }
+                    modified_msg
+                }
+                // Case 2: Array processing
+                Some(serde_json::Value::Array(content_array)) => {
+                    // First, convert any media URL parts to placeholders (e.g., image_url → image)
+                    let content_array = convert_media_url_to_placeholder(
+                        content_array,
+                        DEFAULT_MEDIA_TYPE_CONVERSIONS,
+                    );
+
+                    // Check if it's text-only (after media URL conversion)
+                    let is_text_only_array = !content_array.is_empty()
+                        && content_array.iter().all(|part| {
+                            part.get("type")
+                                .and_then(|type_field| type_field.as_str())
+                                .map(|type_str| type_str == "text")
+                                .unwrap_or(false)
+                        });
+
+                    let mut modified_msg = msg.clone();
+                    if let Some(msg_object) = modified_msg.as_object_mut() {
+                        if is_text_only_array && !preserve_arrays {
+                            // Flatten text-only arrays to string for standard templates
+                            let text_parts: Vec<&str> = content_array
+                                .iter()
+                                .filter_map(|part| part.get("text")?.as_str())
+                                .collect();
+                            let concatenated_text = text_parts.join("\n");
+                            msg_object.insert(
+                                "content".to_string(),
+                                serde_json::Value::String(concatenated_text),
+                            );
+                        } else if !preserve_arrays
+                            && !content_array.is_empty()
+                            && let Some(placeholder_tpl) = image_placeholder_template
+                        {
+                            // Mixed text+image array for a string-content
+                            // template — flatten with model-family image
+                            // placeholders inlined where the image parts were.
+                            // The `is_empty` guard preserves a literal `[]`
+                            // content (matches pre-PR behavior); flattening
+                            // an empty array to `""` would silently change
+                            // what the template renders.
+                            let flattened = flatten_mixed_content(&content_array, placeholder_tpl);
+                            msg_object.insert(
+                                "content".to_string(),
+                                serde_json::Value::String(flattened),
+                            );
+                        } else {
+                            // Keep as array (with media_url → media placeholder conversion applied)
+                            msg_object.insert(
+                                "content".to_string(),
+                                serde_json::Value::Array(content_array),
+                            );
+                        }
+                    }
+                    modified_msg
+                }
+                _ => msg.clone(), // No conversion needed
+            }
+        })
+        .collect();
+
+    Value::from_serialize(&updated_messages)
+}
+
+/// Concatenate a mixed-content array (text parts + image placeholders) into a
+/// single string. Text parts contribute their `text` field as-is; non-text
+/// parts (image, video, audio after the URL→placeholder conversion in
+/// `convert_media_url_to_placeholder`) emit the per-family placeholder with
+/// `{n}` substituted by the 1-based index of the image in the message.
+///
+/// Used in `may_be_fix_msg_content` when `preserve_arrays=false` and the
+/// template knows a placeholder convention — currently Phi-3-vision
+/// (`<|image_{n}|>`) and LLaVA-1.5 (`<image>`).
+///
+/// **Caveat — non-text index slot:** `img_idx` increments for every non-text
+/// part, not just images. The current supported families (Phi-3, LLaVA-1.5)
+/// are image-only so there's no collision today, but a future image+video
+/// family would silently consume an image-index slot for each video/audio
+/// part and emit the image placeholder there. When adding a family that
+/// mixes modalities in one message, either:
+///   1. expand this function with per-modality placeholder strings, or
+///   2. assert in `convert_media_url_to_placeholder` that only "image"
+///      placeholders reach this path.
+fn flatten_mixed_content(parts: &[serde_json::Value], placeholder_tpl: &str) -> String {
+    let mut out = String::new();
+    let mut img_idx: u32 = 1;
+    for part in parts {
+        let type_str = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if type_str == "text" {
+            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                out.push_str(text);
+            }
+        } else if !type_str.is_empty() {
+            let placeholder = placeholder_tpl.replace("{n}", &img_idx.to_string());
+            out.push_str(&placeholder);
+            img_idx += 1;
+        }
+    }
+    out
+}
+
+fn normalize_tool_calls_arguments_in_messages(messages: &mut serde_json::Value) {
+    // Deserialize `tool_calls[].function.arguments` from JSON strings to
+    // objects/arrays before template rendering — avoids double encoding
+    // and enables iteration. Skipped for templates whose own `is string`
+    // branch wants the raw string verbatim (see render()).
+    let Some(msgs) = messages.as_array_mut() else {
+        return;
+    };
+
+    for msg in msgs.iter_mut() {
+        if let Some(tool_calls) = msg.get_mut("tool_calls").and_then(|v| v.as_array_mut()) {
+            for tc in tool_calls {
+                if let Some(function) = tc.get_mut("function").and_then(|v| v.as_object_mut())
+                    && let Some(args) = function.get_mut("arguments")
+                    && let Some(s) = args.as_str()
+                    && let Ok(parsed) = serde_json::from_str(s)
+                {
+                    *args = parsed;
+                }
+            }
+        }
+    }
+}
+
+fn normalize_function_call_arguments_in_messages(messages: &mut serde_json::Value) {
+    // Legacy (deprecated) OpenAI `function_call.arguments` path. Kept separate
+    // from `tool_calls` normalization so the per-template `arguments is string`
+    // opt-out — which only refers to `tool_call.arguments` inside the
+    // tool_calls loop — does not accidentally suppress this path.
+    let Some(msgs) = messages.as_array_mut() else {
+        return;
+    };
+
+    for msg in msgs.iter_mut() {
+        if let Some(function_call) = msg.get_mut("function_call").and_then(|v| v.as_object_mut())
+            && let Some(args) = function_call.get_mut("arguments")
+            && let Some(s) = args.as_str()
+            && let Ok(parsed) = serde_json::from_str(s)
+        {
+            *args = parsed;
+        }
+    }
+}
+
+/// Inject `reasoning_content` back into the `content` field as `<think>` blocks.
+///
+/// Chat templates only reference `{{ message.content }}` — they don't know about
+/// `reasoning_content`. Without this injection, the model's prior chain-of-thought
+/// is silently dropped across turns.
+///
+/// Uses `<think>`/`</think>` delimiters — the same tags that reasoning models emit
+/// and that the reasoning parser strips on output. Reasoning is prepended to content
+/// to match the original generation order (`<think>...</think> response`).
+///
+/// Segments are concatenated rather than interleaved with tool_calls because Jinja
+/// templates render `tool_calls` separately from `content`. The model still sees
+/// all reasoning text before the template-rendered tool call block.
+fn inject_reasoning_content_into_messages(messages: &mut serde_json::Value) {
+    let Some(msgs) = messages.as_array_mut() else {
+        return;
+    };
+
+    for msg in msgs.iter_mut() {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+
+        let reasoning = match msg.get("reasoning_content") {
+            Some(serde_json::Value::String(s)) if !s.is_empty() => {
+                format!("<think>{}</think>", s)
+            }
+            Some(serde_json::Value::Array(segments)) => {
+                let mut result = String::new();
+                for seg in segments {
+                    if let Some(s) = seg.as_str()
+                        && !s.is_empty()
+                    {
+                        result.push_str("<think>");
+                        result.push_str(s);
+                        result.push_str("</think>");
+                    }
+                }
+                if result.is_empty() {
+                    continue;
+                }
+                result
+            }
+            _ => continue,
+        };
+
+        match msg.get("content") {
+            // Content is a string or null — prepend reasoning as text
+            Some(serde_json::Value::String(s)) if !s.is_empty() => {
+                msg["content"] = serde_json::Value::String(format!("{}{}", reasoning, s));
+            }
+            None | Some(serde_json::Value::Null) | Some(serde_json::Value::String(_)) => {
+                msg["content"] = serde_json::Value::String(reasoning);
+            }
+            // Content is an array (multimodal) — prepend as a text part
+            Some(serde_json::Value::Array(_)) => {
+                let think_part = serde_json::json!({
+                    "type": "text",
+                    "text": reasoning
+                });
+                if let Some(arr) = msg.get_mut("content").and_then(|v| v.as_array_mut()) {
+                    arr.insert(0, think_part);
+                }
+            }
+            // Other types (number, bool, object) — skip, don't corrupt
+            _ => continue,
+        }
+
+        // Remove so the template doesn't see both the injected <think> in content
+        // and the original reasoning_content field.
+        if let Some(obj) = msg.as_object_mut() {
+            obj.remove("reasoning_content");
+        }
+    }
+}
+
+/// Default [`OAIChatLikeRequest`] impl for the bare `dynamo-protocols` chat
+/// request. Lets any consumer (e.g. a standalone OpenAI frontend over an
+/// engine) render HF chat templates directly from the wire type, without
+/// defining their own wrapper. Consumers with extra fields (Dynamo's
+/// `NvCreateChatCompletionRequest`) provide their own impl.
+impl OAIChatLikeRequest for dynamo_protocols::types::CreateChatCompletionRequest {
+    fn model(&self) -> String {
+        self.model.clone()
+    }
+
+    fn messages(&self) -> Value {
+        let messages_json = serde_json::to_value(&self.messages).unwrap();
+        Value::from_serialize(&messages_json)
+    }
+
+    fn typed_messages(&self) -> Option<&[dynamo_protocols::types::ChatCompletionRequestMessage]> {
+        Some(self.messages.as_slice())
+    }
+
+    fn tools(&self) -> Option<Value> {
+        if self.tools.is_none() {
+            None
+        } else {
+            Some(may_be_fix_tool_schema(
+                serde_json::to_value(&self.tools).unwrap(),
+            )?)
+        }
+    }
+
+    fn tool_choice(&self) -> Option<Value> {
+        if self.tool_choice.is_none() {
+            None
+        } else {
+            Some(Value::from_serialize(&self.tool_choice))
+        }
+    }
+
+    fn response_format(&self) -> Option<Value> {
+        self.response_format.as_ref().map(Value::from_serialize)
+    }
+
+    fn should_add_generation_prompt(&self) -> bool {
+        // Using vLLM default behavior
+        true
+    }
+
+    fn extract_text(&self) -> Option<TextInput> {
+        Some(TextInput::Single(String::new()))
+    }
+
+    fn mm_processor_kwargs(&self) -> Option<&serde_json::Value> {
+        self.mm_processor_kwargs.as_ref()
+    }
+}
+
+impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
+    fn supports_add_generation_prompt(&self) -> bool {
+        self.supports_add_generation_prompt
+    }
+
+    fn image_placeholder_template(&self) -> Option<&'static str> {
+        self.image_placeholder_template
+    }
+
+    fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String> {
+        let mixins = Value::from_dyn_object(self.mixins.clone());
+
+        let tools = req.tools();
+        // Strip tools when tool_choice is "none" and the flag is enabled, so the model
+        // doesn't see tool definitions and generate raw XML tool calls in its response.
+        let tools = if self.exclude_tools_when_tool_choice_none {
+            match req.tool_choice() {
+                Some(ref tc) if tc.as_str() == Some("none") => None,
+                _ => tools,
+            }
+        } else {
+            tools
+        };
+        // has_tools should be true if tools is a non-empty array
+        let has_tools = tools.as_ref().and_then(|v| v.len()).is_some_and(|l| l > 0);
+        let add_generation_prompt = req.should_add_generation_prompt();
+
+        tracing::trace!(
+            "Rendering prompt with tools: {:?}, add_generation_prompt: {}",
+            has_tools,
+            add_generation_prompt
+        );
+
+        let messages_canonical = req.messages();
+        let mut messages_for_template: serde_json::Value =
+            serde_json::to_value(&messages_canonical).unwrap();
+
+        messages_for_template = serde_json::to_value(may_be_fix_msg_content(
+            messages_for_template,
+            self.requires_content_arrays,
+            self.image_placeholder_template,
+        ))
+        .unwrap();
+
+        // Pick the concrete template first so the normalization opt-out can be
+        // template- and field-specific: only the chosen template's
+        // `tool_call.arguments is string` flag should suppress normalization,
+        // and only for the `tool_calls[].function.arguments` field. Legacy
+        // `function_call.arguments` lives outside that branch and is always
+        // normalized.
+        let (template_name, template_handles_tool_calls_args_string) = if has_tools {
+            (
+                "tool_use",
+                self.tool_use_template_handles_tool_calls_arguments_string,
+            )
+        } else {
+            (
+                "default",
+                self.default_template_handles_tool_calls_arguments_string,
+            )
+        };
+
+        // Pre-parse JSON-string `arguments` into objects — but only for templates
+        // that unconditionally `| tojson` them. Templates that branch on
+        // `tool_call.arguments is string` (Qwen3, Hermes) want the raw string
+        // verbatim so the rendered bytes match what the model emitted on the
+        // prior turn. Re-serializing through minijinja's compact `tojson` here
+        // breaks append-only prefix matching across multi-step tool use.
+        if !template_handles_tool_calls_args_string {
+            normalize_tool_calls_arguments_in_messages(&mut messages_for_template);
+        }
+        // Legacy `function_call.arguments` is always normalized — the
+        // `arguments is string` opt-out only covers the modern `tool_calls`
+        // branch.
+        normalize_function_call_arguments_in_messages(&mut messages_for_template);
+
+        // Inject reasoning_content as <think> blocks into content — but only if
+        // the template doesn't handle it natively. Templates like Nemotron and
+        // Qwen3 reference reasoning_content directly in their Jinja logic; injecting
+        // would produce duplicate <think> blocks.
+        if !self.template_handles_reasoning {
+            inject_reasoning_content_into_messages(&mut messages_for_template);
+        }
+
+        let ctx = context! {
+            messages => messages_for_template,
+            tools => tools,
+            bos_token => self.config.bos_tok(),
+            eos_token => self.config.eos_tok(),
+            unk_token => self.config.unk_tok(),
+            add_generation_prompt => add_generation_prompt,
+            ..mixins
+        };
+
+        // Merge any additional args into the context last so they take precedence
+        let ctx = if let Some(args) = req.chat_template_args() {
+            let extra = Value::from_serialize(args);
+            context! { ..ctx, ..extra }
+        } else {
+            ctx
+        };
+
+        let tmpl: minijinja::Template<'_, '_> = self.env.get_template(template_name)?;
+        Ok(tmpl.render(&ctx)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_protocols::types::ChatCompletionRequestMessage as Msg;
+    // The crate's renderer tests exercise the bare-protocol request type via the
+    // default `OAIChatLikeRequest` impl above; Dynamo's `Nv*` wrapper lives in lib/llm.
+    use dynamo_protocols::types::CreateChatCompletionRequest as NvCreateChatCompletionRequest;
+    use minijinja::{Environment, context};
+
+    /// Tests that media URL content parts are converted to empty placeholders.
+    #[test]
+    fn test_convert_media_url_to_placeholder_single_type() {
+        let content_array = vec![
+            serde_json::json!({"type": "text", "text": "Check this image:"}),
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}),
+            serde_json::json!({"type": "text", "text": "What do you see?"}),
+        ];
+
+        let conversions = &[("image_url", "image")];
+        let result = convert_media_url_to_placeholder(&content_array, conversions);
+
+        assert_eq!(result.len(), 3);
+        // Text parts should be unchanged
+        assert_eq!(result[0]["type"], "text");
+        assert_eq!(result[0]["text"], "Check this image:");
+        // image_url should be converted to image placeholder
+        assert_eq!(result[1]["type"], "image");
+        assert!(result[1].get("image_url").is_none());
+        // Text parts should be unchanged
+        assert_eq!(result[2]["type"], "text");
+        assert_eq!(result[2]["text"], "What do you see?");
+    }
+
+    /// Tests that multiple media URL parts of the same type are all converted.
+    #[test]
+    fn test_convert_media_url_to_placeholder_multiple_same_type() {
+        let content_array = vec![
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}}),
+            serde_json::json!({"type": "text", "text": "vs"}),
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}),
+        ];
+
+        let conversions = &[("image_url", "image")];
+        let result = convert_media_url_to_placeholder(&content_array, conversions);
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0]["type"], "image");
+        assert_eq!(result[1]["type"], "text");
+        assert_eq!(result[2]["type"], "image");
+    }
+
+    /// Tests that only specified media types are converted, others preserved.
+    #[test]
+    fn test_convert_media_url_to_placeholder_selective_conversion() {
+        let content_array = vec![
+            serde_json::json!({"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3"}}),
+            serde_json::json!({"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}),
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}),
+        ];
+
+        // Only convert image_url
+        let conversions = &[("image_url", "image")];
+        let result = convert_media_url_to_placeholder(&content_array, conversions);
+
+        assert_eq!(result.len(), 3);
+        // audio_url and video_url should be preserved as-is
+        assert_eq!(result[0]["type"], "audio_url");
+        assert!(result[0].get("audio_url").is_some());
+        assert_eq!(result[1]["type"], "video_url");
+        assert!(result[1].get("video_url").is_some());
+        // Only image_url should be converted
+        assert_eq!(result[2]["type"], "image");
+        assert!(result[2].get("image_url").is_none());
+    }
+
+    /// Tests converting multiple different media types at once.
+    #[test]
+    fn test_convert_media_url_to_placeholder_multiple_types() {
+        let content_array = vec![
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}),
+            serde_json::json!({"type": "text", "text": "and listen to"}),
+            serde_json::json!({"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3"}}),
+            serde_json::json!({"type": "text", "text": "and watch"}),
+            serde_json::json!({"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}),
+        ];
+
+        // Convert all media types
+        let conversions = &[
+            ("image_url", "image"),
+            ("audio_url", "audio"),
+            ("video_url", "video"),
+        ];
+        let result = convert_media_url_to_placeholder(&content_array, conversions);
+
+        assert_eq!(result.len(), 5);
+        assert_eq!(result[0]["type"], "image");
+        assert!(result[0].get("image_url").is_none());
+        assert_eq!(result[1]["type"], "text");
+        assert_eq!(result[2]["type"], "audio");
+        assert!(result[2].get("audio_url").is_none());
+        assert_eq!(result[3]["type"], "text");
+        assert_eq!(result[4]["type"], "video");
+        assert!(result[4].get("video_url").is_none());
+    }
+
+    /// Tests that empty conversions list preserves all content.
+    #[test]
+    fn test_convert_media_url_to_placeholder_no_conversions() {
+        let content_array = vec![
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}),
+            serde_json::json!({"type": "text", "text": "hello"}),
+        ];
+
+        let conversions: &[(&str, &str)] = &[];
+        let result = convert_media_url_to_placeholder(&content_array, conversions);
+
+        assert_eq!(result.len(), 2);
+        // Everything should be preserved as-is
+        assert_eq!(result[0]["type"], "image_url");
+        assert!(result[0].get("image_url").is_some());
+        assert_eq!(result[1]["type"], "text");
+    }
+
+    /// Tests that DEFAULT_MEDIA_TYPE_CONVERSIONS only converts image_url,
+    /// and preserves other media types like video_url and audio_url.
+    #[test]
+    fn test_default_media_type_conversions_only_converts_image_url() {
+        let content_array = vec![
+            serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}),
+            serde_json::json!({"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}),
+            serde_json::json!({"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3"}}),
+            serde_json::json!({"type": "text", "text": "hello"}),
+        ];
+
+        // Use the actual DEFAULT_MEDIA_TYPE_CONVERSIONS
+        let result =
+            convert_media_url_to_placeholder(&content_array, DEFAULT_MEDIA_TYPE_CONVERSIONS);
+
+        assert_eq!(result.len(), 4);
+
+        // image_url SHOULD be converted to image (it's in the default map)
+        assert_eq!(result[0]["type"], "image");
+        assert!(result[0].get("image_url").is_none());
+
+        // video_url should NOT be converted (not in the default map)
+        assert_eq!(result[1]["type"], "video");
+        assert!(result[1].get("video_url").is_none());
+
+        // audio_url should NOT be converted (not in the default map)
+        assert_eq!(result[2]["type"], "audio");
+        assert!(result[2].get("audio_url").is_none());
+
+        // text should be unchanged
+        assert_eq!(result[3]["type"], "text");
+        assert_eq!(result[3]["text"], "hello");
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_missing_type_and_properties() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {},
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert!(tools[0]["function"]["parameters"]["type"] == "object");
+        assert!(
+            tools[0]["function"]["parameters"]["properties"]
+                == serde_json::Value::Object(Default::default())
+        );
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_missing_type() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "City and state, e.g., 'San Francisco, CA'"
+                                }
+                            }
+                        },
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert_eq!(tools[0]["function"]["parameters"]["type"], "object");
+
+        let mut expected_properties = serde_json::Map::new();
+        let mut location = serde_json::Map::new();
+        location.insert(
+            "type".to_string(),
+            serde_json::Value::String("string".to_string()),
+        );
+        location.insert(
+            "description".to_string(),
+            serde_json::Value::String("City and state, e.g., 'San Francisco, CA'".to_string()),
+        );
+        expected_properties.insert("location".to_string(), serde_json::Value::Object(location));
+
+        assert_eq!(
+            tools[0]["function"]["parameters"]["properties"],
+            serde_json::Value::Object(expected_properties)
+        );
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_missing_properties() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {"type": "object"},
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert_eq!(
+            tools[0]["function"]["parameters"]["properties"],
+            serde_json::Value::Object(Default::default())
+        );
+        assert_eq!(tools[0]["function"]["parameters"]["type"], "object");
+    }
+
+    /// Tests that content arrays (containing only text parts) are correctly concatenated.
+    #[test]
+    fn test_may_be_fix_msg_content_user_multipart() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "part 1"},
+                        {"type": "text", "text": "part 2"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Test array → string normalization (preserve_arrays=false for standard templates)
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: text-only array is concatenated into a single string
+        assert_eq!(
+            messages[0]["content"],
+            serde_json::Value::String("part 1\npart 2".to_string())
+        );
+    }
+
+    /// Tests that the function correctly handles a conversation
+    /// with multiple roles and mixed message types:
+    #[test]
+    fn test_may_be_fix_msg_content_mixed_messages() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant"
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Hello"},
+                        {"type": "text", "text": "World"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": "Hi there!"
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Another"},
+                        {"type": "text", "text": "multi-part"},
+                        {"type": "text", "text": "message"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Test array → string normalization (preserve_arrays=false for standard templates)
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: System message with string content remains unchanged
+        assert_eq!(
+            messages[0]["content"],
+            serde_json::Value::String("You are a helpful assistant".to_string())
+        );
+
+        // Verify: User message with text-only array is concatenated
+        assert_eq!(
+            messages[1]["content"],
+            serde_json::Value::String("Hello\nWorld".to_string())
+        );
+
+        // Verify: Assistant message with string content remains unchanged
+        assert_eq!(
+            messages[2]["content"],
+            serde_json::Value::String("Hi there!".to_string())
+        );
+
+        // Verify: Second user message with text-only array is concatenated
+        assert_eq!(
+            messages[3]["content"],
+            serde_json::Value::String("Another\nmulti-part\nmessage".to_string())
+        );
+    }
+
+    /// Tests that empty content arrays remain unchanged.
+    #[test]
+    fn test_may_be_fix_msg_content_empty_array() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": []
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Empty arrays should be preserved regardless of preserve_arrays setting
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: Empty arrays are preserved as-is
+        assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"].as_array().unwrap().len(), 0);
+    }
+
+    /// Empty arrays must stay as `[]` even when a flatten-time placeholder
+    /// template is provided (Phi-3 / LLaVA-1.5 path). Without the
+    /// `!content_array.is_empty()` guard in `may_be_fix_msg_content`,
+    /// an empty content array would silently flatten to `""` and the
+    /// chat template would render an entirely empty message instead of
+    /// failing or being preserved.
+    #[test]
+    fn test_may_be_fix_msg_content_empty_array_with_placeholder_template() {
+        let json_str = r#"{
+            "model": "phi-3-vision",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": []
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // preserve_arrays=false + image_placeholder_template=Some(...) is
+        // the combination that previously flattened `[]` to `""`.
+        let messages = serde_json::to_value(may_be_fix_msg_content(
+            messages_raw,
+            false,
+            Some("<|image_{n}|>"),
+        ))
+        .unwrap();
+
+        assert!(
+            messages[0]["content"].is_array(),
+            "empty array should be preserved as `[]`, not flattened to `\"\"`"
+        );
+        assert_eq!(messages[0]["content"].as_array().unwrap().len(), 0);
+    }
+
+    /// Tests that messages with simple string content remain unchanged.
+    #[test]
+    fn test_may_be_fix_msg_content_single_text() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Simple text message"
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Test with preserve_arrays=false (standard templates)
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: String content is not modified
+        assert_eq!(
+            messages[0]["content"],
+            serde_json::Value::String("Simple text message".to_string())
+        );
+    }
+
+    /// Tests that content arrays with mixed types (text + non-text) remain as arrays,
+    /// and that image_url is converted to image placeholder.
+    #[test]
+    fn test_may_be_fix_msg_content_mixed_types() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Check this image:"},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                        {"type": "text", "text": "What do you see?"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Mixed content should be preserved regardless of preserve_arrays setting
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: Mixed content types are preserved as array for template handling
+        // image_url should be converted to image placeholder
+        assert!(messages[0]["content"].is_array());
+        let content_array = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content_array.len(), 3);
+        assert_eq!(content_array[0]["type"], "text");
+        assert_eq!(content_array[1]["type"], "image");
+        assert!(content_array[1].get("image_url").is_none());
+        assert_eq!(content_array[2]["type"], "text");
+    }
+
+    /// Mixed text+image array with a string-content template and an
+    /// `<|image_{n}|>`-style placeholder (Phi-3-vision) — content must be
+    /// flattened to a single string with numbered image markers in place of
+    /// the image parts. The previous default (leave as array) would crash
+    /// the Phi-3 template's `'+' message.content` concatenation.
+    #[test]
+    fn test_may_be_fix_msg_content_flattens_phi3_style() {
+        let json_str = r#"{
+            "model": "phi-3-vision",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "First "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+                        {"type": "text", "text": " then "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/b.jpg"}},
+                        {"type": "text", "text": "?"}
+                    ]
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        let messages = serde_json::to_value(may_be_fix_msg_content(
+            messages_raw,
+            false,
+            Some("<|image_{n}|>"),
+        ))
+        .unwrap();
+
+        let content = messages[0]["content"].as_str().expect("content flattened");
+        assert_eq!(content, "First <|image_1|> then <|image_2|>?");
+    }
+
+    /// Same flattening with a static placeholder (LLaVA-1.5 `<image>`).
+    #[test]
+    fn test_may_be_fix_msg_content_flattens_llava_style() {
+        let json_str = r#"{
+            "model": "llava-1.5-7b-hf",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe: "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}}
+                    ]
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, Some("<image>")))
+                .unwrap();
+
+        let content = messages[0]["content"].as_str().expect("content flattened");
+        assert_eq!(content, "Describe: <image>");
+    }
+
+    /// Tests that content arrays containing only non-text types remain as arrays,
+    /// and image_url types are converted to image placeholders.
+    #[test]
+    fn test_may_be_fix_msg_content_non_text_only() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Non-text arrays should be preserved regardless of preserve_arrays setting
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Verify: Non-text content arrays are preserved, with image_url converted to image
+        assert!(messages[0]["content"].is_array());
+        let content_array = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content_array.len(), 2);
+        assert_eq!(content_array[0]["type"], "image");
+        assert_eq!(content_array[1]["type"], "image");
+    }
+
+    #[test]
+    fn test_none_tools_safe_for_all_templates() {
+        use super::tokcfg::ChatTemplate;
+        use super::{ContextMixins, HfTokenizerConfigJsonFormatter};
+
+        // Due to minijinja limitations the expressions in conditional statements may not be short-circuited
+        // This checks that our custom length filter works to avoid errors in this scenario
+        // length should return 0 if tools is None and 'if tools is iterable and tools | length > 0' should evaluate to false
+        let length_template = r#"
+{%- if tools is iterable and tools | length > 0 %}
+Tools available: {{ tools | length }}
+{%- else %}
+No tools
+{%- endif %}
+"#;
+
+        // Because we return None for tools when there are no tools this scenario should also be evaluate to false
+        // This is similar to the default jinja template behavior seen with llama models which check if tools is not none to activate tool mode
+        let no_tool_template = r#"
+{%- if tools is not none %}
+TOOL MODE
+{%- else %}
+NORMAL MODE
+{%- endif %}
+"#;
+
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": [
+                {"safe_length": length_template},
+                {"no_tool": no_tool_template}
+            ]
+        }))
+        .unwrap();
+
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        let ctx = context! { tools => Option::<Value>::None };
+
+        let result1 = formatter
+            .env
+            .get_template("safe_length")
+            .unwrap()
+            .render(&ctx);
+        println!("Safe length template with no tools => None: {:?}", result1);
+        assert!(
+            result1.is_ok(),
+            "Jinja template with and conditional and length filter should handle None: {:?}",
+            result1
+        );
+        assert!(
+            result1.unwrap().contains("No tools"),
+            "Should show 'No tools'"
+        );
+
+        let result2 = formatter.env.get_template("no_tool").unwrap().render(&ctx);
+        println!("Default template with no tools => None: {:?}", result2);
+        assert!(
+            result2.is_ok(),
+            "Jinja template with if tools is not none conditional should handle None: {:?}",
+            result2
+        );
+        assert!(result2.unwrap().contains("NORMAL MODE"));
+    }
+
+    /// Tests mixed content type scenarios.
+    #[test]
+    fn test_may_be_fix_msg_content_multiple_content_types() {
+        // Scenario 1: Multiple different content types (text + image + audio)
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Listen to this:"},
+                        {"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3"}},
+                        {"type": "text", "text": "And look at:"},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+                        {"type": "text", "text": "What do you think?"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Mixed types should preserve array structure, with image_url converted to image
+        assert!(messages[0]["content"].is_array());
+        let content_array = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content_array.len(), 5);
+        assert_eq!(content_array[0]["type"], "text");
+        assert_eq!(content_array[1]["type"], "audio");
+        assert_eq!(content_array[2]["type"], "text");
+        assert_eq!(content_array[3]["type"], "image");
+        assert_eq!(content_array[4]["type"], "text");
+
+        // Scenario 2: Unknown/future content types mixed with text
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Check this:"},
+                        {"type": "video_url", "video_url": {"url": "https://example.com/vid.mp4"}},
+                        {"type": "text", "text": "Interesting?"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        // Unknown types mixed with text should preserve array
+        assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_normalize_tool_arguments_tojson() {
+        let tmpl = r#"{{ messages[0].tool_calls[0].function.arguments | tojson }}"#;
+
+        // Message with tool_calls containing JSON string arguments
+        let mut messages = serde_json::Value::Array(vec![serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "arguments": "{\"format\":\"celsius\",\"location\":\"San Francisco, CA\"}"
+                }
+            }]
+        })]);
+
+        normalize_tool_calls_arguments_in_messages(&mut messages);
+
+        let mut env = Environment::new();
+        env.add_filter("tojson", super::super::tokcfg::tojson);
+        env.add_template("t", tmpl).unwrap();
+        let out = env
+            .get_template("t")
+            .unwrap()
+            .render(context! { messages => messages.as_array().unwrap() })
+            .unwrap();
+
+        // Should produce clean JSON without double-encoding
+        assert_eq!(
+            out,
+            r#"{"format":"celsius","location":"San Francisco, CA"}"#
+        );
+    }
+
+    #[test]
+    fn test_normalize_tool_arguments_items_loop() {
+        let tmpl = r#"{% for k, v in messages[0].tool_calls[0].function.arguments|items %}{{k}}={{v}};{% endfor %}"#;
+
+        let mut messages = serde_json::Value::Array(vec![serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "arguments": "{\"a\":1,\"b\":\"x\"}"
+                }
+            }]
+        })]);
+
+        normalize_tool_calls_arguments_in_messages(&mut messages);
+
+        let mut env = Environment::new();
+        env.add_template("t", tmpl).unwrap();
+        let out = env
+            .get_template("t")
+            .unwrap()
+            .render(context! { messages => messages.as_array().unwrap() })
+            .unwrap();
+
+        assert!(out == "a=1;b=x;" || out == "b=x;a=1;");
+    }
+
+    #[test]
+    fn test_normalize_tool_arguments_legacy_function_call() {
+        // Test deprecated function_call format (OpenAI compat)
+        let mut messages = serde_json::Value::Array(vec![serde_json::json!({
+            "role": "assistant",
+            "function_call": {
+                "name": "get_weather",
+                "arguments": "{\"location\":\"NYC\"}"
+            }
+        })]);
+
+        normalize_function_call_arguments_in_messages(&mut messages);
+
+        assert_eq!(
+            messages[0]["function_call"]["arguments"],
+            serde_json::json!({"location": "NYC"})
+        );
+    }
+
+    #[test]
+    fn test_normalize_tool_arguments_malformed_json_passthrough() {
+        // Malformed JSON should be left as a string
+        let mut messages = serde_json::Value::Array(vec![serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "arguments": "not valid json at all"
+                }
+            }]
+        })]);
+
+        normalize_tool_calls_arguments_in_messages(&mut messages);
+
+        assert_eq!(
+            messages[0]["tool_calls"][0]["function"]["arguments"],
+            serde_json::Value::String("not valid json at all".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_tool_arguments_with_multimodal_content() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Check this:"},
+                        {"type": "video_url", "video_url": {"url": "https://example.com/vid.mp4"}},
+                        {"type": "text", "text": "Interesting?"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "analyze_video",
+                            "arguments": "{\"url\":\"https://example.com/vid.mp4\",\"format\":\"mp4\"}"
+                        }
+                    }]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Apply content normalization with preserve_arrays=false (standard templates)
+        let mut messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+
+        normalize_tool_calls_arguments_in_messages(&mut messages);
+
+        // Multimodal content preserved as array (mixed types not flattened)
+        assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"].as_array().unwrap().len(), 3);
+
+        // Tool arguments deserialized to object
+        assert!(messages[1]["tool_calls"][0]["function"]["arguments"].is_object());
+        assert_eq!(
+            messages[1]["tool_calls"][0]["function"]["arguments"]["url"],
+            "https://example.com/vid.mp4"
+        );
+    }
+
+    /// Tests string → array normalization for multimodal templates
+    #[test]
+    fn test_may_be_fix_msg_content_string_to_array() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Hello, how are you?"
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Test with preserve_arrays=true (multimodal templates)
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
+
+        // Verify: String is converted to array format
+        assert!(messages[0]["content"].is_array());
+        let content_array = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content_array.len(), 1);
+        assert_eq!(content_array[0]["type"], "text");
+        assert_eq!(content_array[0]["text"], "Hello, how are you?");
+    }
+
+    /// Tests that arrays are preserved when preserve_arrays=true
+    #[test]
+    fn test_may_be_fix_msg_content_array_preserved_with_multimodal() {
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "part 1"},
+                        {"type": "text", "text": "part 2"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // Test with preserve_arrays=true (multimodal templates)
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
+
+        // Verify: Array is preserved as-is
+        assert!(messages[0]["content"].is_array());
+        let content_array = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content_array.len(), 2);
+        assert_eq!(content_array[0]["text"], "part 1");
+        assert_eq!(content_array[1]["text"], "part 2");
+    }
+
+    fn user() -> Msg {
+        Msg::User(Default::default())
+    }
+    fn tool() -> Msg {
+        Msg::Tool(Default::default())
+    }
+
+    fn dummy_state(messages: Vec<Msg>) -> NvCreateChatCompletionRequest {
+        let json = serde_json::json!({
+            "model": "test-model",
+            "messages": messages
+        });
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn add_after_user() {
+        let s = dummy_state(vec![user()]);
+        assert!(s.should_add_generation_prompt());
+    }
+
+    #[test]
+    fn add_after_tool() {
+        let s = dummy_state(vec![tool()]);
+        assert!(s.should_add_generation_prompt());
+    }
+
+    #[test]
+    fn add_when_empty() {
+        let s = dummy_state(vec![]);
+        assert!(s.should_add_generation_prompt());
+    }
+
+    /// Helper to build a formatter with a simple tool-aware template.
+    fn tool_aware_formatter(
+        exclude_tools_when_tool_choice_none: bool,
+    ) -> HfTokenizerConfigJsonFormatter {
+        let template = r#"
+{%- if tools is iterable and tools | length > 0 %}
+TOOL_MODE tools={{ tools | length }}
+{%- else %}
+NORMAL_MODE
+{%- endif %}
+{{ messages[0].content }}"#;
+
+        let chat_template: super::tokcfg::ChatTemplate =
+            serde_json::from_value(serde_json::json!({ "chat_template": template })).unwrap();
+
+        HfTokenizerConfigJsonFormatter::with_options(
+            chat_template,
+            ContextMixins::new(&[]),
+            exclude_tools_when_tool_choice_none,
+        )
+        .unwrap()
+    }
+
+    /// Helper to build a request with tools and optional tool_choice.
+    fn request_with_tool_choice(tool_choice: &str) -> NvCreateChatCompletionRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {"location": {"type": "string"}}}
+                }
+            }],
+            "tool_choice": tool_choice
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_exclude_tools_strips_when_tool_choice_none() {
+        let formatter = tool_aware_formatter(true);
+        let request = request_with_tool_choice("none");
+        let result = formatter.render(&request).unwrap();
+        assert!(
+            result.contains("NORMAL_MODE"),
+            "With exclude_tools=true and tool_choice=none, tools should be stripped. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_exclude_tools_keeps_when_tool_choice_auto() {
+        let formatter = tool_aware_formatter(true);
+        let request = request_with_tool_choice("auto");
+        let result = formatter.render(&request).unwrap();
+        assert!(
+            result.contains("TOOL_MODE"),
+            "With tool_choice=auto, tools should be included. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_no_exclude_tools_keeps_when_tool_choice_none() {
+        let formatter = tool_aware_formatter(false);
+        let request = request_with_tool_choice("none");
+        let result = formatter.render(&request).unwrap();
+        assert!(
+            result.contains("TOOL_MODE"),
+            "With exclude_tools=false and tool_choice=none, tools should NOT be stripped. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_inject_reasoning_content_segments_with_tool_calls() {
+        // Assistant message with reasoning_content segments and tool_calls
+        let mut messages = serde_json::json!([
+            {
+                "role": "user",
+                "content": "What is sqrt(144) and sqrt(256)?"
+            },
+            {
+                "role": "assistant",
+                "content": "Let me calculate those.",
+                "reasoning_content": ["I need to compute sqrt(144)", "Now sqrt(256)", ""],
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": "{\"expr\": \"sqrt(144)\"}"
+                        }
+                    },
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": "{\"expr\": \"sqrt(256)\"}"
+                        }
+                    }
+                ]
+            }
+        ]);
+
+        inject_reasoning_content_into_messages(&mut messages);
+
+        let assistant = &messages[1];
+
+        // reasoning_content should be removed
+        assert!(
+            assistant.get("reasoning_content").is_none(),
+            "reasoning_content should be removed after injection"
+        );
+
+        // content should have <think> blocks prepended (empty segment skipped)
+        let content = assistant["content"].as_str().unwrap();
+        assert!(
+            content.starts_with("<think>I need to compute sqrt(144)</think>"),
+            "content should start with first reasoning segment, got: {}",
+            content
+        );
+        assert!(
+            content.contains("<think>Now sqrt(256)</think>"),
+            "content should contain second reasoning segment"
+        );
+        // Empty third segment should NOT produce <think></think>
+        assert!(
+            !content.contains("<think></think>"),
+            "empty segments should be skipped"
+        );
+        // Original content should be preserved at the end
+        assert!(
+            content.ends_with("Let me calculate those."),
+            "original content should be at the end, got: {}",
+            content
+        );
+
+        // tool_calls should be untouched
+        assert!(assistant.get("tool_calls").is_some());
+        assert_eq!(assistant["tool_calls"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_inject_reasoning_content_text_variant() {
+        let mut messages = serde_json::json!([
+            {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_content": "Let me think about this carefully."
+            }
+        ]);
+
+        inject_reasoning_content_into_messages(&mut messages);
+
+        let assistant = &messages[0];
+        assert!(assistant.get("reasoning_content").is_none());
+        let content = assistant["content"].as_str().unwrap();
+        assert_eq!(
+            content,
+            "<think>Let me think about this carefully.</think>The answer is 42."
+        );
+    }
+
+    #[test]
+    fn test_inject_reasoning_content_null_content() {
+        // reasoning_content present but content is null
+        let mut messages = serde_json::json!([
+            {
+                "role": "assistant",
+                "content": null,
+                "reasoning_content": "Thinking...",
+                "tool_calls": [{"id": "call_0", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+            }
+        ]);
+
+        inject_reasoning_content_into_messages(&mut messages);
+
+        let content = messages[0]["content"].as_str().unwrap();
+        assert_eq!(content, "<think>Thinking...</think>");
+        assert!(messages[0].get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn test_inject_reasoning_content_skips_non_assistant() {
+        let mut messages = serde_json::json!([
+            {
+                "role": "user",
+                "content": "hello",
+                "reasoning_content": "should not be touched"
+            }
+        ]);
+
+        inject_reasoning_content_into_messages(&mut messages);
+
+        // User message should be untouched
+        assert!(messages[0].get("reasoning_content").is_some());
+    }
+
+    // Helper: create a formatter with a minimal chat template for render tests
+    fn make_test_formatter() -> HfTokenizerConfigJsonFormatter {
+        use super::tokcfg::ChatTemplate;
+        use super::{ContextMixins, HfTokenizerConfigJsonFormatter};
+
+        // Minimal template that renders content verbatim — enough to verify
+        // that reasoning_content injection works through the full pipeline.
+        let template = r#"{%- for message in messages %}{{ message.role }}: {{ message.content }}
+{%- endfor %}
+{%- if add_generation_prompt %}assistant:{%- endif %}"#;
+
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": template
+        }))
+        .unwrap();
+
+        HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap()
+    }
+
+    // Verify reasoning_content (Text variant) from a prior assistant turn
+    // appears as a <think> block in the rendered prompt.
+    #[test]
+    fn test_reasoning_content_text_roundtrip_render() {
+        use super::OAIPromptFormatter;
+        let formatter = make_test_formatter();
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "What is sqrt(144)?"},
+                {
+                    "role": "assistant",
+                    "content": "The answer is 12.",
+                    "reasoning_content": "I need to compute the square root of 144."
+                },
+                {"role": "user", "content": "Are you sure?"}
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+
+        assert!(
+            rendered.contains("<think>I need to compute the square root of 144.</think>"),
+            "reasoning_content must appear as <think> block, got: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("The answer is 12."),
+            "original content must be preserved"
+        );
+        assert!(
+            !rendered.contains("reasoning_content"),
+            "raw reasoning_content field should not leak into prompt"
+        );
+    }
+
+    // Verify a full agentic flow: assistant reasons, calls a tool, gets a
+    // result, then reasons again before answering. Both reasoning turns must
+    // survive into the rendered prompt.
+    #[test]
+    fn test_reasoning_content_agentic_tool_call_roundtrip_render() {
+        use super::OAIPromptFormatter;
+        let formatter = make_test_formatter();
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "What is sqrt(144) + sqrt(256)?"},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning_content": "I need to compute both square roots. Let me start with sqrt(144).",
+                    "tool_calls": [{
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": "{\"expr\": \"sqrt(144)\"}"
+                        }
+                    }]
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_0",
+                    "content": "12"
+                },
+                {
+                    "role": "assistant",
+                    "content": "sqrt(144) = 12 and sqrt(256) = 16, so the answer is 28.",
+                    "reasoning_content": "Got 12 for sqrt(144). Now sqrt(256) = 16. Sum is 28."
+                },
+                {"role": "user", "content": "Thanks!"}
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+
+        // First assistant turn: reasoning with tool call, null content
+        assert!(
+            rendered.contains("<think>I need to compute both square roots"),
+            "first turn reasoning must be in prompt, got: {}",
+            rendered
+        );
+        // Second assistant turn: reasoning with final answer
+        assert!(
+            rendered.contains("<think>Got 12 for sqrt(144)"),
+            "second turn reasoning must be in prompt"
+        );
+        assert!(
+            rendered.contains("the answer is 28"),
+            "final answer content must be preserved"
+        );
+        // No raw reasoning_content in output
+        assert!(
+            !rendered.contains("reasoning_content"),
+            "raw reasoning_content field should not leak into prompt"
+        );
+    }
+
+    // Template that does NOT reference reasoning_content — injection should happen.
+    #[test]
+    fn test_reasoning_injected_when_template_ignores_it() {
+        use super::OAIPromptFormatter;
+        let formatter = make_test_formatter();
+
+        // Formatter uses a simple template that doesn't reference reasoning_content
+        assert!(!formatter.template_handles_reasoning);
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Hi.",
+                    "reasoning_content": "The user said hello."
+                },
+                {"role": "user", "content": "Bye"}
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+        assert!(
+            rendered.contains("<think>The user said hello.</think>"),
+            "injection must happen when template ignores reasoning_content, got: {}",
+            rendered
+        );
+    }
+
+    // Template that DOES reference reasoning_content — injection must be skipped.
+    #[test]
+    fn test_reasoning_not_injected_when_template_handles_it() {
+        use super::tokcfg::ChatTemplate;
+        use super::{ContextMixins, HfTokenizerConfigJsonFormatter, OAIPromptFormatter};
+
+        // Template that natively renders reasoning_content (like Nemotron/Qwen3)
+        let template = r#"{%- for message in messages %}{%- if message.role == "assistant" and message.reasoning_content is defined and message.reasoning_content %}<think>{{ message.reasoning_content }}</think>
+{%- endif %}{{ message.role }}: {{ message.content }}
+{%- endfor %}
+{%- if add_generation_prompt %}assistant:{%- endif %}"#;
+
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": template
+        }))
+        .unwrap();
+
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        // Verify detection worked
+        assert!(formatter.template_handles_reasoning);
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Hi.",
+                    "reasoning_content": "The user said hello."
+                },
+                {"role": "user", "content": "Bye"}
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+
+        // Template renders reasoning natively — no duplicate injection
+        assert!(
+            rendered.contains("<think>The user said hello.</think>"),
+            "template must render reasoning_content natively, got: {}",
+            rendered
+        );
+        // Must NOT have double <think> blocks
+        let think_count = rendered.matches("<think>").count();
+        assert_eq!(
+            think_count, 1,
+            "must have exactly one <think> block (from template), got {} in: {}",
+            think_count, rendered
+        );
+    }
+
+    /// Real Qwen3-4B-Thinking-2507 chat template (verbatim from
+    /// `Qwen/Qwen3-4B-Thinking-2507/tokenizer_config.json`). Used to
+    /// regression-test append-only rendering across multi-step tool use.
+    const QWEN3_THINKING_TEMPLATE: &str = r##"{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and reasoning_content) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n<think>\n' }}
+{%- endif %}"##;
+
+    fn qwen3_thinking_formatter() -> HfTokenizerConfigJsonFormatter {
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": QWEN3_THINKING_TEMPLATE,
+        }))
+        .unwrap();
+        HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap()
+    }
+
+    #[test]
+    fn test_qwen3_thinking_template_flags_detected() {
+        let formatter = qwen3_thinking_formatter();
+        assert!(
+            formatter.template_handles_reasoning,
+            "template references reasoning_content directly"
+        );
+        // The Qwen3-Thinking template is registered as both `default` and
+        // `tool_use` (single-string HF chat template), so both flags must fire.
+        assert!(
+            formatter.default_template_handles_tool_calls_arguments_string,
+            "default template branches on `arguments is string`"
+        );
+        assert!(
+            formatter.tool_use_template_handles_tool_calls_arguments_string,
+            "tool_use template branches on `arguments is string`"
+        );
+    }
+
+    /// Across a multi-step tool-use turn, the rendered prompt for turn N+1
+    /// must be a strict prefix-extension of [turn-N prompt + bytes the model
+    /// emitted on turn N]. Otherwise KV-cache prefix matching falls off a
+    /// cliff every time a tool result comes back.
+    ///
+    /// The Qwen3-Thinking template's `is string` branch (template lines 63-67)
+    /// renders `tool_call.arguments` verbatim from the OpenAI-canonical JSON
+    /// string. Pre-parsing that string into an object forces the `else` branch
+    /// and re-emits with minijinja's compact `tojson`, breaking append-only.
+    #[test]
+    fn test_qwen3_thinking_append_only_across_tool_use_turn() {
+        let formatter = qwen3_thinking_formatter();
+
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                    },
+                    "required": ["location"]
+                }
+            }
+        }]);
+
+        // Turn 1: server is asked to produce the first assistant turn.
+        let turn1_request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "qwen3-thinking",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's the weather in San Francisco?"},
+                ],
+                "tools": tools,
+            }))
+            .unwrap();
+        let p1 = formatter.render(&turn1_request).unwrap();
+
+        // Bytes the model emits next. Spacing matches the Qwen3 training
+        // distribution (Python jinja2 / json.dumps defaults: `, ` and `: `).
+        // Empty content + reasoning + a tool call.
+        let model_emitted = "I'll call get_weather for SF.\n\
+            </think>\n\n\
+            <tool_call>\n\
+            {\"name\": \"get_weather\", \"arguments\": {\"location\": \"San Francisco\", \"unit\": \"celsius\"}}\n\
+            </tool_call><|im_end|>\n";
+        let wire_after_t1 = format!("{p1}{model_emitted}");
+
+        // Turn 2: client sends the prior assistant turn back in OpenAI canonical
+        // form (arguments as a JSON STRING with spaces) plus the tool result.
+        let turn2_request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "qwen3-thinking",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's the weather in San Francisco?"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "I'll call get_weather for SF.",
+                        "tool_calls": [{
+                            "id": "call_sf",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+                            }
+                        }]
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_sf",
+                        "content": "{\"temp\": 18, \"conditions\": \"Foggy\"}"
+                    }
+                ],
+                "tools": tools,
+            }))
+            .unwrap();
+        let p2 = formatter.render(&turn2_request).unwrap();
+
+        if !p2.starts_with(&wire_after_t1) {
+            // Find first divergence and report it for easy debugging.
+            let div = wire_after_t1
+                .as_bytes()
+                .iter()
+                .zip(p2.as_bytes())
+                .position(|(a, b)| a != b)
+                .unwrap_or_else(|| wire_after_t1.len().min(p2.len()));
+            let lo = div.saturating_sub(40);
+            panic!(
+                "turn-2 prompt is NOT a prefix-extension of [turn-1 + model bytes]\n  \
+                 diverges at byte {div}\n  \
+                 wire ends: ...{}|{}\n  \
+                 t2 has:    ...{}|{}",
+                String::from_utf8_lossy(&wire_after_t1.as_bytes()[lo..div]),
+                String::from_utf8_lossy(
+                    &wire_after_t1.as_bytes()[div..(div + 60).min(wire_after_t1.len())]
+                ),
+                String::from_utf8_lossy(&p2.as_bytes()[lo..div]),
+                String::from_utf8_lossy(&p2.as_bytes()[div..(div + 60).min(p2.len())]),
+            );
+        }
+
+        // The only new bytes in P2 should be the tool response and the next
+        // generation prompt — nothing in the prior conversation should change.
+        let suffix = &p2[wire_after_t1.len()..];
+        assert!(
+            suffix.contains("<tool_response>"),
+            "appended bytes must include the tool response, got: {suffix}"
+        );
+        assert!(
+            suffix.ends_with("<|im_start|>assistant\n<think>\n"),
+            "appended bytes must end with the next generation prompt, got: {suffix}"
+        );
+    }
+}

--- a/renderer/src/template/tokcfg.rs
+++ b/renderer/src/template/tokcfg.rs
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//based on: https://github.com/EricLBuehler/mistral.rs/blob/d970bb5feb863acf8e8ec90de97e18221fb959f1/mistralrs-core/src/pipeline/chat_template.rs
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Local};
+use either::Either;
+use minijinja::{Error, ErrorKind, Value, value::Kwargs};
+use serde::{Deserialize, Serialize};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub struct AddedTokensDecoder {
+    __type: Option<String>,
+    pub content: String,
+    lstrip: bool,
+    normalized: bool,
+    rstrip: bool,
+    single_word: bool,
+    special: Option<bool>,
+}
+
+pub fn raise_exception(msg: String) -> Result<String, minijinja::Error> {
+    Err(minijinja::Error::new(ErrorKind::InvalidOperation, msg))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BeginEndUnkTok(
+    #[serde(with = "either::serde_untagged")] pub Either<String, AddedTokensDecoder>,
+);
+
+/// Support older tool use patterns where the tool use template was separate from the default/chat template.
+/// Modern patterns use a single template with a `tool_use` key, e.g.
+///
+/// ```jinja
+/// {%- if tools is not none and tool_choice is not none %}
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct ChatTemplateValue(
+    #[serde(with = "either::serde_untagged")] pub Either<String, Vec<HashMap<String, String>>>,
+);
+
+/// If present, pad_token is usually a single value. Deepseek R1 and it's distill's use a map.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub struct PadTokenValue(
+    #[serde(with = "either::serde_untagged")] pub Either<String, AddedTokensDecoder>,
+);
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Default)]
+/// Template for chat models including bos/eos/unk as well as the chat template.
+pub struct ChatTemplate {
+    pub bos_token: Option<BeginEndUnkTok>,
+    pub eos_token: Option<BeginEndUnkTok>,
+    pub unk_token: Option<BeginEndUnkTok>,
+
+    /// Jinja format [chat templating] for chat completion.
+    ///
+    /// [chat templating]: https://huggingface.co/docs/transformers/chat_templating
+    pub chat_template: Option<ChatTemplateValue>,
+
+    // future
+    add_bos_token: Option<bool>,
+    add_eos_token: Option<bool>,
+    added_tokens_decoder: Option<HashMap<String, AddedTokensDecoder>>,
+    additional_special_tokens: Option<Vec<String>>,
+    clean_up_tokenization_spaces: Option<bool>,
+    device_map: Option<String>,
+    legacy: Option<bool>,
+    model_max_length: Option<f64>,
+    pad_token: Option<PadTokenValue>,
+    sp_model_kwargs: Option<HashMap<String, String>>,
+    spaces_between_special_tokens: Option<bool>,
+    tokenizer_class: Option<String>,
+    truncation_size: Option<String>,
+    use_default_system_prompt: Option<bool>,
+}
+
+impl ChatTemplate {
+    pub fn eos_tok(&self) -> Option<String> {
+        match self.eos_token.as_ref()?.0 {
+            Either::Left(ref lit) => Some(lit.clone()),
+            Either::Right(ref added) => Some(added.content.clone()),
+        }
+    }
+
+    pub fn bos_tok(&self) -> Option<String> {
+        match self.bos_token.as_ref()?.0 {
+            Either::Left(ref lit) => Some(lit.clone()),
+            Either::Right(ref added) => Some(added.content.clone()),
+        }
+    }
+
+    pub fn unk_tok(&self) -> Option<String> {
+        match self.unk_token.as_ref()?.0 {
+            Either::Left(ref lit) => Some(lit.clone()),
+            Either::Right(ref added) => Some(added.content.clone()),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub struct GenerationConfig {
+    #[serde(with = "either::serde_untagged")]
+    bos_token_id: Either<u32, Vec<u32>>,
+    #[serde(with = "either::serde_untagged")]
+    eos_token_id: Either<u32, Vec<u32>>,
+}
+
+pub fn tojson(value: Value, kwargs: Kwargs) -> Result<Value, Error> {
+    if let Ok(indent) = kwargs.get("indent") {
+        let mut buf = Vec::new();
+        let repeat = b" ".repeat(indent);
+        let formatter = serde_json::ser::PrettyFormatter::with_indent(&repeat);
+        let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+        value.serialize(&mut serializer).unwrap();
+        String::from_utf8(buf).map_err(|err| {
+            Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
+        })
+    } else {
+        serde_json::to_string(&value).map_err(|err| {
+            Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
+        })
+    }
+    .map_err(|err| {
+        Error::new(ErrorKind::InvalidOperation, "cannot serialize to JSON").with_source(err)
+    })
+    .map(|s| {
+        // When this filter is used the return value is safe for both HTML and JSON
+        let mut rv = String::with_capacity(s.len());
+        for c in s.chars() {
+            match c {
+                '<' => rv.push_str("\\u003c"),
+                '>' => rv.push_str("\\u003e"),
+                '&' => rv.push_str("\\u0026"),
+                '\'' => rv.push_str("\\u0027"),
+                _ => rv.push(c),
+            }
+        }
+        Value::from_safe_string(rv)
+    })
+}
+
+pub fn strftime_now(format_str: &str) -> Result<Value, Error> {
+    let local: DateTime<Local> = Local::now();
+    Ok(Value::from_safe_string(
+        local.format(format_str).to_string(),
+    ))
+}

--- a/scripts/sync-from-dynamo.sh
+++ b/scripts/sync-from-dynamo.sh
@@ -4,8 +4,8 @@
 
 # Check (or apply) a one-way sync from a local ai-dynamo/dynamo checkout into this repo.
 #
-# Sources:  $DYNAMO_SRC/lib/{protocols,tokenizers,parsers}/
-# Targets:  ./{protocols,tokenizers,parsers}/
+# Sources:  $DYNAMO_SRC/lib/{protocols,tokenizers,parsers,renderer}/
+# Targets:  ./{protocols,tokenizers,parsers,renderer}/
 #
 # Usage:
 #   scripts/sync-from-dynamo.sh                 # check, against $DYNAMO_SRC (default /ephemeral/dynamo)
@@ -47,7 +47,7 @@ if [ ! -d "$DYNAMO_SRC/lib" ]; then
 fi
 
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
-CRATES=(protocols tokenizers parsers)
+CRATES=(protocols tokenizers parsers renderer)
 
 # Files we own locally that we don't want overwritten by a sync.
 MANUAL_REVIEW=(Cargo.toml README.md CLAUDE.md AGENTS.md)
@@ -65,6 +65,17 @@ for c in "${CRATES[@]}"; do
   src="$DYNAMO_SRC/lib/$c"
   dst="$HERE/$c"
   echo "--- $c ---"
+
+  # TODO(renderer): drop this guard once PR ai-dynamo/dynamo#9946 lands
+  # lib/renderer on dynamo main. Until then `renderer` exists in this repo
+  # but not upstream, so the hourly sync-check (which runs against dynamo
+  # main) has nothing to diff against. Skip it explicitly — rather than
+  # silently comparing nothing — so the temporary state is visible in the
+  # output and intentional.
+  if [ ! -d "$src" ]; then
+    echo "  SKIP: lib/$c not present in $DYNAMO_SRC (not yet on dynamo main); skipping until upstream lands."
+    continue
+  fi
 
   # Sync src/ and tests/ subdirs only. These are pure code.
   # --checksum compares by content hash, not size+mtime — important for CI,


### PR DESCRIPTION
## What

Pulls the new **`dynamo-renderer`** crate over from [ai-dynamo/dynamo#9946](https://github.com/ai-dynamo/dynamo/pull/9946) as a fourth standalone crate here, alongside `protocols` / `tokenizers` / `parsers`, wires it into the sync tooling, and exercises it from the demo server.

`dynamo-renderer` is the *encode* side of serving: OpenAI chat requests → model-ready prompt strings via HF `chat_template` (minijinja + pycompat), plus native Rust DeepSeek V4 / V3.2 formatters. It's the counterpart to `dynamo-parsers` (the *decode* side).

> Note: upstream PR #9946 names this the **renderer** crate (not "parsers" — that already exists here). Mirrored under the same `renderer` name dynamo uses so the path-for-path sync stays trivial.

## Changes

**Crate (`renderer/`)**
- `src/` mirrored verbatim from `lib/renderer` (sync-owned).
- Inlined standalone `Cargo.toml` (version `0.1.0`, deps via `workspace`) + reframed `README.md`, matching the convention of the other crates.

**Workspace**
- Added `renderer` member, `dynamo-renderer` path dep, and new `chrono` / `either` / `minijinja` / `minijinja-contrib` workspace deps (versions matched to dynamo).

**Sync**
- Added `renderer` to `scripts/sync-from-dynamo.sh` `CRATES` + the `sync-check` workflow.
- Guarded so the hourly check (which runs against dynamo **main**) explicitly *skips* renderer until #9946 merges, instead of silently comparing against a non-existent source. `TODO(renderer)` marks the guard for removal post-merge.

**Demo server**
- Fetches `tokenizer_config.json` (alongside `tokenizer.json`) and builds a `PromptFormatter` into `AppState`.
- New `POST /v1/render` endpoint: chat request → rendered prompt string. Returns `503` with a clear message when no chat template was loaded.
- New `--chat-template-config` flag for pointing at a local config; `README` + `smoke.sh` updated (smoke treats the unconfigured `503` as a soft skip).

## Verification

Full CI gate green locally: `fmt`, `clippy -D warnings`, `check --all-targets --locked`, `test` (incl. 87 renderer + 37 deepseek tests), doctests, `cargo deny`, `cargo machete`.

`sync-from-dynamo.sh` exits 0 against a #9946 checkout (renderer in sync) and against dynamo `main` (renderer skipped).

End-to-end render against the `mock-llama-3.1-8b-instruct` fixture:
\`\`\`
POST /v1/render {"messages":[{"role":"system","content":"You are terse."},{"role":"user","content":"hi"}]}
-> "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are terse.<|eot_id|>..."
\`\`\`
All 10 demo smoke checks pass.