### PR TITLE
test(parsers-v2): add stream fixture YAML

### DIFF
--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,34 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,41 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+      normal_text: nonsense
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: ''
+        arguments: {}
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,54 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+
+        ```json
+
+        {"location": "NYC"}
+
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls: []
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,25 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,48 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments: {}
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,34 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.yaml
@@ -1,0 +1,61 @@
+family: deepseek_v3
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments: {}
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,34 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time
+        arguments: {}
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time
+        arguments: {}
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,45 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+      normal_text: nonsense
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: ''
+        arguments: {}
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,48 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,25 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,48 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments: {}
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,35 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+          Then check LA weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.yaml
@@ -1,0 +1,61 @@
+family: deepseek_v3_1
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
+        arguments: {}
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments: {}
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,75 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,40 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,80 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜function_calls>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,29 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,58 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: '2'
+          first_class: 'true'
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: '9007199254740993'
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,59 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.yaml
@@ -1,0 +1,79 @@
+family: deepseek_v3_2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,75 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,40 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,124 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: Boston
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check that. <｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,29 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,58 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: '2'
+          first_class: 'true'
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: '9007199254740993'
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,59 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.yaml
@@ -1,0 +1,79 @@
+family: deepseek_v4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,41 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:  Done.'
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weatherget_weather
+        arguments: '{"location": "NYC"}{"location": "LA"}'
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,43 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,73 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+    sglang:
+      calls: []
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: ''
+        arguments:
+          location: Boston
+    sglang:
+      calls:
+      - name: get_weatherget_weather
+        arguments: '{"location": "Boston"}{"location": "New York"}'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: ''
+        arguments:
+          location: Boston
+    sglang:
+      calls:
+      - name: get_weatherget_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls: []
+      normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+    sglang:
+      calls: []
+      normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,25 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,76 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: 'null'
+            empty: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,41 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weatherget_weather
+        arguments: '{"location": "NYC"}{"location": "LA"}'
+      normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.yaml
@@ -1,0 +1,105 @@
+family: gemma4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weatherget_weather
+        arguments: '{"location": "NYC"}{"location": "LA"}'
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a,b:and{brace}
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT value WHERE note has brace } and bracket ]
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: literal <|tool_call marker> call:get_time{} stays text
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a,b:and{brace}
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT value WHERE note has brace } and bracket ]
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: unknown_tool
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,55 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Checking:  Done.'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'Checking: '
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,41 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC}'
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,85 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC"'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC"'
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    sglang:
+      calls: []
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": N'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "N'
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: '{"location": "New York"'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: '{"location": New York'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls: []
+      normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    sglang:
+      calls: []
+      normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,25 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,58 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,60 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.yaml
@@ -1,0 +1,76 @@
+family: glm47
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,78 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.2.a:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  TOOLCALLING.batch.2.c:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: I need both.  Done.
+  TOOLCALLING.batch.2.d:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,54 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.4.a:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments: not json at all
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: not json at all
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.4.b:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC'
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC'
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.4.c:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.4.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,74 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.5.a:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.5.b:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  TOOLCALLING.batch.5.c:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.5.d:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,43 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.6.a:
+    dynamo:
+      calls:
+      - name: get_time
+        arguments: {}
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  TOOLCALLING.batch.6.b:
+    dynamo:
+      calls:
+      - name: get_time
+        arguments: {}
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  TOOLCALLING.batch.6.c:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,175 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.7.a:
+    dynamo:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  TOOLCALLING.batch.7.b:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  TOOLCALLING.batch.7.c:
+    dynamo:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    vllm:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  TOOLCALLING.batch.7.d:
+    dynamo:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  TOOLCALLING.batch.7.e:
+    dynamo:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+      normal_text: ''
+  TOOLCALLING.batch.7.f:
+    dynamo:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,60 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.8.a:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
+  TOOLCALLING.batch.8.c:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
+  TOOLCALLING.batch.8.d:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.yaml
@@ -1,0 +1,103 @@
+family: harmony
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+  dynamo: Dynamo parser v2
+cases:
+  TOOLCALLING.batch.1:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  TOOLCALLING.batch.3:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.9.b:
+    dynamo:
+      calls: []
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    dynamo:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    dynamo:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: ''
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,50 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    sglang:
+      calls: []
+      normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,43 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC"'
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,61 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    sglang:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: '{"location": "New York'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,33 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,88 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments: {}
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    sglang:
+      calls:
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,49 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.yaml
@@ -1,0 +1,79 @@
+family: hermes
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: unknown_tool
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,26 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,36 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,32 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,21 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,36 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,26 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.yaml
@@ -1,0 +1,68 @@
+family: jamba
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'jamba'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,59 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'I will check both. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,44 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC"'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC"}<|tool_calls_section_end|>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,81 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: '{"location":"New York'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls: []
+      normal_text: I will check that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,29 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,88 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments: {}
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    sglang:
+      calls:
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,52 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      normal_text: 'I''ll check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      normal_text: 'I''ll check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'First check Dallas. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.yaml
@@ -1,0 +1,73 @@
+family: kimi_k2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments: {}
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,34 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+      normal_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,38 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.e:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,45 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York"}'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,27 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,48 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments: {}
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,41 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}}'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}} Let me know if you need more.'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}} Then check LA weather. <|python_tag|>{"name":
+        "get_weather", "arguments": {"location": "LA"}}'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.yaml
@@ -1,0 +1,86 @@
+family: llama3_json
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,79 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          timezone: EST
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          timezone: EST
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          timezone: EST
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: LA
+      - name: get_weather
+        arguments:
+          location: LA

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,38 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC"'
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,140 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'
+    sglang:
+      calls: []
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: New York
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: {}
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>
+
+        '
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls: []
+      normal_text: 'I will check that. <invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'
+    sglang:
+      calls: []
+      normal_text: 'I will check that. <invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,29 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,58 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: '2'
+          first_class: 'true'
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: '9007199254740993'
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740992

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,62 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: LA
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.yaml
@@ -1,0 +1,73 @@
+family: minimax_m2
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: LA
+      - name: get_weather
+        arguments:
+          location: LA
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,27 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,39 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,50 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    sglang:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS'
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    sglang:
+      calls: []
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "Boston"} {"location": "New York"}'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "Boston"} {"location": "New York'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,24 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: '[/TOOL_CALLS]'
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,36 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,29 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.yaml
@@ -1,0 +1,70 @@
+family: mistral
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,35 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.2.b:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name":
+        "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+      normal_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>
+        Done.'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,40 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+      normal_text: <TOOLCALL>not a json array</TOOLCALL>
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,40 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,24 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,47 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination":
+        "Paris", "passengers": 2, "first_class": true}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō
+        \"central\""}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius":
+        "20"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3],
+        "config": {"nested": true}}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions":
+        [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5,
+        6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,35 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
+        Let me know if you need more.'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL> Let me know if you need more.'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL> Then check LA weather. <TOOLCALL>[{"name":
+        "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.yaml
@@ -1,0 +1,58 @@
+family: nemotron_deci
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "unknown_tool", "arguments": {"location":
+        "NYC"}}]</TOOLCALL>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_deci'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,27 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+      normal_text: 'Both: '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,36 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,50 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>'
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,21 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,36 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,29 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.yaml
@@ -1,0 +1,53 @@
+family: nemotron_nano
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'nemotron_nano'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,26 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,36 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,31 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,21 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,36 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,26 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.yaml
@@ -1,0 +1,66 @@
+family: phi4
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls: []
+    sglang:
+      unavailable: No SGLang parser for family 'phi4'.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,59 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+      normal_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")]
+        Done.'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,38 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '[not a valid python call]'
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '[get_weather(location="NYC"]'
+  TOOLCALLING.batch.4.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,48 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: get_weather(location="NYC")]
+    sglang:
+      calls: []
+      normal_text: get_weather(location="NYC")]
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "N'
+    sglang:
+      calls: []
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time![get_weather(location="Boston"), get_weather(location="New
+        York")
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time![get_weather(location="Boston"), get_weather(location="New
+        York
+    sglang:
+      calls: []
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,28 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls: []
+      normal_text: '[get_time( )]'
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,110 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    sglang:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    sglang:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+  TOOLCALLING.batch.7.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,46 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+      normal_text: I will check the weather. [get_weather(location="NYC")]
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+      normal_text: I will check the weather. [get_weather(location="NYC")] Let me
+        know if you need more.
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+      normal_text: I will check the weather. [get_weather(location="NYC")] Then check
+        LA weather. [get_weather(location="LA")]
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.yaml
@@ -1,0 +1,128 @@
+family: pythonic
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+  TOOLCALLING.batch.30.a:
+    vllm:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a, SELECT b
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a, SELECT b
+  TOOLCALLING.batch.30.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket
+        ]'
+  TOOLCALLING.batch.30.c:
+    vllm:
+      calls:
+      - name: run_query
+        arguments:
+          sql: literal [get_time marker] stays text
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: literal [get_time marker] stays text
+  TOOLCALLING.batch.31.a:
+    vllm:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a, SELECT b
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a, SELECT b
+      - name: get_time
+        arguments:
+          timezone: EST
+  TOOLCALLING.batch.31.b:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket
+        ]'
+  TOOLCALLING.batch.13.a:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+  TOOLCALLING.batch.13.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: unknown_tool
+        arguments:
+          location: LA
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,51 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
+        "get_time", "arguments": {"timezone": "EST"}}'
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    sglang:
+      calls: []
+      normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location":
+        "NYC"}}<tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
+        "get_weather", "arguments": {"location": "LA"}}'
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,45 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: <tool_call>not even json
+  TOOLCALLING.batch.4.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"location": "NYC"'
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"'
+  TOOLCALLING.batch.4.c:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,63 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    sglang:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments: '{"loc'
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<tool_call>{"name": "get_weather", "arguments": {"location":
+        "Boston"}}<tool_call>{"name": "get_weather", "arguments": {"location": "New
+        York"}}'
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: '{"location": "New York'
+      normal_text: I'll start by fetching the weather for both Boston and New York
+        at the same time!
+    sglang:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<tool_call>{"name": "get_weather", "arguments": {"location":
+        "Boston"}}<tool_call>{"name": "get_weather", "arguments": {"location": "New
+        York'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,30 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_time", "arguments": {}}'
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_time", "arguments": { }}'
+  TOOLCALLING.batch.6.c:
+    vllm:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_time"}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,88 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination":
+        "Paris", "passengers": 2, "first_class": true}}'
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō
+        \"central\""}}'
+  TOOLCALLING.batch.7.c:
+    vllm:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius":
+        "20"}}'
+  TOOLCALLING.batch.7.d:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3],
+        "config": {"nested": true}}}'
+  TOOLCALLING.batch.7.e:
+    vllm:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions":
+        [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5,
+        6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}'
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,53 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
+        {"location": "NYC"}}'
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}
+        Let me know if you need more.'
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
+        {"location": "NYC"}} Let me know if you need more.'
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls: []
+      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
+        {"location": "NYC"}} Then check LA weather. <tool_call>{"name": "get_weather",
+        "arguments": {"location": "LA"}}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.yaml
@@ -1,0 +1,72 @@
+family: qwen25
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
+        "get_weather", "arguments": {"location": "LA"}}'
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang:
+      calls: []
+      normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location":
+        "NYC"}}'
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,52 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.2.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: '
+
+        '
+  TOOLCALLING.batch.2.c:
+    vllm:
+      calls: []
+      normal_text: 'Both queries: '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: "Both queries: \n Results above."
+  TOOLCALLING.batch.2.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: '
+
+        '
+  TOOLCALLING.batch.2.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,41 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.4.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.4.d:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.4.b:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.4.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: ''
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -1,0 +1,134 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.5.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.5.b:
+    vllm:
+      calls: []
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: '
+
+
+
+        '
+  TOOLCALLING.batch.5.c:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.5.d:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+
+        '
+  TOOLCALLING.batch.5.e:
+    vllm:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: {}
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+
+        '
+  TOOLCALLING.batch.5.f:
+    vllm:
+      calls: []
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>
+
+        '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '
+
+
+
+
+        '
+  TOOLCALLING.batch.5.g:
+    vllm:
+      calls: []
+      normal_text: 'I will check that. <function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>'
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: "I will check that. \n\n\n"

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,25 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.6.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_time
+        arguments: {}
+  TOOLCALLING.batch.6.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,47 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.7.a:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+  TOOLCALLING.batch.7.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+  TOOLCALLING.batch.7.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.d:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.e:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.7.f:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740992

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,48 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.8.a:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
+  TOOLCALLING.batch.8.c:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
+  TOOLCALLING.batch.8.d:
+    vllm:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.yaml
@@ -1,0 +1,70 @@
+family: qwen3_coder
+mode: batch-on-stream
+captured_with:
+  vllm: 0.22.0
+  sglang: 0.5.12.post1
+cases:
+  TOOLCALLING.batch.1:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.3:
+    vllm:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm:
+      calls: []
+    sglang:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm:
+      calls: []
+      normal_text: '   '
+    sglang:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: '
+
+        '
+  TOOLCALLING.batch.30:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.13:
+    vllm:
+      calls: []
+    sglang:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+  TOOLCALLING.batch.13.c:
+    vllm:
+      unavailable: No batch model_text for this case.
+    sglang:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3
 model_label: 'DeepSeek V3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,14 +25,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
 ```json
 {"location": "NYC"}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -41,17 +52,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather
 ```json
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
     - delta_text: '{"location": "NYC"}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []
     - delta_text: '
 ```'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<｜tool▁call▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<｜tool▁calls▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3
