### PR TITLE
chore: trivial parser sync from dynamo @ 9b978b311

### DIFF
--- a/conformance/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -77,19 +77,22 @@ cases:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
   REASONING.batch.3.e:
-    description: Directed Harmony analysis tool call stays in reasoning text
+    description: Directed Harmony analysis tool call is handed off to the tool-call parser
     ref: *upstream_ref
     model_text: <|channel|>analysis to=functions.search <|constrain|>json<|message|>{"q":"x"}<|call|>
     expected:
-      dynamo: &d_12
+      dynamo:
+        reasoning_text: ''
+        normal_text: <|channel|>analysis to=functions.search <|constrain|>json<|message|>{"q":"x"}<|call|>
+        reason: A directed Harmony call (to=functions.*) is a tool call regardless of the channel label — the recipient is the real signal. The gpt-oss engine emits a large fraction of real tool calls on the analysis channel (with a bare `code` constraint), so Dynamo now hands a directed analysis-channel call to the Harmony tool parser (like SGLang) instead of keeping its payload in reasoning_text. Keeping it in reasoning dropped/leaked those tool calls. Supersedes the prior contract from #10111.
+      vllm:
         reasoning_text: '{"q":"x"}'
         normal_text: ''
-        reason: Unlike SGLang, Dynamo only passes GPT-OSS/Harmony function calls from commentary to=functions.* to the tool-call parser. This analysis to=functions.search block is reasoning-channel text, so Dynamo keeps its payload in reasoning_text.
-      vllm: *d_12
+        reason: "vLLM's reasoning layer kept the directed analysis-channel payload in reasoning_text (prior contract). FLAG: this row was previously aliased to Dynamo and has NOT been re-verified against current vLLM after Dynamo's behavior change — confirm before relying on it."
       sglang:
         reasoning_text: ''
         normal_text: <|channel|>analysis to=functions.search <|constrain|>json<|message|>{"q":"x"}<|call|>
-        reason: SGLang classifies a directed Harmony analysis channel ending in <|call|> as a tool_call handoff and emits the raw envelope in normal_text; Dynamo/vLLM keep analysis-channel payload hidden in reasoning_text for this parser-level contract.
+        reason: SGLang classifies a directed Harmony analysis channel ending in <|call|> as a tool_call handoff and emits the raw envelope in normal_text. Dynamo now matches this.
   REASONING.batch.3.f:
     description: Harmony analysis, directed commentary tool call, then final answer
     ref: *upstream_ref

--- a/conformance/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -132,15 +132,36 @@ cases:
     - <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant
     - <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
     expected:
-      dynamo: &id003
+      dynamo:
         reasoning_text: ''
-        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
         reason: Unlike vLLM streaming reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls and remove the markup from final content.
       vllm:
         reasoning_text: ''
         normal_text: ''
         reason: vLLM streaming reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
-      sglang: *id003
+      sglang:
+        reasoning_text: ''
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool recipient split across chunks
+    ref: *upstream_ref
+    chunks:
+    - <|channel|>analysis to=functions.grep code<|message|>
+    - '{"pattern":"foo"}<|call|>'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: '<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>'
+        reason: A directed analysis-channel call (to=functions.*) is a tool call regardless of channel label. Dynamo hands the complete envelope to the Harmony tool parser via normal_text, even when header and <|call|> arrive in separate chunks, by persisting the channel/recipient across the chunk boundary and reconstructing from the cumulative token buffer on the <|call|> chunk.
+      vllm:
+        reasoning_text: '{"pattern":"foo"}'
+        normal_text: ''
+        reason: vLLM streaming reasoning suppresses directed Harmony analysis at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
+      sglang:
+        reasoning_text: ''
+        normal_text: '<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>'
+        reason: SGLang classifies a directed Harmony analysis channel ending in <|call|> as a tool_call handoff, matching Dynamo's behavior.
   REASONING.stream.1.b:
     description: Plain text without Harmony channel markers
     ref: *upstream_ref

--- a/conformance/utils/lib/parsers/REASONING_CASES.md
+++ b/conformance/utils/lib/parsers/REASONING_CASES.md
@@ -114,7 +114,7 @@ content.
 - **`REASONING.batch.3.b`** Open reasoning interrupted by downstream tool-call text — tool-call markers can terminate or escape an open reasoning span for families that define that boundary.
 - **`REASONING.batch.3.c`** Recipientless downstream channel text — format-specific non-tool commentary or equivalent content should remain visible as normal text.
 - **`REASONING.batch.3.d`** Directed downstream tool-call channel without reasoning — parser must suppress tool-call payload from visible normal text when that payload belongs to the downstream tool parser.
-- **`REASONING.batch.3.e`** Directed reasoning-channel tool-call payload — parser must keep the payload in reasoning output when the format labels the channel as reasoning/analysis.
+- **`REASONING.batch.3.e`** Directed reasoning-channel tool-call payload — a directed call (`to=functions.*`) is a tool call regardless of the channel label, so the parser must hand its payload off to the downstream tool-call parser (in `normal_text`), not keep it in reasoning. For GPT-OSS/Harmony this covers the `analysis to=functions.* … <|call|>` form the engine emits for a large fraction of real tool calls. (Supersedes the prior #10111 contract that kept the analysis-channel payload in `reasoning_text`; that dropped/leaked those calls.)
 - **`REASONING.batch.3.f`** Reasoning, downstream directed tool call, then final answer — parser must extract reasoning, suppress downstream tool payload from visible normal text, and preserve later final text.
 - **`REASONING.batch.4`** Malformed reasoning marker syntax — dangling close marker, invalid channel marker, or marker that does not belong to the family grammar.
 - **`REASONING.batch.5`** Missing end-marker recovery — engine hit `max_tokens` mid-think; pin behavior: recover partial reasoning, surface as truncated, or treat all as `normal_text`.
@@ -227,7 +227,7 @@ extract the reasoning content and preserve the tool-call-shaped text in
   closed before downstream tool-call text begins.
 - `3.b` applies only to parser families that intentionally configure a
   downstream boundary while reasoning is still open.
-- `3.c` through `3.f` pin format-specific downstream channel behavior: visible recipientless channel text, directed tool-call handoff preservation, directed reasoning payload extraction, and final-text recovery after a directed downstream tool call.
+- `3.c` through `3.f` pin format-specific downstream channel behavior: visible recipientless channel text, directed tool-call handoff preservation, directed reasoning/analysis-channel tool-call handoff, and final-text recovery after a directed downstream tool call.
 - Failure mode: greedy reasoning parser eats the tool-call content
   that follows. Pin the boundary explicitly.
 
@@ -288,6 +288,10 @@ the right boundary and preserve the downstream parser's input.
 - Applies only to reasoning parser families with an explicit downstream
   boundary. For other families, this bucket is an N/A stub until the
   production path wires such a boundary.
+- **`REASONING.stream.4.a`** Harmony start marker split across chunks — partial `<|channel|>` at a chunk boundary must buffer rather than flush, completing the match when the next chunk arrives.
+- **`REASONING.stream.4.b`** Directed Harmony commentary tool recipient split across chunks — the `to=functions.NAME` header can straddle a chunk boundary; the complete envelope must still reach `normal_text` intact for the downstream jail.
+- **`REASONING.stream.4.c`** Partial Harmony channel marker prefix that resolves to non-channel text — `<|chan` that becomes `chance` must not hold back the preceding visible text indefinitely.
+- **`REASONING.stream.4.d`** Directed Harmony analysis-channel tool call split across chunks — a `to=functions.*` recipient on the `analysis` channel is a tool call; the complete envelope (header + body + `<|call|>`) must reach `normal_text` intact even when `<|call|>` arrives in a later chunk than the header. The parser persists the channel/recipient across the chunk boundary and reconstructs the clean envelope from the cumulative token buffer on the `<|call|>` chunk.
 
 ---
 

--- a/conformance/utils/tests/parity/markup.py
+++ b/conformance/utils/tests/parity/markup.py
@@ -14,21 +14,30 @@ from typing import Any
 # (e.g. `[{...}]`, `[1, 2]`) don't get false-matched as tags.
 _TAG_RE = re.compile(r"<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
 
-# Paired tags and singletons use a stable color derived from the tag identity.
-# This keeps the same tag type visually aligned across side-by-side outputs in
-# one tooltip, instead of assigning colors by render order.
+# Two coloring schemes share one cycling palette:
+#   * Paired open/close: every matched pair gets a *fresh* palette index, so
+#     two `<tool_call>...</tool_call>` instances in the same input render as
+#     two different colors.
+#   * Singletons (e.g. harmony's `<|channel|>` section markers): stable
+#     by-role color so all `<|channel|>` tokens share one class everywhere.
 _PAIRED_PALETTE_SIZE = 8
+_color_seq = 0
+_singleton_classes: dict[str, str] = {}
 
 
-def _stable_color_class(name: str) -> str:
-    acc = 0
-    for i, ch in enumerate(name):
-        acc += (i + 1) * ord(ch)
-    return f"tt-c{acc % _PAIRED_PALETTE_SIZE}"
+def _next_color_class() -> str:
+    global _color_seq
+    cls = f"tt-c{_color_seq % _PAIRED_PALETTE_SIZE}"
+    _color_seq += 1
+    return cls
 
 
 def _singleton_class_for(name: str) -> str:
-    return _stable_color_class(name)
+    cls = _singleton_classes.get(name)
+    if cls is None:
+        cls = _next_color_class()
+        _singleton_classes[name] = cls
+    return cls
 
 
 _PIPES = ("|", "｜")  # ASCII and FULLWIDTH VERTICAL LINE (U+FF5C)
@@ -198,7 +207,7 @@ def _colorize_xml(text: str) -> str:
                         unmatched_idx
                     ] = f'<span class="tt-orphan">{pieces[unmatched_idx]}</span>'
                 open_idx = stack[match_at][1]
-                cls = _stable_color_class(pair_id)
+                cls = _next_color_class()
                 pieces[open_idx] = f'<span class="{cls}">{pieces[open_idx]}</span>'
                 pieces.append(f'<span class="{cls}">{esc}</span>')
                 del stack[match_at:]
@@ -217,7 +226,13 @@ def _colorize_xml(text: str) -> str:
                         unmatched_idx
                     ] = f'<span class="tt-orphan">{pieces[unmatched_idx]}</span>'
                 open_idx = stack[match_at][1]
