### PR TITLE
chore: sync-check renderer against dynamo main

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ cargo deny --all-features check bans licenses
 
 ## Where the code lives
 
-These crates currently mirror `lib/{protocols,tokenizers,parsers,renderer}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The sync is **one-way (dynamo → frontend-crates) and manual** for now — see [`scripts/sync-from-dynamo.sh`](./scripts/sync-from-dynamo.sh) to check for upstream changes. (`renderer` lands upstream with [dynamo#9946](https://github.com/ai-dynamo/dynamo/pull/9946); until that merges the sync check skips it.)
+These crates currently mirror `lib/{protocols,tokenizers,parsers,renderer}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The sync is **one-way (dynamo → frontend-crates) and manual** for now — see [`scripts/sync-from-dynamo.sh`](./scripts/sync-from-dynamo.sh) to check for upstream changes.
 
 > **Heads up:** this mirroring is temporary. Over the next few weeks we plan to **remove the sync entirely and make this repository the source of truth** for these crates — dynamo will then depend on the published crates rather than the other way around. Until that cutover lands, treat dynamo as upstream and land crate changes there first.

--- a/scripts/sync-from-dynamo.sh
+++ b/scripts/sync-from-dynamo.sh
@@ -66,17 +66,6 @@ for c in "${CRATES[@]}"; do
   dst="$HERE/$c"
   echo "--- $c ---"
 
-  # TODO(renderer): drop this guard once PR ai-dynamo/dynamo#9946 lands
-  # lib/renderer on dynamo main. Until then `renderer` exists in this repo
-  # but not upstream, so the hourly sync-check (which runs against dynamo
-  # main) has nothing to diff against. Skip it explicitly — rather than
-  # silently comparing nothing — so the temporary state is visible in the
-  # output and intentional.
-  if [ ! -d "$src" ]; then
-    echo "  SKIP: lib/$c not present in $DYNAMO_SRC (not yet on dynamo main); skipping until upstream lands."
-    continue
-  fi
-
   # Sync src/ and tests/ subdirs only. These are pure code.
   # --checksum compares by content hash, not size+mtime — important for CI,
   # where a freshly-cloned dynamo gives every file a "now" timestamp.


### PR DESCRIPTION
## What

[dynamo#9946](https://github.com/ai-dynamo/dynamo/pull/9946) — the `dynamo-renderer` crate — is now **merged to dynamo main**, so `lib/renderer` exists upstream.

This removes the temporary guard added in #15 that made `scripts/sync-from-dynamo.sh` *skip* `renderer` while it was still PR-only. With the guard gone, the hourly `sync-check` now diffs `renderer/src` against dynamo main exactly like `protocols` / `tokenizers` / `parsers`.

## Changes
- Drop the `TODO(renderer)` skip block in `scripts/sync-from-dynamo.sh`.
- Remove the now-stale README parenthetical about renderer not yet being upstream.

## Verification
- `scripts/sync-from-dynamo.sh <dynamo-main>` exits **0** and now reports `--- renderer ---` with only the intentional `Cargo.toml` / `README.md` NOTE divergences (no `SKIP`, no code drift) — renderer/src is already in sync with what merged to dynamo main.
- `bash -n` clean.

No crate code changes.