+model_label: 'DeepSeek V3'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location": "NYC"}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜>'
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
+    - delta_text: 'get_weather
+```json
+'
+    - delta_text: '{"location": "NYC"}'
+    - delta_text: '
+```'
+    - delta_text: '<｜tool▁call▁end｜>'
+    - delta_text: '<｜tool▁calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3
+model_label: 'DeepSeek V3'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁ca'
+    - delta_text: 'lls▁beg'
+    - delta_text: 'in｜><｜tool▁ca'
+    - delta_text: 'll▁be'
+    - delta_text: 'gin｜>function<｜to'
+    - delta_text: 'ol▁'
+    - delta_text: 'sep｜>get_'
+    - delta_text: 'weather'
+    - delta_text: '
+```json
+{"lo'
+    - delta_text: 'catio'
+    - delta_text: 'n": "NYC"}
+```<｜t'
+    - delta_text: 'ool'
+    - delta_text: '▁call▁end'
+    - delta_text: '｜><｜too'
+    - delta_text: 'l▁call▁begin｜'
+    - delta_text: '>func'
+    - delta_text: 'tion<｜tool▁sep｜>g'
+    - delta_text: 'et_'
+    - delta_text: 'time
+```j'
+    - delta_text: 'son
+{"t'
+    - delta_text: 'imezone": "ES'
+    - delta_text: 'T"}
+`'
+    - delta_text: '``<｜tool▁call▁end'
+    - delta_text: '｜><'
+    - delta_text: '｜tool▁cal'
+    - delta_text: 'ls▁end｜'
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3
 model_label: 'DeepSeek V3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,40 +31,217 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁ca'
+        sglang: '<｜tool▁ca'
     - delta_text: 'lls▁beg'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'lls▁beg'
+        sglang: 'lls▁beg'
     - delta_text: 'in｜><｜tool▁ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'in｜><｜tool▁ca'
+        sglang: 'in｜><｜tool▁ca'
     - delta_text: 'll▁be'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'll▁be'
+        sglang: 'll▁be'
     - delta_text: 'gin｜>function<｜to'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'gin｜>function<｜to'
+        sglang: 'gin｜>function<｜to'
     - delta_text: 'ol▁'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ol▁'
+        sglang: 'ol▁'
     - delta_text: 'sep｜>get_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'sep｜>get_'
+        sglang: 'sep｜>get_'
     - delta_text: 'weather'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'weather'