-                cls = _stable_color_class(color_override or pair_id)
+                # Per-instance color: every matched pair gets a fresh palette
+                # index, so two `<tool_call>...</tool_call>` (or two
+                # `<|start|>...<|call|>`) blocks in the same input render as
+                # different colors. (color_override unused on the paired
+                # path — kept on the singleton-flavor branch only.)
+                _ = color_override
+                cls = _next_color_class()
                 pieces[open_idx] = f'<span class="{cls}">{pieces[open_idx]}</span>'
                 pieces.append(f'<span class="{cls}">{esc}</span>')
                 del stack[match_at:]
@@ -255,7 +270,7 @@ def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
             if match_at >= 0:
                 for _, unmatched_idx in stack[match_at + 1 :]:
                     intervals[unmatched_idx]["class"] = "tt-orphan"
-                cls = _stable_color_class(pair_id)
+                cls = _next_color_class()
                 intervals[stack[match_at][1]]["class"] = cls
                 intervals[idx]["class"] = cls
                 del stack[match_at:]
@@ -270,7 +285,7 @@ def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
             if match_at >= 0:
                 for _, unmatched_idx in stack[match_at + 1 :]:
                     intervals[unmatched_idx]["class"] = "tt-orphan"
-                cls = _stable_color_class(_color_override or pair_id)
+                cls = _next_color_class()
                 intervals[stack[match_at][1]]["class"] = cls
                 intervals[idx]["class"] = cls
                 del stack[match_at:]

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -10,7 +10,6 @@ import argparse
 import datetime
 import html as html_lib
 import json
-import os
 import re
 import subprocess
 import zoneinfo
@@ -32,18 +31,7 @@ from tests.parity.markup import colorize_markup
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/reasoning/fixtures"
 PARSER_FIXTURES = REPO_ROOT / "tests/parity/toolcalling/fixtures"
-_fc_env = os.environ.get("FRONTEND_CRATES_ROOT")
-if _fc_env:
-    PARSERS_ROOT = Path(_fc_env) / "parsers"
-else:
-    # walk up from REPO_ROOT until we find parsers/Cargo.toml (repo root marker)
-    _p = REPO_ROOT
-    while _p.parent != _p:
-        if (_p / "parsers" / "Cargo.toml").exists():
-            break
-        _p = _p.parent
-    PARSERS_ROOT = _p / "parsers"
-REASONING_CASES_MD = PARSERS_ROOT / "REASONING_CASES.md"
+REASONING_CASES_MD = REPO_ROOT / "lib/parsers/REASONING_CASES.md"
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
@@ -157,9 +145,9 @@ _FAMILY_METADATA = {
     },
     "nemotron_deci": {
         "models": [
-            "Nemotron-Super / -Ultra / -Deci",
+            "Nemotron-Super-v1 / Nemotron-Ultra-v1 / Nemotron-Deci-v1",
             "Llama-Nemotron",
-            "GLM-4.5 / GLM-4.7 via glm45 alias",
+            "GLM-4.5 / GLM-4.6 via glm45 alias",
         ],
         "rust_enum": "ReasoningParserType::NemotronDeci",
         "implementation": "BasicReasoningParser `<think>` / `</think>`",
@@ -477,10 +465,16 @@ def _reasoning_markup_re(family: str | None) -> re.Pattern[str]:
 
 
 def _is_gpt_oss_tool_handoff(family: str | None, field: str, value: str) -> bool:
+    # Both `commentary to=functions.X` and `analysis to=functions.X` are
+    # tool-call handoffs after PR #10366: the recipient is the signal, not
+    # the channel label. Either lands in normal_text as the jail's input.
     return (
         family == "gpt_oss"
         and field == "normal_text"
-        and "<|channel|>commentary to=functions." in value
+        and (
+            "<|channel|>commentary to=functions." in value
+            or "<|channel|>analysis to=functions." in value
+        )
         and "<|call|>" in value
     )
 
@@ -2256,7 +2250,7 @@ def _html(
             intro_html="",
             legend_html=_legend_html(rows, columns),
             case_docs_href="../../../lib/parsers/REASONING_CASES.md",
-            case_docs_label="parsers/REASONING_CASES.md",
+            case_docs_label="lib/parsers/REASONING_CASES.md",
             case_prefix="REASONING.",
         )
     )

--- a/conformance/utils/tests/parity/toolcalling/table.py
+++ b/conformance/utils/tests/parity/toolcalling/table.py
@@ -58,7 +58,6 @@ import copy
 import datetime
 import html as html_lib
 import json
-import os
 import re
 import subprocess
 import zoneinfo
@@ -77,22 +76,11 @@ from tests.parity.markup import colorize_markup, colorize_stream_deltas
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/toolcalling/fixtures"
-_fc_env = os.environ.get("FRONTEND_CRATES_ROOT")
-if _fc_env:
-    PARSERS_ROOT = Path(_fc_env) / "parsers"
-else:
-    # walk up from REPO_ROOT until we find parsers/Cargo.toml (repo root marker)
-    _p = REPO_ROOT
-    while _p.parent != _p:
-        if (_p / "parsers" / "Cargo.toml").exists():
-            break
-        _p = _p.parent
-    PARSERS_ROOT = _p / "parsers"
-TOOLCALLING_CASES_MD = PARSERS_ROOT / "TOOLCALLING_CASES.md"
+TOOLCALLING_CASES_MD = REPO_ROOT / "lib/parsers/TOOLCALLING_CASES.md"
 PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
 TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
