### PR TITLE
chore(codeowners): add parser-area owners for parsers + conformance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,9 @@ LICENSE          @ai-dynamo/devops
 release-plz.toml @ai-dynamo/devops
 RELEASING.md     @ai-dynamo/devops
 SECURITY.md      @ai-dynamo/devops
+
+# Tool-calling / reasoning parser crates and their conformance tests.
+/parsers/       @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
+/parsers_v2/    @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
+/parsers_v2-py/ @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
+/conformance/   @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ RELEASING.md     @ai-dynamo/devops
 SECURITY.md      @ai-dynamo/devops
 
 # Tool-calling / reasoning parser crates and their conformance tests.
-/parsers/       @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
-/parsers_v2/    @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
-/parsers_v2-py/ @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
-/conformance/   @keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv
+/parsers/       @ai-dynamo/contributors-frontend-crates
+/parsers_v2/    @ai-dynamo/contributors-frontend-crates
+/parsers_v2-py/ @ai-dynamo/contributors-frontend-crates
+/conformance/   @ai-dynamo/contributors-frontend-crates


### PR DESCRIPTION
#### Overview:

Adds parser-area owners to `.github/CODEOWNERS` so changes under the parser crates and conformance tests require review from the tool-calling/reasoning contributors.

#### Details:

- New CODEOWNERS entries for `/parsers/`, `/parsers_v2/`, `/parsers_v2-py/`, and `/conformance/`: `@keivenchang @rmccormick @indrajit96 @KrishnanPrash @Chokoyo @zhongdaor-nv`
- Existing `@ai-dynamo/devops` entries for `/.github/`, CONTRIBUTING/LICENSE/SECURITY/release config are unchanged.

#### Where should the reviewer start?

`.github/CODEOWNERS`

/coderabbit profile chill