+        sglang: 'weather'
     - delta_text: '
 ```json
 {"lo'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '
+```json
+{"lo'
+        sglang: '
+json
+{"lo'
     - delta_text: 'catio'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'catio'
+        sglang: 'catio'
     - delta_text: 'n": "NYC"}
 ```<｜t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'n": "NYC"}
+```<｜t'
+        sglang: 'n": "NYC"}
+<｜t'
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool'
+        sglang: 'ool'
     - delta_text: '▁call▁end'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '▁call▁end'
+        sglang: '▁call▁end'
     - delta_text: '｜><｜too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜><｜too'
+        sglang: '｜><｜too'
     - delta_text: 'l▁call▁begin｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁call▁begin｜'
+        sglang: 'l▁call▁begin｜'
     - delta_text: '>func'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>func'
+        sglang: '>func'
     - delta_text: 'tion<｜tool▁sep｜>g'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'tion<｜tool▁sep｜>g'
+        sglang: 'tion<｜tool▁sep｜>g'
     - delta_text: 'et_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'et_'
+        sglang: 'et_'
     - delta_text: 'time
 ```j'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'time
+```j'
+        sglang: 'time
+j'
     - delta_text: 'son
 {"t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'son
+{"t'
+        sglang: 'son
+{"t'
     - delta_text: 'imezone": "ES'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'imezone": "ES'
+        sglang: 'imezone": "ES'
     - delta_text: 'T"}
 `'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'T"}
+`'
+        sglang: 'T"}
+`'
     - delta_text: '``<｜tool▁call▁end'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '``<｜tool▁call▁end'
+        sglang: '``<｜tool▁call▁end'
     - delta_text: '｜><'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜><'
+        sglang: '｜><'
     - delta_text: '｜tool▁cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜tool▁cal'
+        sglang: '｜tool▁cal'
     - delta_text: 'ls▁end｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ls▁end｜'
+        sglang: 'ls▁end｜'
     - delta_text: '>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>'
+        sglang: '>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3
+model_label: 'DeepSeek V3'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜'
+    - delta_text: 'too'
+    - delta_text: 'l▁cal'
+    - delta_text: 'ls▁begin｜><'
+    - delta_text: '｜tool▁call▁begin｜>f'
+    - delta_text: 'un'
+    - delta_text: 'cti'
+    - delta_text: 'on<｜t'
+    - delta_text: 'ool▁sep｜>ge'
+    - delta_text: 't_weather
+```json
+{'
+    - delta_text: '"l'
+    - delta_text: 'oca'
+    - delta_text: 'tion"'
+    - delta_text: ': "NYC"}
+``'
+    - delta_text: '`<｜tool▁call▁end｜><'
+    - delta_text: '｜t'
+    - delta_text: 'ool'
+    - delta_text: '▁call'
+    - delta_text: 's▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3
 model_label: 'DeepSeek V3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,29 +25,152 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜'
+        sglang: '<｜'
     - delta_text: 'too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'too'
+        sglang: 'too'
     - delta_text: 'l▁cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁cal'
+        sglang: 'l▁cal'
     - delta_text: 'ls▁begin｜><'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ls▁begin｜><'
+        sglang: 'ls▁begin｜><'
     - delta_text: '｜tool▁call▁begin｜>f'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜tool▁call▁begin｜>f'
+        sglang: '｜tool▁call▁begin｜>f'
     - delta_text: 'un'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'un'
+        sglang: 'un'
     - delta_text: 'cti'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'cti'
+        sglang: 'cti'
     - delta_text: 'on<｜t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'on<｜t'
+        sglang: 'on<｜t'
     - delta_text: 'ool▁sep｜>ge'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool▁sep｜>ge'
+        sglang: 'ool▁sep｜>ge'
     - delta_text: 't_weather
 ```json
 {'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 't_weather
+```json
+{'
+        sglang: 't_weather
+json
+{'
     - delta_text: '"l'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '"l'
+        sglang: '"l'
     - delta_text: 'oca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'oca'
+        sglang: 'oca'
     - delta_text: 'tion"'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'tion"'
+        sglang: 'tion"'
     - delta_text: ': "NYC"}
 ``'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: ': "NYC"}
+``'
+        sglang: ': "NYC"}
+``'
     - delta_text: '`<｜tool▁call▁end｜><'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '`<｜tool▁call▁end｜><'
+        sglang: '`<'
     - delta_text: '｜t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜t'
+        sglang: '｜t'
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool'
+        sglang: 'ool'
     - delta_text: '▁call'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '▁call'
+        sglang: '▁call'
     - delta_text: 's▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 's▁end｜>'
+        sglang: 's▁end｜>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3
+model_label: 'DeepSeek V3'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location": "NYC"}
+```'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>fun'
+    - delta_text: 'ction<｜tool▁sep｜>get_weather
+```json
+{"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location": "NYC"}
+```
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3
 model_label: 'DeepSeek V3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,14 +25,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
 ```json
 {"location": "NYC"}
 ```'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -41,14 +54,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>fun'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ction<｜tool▁sep｜>get_weather
 ```json
 {"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"loc'}
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -60,7 +84,7 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
 ```json
@@ -69,5 +93,21 @@ cases:
 <｜tool▁call▁end｜>
 <｜tool▁call▁end｜>
 <｜tool▁call▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location": "NYC"}
+```
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_1
+model_label: 'DeepSeek V3.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜>'
+    - delta_text: '<｜tool▁call▁begin｜>'
+    - delta_text: 'get_weather'
+    - delta_text: '<｜tool▁sep｜>'
+    - delta_text: '{"location":"NYC"}'
+    - delta_text: '<｜tool▁call▁end｜>'
+    - delta_text: '<｜tool▁calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_1
 model_label: 'DeepSeek V3.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,14 +49,42 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜tool▁call▁begin｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜tool▁sep｜>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: '<｜tool▁call▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜tool▁calls▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_1
+model_label: 'DeepSeek V3.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁ca'
+    - delta_text: 'lls▁beg'
+    - delta_text: 'in｜><｜tool▁ca'
+    - delta_text: 'll▁be'
+    - delta_text: 'gin｜>get_weather<'
+    - delta_text: '｜to'
+    - delta_text: 'ol▁sep｜>{'
+    - delta_text: '"locati'
+    - delta_text: 'on":"NYC"}<｜t'
+    - delta_text: 'ool▁c'
+    - delta_text: 'all▁end｜><｜tool▁c'
+    - delta_text: 'all'
+    - delta_text: '▁begin｜>g'
+    - delta_text: 'et_time'
+    - delta_text: '<｜tool▁sep｜>{'
+    - delta_text: '"time'
+    - delta_text: 'zone":"EST"}<｜too'
+    - delta_text: 'l▁c'
+    - delta_text: 'all▁end｜>'
+    - delta_text: '<｜tool▁'
+    - delta_text: 'calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_1
 model_label: 'DeepSeek V3.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,28 +31,157 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁ca'
+        sglang: '<｜tool▁ca'
     - delta_text: 'lls▁beg'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'lls▁beg'
+        sglang: 'lls▁beg'
     - delta_text: 'in｜><｜tool▁ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'in｜><｜tool▁ca'
+        sglang: 'in｜><｜tool▁ca'
     - delta_text: 'll▁be'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'll▁be'
+        sglang: 'll▁be'
     - delta_text: 'gin｜>get_weather<'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'gin｜>get_weather<'
+        sglang: 'gin｜>get_weather<'
     - delta_text: '｜to'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜to'
+        sglang: '｜to'
     - delta_text: 'ol▁sep｜>{'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ol▁sep｜>{'
+        sglang: 'ol▁sep｜>{'
     - delta_text: '"locati'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '"locati'
+        sglang: '"locati'
     - delta_text: 'on":"NYC"}<｜t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'on":"NYC"}<｜t'
+        sglang: 'on":"NYC"}<｜t'
     - delta_text: 'ool▁c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool▁c'
+        sglang: 'ool▁c'
     - delta_text: 'all▁end｜><｜tool▁c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'all▁end｜><｜tool▁c'
+        sglang: 'all▁end｜><｜tool▁c'
     - delta_text: 'all'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'all'
+        sglang: 'all'
     - delta_text: '▁begin｜>g'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '▁begin｜>g'
+        sglang: '▁begin｜>g'
     - delta_text: 'et_time'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'et_time'
+        sglang: 'et_time'
     - delta_text: '<｜tool▁sep｜>{'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁sep｜>{'
+        sglang: '<｜tool▁sep｜>{'
     - delta_text: '"time'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '"time'
+        sglang: '"time'
     - delta_text: 'zone":"EST"}<｜too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'zone":"EST"}<｜too'
+        sglang: 'zone":"EST"}<｜too'
     - delta_text: 'l▁c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁c'
+        sglang: 'l▁c'
     - delta_text: 'all▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'all▁end｜>'
+        sglang: 'all▁end｜>'
     - delta_text: '<｜tool▁'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁'
+        sglang: '<｜tool▁'
     - delta_text: 'calls▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'calls▁end｜>'
+        sglang: 'calls▁end｜>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_1
+model_label: 'DeepSeek V3.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜'
+    - delta_text: 'too'
+    - delta_text: 'l▁cal'
+    - delta_text: 'ls▁begin｜><'
+    - delta_text: '｜tool▁call▁begin｜>g'
+    - delta_text: 'et'
+    - delta_text: '_we'
+    - delta_text: 'ather'
+    - delta_text: '<｜tool▁sep｜'
+    - delta_text: '>{"location":"NYC"}'
+    - delta_text: '<｜'
+    - delta_text: 'too'
+    - delta_text: 'l▁cal'
+    - delta_text: 'l▁end｜><｜to'
+    - delta_text: 'ol▁calls▁end｜>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_1
 model_label: 'DeepSeek V3.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,22 +25,115 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜'
+        sglang: '<｜'
     - delta_text: 'too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'too'
+        sglang: 'too'
     - delta_text: 'l▁cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁cal'
+        sglang: 'l▁cal'
     - delta_text: 'ls▁begin｜><'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ls▁begin｜><'
+        sglang: 'ls▁begin｜><'
     - delta_text: '｜tool▁call▁begin｜>g'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '｜tool▁call▁begin｜>g'
+        sglang: '｜tool▁call▁begin｜>g'
     - delta_text: 'et'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'et'
+        sglang: 'et'
     - delta_text: '_we'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '_we'
+        sglang: '_we'
     - delta_text: 'ather'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ather'
+        sglang: 'ather'
     - delta_text: '<｜tool▁sep｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁sep｜'
+        sglang: '<｜tool▁sep｜'
     - delta_text: '>{"location":"NYC"}'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>{"location":"NYC"}'
+        sglang: '>{"location":"NYC"}'
     - delta_text: '<｜'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜'
+        sglang: '<｜'
     - delta_text: 'too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'too'
+        sglang: 'too'
     - delta_text: 'l▁cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁cal'
+        sglang: 'l▁cal'
     - delta_text: 'l▁end｜><｜to'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l▁end｜><｜to'
+        sglang: 'l▁end｜><｜to'
     - delta_text: 'ol▁calls▁end｜>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ol▁calls▁end｜>'
+        sglang: 'ol▁calls▁end｜>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_1
+model_label: 'DeepSeek V3.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁b'
+    - delta_text: 'egin｜>get_weather<｜tool▁sep｜>{"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_1
 model_label: 'DeepSeek V3.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +49,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁b'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<｜tool▁call▁b'
     - delta_text: 'egin｜>get_weather<｜tool▁sep｜>{"loc'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: 'egin｜>get_weather<｜tool▁sep｜>{"loc'
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"loc'}
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +81,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_2
 model_label: 'DeepSeek V3.2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,15 +25,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>
 </｜DSML｜function_calls>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -42,18 +54,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜function_calls>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜DSML｜invoke name="get_weather">
 '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: '</｜DSML｜parameter>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '</｜DSML｜invoke>
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: '</｜DSML｜function_calls>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_2
+model_label: 'DeepSeek V3.2'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜function_calls>
+'
+    - delta_text: '<｜DSML｜invoke name="get_weather">
+'
+    - delta_text: '<｜DSML｜parameter name="location" string="true">'
+    - delta_text: 'NYC'
+    - delta_text: '</｜DSML｜parameter>
+'
+    - delta_text: '</｜DSML｜invoke>
+'
+    - delta_text: '</｜DSML｜function_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_2
+model_label: 'DeepSeek V3.2'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜fu'
+    - delta_text: 'nction_'
+    - delta_text: 'calls>
+<｜DSML'
+    - delta_text: '｜invo'
+    - delta_text: 'ke name="get_weat'
+    - delta_text: 'her'
+    - delta_text: '">
+<｜DSML'
+    - delta_text: '｜parame'
+    - delta_text: 'ter name="loc'
+    - delta_text: 'ation'
+    - delta_text: '" string="true">N'
+    - delta_text: 'YC<'
+    - delta_text: '/｜DSML｜pa'
+    - delta_text: 'rameter'
+    - delta_text: '>
+</｜DSML｜inv'
+    - delta_text: 'oke>
+'
+    - delta_text: '<｜DSML｜invoke nam'
+    - delta_text: 'e="'
+    - delta_text: 'get_time"'
+    - delta_text: '>
+<｜DSM'
+    - delta_text: 'L｜parameter n'
+    - delta_text: 'ame="'
+    - delta_text: 'timezone" string='
+    - delta_text: '"tr'
+    - delta_text: 'ue">EST</'
+    - delta_text: '｜DSML｜p'
+    - delta_text: 'arameter>
+</｜'
+    - delta_text: 'DSML｜'
+    - delta_text: 'invoke>
+</｜DSML｜f'
+    - delta_text: 'unc'
+    - delta_text: 'tion_call'
+    - delta_text: 's>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_2
 model_label: 'DeepSeek V3.2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,46 +31,154 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜fu'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'nction_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'calls>
 <｜DSML'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '｜invo'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ke name="get_weat'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'her'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '">
 <｜DSML'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '｜parame'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ter name="loc'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ation'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '" string="true">N'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: 'YC<'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '"location": "N'}
     - delta_text: '/｜DSML｜pa'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'rameter'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>
 </｜DSML｜inv'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'oke>
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: 'YC"}'}
     - delta_text: '<｜DSML｜invoke nam'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e="'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_time"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>
 <｜DSM'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, name: 'get_time'}
     - delta_text: 'L｜parameter n'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ame="'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'timezone" string='
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '"tr'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ue">EST</'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '{'}
     - delta_text: '｜DSML｜p'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'arameter>
 </｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'DSML｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'invoke>
 </｜DSML｜f'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "EST"}'}
+        sglang:
+        - {index: 1, arguments: '"timezone": "EST"}'}
     - delta_text: 'unc'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'tion_call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 's>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_2
+model_label: 'DeepSeek V3.2'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜'
+    - delta_text: 'DSM'
+    - delta_text: 'L｜fun'
+    - delta_text: 'ction_calls'
+    - delta_text: '>
+<｜DSML｜invoke nam'
+    - delta_text: 'e='
+    - delta_text: '"ge'
+    - delta_text: 't_wea'
+    - delta_text: 'ther">
+<｜DS'
+    - delta_text: 'ML｜parameter name="'
+    - delta_text: 'lo'
+    - delta_text: 'cat'
+    - delta_text: 'ion" '
+    - delta_text: 'string="tru'
+    - delta_text: 'e">NYC</｜DSML｜param'
+    - delta_text: 'et'
+    - delta_text: 'er>'
+    - delta_text: '
+</｜D'
+    - delta_text: 'SML｜invoke>'
+    - delta_text: '
+</｜DSML｜function_c'
+    - delta_text: 'al'
+    - delta_text: 'ls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_2
 model_label: 'DeepSeek V3.2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,33 +25,106 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'DSM'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'L｜fun'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ction_calls'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>
 <｜DSML｜invoke nam'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e='
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '"ge'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 't_wea'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ther">
 <｜DS'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'ML｜parameter name="'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'lo'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'cat'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ion" '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'string="tru'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e">NYC</｜DSML｜param'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: 'et'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'er>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '
 </｜D'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'SML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: '
 </｜DSML｜function_c'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'al'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ls>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v3_2
 model_label: 'DeepSeek V3.2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,14 +25,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -41,14 +53,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜function_calls>
 <｜DSML｜invoke name="get_weathe'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'r">
 <｜DSML｜parameter name="location" string="true">NY'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -60,12 +82,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>
 </｜DSML｜invoke>
 </｜DSML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+      normal_text:
+        vllm: '<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜invoke>
+</｜DSML｜invoke>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v3_2
+model_label: 'DeepSeek V3.2'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weathe'
+    - delta_text: 'r">
+<｜DSML｜parameter name="location" string="true">NY'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜invoke>
+</｜DSML｜invoke>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v4
+model_label: 'DeepSeek V4'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜tool_calls>
+'
+    - delta_text: '<｜DSML｜invoke name="get_weather">
+'
+    - delta_text: '<｜DSML｜parameter name="location" string="true">'
+    - delta_text: 'NYC'
+    - delta_text: '</｜DSML｜parameter>
+'
+    - delta_text: '</｜DSML｜invoke>
+'
+    - delta_text: '</｜DSML｜tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,15 +25,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>
 </｜DSML｜tool_calls>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -42,18 +54,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜tool_calls>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<｜DSML｜invoke name="get_weather">
 '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: '</｜DSML｜parameter>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '</｜DSML｜invoke>
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: '</｜DSML｜tool_calls>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,45 +31,149 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜to'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ol_call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 's>
 <｜DSML｜inv'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'oke n'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ame="get_weather"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>
 <'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '｜DSML｜par'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ameter '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'name="locatio'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'n" st'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ring="true">NYC</'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: '｜DS'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ML｜parame'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ter>
 </'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '｜DSML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: '
 <｜DS'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ML｜invoke name="g'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'et_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'time">
 <｜'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, name: 'get_time'}
     - delta_text: 'DSML｜pa'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'rameter name='
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '"time'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'zone" string="tru'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e">'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'EST</｜DSM'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '{'}
     - delta_text: 'L｜param'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'eter>
 </｜DSML'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '｜invo'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ke>
 </｜DSML｜tool_'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "EST"}'}
+        sglang:
+        - {index: 1, arguments: '"timezone": "EST"}'}
     - delta_text: 'cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ls>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v4
+model_label: 'DeepSeek V4'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜to'
+    - delta_text: 'ol_call'
+    - delta_text: 's>
+<｜DSML｜inv'
+    - delta_text: 'oke n'
+    - delta_text: 'ame="get_weather"'
+    - delta_text: '>
+<'
+    - delta_text: '｜DSML｜par'
+    - delta_text: 'ameter '
+    - delta_text: 'name="locatio'
+    - delta_text: 'n" st'
+    - delta_text: 'ring="true">NYC</'
+    - delta_text: '｜DS'
+    - delta_text: 'ML｜parame'
+    - delta_text: 'ter>
+</'
+    - delta_text: '｜DSML｜invoke>'
+    - delta_text: '
+<｜DS'
+    - delta_text: 'ML｜invoke name="g'
+    - delta_text: 'et_'
+    - delta_text: 'time">
+<｜'
+    - delta_text: 'DSML｜pa'
+    - delta_text: 'rameter name='
+    - delta_text: '"time'
+    - delta_text: 'zone" string="tru'
+    - delta_text: 'e">'
+    - delta_text: 'EST</｜DSM'
+    - delta_text: 'L｜param'
+    - delta_text: 'eter>
+</｜DSML'
+    - delta_text: '｜invo'
+    - delta_text: 'ke>
+</｜DSML｜tool_'
+    - delta_text: 'cal'
+    - delta_text: 'ls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,31 +25,99 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'DSM'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'L｜too'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l_calls>
 <｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'DSML｜invoke name="g'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'et'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '_we'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '">
 <｜DSML｜p'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'arameter name="loca'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ti'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'on"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' stri'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ng="true">N'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
     - delta_text: 'YC</｜DSML｜parameter'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '"location": "N'}
     - delta_text: '>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '</｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'DSML｜'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'invoke>
 </｜'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: 'YC"}'}
     - delta_text: 'DSML｜tool_calls>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v4
+model_label: 'DeepSeek V4'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜'
+    - delta_text: 'DSM'
+    - delta_text: 'L｜too'
+    - delta_text: 'l_calls>
+<｜'
+    - delta_text: 'DSML｜invoke name="g'
+    - delta_text: 'et'
+    - delta_text: '_we'
+    - delta_text: 'ather'
+    - delta_text: '">
+<｜DSML｜p'
+    - delta_text: 'arameter name="loca'
+    - delta_text: 'ti'
+    - delta_text: 'on"'
+    - delta_text: ' stri'
+    - delta_text: 'ng="true">N'
+    - delta_text: 'YC</｜DSML｜parameter'
+    - delta_text: '>
+'
+    - delta_text: '</｜'
+    - delta_text: 'DSML｜'
+    - delta_text: 'invoke>
+</｜'
+    - delta_text: 'DSML｜tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: deepseek_v4
+model_label: 'DeepSeek V4'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_weather"'
+    - delta_text: '>
+<｜DSML｜parameter name="location" string="true">NY'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜invoke>
+</｜DSML｜invoke>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,14 +25,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -41,14 +53,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_weather"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>
 <｜DSML｜parameter name="location" string="true">NY'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -60,12 +82,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 </｜DSML｜invoke>
 </｜DSML｜invoke>
 </｜DSML｜invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+      normal_text:
+        vllm: '<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜invoke>
+</｜DSML｜invoke>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: gemma4
 model_label: 'Gemma 4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,15 +49,48 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'call:'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '{location:'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<|"|>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": '}
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"NYC'}
+        sglang: []
     - delta_text: '<|"|>}'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<tool_call|>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"}'}
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: gemma4
+model_label: 'Gemma 4'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_call>'
+    - delta_text: 'call:'
+    - delta_text: 'get_weather'
+    - delta_text: '{location:'
+    - delta_text: '<|"|>'
+    - delta_text: 'NYC'
+    - delta_text: '<|"|>}'
+    - delta_text: '<tool_call|>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: gemma4
 model_label: 'Gemma 4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,22 +31,80 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_ca'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'll>call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ':get_weather{'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'locat'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ion:<|"|>NYC<|"|>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang: []
     - delta_text: '}<t'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: 'ool_call|'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '><|tool'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"}'}
+        sglang: []
     - delta_text: '_call>call:ge'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 't_tim'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e{timezone:<|"|>E'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang:
+        - {index: 1, name: 'get_time'}
     - delta_text: 'ST<'
+      expected:
+        vllm:
+        - {index: 1, arguments: '{"timezone": "EST'}
+        sglang: []
     - delta_text: '|"|>}<too'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: 'l_call|'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>'
+      expected:
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: gemma4
+model_label: 'Gemma 4'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_ca'
+    - delta_text: 'll>call'
+    - delta_text: ':get_weather{'
+    - delta_text: 'locat'
+    - delta_text: 'ion:<|"|>NYC<|"|>'
+    - delta_text: '}<t'
+    - delta_text: 'ool_call|'
+    - delta_text: '><|tool'
+    - delta_text: '_call>call:ge'
+    - delta_text: 't_tim'
+    - delta_text: 'e{timezone:<|"|>E'
+    - delta_text: 'ST<'
+    - delta_text: '|"|>}<too'
+    - delta_text: 'l_call|'
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: gemma4
 model_label: 'Gemma 4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +25,56 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'too'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l_cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l>call:get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'weather{location:<|'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '"|'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>NY'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NY'}
+        sglang: []
     - delta_text: 'C<|"|'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'C'}
+        sglang: []
     - delta_text: '>}<tool_cal'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: 'l|>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"}'}
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: gemma4
+model_label: 'Gemma 4'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|'
+    - delta_text: 'too'
+    - delta_text: 'l_cal'
+    - delta_text: 'l>call:get_'
+    - delta_text: 'weather{location:<|'
+    - delta_text: '"|'
+    - delta_text: '>NY'
+    - delta_text: 'C<|"|'
+    - delta_text: '>}<tool_cal'
+    - delta_text: 'l|>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: gemma4
 model_label: 'Gemma 4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +51,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_call>call:get_w'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'eather{location:<|"|>N'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "N'}
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +80,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><tool_call|><tool_call|>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><tool_call|><tool_call|>'
+        sglang: 'call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><tool_call|><tool_call|>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: gemma4
+model_label: 'Gemma 4'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_call>call:get_w'
+    - delta_text: 'eather{location:<|"|>N'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><tool_call|><tool_call|>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: glm47
+model_label: 'GLM 5.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>'
+    - delta_text: 'get_weather'
+    - delta_text: '<arg_key>location</arg_key>'
+    - delta_text: '<arg_value>'
+    - delta_text: 'NYC'
+    - delta_text: '</arg_value>'
+    - delta_text: '</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: glm47
 model_label: 'GLM 5.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,14 +52,48 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<arg_key>location</arg_key>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": '}
     - delta_text: '<arg_value>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": '}
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'NYC'}
+        sglang:
+        - {index: 0, arguments: '"NYC'}
     - delta_text: '</arg_value>'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'C"'}
+        sglang:
+        - {index: 0, arguments: '"'}
     - delta_text: '</tool_call>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '}'}
+        sglang:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: glm47
+model_label: 'GLM 5.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'l>get_w'
+    - delta_text: 'eather<arg_ke'
+    - delta_text: 'y>loc'
+    - delta_text: 'ation</arg_key><a'
+    - delta_text: 'rg_'
+    - delta_text: 'value>NYC'
+    - delta_text: '</arg_v'
+    - delta_text: 'alue></tool_c'
+    - delta_text: 'all><'
+    - delta_text: 'tool_call>get_tim'
+    - delta_text: 'e<a'
+    - delta_text: 'rg_key>ti'
+    - delta_text: 'mezone<'
+    - delta_text: '/arg_key><arg'
+    - delta_text: '_valu'
+    - delta_text: 'e>EST</arg_value>'
+    - delta_text: '</t'
+    - delta_text: 'ool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: glm47
 model_label: 'GLM 5.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,26 +31,104 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l>get_w'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'eather<arg_ke'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'y>loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
     - delta_text: 'ation</arg_key><a'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '"location": '}
     - delta_text: 'rg_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'value>NYC'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": NYC'}