-RUST_TOOL_CALLING_DIR = PARSERS_ROOT / "src/tool_calling"
+RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
 
 # Row-label / visibility overrides keyed by tool calling family; ‡ is explained
 # by the legend note in parity_table.html.j2.

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -148,10 +148,16 @@ impl ReasoningParser for BasicReasoningParser {
         let mut normal_parts = Vec::new();
         let mut cursor = 0;
         let mut exited_on_tool_start = false;
-        // Dangling-end case enters the loop already in reasoning so the prefix
-        // before `</think>` is captured (the loop's normal-text branch would
-        // otherwise treat it as plain text and re-leak the closer).
-        let mut currently_reasoning = self._in_reasoning || has_dangling_end;
+        // Initial loop state combines two concerns:
+        //   - dangling-end recovery: enter reasoning at cursor 0 so the prefix
+        //     before `</think>` is captured (otherwise the normal-text branch
+        //     would re-leak the closer).
+        //   - force_reasoning + a literal <think> later in the text: defer to
+        //     the explicit-marker path so the prefix before <think> stays in
+        //     normal_text. Without `&& !has_think_tag`, the implicit-reasoning
+        //     span would absorb the literal <think> token into reasoning_text
+        //     as a markup leak (parser-owned syntax surfacing to consumers).
+        let mut currently_reasoning = (self._in_reasoning && !has_think_tag) || has_dangling_end;
 
         while cursor < text.len() {
             if currently_reasoning {
@@ -687,6 +693,42 @@ mod tests {
         let result = parser.detect_and_parse_reasoning("no think tags here", &[]);
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "no think tags here");
+    }
+
+    #[test]
+    fn test_force_reasoning_with_literal_think_prefix_does_not_leak() {
+        // Regression: when force_reasoning=true but the model output also
+        // contains a literal <think> later in the text, the explicit tag
+        // must win. The prefix before <think> belongs in normal_text.
+        // Without the `&& !has_think_tag` guard on currently_reasoning,
+        // the implicit-reasoning span would absorb the literal <think>
+        // into reasoning_text as a markup leak.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let result = parser.detect_and_parse_reasoning("before <think>thinking</think> after", &[]);
+        assert_eq!(result.reasoning_text, "thinking");
+        assert_eq!(result.normal_text, "before  after");
+        assert!(
+            !result.reasoning_text.contains("<think>"),
+            "literal <think> must be stripped, not absorbed; got {:?}",
+            result.reasoning_text
+        );
+    }
+
+    #[test]
+    fn test_force_reasoning_with_multiple_literal_spans() {
+        // Pins multi-span behavior for force_reasoning=true callers: the
+        // cursor-based loop extracts every closed <think>...</think> span
+        // and concatenates their bodies, while the surrounding text stays
+        // in normal_text.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let result = parser.detect_and_parse_reasoning(
+            "<think>first</think> middle <think>second</think> done",
+            &[],
+        );
+        assert_eq!(result.reasoning_text, "firstsecond");
+        assert_eq!(result.normal_text, "middle  done");
     }
 
     #[test] // REASONING.batch.6.b — streaming parity for stray close after complete pair

--- a/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/parsers/src/reasoning/gpt_oss_parser.rs
@@ -53,6 +53,13 @@ pub struct GptOssReasoningParser {
     insert_reasoning_separator: bool,
     emitted_normal_text: bool,
     insert_normal_separator: bool,
+    /// Channel/recipient of the directed tool call currently being streamed.
+    /// Persisted across chunks because the `<|call|>` terminator can arrive in a
+    /// later chunk than the one that resolved the recipient (and `<|call|>` resets
+    /// the live parser state), so the `<|call|>`-chunk envelope reconstruction
+    /// would otherwise lose the channel/recipient. Cleared once the call is emitted.
+    last_directed_channel: Option<String>,
+    last_directed_recipient: Option<String>,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -89,6 +96,8 @@ impl GptOssReasoningParser {
             insert_reasoning_separator: false,
             emitted_normal_text: false,
             insert_normal_separator: false,
+            last_directed_channel: None,
+            last_directed_recipient: None,
         })
     }
 }
@@ -141,8 +150,13 @@ fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
 
 fn harmony_analysis_block_regex() -> &'static Regex {
     HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
+        // Match ONLY recipientless analysis reasoning blocks (the CoT channel).
+        // Requiring `<|message|>` to immediately follow `analysis` (no `.*?`
+        // gap) ensures that `analysis to=functions.X code<|message|>…` tool-call
+        // envelopes are NOT stripped — they must survive into normal_text so
+        // the downstream harmony tool-call jail can recover them.
         Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis.*?<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
         )
             .expect("harmony analysis block regex")
     })
