### PR TITLE
chore: sync from dynamo @ 628904d

### DIFF
--- a/conformance/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -127,3 +127,19 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -114,3 +114,22 @@ cases:
         normal_text: ''
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -147,3 +147,19 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -122,3 +122,22 @@ cases:
         reasoning_text: ''
         normal_text: plain answer
         reason: Dynamo/vLLM keep marker-free stream text in force-reasoning mode; SGLang only enters reasoning after an explicit start marker.
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -158,3 +158,19 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -117,3 +117,22 @@ cases:
         normal_text: plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -174,3 +174,21 @@ cases:
            middle <|channel>thought
           second<channel|> done
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: |-
+      <|channel>thought
+      preamble<channel|>body<channel|>answer
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: stray <channel|> close marker after a complete reasoning span is stripped (parser-owned syntax must not appear in normal_text).'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'

--- a/conformance/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -137,3 +137,22 @@ cases:
         normal_text: plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - "<|channel>thought\npreamble<channel|>"
+    - 'body<channel|>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: stray <channel|> close marker after a complete reasoning span is stripped (parser-owned syntax must not appear in normal_text).'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'

--- a/conformance/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -195,3 +195,15 @@ cases:
     description: Open analysis channel interrupted by downstream tool-call text is not configured for Harmony
     ref: *upstream_ref
     reason: Harmony tool calls require a commentary channel envelope; the closed analysis to commentary handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: ''
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      vllm:
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      sglang:
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'

--- a/conformance/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -153,3 +153,15 @@ cases:
         normal_text: ''
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks: []
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      vllm:
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      sglang:
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'

--- a/conformance/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -142,3 +142,15 @@ cases:
     description: Open Granite reasoning interrupted by downstream tool-call text is not covered by a paired Dynamo tool call parser
     ref: *upstream_ref
     reason: Granite reasoning parsing has no paired Dynamo tool call parser fixture or open-reasoning tool boundary in this seed fixture set.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: ''
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      vllm:
+        unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      sglang:
+        unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/conformance/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -109,3 +109,15 @@ cases:
       vllm: *d_s4
       sglang:
         unavailable: SGLang has no reasoning parser for family='granite'
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks: []
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      vllm:
+        unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      sglang:
+        unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -141,3 +141,18 @@ cases:
     description: Open reasoning interrupted by downstream tool-call text is not configured for this Kimi delimiter family
     ref: dynamo
     reason: Dynamo's Kimi Unicode-delimiter reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '◁think▷preamble◁/think▷body◁/think▷answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body◁/think▷answer'

--- a/conformance/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -101,3 +101,21 @@ cases:
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '◁think▷preamble◁/think▷'
+    - 'body◁/think▷'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body◁/think▷answer'

--- a/conformance/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -164,3 +164,19 @@ cases:
         reasoning_text: choose tool
         normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       sglang: *id004
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -119,3 +119,22 @@ cases:
         reasoning_text: plain answer
         normal_text: ''
       sglang: *sg_stream_1_b
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: '<think>preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -137,3 +137,19 @@ cases:
     description: Open reasoning interrupted by downstream tool-call text is not configured for MiniMax append-think
     ref: *upstream_ref
     reason: MiniMax append-think emits a synthetic normal-text wrapper instead of running an open reasoning-span boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag; passthrough — model output has no leading <think>, parser prepends it)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: 'preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+        reason: 'MiniMaxAppendThinkParser prepends <think> before parsing (matching the append-think chat template); in default mode (no force_reasoning) the parser does not split on </think>, so the entire output stays in normal_text. This mirrors REASONING.batch.6.a passthrough behavior.'
+      vllm:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+      sglang:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'

--- a/conformance/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -91,3 +91,22 @@ cases:
         normal_text: <think>plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag; passthrough — chunks reassemble without leading <think>)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - 'preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+        reason: 'MiniMaxAppendThinkParser prepends <think> before parsing (matching the append-think chat template); in default mode (no force_reasoning) the parser does not split on </think>, so the entire output stays in normal_text. This mirrors REASONING.batch.6.a passthrough behavior.'
+      vllm:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+      sglang:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'

--- a/conformance/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -139,3 +139,19 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle [THINK]second[/THINK] done'
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '[THINK]preamble[/THINK]body[/THINK]answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'

--- a/conformance/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -113,3 +113,22 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain answer
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '[THINK]preamble[/THINK]'
+    - 'body[/THINK]'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'