+        sglang:
+        - {index: 0, arguments: '"NYC'}
     - delta_text: '</arg_v'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'alue></tool_c'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'C"'}
+        sglang:
+        - {index: 0, arguments: '"'}
     - delta_text: 'all><'
+      expected:
+        vllm:
+        - {index: 0, arguments: '}'}
+        sglang:
+        - {index: 0, arguments: '}'}
     - delta_text: 'tool_call>get_tim'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e<a'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'rg_key>ti'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang:
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{'}
     - delta_text: 'mezone<'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '/arg_key><arg'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '"timezone": '}
     - delta_text: '_valu'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e>EST</arg_value>'
+      expected:
+        vllm:
+        - {index: 1, arguments: '{"timezone": "EST"'}
+        sglang:
+        - {index: 1, arguments: '"EST"'}
     - delta_text: '</t'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ool_call>'
+      expected:
+        vllm:
+        - {index: 1, arguments: '}'}
+        sglang:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: glm47
+model_label: 'GLM 5.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: '>get_weathe'
+    - delta_text: 'r<arg_key>location<'
+    - delta_text: '/a'
+    - delta_text: 'rg_'
+    - delta_text: 'key><'
+    - delta_text: 'arg_value>N'
+    - delta_text: 'YC</arg_value></too'
+    - delta_text: 'l_'
+    - delta_text: 'cal'
+    - delta_text: 'l>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: glm47
 model_label: 'GLM 5.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,20 +25,72 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '_call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>get_weathe'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'r<arg_key>location<'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
     - delta_text: '/a'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'rg_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'key><'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '"location": '}
     - delta_text: 'arg_value>N'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": N'}
+        sglang:
+        - {index: 0, arguments: '"N'}
     - delta_text: 'YC</arg_value></too'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'NYC"'}
+        sglang:
+        - {index: 0, arguments: 'YC"'}
     - delta_text: 'l_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l>'
+      expected:
+        vllm:
+        - {index: 0, arguments: '}'}
+        sglang:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: glm47
 model_label: 'GLM 5.1'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"location": "NYC"'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +51,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>get_weather<arg_key'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '>location</arg_key><arg_value>N'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"location": N'}
+        sglang:
+        - {index: 0, arguments: '{"location": "N'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +81,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call></tool_call></tool_call>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call></tool_call></tool_call>'
+        sglang: 'get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: glm47
+model_label: 'GLM 5.1'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>get_weather<arg_key'
+    - delta_text: '>location</arg_key><arg_value>N'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call></tool_call></tool_call>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony
+model_label: 'gpt-oss (harmony, token-id)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: tool_calls
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'get_weather'
+      delta_token_ids: [775, 170154]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: ' <|constrain|>json'
+      delta_token_ids: [220, 200003, 4108]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: '<|message|>'
+      delta_token_ids: [200008]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang: []
+    - delta_text: '{"location":"NYC"}'
+      delta_token_ids: [10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: tool_calls
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony
+model_label: 'gpt-oss (harmony, token-id)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    chunks:
+    - delta_text: '<|start|>'
+      delta_token_ids: [200006]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'assista'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'nt<|channel|>'
+      delta_token_ids: [173781, 200005]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'comme'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ntary to=function'
+      delta_token_ids: [12606, 815, 316, 28]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 's.g'
+      delta_token_ids: [44580]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'et_weathe'
+      delta_token_ids: [775]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'r <|con'
+      delta_token_ids: [170154, 220]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'strain|>json<'
+      delta_token_ids: [200003, 4108]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: '|mess'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'age|>{"location":'
+      delta_token_ids: [200008, 10848, 7693]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        sglang: []
+    - delta_text: '"NY'
+      delta_token_ids: [7534, 24202]
+      expected:
+        dynamo:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        vllm:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        sglang: []
+    - delta_text: 'C"}<|call'
+      delta_token_ids: [34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: '|><|sta'
+      delta_token_ids: [200012]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
+    - delta_text: 'rt|>assistant'
+      delta_token_ids: [200006, 173781]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'rt|>assistant'
+    - delta_text: '<|cha'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|cha'
+    - delta_text: 'nnel|>commentary '
+      delta_token_ids: [200005, 12606, 815]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'nnel|>commentary '
+    - delta_text: 'to='
+      delta_token_ids: [316, 28]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'to='
+    - delta_text: 'functions'
+      delta_token_ids: [44580]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'functions'
+    - delta_text: '.get_ti'
+      delta_token_ids: [775]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '.get_ti'
+    - delta_text: 'me <|constrai'
+      delta_token_ids: [6425, 220]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'me <|constrai'
+    - delta_text: 'n|>js'
+      delta_token_ids: [200003]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'n|>js'
+    - delta_text: 'on<|message|>{"ti'
+      delta_token_ids: [4108, 200008, 10848]
+      expected:
+        dynamo:
+        - {index: 1, id: true, name: 'get_time'}
+        - {index: 1, arguments: '{"'}
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        - {index: 1, arguments: '{"'}
+        sglang: []
+    - delta_text: 'mez'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'one":"EST'
+      delta_token_ids: [106775, 7534, 8292]
+      expected:
+        dynamo:
+        - {index: 1, arguments: 'timezone'}
+        - {index: 1, arguments: '":"'}
+        - {index: 1, arguments: 'EST'}
+        vllm:
+        - {index: 1, arguments: 'timezone'}
+        - {index: 1, arguments: '":"'}
+        - {index: 1, arguments: 'EST'}
+        sglang: []
+    - delta_text: '"}<|cal'
+      delta_token_ids: [18583]
+      expected:
+        dynamo:
+        - {index: 1, arguments: '"}'}
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang: []
+    - delta_text: 'l|>'
+      delta_token_ids: [200012]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: tool_calls
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony
+model_label: 'gpt-oss (harmony, token-id)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|'
+    - delta_text: 'cha'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'cha'
+    - delta_text: 'nnel|'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'nnel|'
+    - delta_text: '>commentary'
+      delta_token_ids: [200005, 12606, 815]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '>commentary'
+    - delta_text: ' to=functions.get_w'
+      delta_token_ids: [316, 28, 44580, 775]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: ' to=functions.get_w'
+    - delta_text: 'ea'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ea'
+    - delta_text: 'the'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'the'
+    - delta_text: 'r <|c'
+      delta_token_ids: [170154, 220]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'r <|c'
+    - delta_text: 'onstrain|>j'
+      delta_token_ids: [200003]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'onstrain|>j'
+    - delta_text: 'son<|message|>{"loc'
+      delta_token_ids: [4108, 200008, 10848]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        sglang: []
+    - delta_text: 'at'
+      delta_token_ids: []
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ion'
+      delta_token_ids: [7693]
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'location'}
+        vllm:
+        - {index: 0, arguments: 'location'}
+        sglang: []
+    - delta_text: '":"NY'
+      delta_token_ids: [7534, 24202]
+      expected:
+        dynamo:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        vllm:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        sglang: []
+    - delta_text: 'C"}<|call|>'
+      delta_token_ids: [34, 18583, 200012]
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: tool_calls
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony
+model_label: 'gpt-oss (harmony, token-id)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}'
+      delta_token_ids: [200006, 173781, 200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: stop
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|start|>assistant<|channel|>commentary to=functi'
+      delta_token_ids: [200006, 173781, 200005, 12606, 815, 316, 28]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ons.get_weather <|constrain|>json<|message|>{"loc'
+      delta_token_ids: [44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 9453]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'loc'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'loc'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: stop
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|call|><|call|>'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583, 200012, 200012, 200012]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: length
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony_text
+model_label: 'gpt-oss (harmony, text)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      finish_reason: tool_calls
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'get_weather'
+      delta_token_ids: [775, 170154]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: ' <|constrain|>json'
+      delta_token_ids: [220, 200003, 4108]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: '<|message|>'
+      delta_token_ids: [200008]
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang: []
+    - delta_text: '{"location":"NYC"}'
+      delta_token_ids: [10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm:
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      finish_reason: tool_calls
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony_text
+model_label: 'gpt-oss (harmony, text)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    chunks:
+    - delta_text: '<|start|>'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'assista'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'nt<|channel|>'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'comme'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ntary to=function'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 's.g'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'et_weathe'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'r <|con'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'strain|>json<'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: '|mess'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'age|>{"location":'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        sglang: []
+    - delta_text: '"NY'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        sglang: []
+    - delta_text: 'C"}<|call'
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: '|><|sta'
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
+    - delta_text: 'rt|>assistant'
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'rt|>assistant'
+    - delta_text: '<|cha'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|cha'
+    - delta_text: 'nnel|>commentary '
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'nnel|>commentary '
+    - delta_text: 'to='
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'to='
+    - delta_text: 'functions'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'functions'
+    - delta_text: '.get_ti'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '.get_ti'
+    - delta_text: 'me <|constrai'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'me <|constrai'
+    - delta_text: 'n|>js'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'n|>js'
+    - delta_text: 'on<|message|>{"ti'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        - {index: 1, arguments: '{"'}
+        sglang: []
+    - delta_text: 'mez'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'one":"EST'
+      expected:
+        dynamo:
+        - {index: 1, id: true, name: 'get_time'}
+        vllm:
+        - {index: 1, arguments: 'timezone'}
+        - {index: 1, arguments: '":"'}
+        - {index: 1, arguments: 'EST'}
+        sglang: []
+    - delta_text: '"}<|cal'
+      expected:
+        dynamo:
+        - {index: 1, arguments: '{"'}
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang: []
+    - delta_text: 'l|>'
+      expected:
+        dynamo:
+        - {index: 1, arguments: 'timezone'}
+        vllm: []
+        sglang: []
+    - delta_text: ''
+      finish_reason: tool_calls
+      expected:
+        dynamo:
+        - {index: 1, arguments: '":"'}
+        - {index: 1, arguments: 'EST'}
+        - {index: 1, arguments: '"}'}
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony_text
+model_label: 'gpt-oss (harmony, text)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|'
+    - delta_text: 'cha'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'cha'
+    - delta_text: 'nnel|'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'nnel|'
+    - delta_text: '>commentary'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '>commentary'
+    - delta_text: ' to=functions.get_w'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: ' to=functions.get_w'
+    - delta_text: 'ea'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ea'
+    - delta_text: 'the'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'the'
+    - delta_text: 'r <|c'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'r <|c'
+    - delta_text: 'onstrain|>j'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'onstrain|>j'
+    - delta_text: 'son<|message|>{"loc'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        sglang: []
+    - delta_text: 'at'
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ion'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, arguments: 'location'}
+        sglang: []
+    - delta_text: '":"NY'
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        sglang: []
+    - delta_text: 'C"}<|call|>'
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        vllm:
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      finish_reason: tool_calls
+      expected:
+        dynamo:
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: harmony_text
+model_label: 'gpt-oss (harmony, text)'
+mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}'
+      delta_token_ids: [200006, 173781, 200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: stop
+      expected:
+        dynamo:
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|start|>assistant<|channel|>commentary to=functi'
+      delta_token_ids: [200006, 173781, 200005, 12606, 815, 316, 28]
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []
+    - delta_text: 'ons.get_weather <|constrain|>json<|message|>{"loc'
+      delta_token_ids: [44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 9453]
+      expected:
+        dynamo: []
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'loc'}
+        sglang: []
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: stop
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'loc'}
+        vllm: []
+        sglang: []
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    chunks:
+    - delta_text: '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|call|><|call|>'
+      delta_token_ids: [200005, 12606, 815, 316, 28, 44580, 775, 170154, 220, 200003, 4108, 200008, 10848, 7693, 7534, 24202, 34, 18583, 200012, 200012, 200012]
+      expected:
+        dynamo:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        - {index: 0, arguments: '{"'}
+        - {index: 0, arguments: 'location'}
+        - {index: 0, arguments: '":"'}
+        - {index: 0, arguments: 'NY'}
+        - {index: 0, arguments: 'C'}
+        - {index: 0, arguments: '"}'}
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
+    - delta_text: ''
+      delta_token_ids: []
+      finish_reason: length
+      expected:
+        dynamo: []
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: hermes
 model_label: 'Hermes-3 / Llama variants'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,11 +51,30 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '{"name": "get_weather", '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '"arguments": {"location": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '</tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: hermes
+model_label: 'Hermes-3 / Llama variants'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>'
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: '</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: hermes
+model_label: 'Hermes-3 / Llama variants'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'l>{"nam'
+    - delta_text: 'e": "get_weat'
+    - delta_text: 'her",'
+    - delta_text: ' "arguments": {"l'
+    - delta_text: 'oca'
+    - delta_text: 'tion": "N'
+    - delta_text: 'YC"}}</'
+    - delta_text: 'tool_call><to'
+    - delta_text: 'ol_ca'
+    - delta_text: 'll>{"name": "get_'
+    - delta_text: 'tim'
+    - delta_text: 'e", "argu'
+    - delta_text: 'ments":'
+    - delta_text: ' {"timezone":'
+    - delta_text: ' "EST'
+    - delta_text: '"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: hermes
 model_label: 'Hermes-3 / Llama variants'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,24 +31,91 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l>{"nam'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e": "get_weat'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'her",'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"l'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"l'}
+        sglang: []
     - delta_text: 'oca'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'oca'}
+        sglang: []
     - delta_text: 'tion": "N'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'tion": "N'}
+        sglang: []
     - delta_text: 'YC"}}</'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'YC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: 'tool_call><to'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ol_ca'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'll>{"name": "get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'tim'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'e", "argu'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang:
+        - {index: 1, name: 'get_time'}
     - delta_text: 'ments":'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' {"timezone":'
+      expected:
+        vllm:
+        - {index: 1, arguments: '{"timezone":'}
+        sglang: []
     - delta_text: ' "EST'
+      expected:
+        vllm:
+        - {index: 1, arguments: ' "EST'}
+        sglang: []
     - delta_text: '"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: hermes
 model_label: 'Hermes-3 / Llama variants'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +25,56 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '_call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>{"name": "'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather", "argu'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'me'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'nts'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '": {"'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"'}
+        sglang: []
     - delta_text: 'location": '
+      expected:
+        vllm:
+        - {index: 0, arguments: 'location":'}
+        sglang: []
     - delta_text: '"NYC"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: hermes
+model_label: 'Hermes-3 / Llama variants'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: '>{"name": "'
+    - delta_text: 'get_weather", "argu'
+    - delta_text: 'me'
+    - delta_text: 'nts'
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: hermes
 model_label: 'Hermes-3 / Llama variants'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +51,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_w'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'eather", "arguments": {"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"loc'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +80,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+        sglang: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: hermes
+model_label: 'Hermes-3 / Llama variants'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,8 @@
 family: jamba
 model_label: 'AI21 Jamba'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +24,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,11 +46,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>'
+      expected:
+        vllm: []
     - delta_text: '[{"name": "get_weather", '
+      expected:
+        vllm: []
     - delta_text: '"arguments": {"location": "NYC"}}]'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
     - delta_text: '</tool_calls>'
+      expected:
+        vllm:
+        - {index: 0, arguments: ''}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: jamba
+model_label: 'AI21 Jamba'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_calls>'
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: '</tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: jamba
+model_label: 'AI21 Jamba'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'ls>[{"n'
+    - delta_text: 'ame": "get_we'
+    - delta_text: 'ather'
+    - delta_text: '", "arguments": {'
+    - delta_text: '"lo'
+    - delta_text: 'cation": '
+    - delta_text: '"NYC"}}'
+    - delta_text: ', {"name": "g'
+    - delta_text: 'et_ti'
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: 'timezone"'
+    - delta_text: ': "EST"'
+    - delta_text: '}}]</tool_cal'
+    - delta_text: 'ls>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,8 @@
 family: jamba
 model_label: 'AI21 Jamba'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,23 +30,66 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<tool_cal'
     - delta_text: 'ls>[{"n'
+      expected:
+        vllm: []
     - delta_text: 'ame": "get_we'
+      expected:
+        vllm: []
     - delta_text: 'ather'
+      expected:
+        vllm: []
     - delta_text: '", "arguments": {'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
     - delta_text: '"lo'
+      expected:
+        vllm: []
     - delta_text: 'cation": '
+      expected:
+        vllm: []
     - delta_text: '"NYC"}}'
+      expected:
+        vllm: []
     - delta_text: ', {"name": "g'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: 'et_ti'
+      expected:
+        vllm: []
     - delta_text: 'me", "arguments":'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time'}
     - delta_text: ' {"'
+      expected:
+        vllm: []
     - delta_text: 'timezone"'
+      expected:
+        vllm: []
     - delta_text: ': "EST"'
+      expected:
+        vllm:
+        - {index: 1, arguments: '{"timezone": "EST"'}
     - delta_text: '}}]</tool_cal'
+      expected:
+        vllm: []
     - delta_text: 'ls>'
+      expected:
+        vllm:
+        - {index: 1, arguments: ''}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,8 @@
 family: jamba
 model_label: 'AI21 Jamba'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,19 +24,54 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<t'
     - delta_text: 'ool'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'ool'
     - delta_text: '_call'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '_call'
     - delta_text: 's>[{"name":'
+      expected:
+        vllm: []
     - delta_text: ' "get_weather", "ar'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
     - delta_text: 'gu'
+      expected:
+        vllm: []
     - delta_text: 'men'
+      expected:
+        vllm: []
     - delta_text: 'ts": '
+      expected:
+        vllm: []
     - delta_text: '{"location"'
+      expected:
+        vllm: []
     - delta_text: ': "NYC"}}]</tool_ca'
+      expected:
+        vllm: []
     - delta_text: 'll'
+      expected:
+        vllm: []
     - delta_text: 's>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: jamba
+model_label: 'AI21 Jamba'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: 's>[{"name":'
+    - delta_text: ' "get_weather", "ar'
+    - delta_text: 'gu'
+    - delta_text: 'men'
+    - delta_text: 'ts": '
+    - delta_text: '{"location"'
+    - delta_text: ': "NYC"}}]</tool_ca'
+    - delta_text: 'll'
+    - delta_text: 's>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: jamba
+model_label: 'AI21 Jamba'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls></tool_calls></tool_calls>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,8 @@
 family: jamba
 model_label: 'AI21 Jamba'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +24,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +45,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name": "get_'
+      expected:
+        vllm: []
     - delta_text: 'weather", "arguments": {"loc'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +70,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''jamba''.'
     chunks:
     - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls></tool_calls></tool_calls>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls></tool_calls></tool_calls>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: kimi_k2
 model_label: 'Kimi K2.6'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,16 +51,53 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_calls_section_begin|>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<|tool_call_begin|>functions.'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather:0'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<|tool_call_argument_begin|>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
     - delta_text: '{"location":"'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location":"'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'NYC'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'NYC'}
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC'}
     - delta_text: '"}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"}'}
+        sglang:
+        - {index: 0, arguments: '"}'}
     - delta_text: '<|tool_call_end|>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<|tool_calls_section_end|>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: kimi_k2
+model_label: 'Kimi K2.6'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_calls_section_begin|>'
+    - delta_text: '<|tool_call_begin|>functions.'
+    - delta_text: 'get_weather:0'
+    - delta_text: '<|tool_call_argument_begin|>'
+    - delta_text: '{"location":"'
+    - delta_text: 'NYC'
+    - delta_text: '"}'
+    - delta_text: '<|tool_call_end|>'
+    - delta_text: '<|tool_calls_section_end|>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: kimi_k2
 model_label: 'Kimi K2.6'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,36 +31,192 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|tool_ca'
     - delta_text: 'lls_sec'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'lls_sec'
     - delta_text: 'tion_begin|><'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'tion_begin|><'
     - delta_text: '|tool'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '|tool'
     - delta_text: '_call_begin|>func'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '_call_begin|>func'
     - delta_text: 'tio'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'tio'
     - delta_text: 'ns.get_we'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ns.get_we'
     - delta_text: 'ather:0'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ather:0'
     - delta_text: '<|tool_call_a'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|tool_call_a'
     - delta_text: 'rgume'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'rgume'
     - delta_text: 'nt_begin|>{"locat'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"locat'}
+        sglang: []
+      normal_text:
+        sglang: 'nt_begin|>{"locat'
     - delta_text: 'ion'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'ion'}