@@ -187,7 +201,9 @@ fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
 }
 
 fn contains_directed_harmony_function_call(text: &str) -> bool {
-    text.contains("<|channel|>commentary to=functions.") && text.contains(HARMONY_CALL_MARKER)
+    (text.contains("<|channel|>commentary to=functions.")
+        || text.contains("<|channel|>analysis to=functions."))
+        && text.contains(HARMONY_CALL_MARKER)
 }
 
 fn strip_analysis_blocks_for_tool_handoff(text: &str) -> String {
@@ -216,7 +232,13 @@ fn append_text_content(target: &mut String, content: &[Content]) {
 
 fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
     match msg.channel.as_deref() {
-        Some("analysis") => append_text_content(reasoning_text, &msg.content),
+        // Analysis WITHOUT a recipient is chain-of-thought reasoning.
+        // Analysis WITH a functions recipient is a (malformed) tool call whose
+        // payload is handed off via strip_analysis_blocks_for_tool_handoff —
+        // do not also surface it as reasoning_content.
+        Some("analysis") if msg.recipient.is_none() => {
+            append_text_content(reasoning_text, &msg.content)
+        }
         Some("final") => append_text_content(normal_text, &msg.content),
         Some("commentary") if msg.recipient.is_none() => {
             append_text_content(normal_text, &msg.content)
@@ -246,11 +268,58 @@ fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> 
 
 fn starts_directed_harmony_tool_call(text: &str) -> bool {
     text.contains("<|channel|>commentary to=functions.")
+        || text.contains("<|channel|>analysis to=functions.")
+}
+
+/// Reconstruct the complete harmony envelope for the directed tool call that
+/// just terminated, by decoding the cumulative parser token buffer from its
+/// last `<|channel|>` token to the end.
+///
+/// This is the canonical handoff to the downstream tool-call jail: it always
+/// starts exactly at the tool call's `<|channel|>` token, so it (a) survives a
+/// channel header that was split across streaming chunks, and (b) excludes any
+/// leading `<|end|>` / text from a preceding reasoning message that raw
+/// per-chunk accumulation would otherwise prepend (and leak).
+///
+/// Returns `None` when the captured channel is not a directed tool call, when
+/// the harmony encoding is unavailable, or when no `<|channel|>` token is found.
+fn reconstruct_directed_envelope(
+    parser: &StreamableParser,
+    channel: Option<&str>,
+    recipient: Option<&str>,
+) -> Option<String> {
+    let ch = channel?;
+    let is_tool_ch = ch == "commentary"
+        || (ch == "analysis" && recipient.is_some_and(|r| r.starts_with("functions.")));
+    if !is_tool_ch {
+        return None;
+    }
+    let Ok(enc) = get_harmony_encoding() else {
+        return None;
+    };
+    let tokens = parser.tokens();
+    let channel_token_id = enc
+        .tokenizer()
+        .encode_with_special_tokens("<|channel|>")
+        .into_iter()
+        .next()?;
+    let last_channel_idx = tokens.iter().rposition(|t| *t == channel_token_id)?;
+    let decoded = enc
+        .tokenizer()
+        .decode_utf8(&tokens[last_channel_idx..])
+        .unwrap_or_default();
+    if decoded.is_empty() {
+        None
+    } else {
+        Some(decoded)
+    }
 }
 
 impl ReasoningParser for GptOssReasoningParser {
     fn finish_reasoning_stream(&mut self) -> ParserResult {
         self.pending_tool_call_text.clear();
+        self.last_directed_channel = None;
+        self.last_directed_recipient = None;
         let pending = std::mem::take(&mut self.pending_text);
         if pending.is_empty() {
             return ParserResult::default();
@@ -383,6 +452,11 @@ impl ReasoningParser for GptOssReasoningParser {
         let parser: &mut StreamableParser = &mut self.parser;
         let mut normal_delta = String::new();
         let mut reasoning_delta = String::new();
+        // Tracks whether at least one directed call envelope was reconstructed inside
+        // the per-token loop below. When true the post-loop `has_call_marker` branch
+        // must not reconstruct again (it would pick the wrong `<|channel|>` token
+        // because the cumulative buffer by then includes post-`<|call|>` tokens).
+        let mut call_reconstructed_in_loop = false;
 
         for (i, token_id) in token_ids.iter().enumerate() {
             tracing::debug!(
@@ -399,6 +473,51 @@ impl ReasoningParser for GptOssReasoningParser {
             }
             let current_channel = parser.current_channel();
             let current_recipient = parser.current_recipient();
+
+            // Persist directed tool-call context before `<|call|>` can reset it.
+            // This is stored on `self` (not a local) because the `<|call|>`
+            // terminator can arrive in a later chunk than the one that resolved
+            // the recipient — e.g. for short responses split into tiny chunks the
+            // `<|call|>` token can be the first token of its own chunk, by which
+            // point the live parser recipient is already gone.
+            if let (Some(ch), Some(rec)) = (&current_channel, &current_recipient)
+                && (ch.as_str() == "commentary" || ch.as_str() == "analysis")
+                && rec.starts_with("functions.")
+            {
+                self.last_directed_channel = current_channel.clone();
+                self.last_directed_recipient = current_recipient.clone();
+            }
+
+            // Reconstruct each directed tool-call envelope the moment `<|call|>`
+            // resets the parser channel to None (detected by the directed→None
+            // channel transition while `last_directed_channel` is set).
+            //
+            // Doing this here — not in the post-loop section — is critical: at this
+            // point `parser.tokens()` ends exactly at the `<|call|>` token, so
+            // `reconstruct_directed_envelope`'s `rposition` scan finds the correct
+            // `<|channel|>` token for this call.  If we waited until after all
+            // tokens in the chunk were processed, subsequent tokens (e.g. a
+            // `<|channel|>final` that arrived in the same chunk) would have been
+            // appended to the buffer first, making `rposition` return the wrong
+            // index and corrupting the reconstructed envelope.
+            //
+            // If reconstruction returns None (encoding unavailable), `last_directed_channel`
+            // is left set so the post-loop fallback can flush `pending_tool_call_text`.
+            if self.last_directed_channel.is_some()
+                && previous_channel.is_some()
+                && current_channel.is_none()
+                && let Some(env) = reconstruct_directed_envelope(
+                    parser,
+                    self.last_directed_channel.as_deref(),
+                    self.last_directed_recipient.as_deref(),
+                )
+            {
+                self.pending_tool_call_text.clear();
+                normal_delta.push_str(&env);
+                self.last_directed_channel = None;
+                self.last_directed_recipient = None;
+                call_reconstructed_in_loop = true;
+            }
 
             if previous_channel.as_deref() != Some("analysis")
                 && current_channel.as_deref() == Some("analysis")
@@ -433,12 +552,18 @@ impl ReasoningParser for GptOssReasoningParser {
                         self.emitted_normal_text = true;
                     }
                     "analysis" => {
-                        if self.insert_reasoning_separator {
-                            reasoning_delta.push('\n');
-                            self.insert_reasoning_separator = false;
+                        // Analysis WITHOUT a recipient is reasoning content.
+                        // Analysis WITH a functions recipient is a (malformed)
+                        // tool call — its payload is handed off via normal_delta
+                        // below; do not also surface it as reasoning_content.
+                        if current_recipient.is_none() {
+                            if self.insert_reasoning_separator {
+                                reasoning_delta.push('\n');
+                                self.insert_reasoning_separator = false;
+                            }
+                            reasoning_delta.push_str(&delta);
+                            self.emitted_reasoning_text = true;
                         }
-                        reasoning_delta.push_str(&delta);
-                        self.emitted_reasoning_text = true;
                     }
                     "commentary" => {
                         if current_recipient.is_none() {
@@ -471,19 +596,54 @@ impl ReasoningParser for GptOssReasoningParser {
         };
 
         if let Some(raw_input_text) = raw_input_text {
-            // Streaming currently feeds the downstream Harmony tool parser through
+            // Streaming feeds the downstream Harmony tool parser through
             // `normal_text`. This is an internal handoff, not visible-content
-            // semantics: directed commentary tool payloads must become tool calls,
-            // not assistant `content`.
-            if !self.pending_tool_call_text.is_empty() {
-                self.pending_tool_call_text.push_str(&raw_input_text);
-                if has_call_marker {
-                    normal_delta.push_str(&std::mem::take(&mut self.pending_tool_call_text));
+            // semantics: directed commentary/analysis tool payloads must become
+            // tool calls, not assistant `content`.
+            if has_call_marker {
+                if call_reconstructed_in_loop {
+                    // The per-token loop already reconstructed every directed
+                    // envelope in this chunk at the correct buffer position (right
+                    // after each `<|call|>` token).  Nothing more to do here —
+                    // attempting another reconstruction now would use a stale
+                    // `rposition` over a buffer that includes post-`<|call|>` tokens
+                    // and would produce the wrong envelope or duplicate content.
+                } else {
+                    // Fallback: in-loop reconstruction was not attempted (encoding
+                    // unavailable) or did not complete.  Use the post-loop path,
+                    // which may produce a slightly wrong result when trailing tokens
+                    // follow `<|call|>` in the same chunk, but is still better than
+                    // silently dropping the tool call.
+                    let reconstructed = reconstruct_directed_envelope(
+                        parser,
+                        self.last_directed_channel.as_deref(),
+                        self.last_directed_recipient.as_deref(),
+                    );
+                    match reconstructed {
+                        Some(env) => {
+                            self.pending_tool_call_text.clear();
+                            normal_delta.push_str(&env);
+                        }
+                        None if !self.pending_tool_call_text.is_empty() => {
+                            // Fallback: no clean reconstruction available; flush the
+                            // accumulated raw text plus this chunk.
+                            self.pending_tool_call_text.push_str(&raw_input_text);
+                            normal_delta
+                                .push_str(&std::mem::take(&mut self.pending_tool_call_text));
+                        }
+                        None => normal_delta.push_str(&raw_input_text),
+                    }
+                    // Clear the persisted context so the next call (or trailing
+                    // reasoning) starts fresh.
+                    self.last_directed_channel = None;
+                    self.last_directed_recipient = None;
                 }
-            } else if starts_directed_harmony_tool_call(&raw_input_text) && !has_call_marker {
+            } else if !self.pending_tool_call_text.is_empty()
+                || starts_directed_harmony_tool_call(&raw_input_text)
+            {
+                // Mid tool call, terminator not yet seen: keep accumulating as a
+                // fallback (e.g. truncated streams that never emit `<|call|>`).
                 self.pending_tool_call_text.push_str(&raw_input_text);
-            } else if has_call_marker {
-                normal_delta.push_str(&raw_input_text);
             }
         }
 
@@ -500,61 +660,35 @@ impl ReasoningParser for GptOssReasoningParser {
         }
 
         if let Some(channel) = parser.current_channel() {
-            if channel == "commentary" {
-                tracing::debug!("In commentary channel, recovering full content");
-                // If we're in the commentary channel, we should return raw token content and recover content that has been consumed by the parser
-                // so that the tool parser can process it properly
-                if let Ok(enc) = get_harmony_encoding() {
-                    let current_content = parser.current_content().unwrap_or_default();
-                    let mut final_text = text.to_string();
+            let is_directed_tool_call = channel == "commentary"
+                || (channel == "analysis"
+                    && parser
+                        .current_recipient()
+                        .as_deref()
+                        .is_some_and(|r| r.starts_with("functions.")));
 
-                    // Restore commentary metadata consumed by the parser so the tool-call parser can
-                    // process it correctly.
-                    //
-                    // Example:
-                    //   Before parsing:
-                    //   "<|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{\"format\":\"celsius\",\"location\":\"San Francisco\"}<|call|>"
-                    //   After parsing, the header is stripped, so we must reconstruct it:
-                    //   "<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>"
-                    //
-                    // This ensures downstream tool-call parsing receives the channel, target, and
-                    // constraint metadata together with the message payload.
-
-                    // Recovery should only happen once, and only when `current_content` is empty.
-                    if current_content.is_empty() {
-                        let tokens = parser.tokens();
-
-                        // Get the token id for " <|channel|>"
-                        let channel_token_id = enc
-                            .tokenizer()
-                            .encode_with_special_tokens("<|channel|>")
-                            .last()
-                            .copied();
-
-                        // Find the last occurrence of the <|channel|> token (id 20005) in the tokens vector
-                        let last_channel_token_idx = channel_token_id
-                            .and_then(|token_id| {
-                                tokens.iter().rposition(|token| *token == token_id)
-                            })
-                            .unwrap_or(0);
-
-                        // Then get the generated text from the last <|channel|> to the end of parser.tokens()
-                        let end_token_idx = parser.tokens().len();
-                        // Use Harmony's decode_utf8 to decode tokens into text
-                        let generated_text = enc
-                            .tokenizer()
-                            .decode_utf8(&parser.tokens()[last_channel_token_idx..end_token_idx])
-                            .unwrap_or_default();
-
-                        final_text = generated_text;
-                    }
-
-                    return ParserResult {
-                        normal_text: final_text,
-                        reasoning_text: String::new(),
-                    };
-                }
-            } else {
+            if is_directed_tool_call {
+                // We are mid directed-tool-call (channel + functions recipient) but
+                // produced no delta this chunk. Emit NOTHING here:
+                //
+                //  * A complete tool call is reconstructed in full — header, message
+                //    and `<|call|>` together — from the cumulative token buffer on
+                //    the `<|call|>` chunk (the `has_call_marker` branch above). Any
+                //    emission here would be a redundant partial: a bare header (when
+                //    a chunk boundary lands at `<|message|>`) or a header-less body
+                //    fragment, neither of which the downstream jail can assemble into
+                //    a tool call — they only leak raw harmony markup into
+                //    `response_text`.
+                //  * A truncated tool call that never emits `<|call|>` has no complete
+                //    envelope to recover, so emitting its partial header would leak
+                //    too. Suppressing loses nothing recoverable.
+                tracing::debug!(
+                    "In directed tool-call channel ({channel}); suppressing partial mid-stream \
+                     content (complete envelope is recovered on the <|call|> chunk)"
+                );
+            } else if channel != "analysis" {
+                // Pure analysis reasoning (no recipient) is expected to be silent here —
+                // it was already emitted to reasoning_delta in the per-token loop.
                 tracing::warn!("Shouldn't be delta content after in channel: {}", channel);
             }
         }
@@ -613,10 +747,17 @@ mod tests {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
         let result = parser.detect_and_parse_reasoning(text, &[]);
-        assert_eq!(result.reasoning_text, "{\"q\":\"x\"}");
+        // An analysis-channel message WITH a `to=functions.` recipient is a
+        // (malformed) directed tool call, not chain-of-thought: its args are NOT
+        // leaked to reasoning_text.
+        assert_eq!(result.reasoning_text, "");
+        // Both directed tool-call envelopes (the analysis `search` call and the
+        // commentary `get_weather` call) plus the final message are handed off
+        // intact to the downstream tool-call jail — the analysis call no longer
+        // swallows or strips the commentary handoff.
         assert_eq!(
             result.normal_text,
-            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+            "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
         );
     }
 
@@ -804,11 +945,13 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            // [gluo TODO] missing "<|start|>assistant" and "{}" from original message
-            assert_eq!(
-                normal_text_incr,
-                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
-            );
+            // This input is a TRUNCATED tool call: it ends at `<|message|>{}` with
+            // no `<|call|>` terminator. A complete directed tool call is handed off
+            // to the jail in one piece (header + body + `<|call|>`) on the `<|call|>`
+            // chunk; without a terminator there is no complete envelope to recover,
+            // so the streaming parser emits no normal_text rather than leaking a
+            // partial `<|channel|>…<|message|>` header.
+            assert_eq!(normal_text_incr, "");
         }
 
         // Send token in chunks (chunking obtained from actual model output)
@@ -842,10 +985,115 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            assert_eq!(
-                normal_text_incr,
-                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
-            );
+            // Same truncated-call contract as the token-by-token case above:
+            // no <|call|> terminator → no complete envelope → no normal_text.
+            assert_eq!(normal_text_incr, "");
         }
+    }
+
+    /// `<|call|>` and the following `final` text arrive in the **same chunk**.
+    /// Before the fix, `reconstruct_directed_envelope` ran after the whole token
+    /// loop and `rposition` would find the `final` channel's `<|channel|>` token
+    /// (the last one in the buffer) instead of the tool call's, producing the wrong
+    /// envelope.  The in-loop reconstruction fixes this by calling
+    /// `reconstruct_directed_envelope` the moment `<|call|>` resets the parser,
+    /// before any subsequent tokens are appended to the buffer.
+    #[test] // TOOLCALLING.harmony.same-chunk-call-and-final
+    fn test_gpt_oss_streaming_call_and_final_in_same_chunk() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis to=functions.search code<|message|>",
+            // `<|call|>` and `<|channel|>final` land in one chunk — this is the
+            // scenario that the original post-loop reconstruction mis-handled.
+            r#"{"q":"foo"}<|call|><|start|>assistant<|channel|>final<|message|>done"#,
+        ];
+        let mut normal_text = String::new();
+        let mut reasoning_text = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text.push_str(&result.normal_text);
+            reasoning_text.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text, "");
+        assert!(
+            normal_text.contains("analysis to=functions.search"),
+            "tool call envelope must be present: {normal_text:?}"
+        );
+        assert!(
+            normal_text.contains("<|call|>"),
+            "call terminator must be present: {normal_text:?}"
+        );
+        assert!(
+            normal_text.ends_with("done"),
+            "final text must follow tool call: {normal_text:?}"
+        );
+        let call_pos = normal_text.find("<|call|>").unwrap();
+        let done_pos = normal_text.find("done").unwrap();
+        assert!(
+            call_pos < done_pos,
+            "tool call must precede final text in output"
+        );
+    }
+
+    /// Two directed tool calls arriving in a single chunk.  The original code had
+    /// only one post-loop reconstruction path, so the second `<|call|>` clobbered
+    /// the first.  The in-loop per-`<|call|>` reconstruction handles each
+    /// terminator independently and preserves both envelopes.
+    #[test] // TOOLCALLING.harmony.two-calls-one-chunk
+    fn test_gpt_oss_streaming_two_calls_in_one_chunk() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            // Both tool calls arrive together.
+            "<|channel|>analysis to=functions.search code<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>",
+        ];
+        let mut normal_text = String::new();
+        let mut reasoning_text = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text.push_str(&result.normal_text);
+            reasoning_text.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text, "");
+        assert!(
+            normal_text.contains("analysis to=functions.search"),
+            "first tool call must be present: {normal_text:?}"
+        );
+        assert!(
+            normal_text.contains("commentary to=functions.get_weather"),
+            "second tool call must be present: {normal_text:?}"
+        );
+        // First call must precede second call in the output.
+        let first_pos = normal_text.find("search").unwrap();
+        let second_pos = normal_text.find("get_weather").unwrap();
+        assert!(first_pos < second_pos, "calls must appear in stream order");
+    }
+
+    #[test] // REASONING.stream.4.d
+    fn test_gpt_oss_reasoning_parser_streaming_split_directed_analysis() {
+        // Header arrives in chunk 1; body + <|call|> arrive in chunk 2.
+        // This is the exact case last_directed_channel / reconstruct_directed_envelope
+        // is designed for: the parser state resets on <|call|>, so the channel
+        // and recipient must be persisted from the earlier chunk.
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis to=functions.grep code<|message|>",
+            r#"{"pattern":"foo"}<|call|>"#,
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert!(
+            normal_text_incr.contains("analysis to=functions.grep"),
+            "channel header must survive into normal_text: {normal_text_incr:?}"
+        );
+        assert!(
+            normal_text_incr.ends_with("<|call|>"),
+            "terminator must be present: {normal_text_incr:?}"
+        );
     }
 }

--- a/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -21,14 +21,20 @@ static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
 /// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
+///
+/// Matches tool calls on either `commentary` or `analysis` channel: the model
+/// emits ~47% of tool calls on the `analysis` channel with a bare `code`
+/// constraint marker instead of `<|constrain|>json`. The `.*?` non-greedy span
+/// between the recipient and `<|message|>` already tolerates any constraint
+/// marker form (`code`, `<|constrain|>json`, or nothing).
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
-        // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
+        // `<|constrain|>json`, bare `code`, or nothing (non-greedy `.*?`).
         // Args must end at `<|call|>`, the required Harmony tool-call stop token.
         Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>(?:commentary|analysis) to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
     })
@@ -54,8 +60,16 @@ fn commentary_header_cleanup_regex() -> &'static Regex {
 
 fn analysis_block_cleanup_regex() -> &'static Regex {
     ANALYSIS_BLOCK_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>(?P<body>.*?)(?:<\|end\|>|\z)")
-            .expect("analysis block cleanup regex")
+        // Accepts both the spec-compliant reasoning form
+        //   `<|channel|>analysis<|message|>...<|end|>`
+        // and the gpt-oss model-bug directed-tool-call form (recovered by PR #10366)
+        //   `<|channel|>analysis to=functions.X[ <|constrain|>json]<|message|>{args}<|call|>`
+        // The `name` capture distinguishes the two in the strip log so analysis
+        // stays semantically "thinking" while the bug-shape is logged as a tool call.
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*?<\|message\|>(?P<body>.*?)(?:<\|call\|>|<\|end\|>|\z)",
+        )
+        .expect("analysis block cleanup regex")
     })
 }
 