--- a/conformance/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -150,3 +150,19 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -122,3 +122,22 @@ cases:
         normal_text: ''
         reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and routes marker-free deltas to reasoning.
       sglang: *id001
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -164,3 +164,19 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/conformance/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -118,3 +118,22 @@ cases:
         normal_text: ''
         reason: vLLM Qwen streaming parser treats text before a reasoning end marker as reasoning; serving may bypass it when thinking is disabled.
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -196,15 +196,35 @@ impl ReasoningParser for BasicReasoningParser {
                     }
                 }
             } else {
-                // We're in normal text — look for start token
-                if let Some(start_offset) = text[cursor..].find(&self.think_start_token) {
-                    normal_parts.push(&text[cursor..cursor + start_offset]);
-                    cursor += start_offset + self.think_start_token.len();
-                    currently_reasoning = true;
-                } else {
-                    // No more think blocks — rest is normal text
-                    normal_parts.push(&text[cursor..]);
-                    cursor = text.len();
+                // We're in normal text. Look for the next reasoning open marker,
+                // but also detect any stray close marker (unmatched </think>) and
+                // strip it: parser-owned syntax must never reach normal_text per the
+                // lossless-split contract.
+                let start_offset = text[cursor..].find(&self.think_start_token);
+                let end_offset = text[cursor..].find(&self.think_end_token);
+                match (start_offset, end_offset) {
+                    (Some(s), Some(e)) if s <= e => {
+                        // <think> appears first → enter reasoning normally.
+                        normal_parts.push(&text[cursor..cursor + s]);
+                        cursor += s + self.think_start_token.len();
+                        currently_reasoning = true;
+                    }
+                    (Some(s), None) => {
+                        normal_parts.push(&text[cursor..cursor + s]);
+                        cursor += s + self.think_start_token.len();
+                        currently_reasoning = true;
+                    }
+                    (_, Some(e)) => {
+                        // Stray </think> before the next <think> (or no <think> at all).
+                        // Drop the marker, keep the text on both sides, stay in normal mode.
+                        normal_parts.push(&text[cursor..cursor + e]);
+                        cursor += e + self.think_end_token.len();
+                    }
+                    (None, None) => {
+                        // No more markers — rest is normal text.
+                        normal_parts.push(&text[cursor..]);
+                        cursor = text.len();
+                    }
                 }
             }
         }