+        sglang: []
+      normal_text:
+        sglang: 'ion'
     - delta_text: '":"NYC"}<'
+      expected:
+        vllm:
+        - {index: 0, arguments: '":"NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: '":"NYC"}<'
     - delta_text: '|tool_c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '|tool_c'
     - delta_text: 'all_end|><|to'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'all_end|><|to'
     - delta_text: 'ol_ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ol_ca'
     - delta_text: 'll_begin|>functio'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'll_begin|>functio'
     - delta_text: 'ns.'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ns.'
     - delta_text: 'get_time:'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'get_time:'
     - delta_text: '1<|tool'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '1<|tool'
     - delta_text: '_call_argumen'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '_call_argumen'
     - delta_text: 't_beg'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 't_beg'
     - delta_text: 'in|>{"timezone":"'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":"'}
+        sglang: []
+      normal_text:
+        sglang: 'in|>{"timezone":"'
     - delta_text: 'EST'
+      expected:
+        vllm:
+        - {index: 1, arguments: 'EST'}
+        sglang: []
+      normal_text:
+        sglang: 'EST'
     - delta_text: '"}<|tool_'
+      expected:
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang: []
+      normal_text:
+        sglang: '"}<|tool_'
     - delta_text: 'call_en'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'call_en'
     - delta_text: 'd|><|tool_cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'd|><|tool_cal'
     - delta_text: 'ls_se'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ls_se'
     - delta_text: 'ction_end|>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ction_end|>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: kimi_k2
+model_label: 'Kimi K2.6'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_ca'
+    - delta_text: 'lls_sec'
+    - delta_text: 'tion_begin|><'
+    - delta_text: '|tool'
+    - delta_text: '_call_begin|>func'
+    - delta_text: 'tio'
+    - delta_text: 'ns.get_we'
+    - delta_text: 'ather:0'
+    - delta_text: '<|tool_call_a'
+    - delta_text: 'rgume'
+    - delta_text: 'nt_begin|>{"locat'
+    - delta_text: 'ion'
+    - delta_text: '":"NYC"}<'
+    - delta_text: '|tool_c'
+    - delta_text: 'all_end|><|to'
+    - delta_text: 'ol_ca'
+    - delta_text: 'll_begin|>functio'
+    - delta_text: 'ns.'
+    - delta_text: 'get_time:'
+    - delta_text: '1<|tool'
+    - delta_text: '_call_argumen'
+    - delta_text: 't_beg'
+    - delta_text: 'in|>{"timezone":"'
+    - delta_text: 'EST'
+    - delta_text: '"}<|tool_'
+    - delta_text: 'call_en'
+    - delta_text: 'd|><|tool_cal'
+    - delta_text: 'ls_se'
+    - delta_text: 'ction_end|>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: kimi_k2
+model_label: 'Kimi K2.6'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|'
+    - delta_text: 'too'
+    - delta_text: 'l_cal'
+    - delta_text: 'ls_section_'
+    - delta_text: 'begin|><|tool_call_'
+    - delta_text: 'be'
+    - delta_text: 'gin'
+    - delta_text: '|>fun'
+    - delta_text: 'ctions.get_'
+    - delta_text: 'weather:0<|tool_cal'
+    - delta_text: 'l_'
+    - delta_text: 'arg'
+    - delta_text: 'ument'
+    - delta_text: '_begin|>{"l'
+    - delta_text: 'ocation":"NYC"}<|to'
+    - delta_text: 'ol'
+    - delta_text: '_ca'
+    - delta_text: 'll_en'
+    - delta_text: 'd|><|tool_c'
+    - delta_text: 'alls_section_end|>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: kimi_k2
 model_label: 'Kimi K2.6'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,27 +25,133 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<|'
     - delta_text: 'too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'too'
     - delta_text: 'l_cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'l_cal'
     - delta_text: 'ls_section_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ls_section_'
     - delta_text: 'begin|><|tool_call_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'begin|><|tool_call_'
     - delta_text: 'be'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'be'
     - delta_text: 'gin'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'gin'
     - delta_text: '|>fun'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '|>fun'
     - delta_text: 'ctions.get_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ctions.get_'
     - delta_text: 'weather:0<|tool_cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'weather:0<|tool_cal'
     - delta_text: 'l_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'l_'
     - delta_text: 'arg'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'arg'
     - delta_text: 'ument'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ument'
     - delta_text: '_begin|>{"l'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"l'}
+        sglang: []
+      normal_text:
+        sglang: '_begin|>{"l'
     - delta_text: 'ocation":"NYC"}<|to'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'ocation":"NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: 'ocation":"NYC"}<|to'
     - delta_text: 'ol'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ol'
     - delta_text: '_ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '_ca'
     - delta_text: 'll_en'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'll_en'
     - delta_text: 'd|><|tool_c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'd|><|tool_c'
     - delta_text: 'alls_section_end|>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'alls_section_end|>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: kimi_k2
+model_label: 'Kimi K2.6'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated before tool_call_end with complete JSON arguments'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: Write
+      parameters:
+        type: object
+        properties:
+          file_path:
+            type: string
+          content:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_calls_section_begin|>'
+    - delta_text: '<|tool_call_begin|>functions.Write:42'
+    - delta_text: '<|tool_call_argument_begin|>'
+    - delta_text: '{"file_path":"/app/main.rs","content":"fn main() {}"}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>func'
+    - delta_text: 'tions.get_weather:0<|tool_call_argument_begin|>{"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_end|><|tool_call_end|>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: kimi_k2
 model_label: 'Kimi K2.6'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated before tool_call_end with complete JSON arguments'
@@ -24,14 +27,33 @@ cases:
           content:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_calls_section_begin|>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<|tool_call_begin|>functions.Write:42'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<|tool_call_argument_begin|>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'Write'}
+        sglang: []
     - delta_text: '{"file_path":"/app/main.rs","content":"fn main() {}"}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"file_path":"/app/main.rs","content":"fn main() {}"}'}