@@ -121,7 +135,11 @@ fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> 
     let cleaned = analysis_block_cleanup_regex()
         .replace_all(&cleaned, |caps: &Captures<'_>| {
             record_special_tokens(&caps[0], &mut stripped);
-            push_unique(&mut stripped, "analysis_envelope".to_string());
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("analysis_tool_call:functions.{name}"),
+                None => "analysis_envelope".to_string(),
+            };
+            push_unique(&mut stripped, item);
             ""
         })
         .into_owned();
@@ -376,46 +394,50 @@ pub async fn parse_tool_calls_harmony_complete(
         let channel = message.channel.as_deref();
         let recipient = message.recipient.as_deref().unwrap_or_default();
 
-        if channel == Some("commentary") {
-            if recipient.starts_with("functions.") {
-                if !has_tool_call_stop {
-                    continue;
-                }
+        // A `to=functions.NAME` recipient is the definitive signal of a tool
+        // call, regardless of channel label. The model emits tool calls on both
+        // `commentary` (canonical) and `analysis` (malformed-but-common) channels.
+        let is_tool_channel = channel == Some("commentary") || channel == Some("analysis");
+        if is_tool_channel && recipient.starts_with("functions.") {
+            if !has_tool_call_stop {
+                continue;
+            }
 
-                let Some(fname) = message
-                    .recipient
-                    .as_ref()
-                    .and_then(|r| r.split('.').nth(1))
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string())
-                else {
-                    continue;
-                };
+            let Some(fname) = message
+                .recipient
+                .as_ref()
+                .and_then(|r| r.split('.').nth(1))
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+            else {
+                continue;
+            };
 
-                let Some(args_json) = message.content.first().and_then(|content| match content {
-                    Content::Text(text) => Some(serialize_harmony_arguments(&text.text)),
-                    _ => None,
-                }) else {
-                    continue;
-                };
+            let Some(args_json) = message.content.first().and_then(|content| match content {
+                Content::Text(text) => Some(serialize_harmony_arguments(&text.text)),
+                _ => None,
+            }) else {
+                continue;
+            };
 
-                call_idx += 1;
-                res.push(ToolCallResponse {
-                    id: format!("call-{}", call_idx),
-                    tp: ToolCallType::Function,
-                    function: CalledFunction {
-                        name: fname.to_string(),
-                        arguments: args_json,
-                    },
-                });
-            } else if recipient.is_empty()
+            call_idx += 1;
+            res.push(ToolCallResponse {
+                id: format!("call-{}", call_idx),
+                tp: ToolCallType::Function,
+                function: CalledFunction {
+                    name: fname.to_string(),
+                    arguments: args_json,
+                },
+            });
+        } else if channel == Some("final")
+            || (channel == Some("commentary")
+                && recipient.is_empty()
                 && !(has_recipientless_commentary_call
                     && (message.content_type.as_deref() == Some("<|constrain|>json")
-                        || content_looks_like_json(&message.content)))
-            {
-                push_harmony_text(&mut normal_text, &message.content);
-            }
-        } else if channel == Some("final") {
+                        || content_looks_like_json(&message.content))))
+        {
+            // Final-channel answer text, or recipientless commentary that isn't a
+            // tool-call payload, both surface as assistant content.
             push_harmony_text(&mut normal_text, &message.content);
         }
     }
