### PR TITLE
docs: correct crate dependency description (dynamo-parsers is a leaf crate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Standalone Rust crates for building OpenAI/Anthropic-compatible inference server
 | [`dynamo-parsers`](./parsers/)       | Reasoning + tool-calling parsers across 18+ model families (DeepSeek R1/V4, Qwen3, GPT-OSS, Kimi K2, Gemma 4, Llama, Hermes, ...). Streaming-first. The *decode* side. |
 | [`dynamo-renderer`](./renderer/)     | Chat-template / prompt rendering: OpenAI chat requests → model-ready prompt strings via HF `chat_template` (minijinja), plus native DeepSeek formatters. The *encode* side. |
 
-Each crate is independently published to crates.io and can be adopted on its own. `dynamo-parsers` and `dynamo-renderer` depend on `dynamo-protocols` (`dynamo-renderer` also re-exports `dynamo-tokenizers` for convenience); the leaf crates have no internal deps. The repository itself is a Cargo workspace so shared dependency versions, CI checks, and the demo build stay consistent.
+Each crate is independently published to crates.io and can be adopted on its own. Only `dynamo-renderer` has internal deps — it depends on `dynamo-protocols` and re-exports `dynamo-tokenizers` for convenience; `dynamo-protocols`, `dynamo-tokenizers`, and `dynamo-parsers` are leaf crates with no internal deps. The repository itself is a Cargo workspace so shared dependency versions, CI checks, and the demo build stay consistent.
 
 ## Layout
 
@@ -17,7 +17,7 @@ Each crate is independently published to crates.io and can be adopted on its own
 frontend-crates/
 ├── protocols/              # dynamo-protocols
 ├── tokenizers/             # dynamo-tokenizers
-├── parsers/                # dynamo-parsers (deps protocols)
+├── parsers/                # dynamo-parsers
 ├── renderer/               # dynamo-renderer (deps protocols, tokenizers)
 ├── examples/
 │   └── dynamo-demo-server/ # axum server wiring them together


### PR DESCRIPTION
#### Overview:

Corrects two inaccurate dependency descriptions in the README: `dynamo-parsers` is a leaf crate, not a dependent of `dynamo-protocols`.

#### Details:

- Prose: only `dynamo-renderer` has internal deps (depends on `dynamo-protocols`, re-exports `dynamo-tokenizers`); `dynamo-protocols`, `dynamo-tokenizers`, and `dynamo-parsers` are leaf crates with no internal deps.
- Layout comment: drop `(deps protocols)` from the `parsers/` line.
- Verified against each crate's `Cargo.toml`: only `renderer/Cargo.toml` declares `dynamo-protocols` + `dynamo-tokenizers`; `parsers/Cargo.toml` has no internal deps.



[DIS-2191](https://linear.app/nvidia/issue/DIS-2191)