+        sglang:
+        - {index: 0, name: 'Write'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"file_path":"/app/main.rs","content":"fn main() {}"}'}
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -43,12 +65,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>func'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'tions.get_weather:0<|tool_call_argument_begin|>{"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"loc'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"loc'}
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -60,8 +95,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_end|><|tool_call_end|>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_end|><|tool_call_end|>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: llama3_json
 model_label: 'Llama 3 (JSON fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,10 +50,26 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '{"name": "get_weather", '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '"arguments": {"location": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: llama3_json
+model_label: 'Llama 3 (JSON fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|python_tag|>'
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: llama3_json
 model_label: 'Llama 3 (JSON fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,22 +31,78 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<|python_'
     - delta_text: 'tag|>{"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'name": "get_w'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'eathe'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'r", "arguments": '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"l'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ocation":'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' "NYC"}'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '};{"name": "g'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: 'et_ti'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'me", "arguments":'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' {"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'timezone"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ': "EST"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '}}'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: llama3_json
+model_label: 'Llama 3 (JSON fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|python_'
+    - delta_text: 'tag|>{"'
+    - delta_text: 'name": "get_w'
+    - delta_text: 'eathe'
+    - delta_text: 'r", "arguments": '
+    - delta_text: '{"l'
+    - delta_text: 'ocation":'
+    - delta_text: ' "NYC"}'
+    - delta_text: '};{"name": "g'
+    - delta_text: 'et_ti'
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: 'timezone"'
+    - delta_text: ': "EST"'
+    - delta_text: '}}'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: llama3_json
+model_label: 'Llama 3 (JSON fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|'
+    - delta_text: 'pyt'
+    - delta_text: 'hon_t'
+    - delta_text: 'ag|>{"name"'
+    - delta_text: ': "get_weather", "a'
+    - delta_text: 'rg'
+    - delta_text: 'ume'
+    - delta_text: 'nts":'
+    - delta_text: ' {"location'
+    - delta_text: '": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: llama3_json
 model_label: 'Llama 3 (JSON fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +25,61 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<|'
     - delta_text: 'pyt'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'pyt'
     - delta_text: 'hon_t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'hon_t'
     - delta_text: 'ag|>{"name"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ': "get_weather", "a'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: 'rg'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ume'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'nts":'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' {"location'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm:
+        - {index: 0, arguments: ''}
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: llama3_json
 model_label: 'Llama 3 (JSON fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +49,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name": "get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'weather", "arguments": {"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +77,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</|python_tag|></|python_tag|></|python_tag|>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: llama3_json
+model_label: 'Llama 3 (JSON fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</|python_tag|></|python_tag|></|python_tag|>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: minimax_m2
+model_label: 'MiniMax 2.7'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<minimax:tool_call>
+<invoke name="get_weather">
+<parameter name="location">NYC</parameter>
+</invoke>
+</minimax:tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<minimax:tool_call>
+'
+    - delta_text: '<invoke name="get_weather">
+'
+    - delta_text: '<parameter name="location">'
+    - delta_text: 'NYC'
+    - delta_text: '</parameter>
+'
+    - delta_text: '</invoke>
+'
+    - delta_text: '</minimax:tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: minimax_m2
 model_label: 'MiniMax 2.7'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,15 +25,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<minimax:tool_call>
 <invoke name="get_weather">
 <parameter name="location">NYC</parameter>
 </invoke>
 </minimax:tool_call>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -42,18 +55,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<minimax:tool_call>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<invoke name="get_weather">
 '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<parameter name="location">'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '</parameter>
 '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{"location": "NYC"'}
     - delta_text: '</invoke>
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, arguments: '}'}
     - delta_text: '</minimax:tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: minimax_m2
+model_label: 'MiniMax 2.7'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<minimax:'
+    - delta_text: 'tool_ca'
+    - delta_text: 'll>
+<invoke n'
+    - delta_text: 'ame="'
+    - delta_text: 'get_weather">
+<pa'
+    - delta_text: 'ram'
+    - delta_text: 'eter name'
+    - delta_text: '="locat'
+    - delta_text: 'ion">NYC</par'
+    - delta_text: 'amete'
+    - delta_text: 'r>
+</invoke>
+<inv'
+    - delta_text: 'oke'
+    - delta_text: ' name="ge'
+    - delta_text: 't_time"'
+    - delta_text: '>
+<parameter '
+    - delta_text: 'name='
+    - delta_text: '"timezone">EST</p'
+    - delta_text: 'ara'
+    - delta_text: 'meter>
+</'
+    - delta_text: 'invoke>'
+    - delta_text: '
+</minimax:to'
+    - delta_text: 'ol_ca'
+    - delta_text: 'll>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: minimax_m2
 model_label: 'MiniMax 2.7'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,37 +31,192 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<minimax:'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<minimax:'
+        sglang: '<minimax:'
     - delta_text: 'tool_ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'tool_ca'
+        sglang: 'tool_ca'
     - delta_text: 'll>
 <invoke n'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'll>
+<invoke n'
+        sglang: 'll>
+<invoke n'
     - delta_text: 'ame="'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ame="'
+        sglang: 'ame="'
     - delta_text: 'get_weather">
 <pa'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'get_weather">
+<pa'
+        sglang: 'get_weather">
+<pa'
     - delta_text: 'ram'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ram'
+        sglang: 'ram'
     - delta_text: 'eter name'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'eter name'
+        sglang: 'eter name'
     - delta_text: '="locat'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '="locat'
+        sglang: '="locat'
     - delta_text: 'ion">NYC</par'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ion">NYC</par'
+        sglang: 'ion">NYC</par'
     - delta_text: 'amete'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'amete'
+        sglang: 'amete'
     - delta_text: 'r>
 </invoke>
 <inv'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'r>
+</invoke>
+<inv'
+        sglang: 'r>
+</invoke>
+<inv'
     - delta_text: 'oke'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'oke'
+        sglang: 'oke'
     - delta_text: ' name="ge'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: ' name="ge'
+        sglang: ' name="ge'
     - delta_text: 't_time"'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 't_time"'
+        sglang: 't_time"'
     - delta_text: '>
 <parameter '
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>
+<parameter '
+        sglang: '>
+<parameter '
     - delta_text: 'name='
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'name='
+        sglang: 'name='
     - delta_text: '"timezone">EST</p'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '"timezone">EST</p'
+        sglang: '"timezone">EST</p'
     - delta_text: 'ara'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ara'
+        sglang: 'ara'
     - delta_text: 'meter>
 </'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'meter>
+</'
+        sglang: 'meter>
+</'
     - delta_text: 'invoke>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'invoke>'
+        sglang: 'invoke>'
     - delta_text: '
 </minimax:to'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '
+</minimax:to'
+        sglang: '
+</minimax:to'
     - delta_text: 'ol_ca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ol_ca'
+        sglang: 'ol_ca'
     - delta_text: 'll>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'll>'
+        sglang: 'll>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: minimax_m2
+model_label: 'MiniMax 2.7'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<m'
+    - delta_text: 'ini'
+    - delta_text: 'max:t'
+    - delta_text: 'ool_call>
+<'
+    - delta_text: 'invoke name="get_we'
+    - delta_text: 'at'
+    - delta_text: 'her'
+    - delta_text: '">
+<p'
+    - delta_text: 'arameter na'
+    - delta_text: 'me="location">NYC</'
+    - delta_text: 'pa'
+    - delta_text: 'ram'
+    - delta_text: 'eter>'
+    - delta_text: '
+</invoke>
+'
+    - delta_text: '</minimax:tool_call'
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: minimax_m2
 model_label: 'MiniMax 2.7'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,27 +25,134 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<m'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<m'
+        sglang: '<m'
     - delta_text: 'ini'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ini'
+        sglang: 'ini'
     - delta_text: 'max:t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'max:t'
+        sglang: 'max:t'
     - delta_text: 'ool_call>
 <'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool_call>
+<'
+        sglang: 'ool_call>
+<'
     - delta_text: 'invoke name="get_we'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'invoke name="get_we'
+        sglang: 'invoke name="get_we'
     - delta_text: 'at'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'at'
+        sglang: 'at'
     - delta_text: 'her'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'her'
+        sglang: 'her'
     - delta_text: '">
 <p'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '">
+<p'
+        sglang: '">
+<p'
     - delta_text: 'arameter na'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'arameter na'
+        sglang: 'arameter na'
     - delta_text: 'me="location">NYC</'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'me="location">NYC</'
+        sglang: 'me="location">NYC</'
     - delta_text: 'pa'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'pa'
+        sglang: 'pa'
     - delta_text: 'ram'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ram'
+        sglang: 'ram'
     - delta_text: 'eter>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'eter>'
+        sglang: 'eter>'
     - delta_text: '
 </invoke>
 '
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '
+</invoke>
+'
+        sglang: '
+</invoke>
+'
     - delta_text: '</minimax:tool_call'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '</minimax:tool_call'
+        sglang: '</minimax:tool_call'
     - delta_text: '>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>'
+        sglang: '>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: minimax_m2
 model_label: 'MiniMax 2.7'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,14 +25,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<minimax:tool_call>
 <invoke name="get_weather">
 <parameter name="location">NYC</parameter>
 </invoke>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -41,14 +54,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<minimax:tool_call>
 <invoke name="get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'weather">
 <parameter name="location">NY'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -60,12 +83,29 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<invoke name="get_weather">
 <parameter name="location">NYC</parameter>
 </invoke>
 </invoke>
 </invoke>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<invoke name="get_weather">
+<parameter name="location">NYC</parameter>
+</invoke>
+</invoke>
+</invoke>'
+        sglang: '<invoke name="get_weather">
+<parameter name="location">NYC</parameter>
+</invoke>
+</invoke>
+</invoke>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: minimax_m2
+model_label: 'MiniMax 2.7'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<minimax:tool_call>
+<invoke name="get_weather">
+<parameter name="location">NYC</parameter>
+</invoke>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<minimax:tool_call>
+<invoke name="get_'
+    - delta_text: 'weather">
+<parameter name="location">NY'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<invoke name="get_weather">
+<parameter name="location">NYC</parameter>
+</invoke>
+</invoke>
+</invoke>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: mistral
+model_label: 'Mistral series'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[TOOL_CALLS]'
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: '[/TOOL_CALLS]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: mistral
 model_label: 'Mistral series'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,11 +47,30 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS]'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '[{"name": "get_weather", '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
     - delta_text: '"arguments": {"location": "NYC"}}]'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []
     - delta_text: '[/TOOL_CALLS]'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '[/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: mistral
 model_label: 'Mistral series'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,23 +31,76 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CAL'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '[TOOL_CAL'
     - delta_text: 'LS][{"n'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ame": "get_we'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '", "arguments": {'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '"lo'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'cation": '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '"NYC"}}'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ', {"name": "g'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'et_ti'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'me", "arguments":'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' {"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'timezone"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ': "EST"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '}}][/TOOL_CAL'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'LS]'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: mistral
+model_label: 'Mistral series'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[TOOL_CAL'
+    - delta_text: 'LS][{"n'
+    - delta_text: 'ame": "get_we'
+    - delta_text: 'ather'
+    - delta_text: '", "arguments": {'
+    - delta_text: '"lo'
+    - delta_text: 'cation": '
+    - delta_text: '"NYC"}}'
+    - delta_text: ', {"name": "g'
+    - delta_text: 'et_ti'
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: 'timezone"'
+    - delta_text: ': "EST"'
+    - delta_text: '}}][/TOOL_CAL'
+    - delta_text: 'LS]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: mistral
+model_label: 'Mistral series'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[T'
+    - delta_text: 'OOL'
+    - delta_text: '_CALL'
+    - delta_text: 'S][{"name":'
+    - delta_text: ' "get_weather", "ar'
+    - delta_text: 'gu'
+    - delta_text: 'men'
+    - delta_text: 'ts": '
+    - delta_text: '{"location"'
+    - delta_text: ': "NYC"}}][/TOOL_CA'
+    - delta_text: 'LL'
+    - delta_text: 'S]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: mistral
 model_label: 'Mistral series'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,19 +25,64 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[T'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '[T'
     - delta_text: 'OOL'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'OOL'
     - delta_text: '_CALL'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '_CALL'
     - delta_text: 'S][{"name":'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ' "get_weather", "ar'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'gu'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'men'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ts": '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '{"location"'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ': "NYC"}}][/TOOL_CA'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'LL'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'S]'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: mistral
 model_label: 'Mistral series'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +48,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name": "get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'weather", "arguments": {"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"loc'}
+        sglang: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +75,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
+        sglang: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: mistral
+model_label: 'Mistral series'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,8 @@
 family: nemotron_deci
 model_label: 'Nemotron (DeciLM) v1/v2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +24,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,11 +47,30 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<TOOLCALL>'
     - delta_text: '[{"name": "get_weather", '
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '[{"name": "get_weather", '
     - delta_text: '"arguments": {"location": "NYC"}}]'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '"arguments": {"location": "NYC"}}]'
     - delta_text: '</TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '</TOOLCALL>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_deci
+model_label: 'Nemotron (DeciLM) v1/v2'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<TOOLCALL>'
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,8 @@
 family: nemotron_deci
 model_label: 'Nemotron (DeciLM) v1/v2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,22 +30,85 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<TOOLCALL'
     - delta_text: '>[{"nam'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '>[{"nam'
     - delta_text: 'e": "get_weat'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'e": "get_weat'
     - delta_text: 'her",'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'her",'
     - delta_text: ' "arguments": {"l'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: ' "arguments": {"l'
     - delta_text: 'oca'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'oca'
     - delta_text: 'tion": "N'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'tion": "N'
     - delta_text: 'YC"}}, '
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'YC"}}, '
     - delta_text: '{"name": "get'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '{"name": "get'
     - delta_text: '_time'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '_time'
     - delta_text: '", "arguments": {'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '", "arguments": {'
     - delta_text: '"ti'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '"ti'
     - delta_text: 'mezone": '
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'mezone": '
     - delta_text: '"EST"}}'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '"EST"}}'
     - delta_text: ']</TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: ']</TOOLCALL>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_deci
+model_label: 'Nemotron (DeciLM) v1/v2'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<TOOLCALL'
+    - delta_text: '>[{"nam'
+    - delta_text: 'e": "get_weat'
+    - delta_text: 'her",'
+    - delta_text: ' "arguments": {"l'
+    - delta_text: 'oca'
+    - delta_text: 'tion": "N'
+    - delta_text: 'YC"}}, '
+    - delta_text: '{"name": "get'
+    - delta_text: '_time'
+    - delta_text: '", "arguments": {'
+    - delta_text: '"ti'
+    - delta_text: 'mezone": '
+    - delta_text: '"EST"}}'
+    - delta_text: ']</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,8 @@
 family: nemotron_deci
 model_label: 'Nemotron (DeciLM) v1/v2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +24,60 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<T'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<T'
     - delta_text: 'OOL'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'OOL'
     - delta_text: 'CALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'CALL>'
     - delta_text: '[{"name": "'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '[{"name": "'
     - delta_text: 'get_weather", "argu'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'get_weather", "argu'
     - delta_text: 'me'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'me'
     - delta_text: 'nts'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'nts'
     - delta_text: '": {"'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '": {"'
     - delta_text: 'location": '
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'location": '
     - delta_text: '"NYC"}}]</TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '"NYC"}}]</TOOLCALL>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_deci
+model_label: 'Nemotron (DeciLM) v1/v2'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<T'
+    - delta_text: 'OOL'
+    - delta_text: 'CALL>'
+    - delta_text: '[{"name": "'
+    - delta_text: 'get_weather", "argu'
+    - delta_text: 'me'
+    - delta_text: 'nts'
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,8 @@
 family: nemotron_deci
 model_label: 'Nemotron (DeciLM) v1/v2'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +24,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +47,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name": "get_w'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<TOOLCALL>[{"name": "get_w'
     - delta_text: 'eather", "arguments": {"loc'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: 'eather", "arguments": {"loc'
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +75,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL></TOOLCALL></TOOLCALL>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL></TOOLCALL></TOOLCALL>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_deci
+model_label: 'Nemotron (DeciLM) v1/v2'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL></TOOLCALL></TOOLCALL>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_nano
+model_label: 'Nemotron Nano v3'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+'
+    - delta_text: '<function=get_weather>
+'
+    - delta_text: '<parameter=location>
+'
+    - delta_text: 'NYC
+'
+    - delta_text: '</parameter>
+'
+    - delta_text: '</function>
+'
+    - delta_text: '</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,8 @@
 family: nemotron_nano
 model_label: 'Nemotron Nano v3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,7 +24,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_weather>
@@ -31,8 +34,12 @@ NYC
 </parameter>
 </function>
 </tool_call>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -44,20 +51,37 @@ NYC
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<tool_call>
 '
+      expected:
+        vllm: []
     - delta_text: '<function=get_weather>
 '
+      expected:
+        vllm: []
     - delta_text: '<parameter=location>
 '
+      expected:
+        vllm: []
     - delta_text: 'NYC
 '
+      expected:
+        vllm: []
     - delta_text: '</parameter>
 '
+      expected:
+        vllm: []
     - delta_text: '</function>
 '
+      expected:
+        vllm: []
     - delta_text: '</tool_call>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_nano
+model_label: 'Nemotron Nano v3'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'l>
+<fun'
+    - delta_text: 'ction=get_wea'
+    - delta_text: 'ther>'
+    - delta_text: '
+<parameter=locat'
+    - delta_text: 'ion'
+    - delta_text: '>
+NYC
+</p'
+    - delta_text: 'aramete'
+    - delta_text: 'r>
+</function'
+    - delta_text: '>
+</t'
+    - delta_text: 'ool_call>
+<tool_c'
+    - delta_text: 'all'
+    - delta_text: '>
+<functi'
+    - delta_text: 'on=get_'
+    - delta_text: 'time>
+<parame'
+    - delta_text: 'ter=t'
+    - delta_text: 'imezone>
+EST
+</pa'
+    - delta_text: 'ram'
+    - delta_text: 'eter>
+</f'
+    - delta_text: 'unction'
+    - delta_text: '>
+</tool_call'
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,8 @@
 family: nemotron_nano
 model_label: 'Nemotron Nano v3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,42 +30,89 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
     - delta_text: 'l>
 <fun'
+      expected:
+        vllm: []
     - delta_text: 'ction=get_wea'
+      expected:
+        vllm: []
     - delta_text: 'ther>'
+      expected:
+        vllm: []
     - delta_text: '
 <parameter=locat'
+      expected:
+        vllm: []
     - delta_text: 'ion'
+      expected:
+        vllm: []
     - delta_text: '>
 NYC
 </p'
+      expected:
+        vllm: []
     - delta_text: 'aramete'
+      expected:
+        vllm: []
     - delta_text: 'r>
 </function'
+      expected:
+        vllm: []
     - delta_text: '>
 </t'
+      expected:
+        vllm: []
     - delta_text: 'ool_call>
 <tool_c'
+      expected:
+        vllm: []
     - delta_text: 'all'
+      expected:
+        vllm: []
     - delta_text: '>
 <functi'
+      expected:
+        vllm: []
     - delta_text: 'on=get_'
+      expected:
+        vllm: []
     - delta_text: 'time>
 <parame'
+      expected:
+        vllm: []
     - delta_text: 'ter=t'
+      expected:
+        vllm: []
     - delta_text: 'imezone>
 EST
 </pa'
+      expected:
+        vllm: []
     - delta_text: 'ram'
+      expected:
+        vllm: []
     - delta_text: 'eter>
 </f'
+      expected:
+        vllm: []
     - delta_text: 'unction'
+      expected:
+        vllm: []
     - delta_text: '>
 </tool_call'
+      expected:
+        vllm: []
     - delta_text: '>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,8 @@
 family: nemotron_nano
 model_label: 'Nemotron Nano v3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,27 +24,58 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
     - delta_text: 'ool'
+      expected:
+        vllm: []
     - delta_text: '_call'
+      expected:
+        vllm: []
     - delta_text: '>
 <function'
+      expected:
+        vllm: []
     - delta_text: '=get_weather>
 <para'
+      expected:
+        vllm: []
     - delta_text: 'me'
+      expected:
+        vllm: []
     - delta_text: 'ter'
+      expected:
+        vllm: []
     - delta_text: '=loca'
+      expected:
+        vllm: []
     - delta_text: 'tion>
 NYC
 <'
+      expected:
+        vllm: []
     - delta_text: '/parameter>
 </funct'
+      expected:
+        vllm: []
     - delta_text: 'io'
+      expected:
+        vllm: []
     - delta_text: 'n>
 '
+      expected:
+        vllm: []
     - delta_text: '</too'
+      expected:
+        vllm: []
     - delta_text: 'l_call>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_nano
+model_label: 'Nemotron Nano v3'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: '>
+<function'
+    - delta_text: '=get_weather>
+<para'
+    - delta_text: 'me'
+    - delta_text: 'ter'
+    - delta_text: '=loca'
+    - delta_text: 'tion>
+NYC
+<'
+    - delta_text: '/parameter>
+</funct'
+    - delta_text: 'io'
+    - delta_text: 'n>
+'
+    - delta_text: '</too'
+    - delta_text: 'l_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,8 @@
 family: nemotron_nano
 model_label: 'Nemotron Nano v3'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,7 +24,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_weather>
@@ -30,8 +33,12 @@ cases:
 NYC
 </parameter>
 </function>'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -43,15 +50,22 @@ NYC
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_wea'
+      expected:
+        vllm: []
     - delta_text: 'ther>
 <parameter=location>
 NY'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -63,7 +77,8 @@ NY'
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '<function=get_weather>
 <parameter=location>
@@ -72,5 +87,17 @@ NYC
 </function>
 </function>
 </function>'
+      expected:
+        vllm: []
+      normal_text:
+        vllm: '<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</function>
+</function>'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: nemotron_nano
+model_label: 'Nemotron Nano v3'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_wea'
+    - delta_text: 'ther>
+<parameter=location>
+NY'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</function>
+</function>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,8 @@
 family: phi4
 model_label: 'Phi-4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +24,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,10 +45,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools'
+      expected:
+        vllm: []
     - delta_text: '[{"name": "get_weather", '
+      expected:
+        vllm: []
     - delta_text: '"arguments": {"location": "NYC"}}]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: phi4
+model_label: 'Phi-4'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'functools'
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: phi4
+model_label: 'Phi-4'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'functools'
+    - delta_text: '[{"name'
+    - delta_text: '": "get_weath'
+    - delta_text: 'er", '
+    - delta_text: '"arguments": {"lo'
+    - delta_text: 'cat'
+    - delta_text: 'ion": "NY'
+    - delta_text: 'C"}}, {'
+    - delta_text: '"name": "get_'
+    - delta_text: 'time"'
+    - delta_text: ', "arguments": {"'
+    - delta_text: 'tim'
+    - delta_text: 'ezone": "'
+    - delta_text: 'EST"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,8 @@
 family: phi4
 model_label: 'Phi-4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,21 +30,52 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools'
+      expected:
+        vllm: []
     - delta_text: '[{"name'
+      expected:
+        vllm: []
     - delta_text: '": "get_weath'
+      expected:
+        vllm: []
     - delta_text: 'er", '
+      expected:
+        vllm: []
     - delta_text: '"arguments": {"lo'
+      expected:
+        vllm: []
     - delta_text: 'cat'
+      expected:
+        vllm: []
     - delta_text: 'ion": "NY'
+      expected:
+        vllm: []
     - delta_text: 'C"}}, {'
+      expected:
+        vllm: []
     - delta_text: '"name": "get_'
+      expected:
+        vllm: []
     - delta_text: 'time"'
+      expected:
+        vllm: []
     - delta_text: ', "arguments": {"'
+      expected:
+        vllm: []
     - delta_text: 'tim'
+      expected:
+        vllm: []
     - delta_text: 'ezone": "'
+      expected:
+        vllm: []
     - delta_text: 'EST"}}]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: phi4
+model_label: 'Phi-4'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'fu'
+    - delta_text: 'nct'
+    - delta_text: 'ools['
+    - delta_text: '{"name": "g'
+    - delta_text: 'et_weather", "argum'
+    - delta_text: 'en'
+    - delta_text: 'ts"'
+    - delta_text: ': {"l'
+    - delta_text: 'ocation": "'
+    - delta_text: 'NYC"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,8 @@
 family: phi4
 model_label: 'Phi-4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +24,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'fu'
+      expected:
+        vllm: []
     - delta_text: 'nct'
+      expected:
+        vllm: []
     - delta_text: 'ools['
+      expected:
+        vllm: []
     - delta_text: '{"name": "g'
+      expected:
+        vllm: []
     - delta_text: 'et_weather", "argum'
+      expected:
+        vllm: []
     - delta_text: 'en'
+      expected:
+        vllm: []
     - delta_text: 'ts"'
+      expected:
+        vllm: []
     - delta_text: ': {"l'
+      expected:
+        vllm: []
     - delta_text: 'ocation": "'
+      expected:
+        vllm: []
     - delta_text: 'NYC"}}]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,8 @@
 family: phi4
 model_label: 'Phi-4'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +24,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +45,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_we'
+      expected:
+        vllm: []
     - delta_text: 'ather", "arguments": {"loc'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +69,13 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      sglang: 'No SGLang parser for family ''phi4''.'
     chunks:
     - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}]functools]functools]'