@@ -430,6 +452,14 @@ pub fn detect_tool_call_start_harmony(
     let trimmed = chunk.trim();
     if trimmed.is_empty() {
         return false;
+    }
+
+    let has_complete_end_token = config
+        .tool_call_end_tokens
+        .iter()
+        .any(|token| !token.is_empty() && trimmed.contains(token));
+    if has_complete_end_token {
+        return true;
     }
 
     if strict {
@@ -919,6 +949,24 @@ mod detect_parser_tests {
         assert!(result);
     }
 
+    #[tokio::test]
+    async fn test_parse_harmony_orphan_call_marker_does_not_leak() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
+            tool_call_end_tokens: vec!["<|call|>".to_string()],
+            ..Default::default()
+        };
+
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, false));
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, true));
+
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete("<|call|>", &config, None)
+            .await
+            .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
+    }
+
     #[test] // helper, TOOLCALLING.stream.3
     fn test_detect_tool_call_start_harmony_partial_tokens() {
         // Test partial token detection for streaming scenarios
@@ -955,5 +1003,96 @@ mod detect_parser_tests {
             !detect_tool_call_start_harmony("xyz", &config, true),
             "'xyz' should not be detected in strict mode"
         );
+    }
+
+    // --- analysis-channel tool-call recovery (the gpt-oss-120b malformed form) ---
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_code_tool_call_recovered() {
+        // Exact form emitted by the gpt-oss-120b worker: channel=analysis, constraint=code.
+        let text =
+            r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>"#;
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(calls.len(), 1, "analysis/code tool call must be recovered");
+        assert_eq!(calls[0].function.name, "grep");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["pattern"], "foo");
+        assert_eq!(
+            normal,
+            Some("".to_string()),
+            "no markup should leak into normal_text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_no_constraint_tool_call_recovered() {
+        // analysis channel with no constraint marker at all.
+        let text = r#"<|channel|>analysis to=functions.bash<|message|>{"command":"ls"}<|call|>"#;
+        let (calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(
+            calls.len(),
+            1,
+            "analysis tool call without constraint must be recovered"
+        );
+        assert_eq!(calls[0].function.name, "bash");
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_recipientless_analysis_is_not_tool_call() {
+        // Recipientless analysis is pure reasoning — must never become a tool call
+        // and must not leak markup into normal_text.
+        let text = r#"<|channel|>analysis<|message|>Let me think about grep.<|end|><|channel|>final<|message|>Done.<|return|>"#;
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert!(
+            calls.is_empty(),
+            "recipientless analysis must not produce a tool call"
+        );
+        assert_eq!(
+            normal,
+            Some("Done.".to_string()),
+            "only the final-channel text should appear in normal_text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_tool_call_without_stop_drops() {
+        // Analysis tool call missing the required <|call|> terminator must be dropped.
+        let text = r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}"#;
+        let (calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert!(
+            calls.is_empty(),
+            "analysis tool call without <|call|> terminator must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_tool_call_then_final() {
+        // Reasoning block + analysis tool call + final answer: one tool call recovered,
+        // normal_text = only the final-channel content.
+        let text = concat!(
+            "<|channel|>analysis<|message|>think<|end|>",
+            "<|start|>assistant<|channel|>analysis to=functions.get_weather code<|message|>",
+            r#"{"location":"NYC"}<|call|>"#,
+            "<|start|>assistant<|channel|>final<|message|>Checked.<|return|>",
+        );
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(normal, Some("Checked.".to_string()));
     }
 }

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -87,6 +87,133 @@ fn remove_known_non_jinja2_tags(template: &str) -> String {
         .replace("{% endgeneration %}", "")
 }
 
+/// Normalize common Python/Jinja dict method calls that are ambiguous in minijinja.
+///
+/// JSON schemas commonly use an `items` key for array item definitions. In
+/// minijinja, `foo.items()` can resolve `items` as a map entry before the
+/// pycompat method callback sees it, causing "object is not callable" for
+/// templates that iterate OpenAI tool schemas. The `items` filter gives the same
+/// map iteration behavior without colliding with schema keys.
+fn normalize_dict_method_calls(template: &str) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+
+    while i < template.len() {
+        if template[i..].starts_with("{#") {
+            let Some(end) = find_tag_end(template, i + 2, "#}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            out.push_str(&template[i..end]);
+            i = end;
+        } else if template[i..].starts_with("{{") {
+            let Some(end) = find_tag_end(template, i + 2, "}}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            out.push_str("{{");
+            out.push_str(&normalize_jinja_code_segment(&template[i + 2..end - 2]));
+            out.push_str("}}");
+            i = end;
+        } else if template[i..].starts_with("{%") {
+            let Some(end) = find_tag_end(template, i + 2, "%}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            let inner = &template[i + 2..end - 2];
+            if is_jinja_block_name(inner, "raw") {
+                if let Some(raw_end) = find_raw_block_end(template, end) {
+                    out.push_str(&template[i..raw_end]);
+                    i = raw_end;
+                } else {
+                    out.push_str(&template[i..]);
+                    break;
+                }
+            } else {
+                out.push_str("{%");
+                out.push_str(&normalize_jinja_code_segment(inner));
+                out.push_str("%}");
+                i = end;
+            }
+        } else {
+            let ch = template[i..].chars().next().expect("valid char boundary");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    out
+}
+
+fn find_tag_end(template: &str, start: usize, close: &str) -> Option<usize> {
+    template[start..]
+        .find(close)
+        .map(|relative| start + relative + close.len())
+}
+
+fn find_raw_block_end(template: &str, start: usize) -> Option<usize> {
+    let mut i = start;
+    while let Some(relative_open) = template[i..].find("{%") {
+        let open = i + relative_open;
+        let end = find_tag_end(template, open + 2, "%}")?;
+        if is_jinja_block_name(&template[open + 2..end - 2], "endraw") {
+            return Some(end);
+        }
+        i = end;
+    }
+    None
+}
+
+fn is_jinja_block_name(inner: &str, name: &str) -> bool {
+    let trimmed = inner.trim_start();
+    let trimmed = trimmed
+        .strip_prefix('-')
+        .or_else(|| trimmed.strip_prefix('+'))
+        .unwrap_or(trimmed)
+        .trim_start();
+    let Some(rest) = trimmed.strip_prefix(name) else {
+        return false;
+    };
+    rest.chars()
+        .next()
+        .is_none_or(|ch| ch.is_whitespace() || ch == '-' || ch == '+')
+}
+
+fn normalize_jinja_code_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    let mut i = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    while i < segment.len() {
+        let ch = segment[i..].chars().next().expect("valid char boundary");
+
+        if let Some(q) = quote {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == q {
+                quote = None;
+            }
+            i += ch.len_utf8();
+        } else if ch == '\'' || ch == '"' {
+            quote = Some(ch);
+            out.push(ch);
+            i += ch.len_utf8();
+        } else if segment[i..].starts_with(".items()") {
+            out.push_str("|items");
+            i += ".items()".len();
+        } else {
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    out
+}
+
 impl JinjaEnvironment {
     fn env(self) -> Environment<'static> {
         self.env
@@ -152,7 +279,8 @@ impl HfTokenizerConfigJsonFormatter {
                     supports_add_generation_prompt = Some(true);
                 }
                 // Remove known non-standard tags before validation (they don't affect output)
-                let template_cleaned = remove_known_non_jinja2_tags(x);
+                let template_cleaned =
+                    normalize_dict_method_calls(&remove_known_non_jinja2_tags(x));
                 env.add_template_owned("default", template_cleaned.clone())?;
                 env.add_template_owned("tool_use", template_cleaned)?;
             }
@@ -177,7 +305,8 @@ impl HfTokenizerConfigJsonFormatter {
                             supports_add_generation_prompt = Some(false);
                         }
                         // Remove known non-standard tags before validation (they don't affect output)
-                        let template_cleaned = remove_known_non_jinja2_tags(v);
+                        let template_cleaned =
+                            normalize_dict_method_calls(&remove_known_non_jinja2_tags(v));
                         env.add_template_owned(k.to_string(), template_cleaned)?;
                     }
                 }
@@ -277,6 +406,71 @@ mod tests {
         let template = "Start {% generation %}Part 1{% endgeneration %} middle {% generation %}Part 2{% endgeneration %}";
         let result = remove_known_non_jinja2_tags(template);
         assert_eq!(result, "Start Part 1 middle Part 2");
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_rewrites_items_method() {
+        let template = "{% for k, v in tool.parameters.properties.items() %}{{ k }}{% endfor %}";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(
+            result,
+            "{% for k, v in tool.parameters.properties|items %}{{ k }}{% endfor %}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_rewrites_expression_items_method() {
+        let template = "{{ tool.parameters.properties.items() }}";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, "{{ tool.parameters.properties|items }}");
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_preserves_literal_text() {
+        let template = "Do not rewrite literal .items() text.";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, template);
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_preserves_comments_raw_and_strings() {
+        let template = concat!(
+            "{# comment .items() #}",
+            "{% raw %}{{ tool.parameters.properties.items() }}{% endraw %}",
+            "{{ '.items()' }}",
+            "{{ \".items()\" }}",
+        );
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, template);
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_avoids_schema_items_collision() {
+        let template = normalize_dict_method_calls(
+            "{% for param_name, param_spec in tool.parameters.properties.items() %}{{ param_name }}={{ param_spec.type }};{% endfor %}",
+        );
+
+        let mut env = Environment::new();
+        env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+        env.add_template("t", &template).unwrap();
+
+        let tool = json!({
+            "parameters": {
+                "properties": {
+                    "items": {"type": "array", "items": {"type": "object"}},
+                    "message": {"type": "string"}
+                }
+            }
+        });
+
+        let out = env
+            .get_template("t")
+            .unwrap()
+            .render(context! { tool => tool })
+            .unwrap();
+
+        assert!(out.contains("items=array;"));
+        assert!(out.contains("message=string;"));
     }
 
     #[test]

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -522,6 +522,112 @@ mod tests {
     use dynamo_protocols::types::CreateChatCompletionRequest as NvCreateChatCompletionRequest;
     use minijinja::{Environment, context};
 
+    /// Dev utility (ignored by default): dump the prompt Dynamo's renderer
+    /// produces for a tool-calling chat request, so it can be diffed against
+    /// vLLM's `openai_harmony` rendering — to see whether the gpt-oss Jinja
+    /// `chat_template` actually emits the harmony "tool calls go to the
+    /// commentary channel" guidance + `functions` namespace.
+    ///
+    /// Point GPTOSS_CHAT_TEMPLATE at the model's tokenizer_config.json (its
+    /// `chat_template` field is extracted) OR a raw chat_template.jinja file:
+    ///   GPTOSS_CHAT_TEMPLATE=/path/openai-gpt-oss-120b/tokenizer_config.json \
+    ///     cargo test -p dynamo-renderer dump_gptoss_tool_prompt -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn dump_gptoss_tool_prompt() {
+        use super::tokcfg::ChatTemplate;
+        use super::{ContextMixins, HfTokenizerConfigJsonFormatter};
+
+        let path = std::env::var("GPTOSS_CHAT_TEMPLATE").expect(
+            "set GPTOSS_CHAT_TEMPLATE to the tokenizer_config.json, chat_template.jinja, or model dir path",
+        );
+        let input_path = std::path::Path::new(&path);
+        let file_path = if input_path.is_dir() {
+            // Prefer tokenizer_config.json from model dir if provided
+            input_path.join("tokenizer_config.json")
+        } else {
+            input_path.to_path_buf()
+        };
+        let raw = std::fs::read_to_string(&file_path).expect("read chat template file");
+        // Resolve the actual Jinja template. gpt-oss ships its chat template in a
+        // separate `chat_template.jinja` file, NOT inside tokenizer_config.json,
+        // so:
+        //   * if the file is JSON with a `chat_template` field, use it;
+        //   * otherwise, if a sibling `chat_template.jinja` exists, read that;
+        //   * otherwise treat the file itself as the template.
+        let template_string: String = match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(v) if v.get("chat_template").is_some() => v["chat_template"]
+                .as_str()
+                .expect("chat_template field must be a string")
+                .to_string(),
+            _ => {
+                let sibling = std::path::Path::new(&path)
+                    .parent()
+                    .map(|d| d.join("chat_template.jinja"));
+                match sibling {
+                    Some(p) if p.exists() => {
+                        eprintln!(
+                            "[info] {path} had no chat_template field; using {}",
+                            p.display()
+                        );
+                        std::fs::read_to_string(&p).expect("read sibling chat_template.jinja")
+                    }
+                    _ => raw,
+                }
+            }
+        };
+
+        // Guard against silently echoing a non-template (e.g. a tokenizer_config.json
+        // with no chat_template and no sibling .jinja).
+        assert!(
+            template_string.contains("{%") || template_string.contains("{{"),
+            "resolved template has no Jinja tags — GPTOSS_CHAT_TEMPLATE ({path}) is probably \
+             tokenizer_config.json with no chat_template field and no sibling chat_template.jinja. \
+             Point it at the chat_template.jinja file."
+        );
+
+        let chat_template: ChatTemplate =
+            serde_json::from_value(serde_json::json!({ "chat_template": template_string }))
+                .unwrap();
+
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        // Declare tools — the tool-channel guidance only renders when tools are present.
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
+              "model": "openai/gpt-oss-120b",
+              "messages": [{"role":"user","content":"Search the repo for the string \"countHook\"."}],
+              "tools": [
+                {"type":"function","function":{"name":"grep","description":"search files","parameters":{"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"}},"required":["pattern"]}}},
+                {"type":"function","function":{"name":"read","description":"read a file","parameters":{"type":"object","properties":{"filePath":{"type":"string"}},"required":["filePath"]}}}
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+        eprintln!("================ RENDERED gpt-oss PROMPT (tools declared) ================");
+        eprintln!("{rendered}");
+        eprintln!("================ END RENDERED PROMPT ================");
+        eprintln!("[diagnostics] does the rendered prompt contain…");
+        for needle in [
+            "commentary",
+            "Calls to these tools",
+            "functions",
+            "# Tools",
+            "<|channel|>",
+            "constrain",
+            "analysis",
+        ] {
+            eprintln!(
+                "  {:>22}: {}",
+                format!("{needle:?}"),
+                rendered.contains(needle)
+            );
+        }
+    }
+
     /// Tests that media URL content parts are converted to empty placeholders.
     #[test]
     fn test_convert_media_url_to_placeholder_single_type() {


### PR DESCRIPTION
#### Overview:

Trivial sync: mechanical mirror from ai-dynamo/dynamo `main` @ `9b978b311` via `manual-sync-parsers.sh` + `sync-from-dynamo.sh`. No original frontend-crates logic — every change was authored and reviewed upstream in dynamo. Mostly parser; the 2 renderer template files ride along because the `sync-check` CI gate keeps `renderer/` in lockstep with dynamo main.

#### Upstream attribution (one row per dynamo PR):

| Upstream dynamo PR | Author | Synced files |
| -- | -- | -- |
| [#10366](https://github.com/ai-dynamo/dynamo/pull/10366) fix(parsers): recover Harmony analysis-channel tool calls | Kyle McGill | `parsers/src/reasoning/gpt_oss_parser.rs`, `parsers/src/tool_calling/harmony/harmony_parser.rs`, `conformance/utils/lib/parsers/REASONING_CASES.md`, `conformance/utils/tests/parity/reasoning/table.py`, `conformance/reasoning/fixtures/gpt_oss/REASONING.{batch,stream}.yaml`, `renderer/src/template/oai.rs` |
| [#9995](https://github.com/ai-dynamo/dynamo/pull/9995) fix(parsers): close `<think>` markup leak in force_reasoning batch path | Krishnan Prashanth | `parsers/src/reasoning/base_parser.rs` |
| [#10235](https://github.com/ai-dynamo/dynamo/pull/10235) test(parity): merge Nemotron V3 with Qwen3 coder row | Jesse Gu | `conformance/utils/tests/parity/toolcalling/table.py` |
| [#10175](https://github.com/ai-dynamo/dynamo/pull/10175) test: add batch.5.g parity coverage, unify 5.f/5.g taxonomy | Keiven Chang | `conformance/utils/tests/parity/markup.py` |
| [#9778](https://github.com/ai-dynamo/dynamo/pull/9778) fix(llm): support GPT-OSS tool calling from Codex | Jesse Gu | `renderer/src/template/formatters.rs` |

(Primary = most-recent upstream PR per file; #10366 is the bulk. See dynamo history for the full chain.)

#### Verification:

`cargo test --locked -p dynamo-parsers -p dynamo-parsers-v2 -p dynamo-conformance-fixtures-v2`: 605 parser + 4 parser-v2 + conformance fixtures all pass. v1 + v2 conformance tables render. `git diff --check` clean.

#### Where should the reviewer start?

This is a mirror — review the upstream dynamo PRs above. Here, just confirm the sync is mechanical: `parsers/src/reasoning/gpt_oss_parser.rs` and `parsers/src/tool_calling/harmony/harmony_parser.rs`.

/coderabbit profile chill
