### PR TITLE
ci: add parity-table render smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,44 @@ jobs:
 
       - name: Verify crates are publishable
         run: cargo publish --workspace --dry-run --locked
+
+  # Render-smoke for the vendored conformance-table generator. Catches generator/fixture
+  # breakage. Python + pyyaml/jinja2 only — no engines (vLLM/SGLang conformance runs in
+  # dynamo's CI lanes; here the engine lanes are on-demand/local).
+  conformance-table:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Render conformance matrix (no engines)
+        run: |
+          python3 -m venv /tmp/pvenv
+          /tmp/pvenv/bin/pip install --quiet pyyaml jinja2
+          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_parity_v1.sh
+          OUT=conformance/utils/.stage/tests/parity/PARITY_v1.html
+          test -s "$OUT"
+          grep -q "TOOLCALLING.batch" "$OUT"
+          grep -q "REASONING.batch" "$OUT"
+          echo "conformance matrix rendered: $(wc -c < "$OUT") bytes"
+          cp "$OUT" conformance/utils/CONFORMITY.html
+
+      - name: Upload conformance matrix
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: conformity-html
+          path: conformance/utils/CONFORMITY.html
+          retention-days: 14
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --edit-last --create-if-none \
+            --body "📊 **Conformance matrix** rendered — [view in CI summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/conformance/utils/_common.sh
+++ b/conformance/utils/_common.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 # conformance/utils/ is two levels below the repo root.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export FRONTEND_CRATES_ROOT="$ROOT"
 TOOLS="$ROOT/conformance/utils"
 STAGE="${STAGE:-$TOOLS/.stage-v2}"
 # Override when the default cargo can't build the workspace (edition 2024 /

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -10,6 +10,7 @@ import argparse
 import datetime
 import html as html_lib
 import json
+import os
 import re
 import subprocess
 import zoneinfo
@@ -31,7 +32,18 @@ from tests.parity.markup import colorize_markup
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/reasoning/fixtures"
 PARSER_FIXTURES = REPO_ROOT / "tests/parity/toolcalling/fixtures"
-REASONING_CASES_MD = REPO_ROOT / "lib/parsers/REASONING_CASES.md"
+_fc_env = os.environ.get("FRONTEND_CRATES_ROOT")
+if _fc_env:
+    PARSERS_ROOT = Path(_fc_env) / "parsers"
+else:
+    # walk up from REPO_ROOT until we find parsers/Cargo.toml (repo root marker)
+    _p = REPO_ROOT
+    while _p.parent != _p:
+        if (_p / "parsers" / "Cargo.toml").exists():
+            break
+        _p = _p.parent
+    PARSERS_ROOT = _p / "parsers"
+REASONING_CASES_MD = PARSERS_ROOT / "REASONING_CASES.md"
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
@@ -2244,7 +2256,7 @@ def _html(
             intro_html="",
             legend_html=_legend_html(rows, columns),
             case_docs_href="../../../lib/parsers/REASONING_CASES.md",
-            case_docs_label="lib/parsers/REASONING_CASES.md",
+            case_docs_label="parsers/REASONING_CASES.md",
             case_prefix="REASONING.",
         )
     )

--- a/conformance/utils/tests/parity/toolcalling/table.py
+++ b/conformance/utils/tests/parity/toolcalling/table.py
@@ -58,6 +58,7 @@ import copy
 import datetime
 import html as html_lib
 import json
+import os
 import re
 import subprocess
 import zoneinfo
@@ -76,11 +77,22 @@ from tests.parity.markup import colorize_markup, colorize_stream_deltas
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/toolcalling/fixtures"
-TOOLCALLING_CASES_MD = REPO_ROOT / "lib/parsers/TOOLCALLING_CASES.md"
+_fc_env = os.environ.get("FRONTEND_CRATES_ROOT")
+if _fc_env:
+    PARSERS_ROOT = Path(_fc_env) / "parsers"
+else:
+    # walk up from REPO_ROOT until we find parsers/Cargo.toml (repo root marker)
+    _p = REPO_ROOT
+    while _p.parent != _p:
+        if (_p / "parsers" / "Cargo.toml").exists():
+            break
+        _p = _p.parent
+    PARSERS_ROOT = _p / "parsers"
+TOOLCALLING_CASES_MD = PARSERS_ROOT / "TOOLCALLING_CASES.md"
 PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
 TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
-RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
+RUST_TOOL_CALLING_DIR = PARSERS_ROOT / "src/tool_calling"
 
 # Row-label / visibility overrides keyed by tool calling family; ‡ is explained
 # by the legend note in parity_table.html.j2.


### PR DESCRIPTION
Adds a `parity-table` CI job that renders the parity matrix using the vendored Python generator and verifies the output contains expected sections.

Depends on #28 (the parity-harness itself). Can merge independently once #28 lands.

- Python + pyyaml/jinja2 only; no engines required
- Smoke-checks that `PARITY.html` is non-empty and contains `TOOLCALLING.batch` + `REASONING.batch` sections
- Engine validation (vLLM/SGLang) stays in dynamo's CI lanes; local runs via `parity-harness/run.sh`