@@ -328,31 +348,62 @@ impl ReasoningParser for BasicReasoningParser {
                     break;
                 }
             } else {
-                // Not in reasoning — look for the next <think> block.
-                if let Some(think_pos) = current_text.find(self.think_start_token.as_str()) {
-                    accumulated_normal.push_str(&current_text[..think_pos]);
-                    let after_start = think_pos + self.think_start_token.len();
-                    self._buffer = current_text[after_start..].to_string();
-                    self._in_reasoning = true;
-                    self.stripped_think_start = true;
-                    continue; // Process reasoning content
-                } else {
-                    // No complete start token — check for partial at end of buffer
-                    // (e.g., "Hello world <th" where "<th" is a prefix of "<think>").
-                    // Require overlap >= 2 so a lone `<` passes through for tool call
-                    // XML tags like `<invoke>` or `<minimax:tool_call>`.
-                    let ol = overlap(&current_text, &self.think_start_token);
-                    if ol >= 2 {
-                        let safe_end = current_text.len() - ol;
-                        if safe_end > 0 {
-                            accumulated_normal.push_str(&current_text[..safe_end]);
-                        }
-                        self._buffer = current_text[safe_end..].to_string();
-                    } else {
-                        accumulated_normal.push_str(&current_text);
-                        self._buffer.clear();
+                // Not in reasoning. Look for the next <think> block, but also detect
+                // a stray </think> (unmatched close marker) and drop it: parser-owned
+                // syntax must never reach normal_text per the lossless-split contract.
+                let think_pos = current_text.find(self.think_start_token.as_str());
+                let stray_close_pos = current_text.find(self.think_end_token.as_str());
+                match (think_pos, stray_close_pos) {
+                    (Some(s), Some(e)) if s <= e => {
+                        // <think> arrives first → enter reasoning.
+                        accumulated_normal.push_str(&current_text[..s]);
+                        let after_start = s + self.think_start_token.len();
+                        self._buffer = current_text[after_start..].to_string();
+                        self._in_reasoning = true;
+                        self.stripped_think_start = true;
+                        continue;
                     }
-                    break;
+                    (Some(s), None) => {
+                        // Only <think> remains; enter reasoning.
+                        accumulated_normal.push_str(&current_text[..s]);
+                        let after_start = s + self.think_start_token.len();
+                        self._buffer = current_text[after_start..].to_string();
+                        self._in_reasoning = true;
+                        self.stripped_think_start = true;
+                        continue;
+                    }
+                    (_, Some(e)) => {
+                        // Stray </think> arrives before the next <think> (or with no
+                        // opener remaining). Drop the marker, keep the text on either
+                        // side, stay in normal mode. Mirrors the batch path so a
+                        // pattern like `<o>A</c>B</c>C<o>D</c>E` does not leak the
+                        // middle stray close even when a later opener is in buffer.
+                        accumulated_normal.push_str(&current_text[..e]);
+                        let after_end = e + self.think_end_token.len();
+                        self._buffer = current_text[after_end..].to_string();
+                        continue;
+                    }
+                    (None, None) => {
+                        // No complete marker — check for partial at end of buffer.
+                        // The partial could be a prefix of either <think> or </think>
+                        // (both start with `<`), so check both and use the wider overlap.
+                        // Require overlap >= 2 so a lone `<` passes through for tool call
+                        // XML tags like `<invoke>` or `<minimax:tool_call>`.
+                        let ol_start = overlap(&current_text, &self.think_start_token);
+                        let ol_end = overlap(&current_text, &self.think_end_token);
+                        let ol = ol_start.max(ol_end);
+                        if ol >= 2 {
+                            let safe_end = current_text.len() - ol;
+                            if safe_end > 0 {
+                                accumulated_normal.push_str(&current_text[..safe_end]);
+                            }
+                            self._buffer = current_text[safe_end..].to_string();
+                        } else {
+                            accumulated_normal.push_str(&current_text);
+                            self._buffer.clear();
+                        }
+                        break;
+                    }
                 }
             }
         }
@@ -555,7 +606,7 @@ mod tests {
         assert_eq!(result3.reasoning_text, "more");
     }
 
-    #[test] // REASONING.batch.2.f — nested marker-looking content
+    #[test] // REASONING.batch.6.b — stray close marker after a complete reasoning span
     fn test_nested_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -565,9 +616,11 @@ mod tests {
         );
         // Cursor-based parsing: first <think> starts reasoning, first </think> ends it.
         // "outer <think>inner" is reasoning (inner <think> is just text within reasoning).
-        // " reasoning</think> normal" is normal text (stray </think> passes through).
+        // After exiting reasoning, the cursor encounters another stray </think> in
+        // " reasoning</think> normal"; per the lossless-split contract it is stripped,
+        // leaving "reasoning normal" in normal_text after trim.
         assert_eq!(result.reasoning_text, "outer <think>inner");
-        assert_eq!(result.normal_text, "reasoning</think> normal");
+        assert_eq!(result.normal_text, "reasoning normal");
     }
 
     #[test] // REASONING.batch.5
@@ -634,6 +687,26 @@ mod tests {
         let result = parser.detect_and_parse_reasoning("no think tags here", &[]);
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "no think tags here");
+    }
+
+    #[test] // REASONING.batch.6.b — streaming parity for stray close after complete pair
+    fn test_streaming_stray_close_between_two_reasoning_spans() {
+        // Pattern: <open>A</close>B</close>C<open>D</close>E — the middle </close>
+        // has no matching open and must be stripped, even though a later <open>
+        // exists in the buffer. Previously the streaming path entered the next
+        // reasoning block first and leaked the middle stray close into
+        // normal_text. The batch path was already correct.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
+        let input = "<think>checking the weather</think>It is sunny.</think> Have a nice day.<think>double-checking</think> Confirmed.";
+        let r = parser.parse_reasoning_streaming_incremental(input, &[]);
+        assert!(
+            !r.normal_text.contains("</think>"),
+            "stray </think> must not leak into normal_text; got {:?}",
+            r.normal_text
+        );
+        assert_eq!(r.normal_text, "It is sunny. Have a nice day. Confirmed.");
+        assert_eq!(r.reasoning_text, "checking the weatherdouble-checking");
     }
 
     #[test] // REASONING.stream.2.b, REASONING.batch.2.c, REASONING.stream.1.b