+      expected:
+        vllm: []
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: phi4
+model_label: 'Phi-4'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'functools[{"name": "get_we'
+    - delta_text: 'ather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}]functools]functools]'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[get_weather(location="NYC")]'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,13 +49,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '['
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'get_weather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '(location="'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "'}
+        sglang: []
     - delta_text: 'NYC'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'NYC'}
+        sglang: []
     - delta_text: '")'
+      expected:
+        vllm:
+        - {index: 0, arguments: '"}'}
+        sglang: []
     - delta_text: ']'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: pythonic
+model_label: 'Llama 4 (pythonic fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[get_weather(location="NYC")]'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '['
+    - delta_text: 'get_weather'
+    - delta_text: '(location="'
+    - delta_text: 'NYC'
+    - delta_text: '")'
+    - delta_text: ']'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,14 +31,43 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[get_weat'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'her(loc'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ation="NYC"),'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang: []
     - delta_text: ' get_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'time(timezone="ES'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "ES'}
+        sglang: []
     - delta_text: 'T")'
+      expected:
+        vllm:
+        - {index: 1, arguments: 'T"}'}
+        sglang: []
     - delta_text: ']'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        - {index: 1, name: 'get_time', arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: pythonic
+model_label: 'Llama 4 (pythonic fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[get_weat'
+    - delta_text: 'her(loc'
+    - delta_text: 'ation="NYC"),'
+    - delta_text: ' get_'
+    - delta_text: 'time(timezone="ES'
+    - delta_text: 'T")'
+    - delta_text: ']'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: pythonic
+model_label: 'Llama 4 (pythonic fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[g'
+    - delta_text: 'et_'
+    - delta_text: 'weath'
+    - delta_text: 'er(location'
+    - delta_text: '="NYC")]'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,12 +25,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[g'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'et_'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'weath'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'er(location'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '="NYC")]'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang:
+        - {index: 0, name: 'get_weather', arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: pythonic
+model_label: 'Llama 4 (pythonic fmt)'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[get_weather(location="NYC")'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '[get_weather'
+    - delta_text: '(location="N'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: 'get_weather(location="NYC")]]]'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[get_weather(location="NYC")'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
+        sglang: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +48,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[get_weather'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '(location="N'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "N'}
+        sglang: []
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +75,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'get_weather(location="NYC")]]]'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'get_weather(location="NYC")]]]'
+        sglang: 'get_weather(location="NYC")]]]'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen25
+model_label: 'Qwen 2.5'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>'
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: '</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: qwen25
 model_label: 'Qwen 2.5'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -38,11 +51,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '{"name": "get_weather", '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "get_weather", '
     - delta_text: '"arguments": {"location": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: '"arguments": {"location": "NYC"}}'
     - delta_text: '</tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: qwen25
 model_label: 'Qwen 2.5'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,24 +31,115 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'l>{"nam'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"nam'
     - delta_text: 'e": "get_weat'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'e": "get_weat'
     - delta_text: 'her",'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
+      normal_text:
+        sglang: 'her",'
     - delta_text: ' "arguments": {"l'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"l'}
+        sglang: []
+      normal_text:
+        sglang: ' "arguments": {"l'
     - delta_text: 'oca'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'oca'}
+        sglang: []
+      normal_text:
+        sglang: 'oca'
     - delta_text: 'tion": "N'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'tion": "N'}
+        sglang: []
+      normal_text:
+        sglang: 'tion": "N'
     - delta_text: 'YC"}}</'
+      expected:
+        vllm:
+        - {index: 0, arguments: 'YC"}'}
+        sglang: []
+      normal_text:
+        sglang: 'YC"}}'
     - delta_text: 'tool_call><to'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ol_ca'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'll>{"name": "get_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "get_'
     - delta_text: 'tim'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'tim'
     - delta_text: 'e", "argu'
+      expected:
+        vllm:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang: []
+      normal_text:
+        sglang: 'e", "argu'
     - delta_text: 'ments":'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'ments":'
     - delta_text: ' {"timezone":'
+      expected:
+        vllm:
+        - {index: 1, arguments: '{"timezone":'}
+        sglang: []
+      normal_text:
+        sglang: ' {"timezone":'
     - delta_text: ' "EST'
+      expected:
+        vllm:
+        - {index: 1, arguments: ' "EST'}
+        sglang: []
+      normal_text:
+        sglang: ' "EST'
     - delta_text: '"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 1, arguments: '"}'}
+        sglang: []
+      normal_text:
+        sglang: '"}}'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen25
+model_label: 'Qwen 2.5'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'l>{"nam'
+    - delta_text: 'e": "get_weat'
+    - delta_text: 'her",'
+    - delta_text: ' "arguments": {"l'
+    - delta_text: 'oca'
+    - delta_text: 'tion": "N'
+    - delta_text: 'YC"}}</'
+    - delta_text: 'tool_call><to'
+    - delta_text: 'ol_ca'
+    - delta_text: 'll>{"name": "get_'
+    - delta_text: 'tim'
+    - delta_text: 'e", "argu'
+    - delta_text: 'ments":'
+    - delta_text: ' {"timezone":'
+    - delta_text: ' "EST'
+    - delta_text: '"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: qwen25
 model_label: 'Qwen 2.5'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,17 +25,68 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '_call'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '>{"name": "'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "'
     - delta_text: 'get_weather", "argu'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang: []
+      normal_text:
+        sglang: 'get_weather", "argu'
     - delta_text: 'me'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'me'
     - delta_text: 'nts'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: 'nts'
     - delta_text: '": {"'
+      expected:
+        vllm:
+        - {index: 0, arguments: '{"'}
+        sglang: []
+      normal_text:
+        sglang: '": {"'
     - delta_text: 'location": '
+      expected:
+        vllm:
+        - {index: 0, arguments: 'location":'}
+        sglang: []
+      normal_text:
+        sglang: 'location": '
     - delta_text: '"NYC"}}</tool_call>'
+      expected:
+        vllm:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: '"NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen25
+model_label: 'Qwen 2.5'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: '>{"name": "'
+    - delta_text: 'get_weather", "argu'
+    - delta_text: 'me'
+    - delta_text: 'nts'
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: qwen25
 model_label: 'Qwen 2.5'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,11 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -38,12 +51,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name": "get_w'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        sglang: '<tool_call>{"name": "get_w'
     - delta_text: 'eather", "arguments": {"loc'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"loc'}
+        sglang: []
+      normal_text:
+        sglang: 'eather", "arguments": {"loc'
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -55,8 +83,17 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+        sglang: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen25
+model_label: 'Qwen 2.5'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.1.yaml
@@ -10,6 +10,9 @@
 family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.1.a:
     description: 'Complete tool-call payload delivered in one content chunk'
@@ -22,7 +25,7 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_weather>
@@ -31,8 +34,18 @@ NYC
 </parameter>
 </function>
 </tool_call>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.1.b:
     description: 'Complete tool call split across parser-significant boundaries'
     ref: 'derived from TOOLCALLING.batch.1'
@@ -44,20 +57,52 @@ NYC
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '<function=get_weather>
 '
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '<parameter=location>
 '
+      expected:
+        vllm:
+        - {index: 0, arguments: '{'}
+        sglang: []
     - delta_text: 'NYC
 '
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: '</parameter>
 '
+      expected:
+        vllm:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
     - delta_text: '</function>
 '
+      expected:
+        vllm:
+        - {index: 0, arguments: '}'}
+        sglang:
+        - {index: 0, arguments: '}'}
     - delta_text: '</tool_call>'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen3_coder
+model_label: 'Qwen 3 Coder'
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: 'Complete tool-call payload delivered in one content chunk'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.stream.1.b:
+    description: 'Complete tool call split across parser-significant boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+'
+    - delta_text: '<function=get_weather>
+'
+    - delta_text: '<parameter=location>
+'
+    - delta_text: 'NYC
+'
+    - delta_text: '</parameter>
+'
+    - delta_text: '</function>
+'
+    - delta_text: '</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.2.yaml
@@ -10,6 +10,9 @@
 family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.2:
     description: 'Multiple tool calls split across multiple content chunks'
@@ -28,42 +31,178 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_cal'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<tool_cal'
     - delta_text: 'l>
 <fun'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l>
+<fun'
     - delta_text: 'ction=get_wea'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ction=get_wea'
     - delta_text: 'ther>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: 'ther>'
     - delta_text: '
 <parameter=locat'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '
+<parameter=locat'
     - delta_text: 'ion'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ion'
     - delta_text: '>
 NYC
 </p'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>
+NYC
+</p'
     - delta_text: 'aramete'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'aramete'
     - delta_text: 'r>
+</function'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+      normal_text:
+        vllm: 'r>
 </function'
     - delta_text: '>
 </t'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '}'}
+      normal_text:
+        vllm: '>
+</t'
     - delta_text: 'ool_call>
 <tool_c'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool_call>
+<tool_c'
+        sglang: '
+'
     - delta_text: 'all'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'all'
     - delta_text: '>
 <functi'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>
+<functi'
     - delta_text: 'on=get_'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'on=get_'
     - delta_text: 'time>
 <parame'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, name: 'get_time'}
+      normal_text:
+        vllm: 'time>
+<parame'
     - delta_text: 'ter=t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ter=t'
     - delta_text: 'imezone>
 EST
 </pa'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'imezone>
+EST
+</pa'
     - delta_text: 'ram'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ram'
     - delta_text: 'eter>
 </f'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"timezone": "EST"'}
+      normal_text:
+        vllm: 'eter>
+</f'
     - delta_text: 'unction'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'unction'
     - delta_text: '>
 </tool_call'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 1, arguments: '}'}
+      normal_text:
+        vllm: '>
+</tool_call'
     - delta_text: '>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen3_coder
+model_label: 'Qwen 3 Coder'
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: 'Multiple tool calls split across multiple content chunks'
+    ref: 'derived from TOOLCALLING.batch.2.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_cal'
+    - delta_text: 'l>
+<fun'
+    - delta_text: 'ction=get_wea'
+    - delta_text: 'ther>'
+    - delta_text: '
+<parameter=locat'
+    - delta_text: 'ion'
+    - delta_text: '>
+NYC
+</p'
+    - delta_text: 'aramete'
+    - delta_text: 'r>
+</function'
+    - delta_text: '>
+</t'
+    - delta_text: 'ool_call>
+<tool_c'
+    - delta_text: 'all'
+    - delta_text: '>
+<functi'
+    - delta_text: 'on=get_'
+    - delta_text: 'time>
+<parame'
+    - delta_text: 'ter=t'
+    - delta_text: 'imezone>
+EST
+</pa'
+    - delta_text: 'ram'
+    - delta_text: 'eter>
+</f'
+    - delta_text: 'unction'
+    - delta_text: '>
+</tool_call'
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.3.yaml
@@ -10,6 +10,9 @@
 family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.3:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -22,27 +25,110 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '<t'
     - delta_text: 'ool'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ool'
     - delta_text: '_call'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '_call'
     - delta_text: '>
+<function'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '>
 <function'
     - delta_text: '=get_weather>
 <para'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm: '=get_weather>
+<para'
     - delta_text: 'me'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'me'
     - delta_text: 'ter'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'ter'
     - delta_text: '=loca'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '=loca'
     - delta_text: 'tion>
+NYC
+<'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'tion>
 NYC
 <'
     - delta_text: '/parameter>
 </funct'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+      normal_text:
+        vllm: '/parameter>
+</funct'
     - delta_text: 'io'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'io'
     - delta_text: 'n>
 '
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, arguments: '}'}
+      normal_text:
+        vllm: 'n>
+'
     - delta_text: '</too'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: '</too'
     - delta_text: 'l_call>'
+      expected:
+        vllm: []
+        sglang: []
+      normal_text:
+        vllm: 'l_call>'
     - delta_text: ''
       finish_reason: tool_calls
+      expected:
+        vllm: []
+        sglang: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen3_coder
+model_label: 'Qwen 3 Coder'
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<t'
+    - delta_text: 'ool'
+    - delta_text: '_call'
+    - delta_text: '>
+<function'
+    - delta_text: '=get_weather>
+<para'
+    - delta_text: 'me'
+    - delta_text: 'ter'
+    - delta_text: '=loca'
+    - delta_text: 'tion>
+NYC
+<'
+    - delta_text: '/parameter>
+</funct'
+    - delta_text: 'io'
+    - delta_text: 'n>
+'
+    - delta_text: '</too'
+    - delta_text: 'l_call>'
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
+family: qwen3_coder
+model_label: 'Qwen 3 Coder'
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: 'Truncated stream terminates after a complete in-flight tool-call body'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.b:
+    description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<tool_call>
+<function=get_wea'
+    - delta_text: 'ther>
+<parameter=location>
+NY'
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.stream.4.c:
+    description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
+    ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+    chunks:
+    - delta_text: '<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</function>
+</function>'
+    - delta_text: ''
+      finish_reason: length

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.stream.4.yaml
@@ -10,6 +10,9 @@
 family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: stream
+captured_with:
+  vllm: '0.22.0'
+  sglang: '0.5.12.post1'
 cases:
   TOOLCALLING.stream.4.a:
     description: 'Truncated stream terminates after a complete in-flight tool-call body'
@@ -22,7 +25,7 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_weather>
@@ -30,8 +33,18 @@ cases:
 NYC
 </parameter>
 </function>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.b:
     description: 'Stream terminates mid-call body before the in-flight argument payload is complete'
     ref: 'derived from TOOLCALLING.batch.5.c'
@@ -43,15 +56,26 @@ NYC
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>
 <function=get_wea'
+      expected:
+        vllm: []
+        sglang: []
     - delta_text: 'ther>
 <parameter=location>
 NY'
+      expected:
+        vllm:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
+      expected:
+        vllm: []
+        sglang: []
   TOOLCALLING.stream.4.c:
     description: 'Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by repeated close markers'
     ref: 'derived from nemotron-ultra-preview-tool-call-leak-repro/repro_tool_call_leak.py'
@@ -63,7 +87,7 @@ NY'
           location:
             type: string
     unavailable:
-      dynamo: 'Dynamo TC streaming not yet implemented for this family. Text-based; token-id path is harmony-only for now.'
+      dynamo: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<function=get_weather>
 <parameter=location>
@@ -72,5 +96,30 @@ NYC
 </function>
 </function>
 </function>'
+      expected:
+        vllm: []
+        sglang:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
+        - {index: 0, arguments: '}'}
+        - {index: 0, arguments: '}'}
+      normal_text:
+        vllm: '<function=get_weather>
+<parameter=location>
+NYC
+</parameter>
+</function>
+</function>
+</function>'
+        sglang: '
+
+
+
+'
     - delta_text: ''
       finish_reason: length
+      expected:
+        vllm: []
+        sglang: []


### PR DESCRIPTION
#### Overview:

This PR adds the v2 tool-calling stream fixture YAML used by the v2 streaming parser stack.

#### Details:

- **How is this fixed?** Add YAML-only fixtures under `conformance/toolcalling/fixtures-stream-v2/`.
- No parser code, renderer code, generated HTML, or screenshots are included.
- This is the bottom PR for the v2 streaming parser split; #32 contains the parser/conformance code stacked on top.

#### Verification:

`git diff --check` passed.

#### Where should the reviewer start?

`conformance/toolcalling/fixtures-stream-v2/`

/coderabbit profile chill