--- a/parsers/src/reasoning/gemma4_parser.rs
+++ b/parsers/src/reasoning/gemma4_parser.rs
@@ -165,7 +165,25 @@ impl ReasoningParser for Gemma4ReasoningParser {
         let mut reasoning = String::new();
         let mut cursor = 0;
 
-        while let Some(start_rel) = text[cursor..].find(START_TOKEN) {
+        loop {
+            let next_start = text[cursor..].find(START_TOKEN);
+            let stray_end = text[cursor..].find(END_TOKEN);
+
+            // Stray END_TOKEN appears before the next START_TOKEN (or no next start).
+            // Drop it per the lossless-split contract: parser-owned syntax must never
+            // reach normal_text.
+            if let Some(e_rel) = stray_end
+                && next_start.is_none_or(|s_rel| e_rel < s_rel)
+            {
+                let e = cursor + e_rel;
+                normal.push_str(&text[cursor..e]);
+                cursor = e + END_TOKEN.len();
+                continue;
+            }
+
+            let Some(start_rel) = next_start else {
+                break;
+            };
             let start = cursor + start_rel;
             normal.push_str(&text[cursor..start]);
 
@@ -204,9 +222,21 @@ impl ReasoningParser for Gemma4ReasoningParser {
 
         loop {
             if !self.in_reasoning {
-                // Look for either the full start marker or a partial-prefix at
-                // the buffer's end (which we must hold back).
-                if let Some(idx) = work.find(START_TOKEN) {
+                // Look for the next start marker, but also drop any stray end
+                // marker that appears before a start (lossless-split contract).
+                // Prefer the earlier of the two.
+                let next_start = work.find(START_TOKEN);
+                let stray_end = work.find(END_TOKEN);
+
+                if let Some(e_idx) = stray_end
+                    && next_start.is_none_or(|s_idx| e_idx < s_idx)
+                {
+                    normal.push_str(&work[..e_idx]);
+                    work = work[e_idx + END_TOKEN.len()..].to_string();
+                    continue;
+                }
+
+                if let Some(idx) = next_start {
                     normal.push_str(&work[..idx]);
                     work = work[idx + START_TOKEN.len()..].to_string();
                     self.in_reasoning = true;
@@ -214,7 +244,12 @@ impl ReasoningParser for Gemma4ReasoningParser {
                     self.reasoning_accum.clear();
                     continue;
                 }
-                let lap = overlap(&work, START_TOKEN);
+                // No complete marker — check for partial at end of buffer.
+                // The partial could be a prefix of either START_TOKEN or
+                // END_TOKEN (both begin with `<`), so use the wider overlap.
+                let lap_start = overlap(&work, START_TOKEN);
+                let lap_end = overlap(&work, END_TOKEN);
+                let lap = lap_start.max(lap_end);
                 if lap > 0 {
                     let split = work.len() - lap;
                     normal.push_str(&work[..split]);

--- a/tokenizers/src/cache/l1.rs
+++ b/tokenizers/src/cache/l1.rs
@@ -153,7 +153,7 @@ impl L1Cache {
     /// extends the cached tokens with a fresh encode of `input[byte_offset..]`;
     /// `deepest_boundary` is the deepest special-token boundary in `input` (end-exclusive),
     /// handed back so [`extend_after_match`] need not rescan the input for it.
-    pub fn longest_prefix_match(&self, input: &str) -> Option<(Vec<TokenIdType>, usize, usize)> {
+    pub fn longest_prefix_match(&self, input: &str) -> Option<(Arc<[TokenIdType]>, usize, usize)> {
         let boundaries = self.boundaries(input);
 
         if boundaries.is_empty() {
@@ -188,7 +188,10 @@ impl L1Cache {
                 if let Some(cb) = &self.on_hit {
                     cb();
                 }
-                return Some((tokens.to_vec(), boundary_pos, deepest_boundary));
+                // Return the shared `Arc` directly — the caller decides whether to
+                // materialize a `Vec` (and reserves exact capacity when it does),
+                // avoiding a clone of the (large) cached prefix on every hit.
+                return Some((tokens, boundary_pos, deepest_boundary));
             }
         }
 
@@ -304,7 +307,7 @@ impl L1Cache {
     pub fn extend_after_match<E: Encoder + ?Sized>(
         &self,
         input: &str,
-        prefix_tokens: Vec<TokenIdType>,
+        prefix_tokens: Arc<[TokenIdType]>,
         prefix_len: usize,
         deepest_boundary: usize,
         tokenizer: &E,
@@ -318,9 +321,11 @@ impl L1Cache {
 
         let Some(deepest) = deepest else {
             // No new boundary in the suffix — nothing worth caching. Encode the suffix
-            // once and merge, identical to the non-extend hit path.
+            // once and merge, identical to the non-extend hit path. Reserve exact capacity
+            // so the prefix isn't re-copied by a Vec grow-realloc.
             let suffix_enc = tokenizer.encode(&input[prefix_len..])?;
-            let mut merged = prefix_tokens;
+            let mut merged = Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
+            merged.extend_from_slice(&prefix_tokens);
             merged.extend_from_slice(suffix_enc.token_ids());
             return Ok(merged);
         };
@@ -328,8 +333,15 @@ impl L1Cache {
         // Cumulative tokens up to `deepest` = matched prefix + the spanning segment.
         // Both `prefix_len` and `deepest` are special-token boundaries, so encoding the
         // span as one chunk and concatenating preserves the merge invariant.
+        // Encode both segments up front so `cumulative` can be reserved to its final
+        // size (prefix + seg_a + seg_b) — this eliminates the two grow-reallocs (each of
+        // which re-copied the whole large prefix) the previous Vec-append path incurred.
         let seg_a = tokenizer.encode(&input[prefix_len..deepest])?;
-        let mut cumulative = prefix_tokens;
+        let seg_b = tokenizer.encode(&input[deepest..])?;
+        let mut cumulative = Vec::with_capacity(
+            prefix_tokens.len() + seg_a.token_ids().len() + seg_b.token_ids().len(),
+        );
+        cumulative.extend_from_slice(&prefix_tokens);
         cumulative.extend_from_slice(seg_a.token_ids());
 
         // Key is blake3 of input[0..deepest]. Built with the same streaming idiom as
@@ -339,14 +351,15 @@ impl L1Cache {
         hasher.update(&input.as_bytes()[..deepest]);
         let hash_bytes: Blake3Hash = *hasher.finalize().as_bytes();
 
+        // Snapshot prefix+seg_a (`as_slice().into()` copies only the populated len, not the
+        // reserved capacity) and cache it.
         let tokens: Arc<[TokenIdType]> = cumulative.as_slice().into();
         self.cache.insert(hash_bytes, tokens);
 
-        // Tokenize the trailing segment after `deepest` for the returned result.
-        let seg_b = tokenizer.encode(&input[deepest..])?;
-        let mut merged = cumulative;
-        merged.extend_from_slice(seg_b.token_ids());
-        Ok(merged)
+        // Append the trailing segment for the returned result — no realloc, capacity was
+        // reserved above.
+        cumulative.extend_from_slice(seg_b.token_ids());
+        Ok(cumulative)
     }
 
     /// Number of live entries. Flushes moka's deferred maintenance first so the count is
@@ -505,7 +518,8 @@ mod tests {
 
         let suffix = &target[prefix_len..];
         let suffix_enc = tokenizer.encode(suffix).unwrap();
-        let mut merged = prefix_tokens.clone();
+        // longest_prefix_match returns the shared `Arc<[u32]>`; copy into a Vec to append the suffix.
+        let mut merged = prefix_tokens.to_vec();
         merged.extend_from_slice(suffix_enc.token_ids());
 
         let plain = tokenizer.encode(&target).unwrap();
@@ -758,7 +772,7 @@ mod tests {
         );
         let expected = tok.encode(&turns[1][..deepest]).unwrap();
         assert_eq!(
-            saved_tokens,
+            &*saved_tokens,
             expected.token_ids(),
             "persisted entry tokens must equal the uncached encode of the cached prefix"
         );

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -149,7 +149,7 @@ impl Encoder for CachedTokenizer {
         {
             let suffix = &input[prefix_len..];
             if suffix.is_empty() {
-                return Ok(Encoding::Sp(prefix_tokens));
+                return Ok(Encoding::Sp(prefix_tokens.to_vec()));
             }
             if self.extend_on_hit {
                 // Cache the new suffix at its deepest boundary so the next turn hits
@@ -164,7 +164,11 @@ impl Encoder for CachedTokenizer {
                 )?));
             }
             let suffix_enc = self.inner.encode(suffix)?;
-            let mut merged: Vec<TokenIdType> = prefix_tokens;
+            // Reserve exact capacity so appending the suffix doesn't grow-realloc and
+            // re-copy the (large) cached prefix.
+            let mut merged: Vec<TokenIdType> =
+                Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
+            merged.extend_from_slice(&prefix_tokens);
             merged.extend_from_slice(suffix_enc.token_ids());
             return Ok(Encoding::Sp(merged));
         }


### PR DESCRIPTION
Syncs `tokenizers/src/cache/` and `conformance/reasoning/fixtures/` to dynamo `628904d`.

- `tokenizers/src/cache/l1.rs`, `cache/mod.rs` — upstream changes
- `conformance/reasoning/fixtures/` — 24 YAML files updated across 12 models (deepseek_r1/v3/v4, gemma4, gpt_oss, granite, kimi, kimi_k25, minimax_append_think, mistral, nemotron_deci, qwen3)

`parsers/` is excluded — it is permanently detached from the automated sync (see `PARSERS-SYNC.md`); parser changes for this SHA are handled in #28.