### PR TITLE
ci: point conformance smoke test at render_table_v1.sh + RELEASING.md wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           python3 -m venv /tmp/pvenv
           /tmp/pvenv/bin/pip install --quiet pyyaml jinja2
-          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_parity_v1.sh
+          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_table_v1.sh
           OUT=conformance/utils/.stage/tests/parity/PARITY_v1.html
           test -s "$OUT"
           grep -q "TOOLCALLING.batch" "$OUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,8 @@ recover when it goes wrong.
    via `include = [...]` in each crate's `Cargo.toml`: `src/**/*`,
    `Cargo.toml`, and `README.md`. Anything outside that list — `tests/`,
    root `README.md`, `.github/`, `scripts/`, `deny.toml`, the
-   `examples/dynamo-demo-server/` crate (`publish = false`), and per-crate
-   contributor docs like `CLAUDE.md` / `PARSER_CASES.md` — does not trigger a
+   `examples/dynamo-demo-server/` crate (`publish = false`), and contributor
+   docs outside the packaged crate include list — does not trigger a
    release. A second filter, `release_commits` in `release-plz.toml`, only
    considers commits whose messages start with `feat:`, `fix:`, `perf:`,
    `refactor:`, or `sync:`. That filter keeps `chore:` / `ci:` / `build:` /


### PR DESCRIPTION
Split out of #42 to keep that PR scoped to the parser conformance harness.

- `.github/workflows/ci.yml`: point the conformance render smoke test at `render_table_v1.sh` (the canonical name after #42 renamed `render_parity_v1.sh` -> `render_table_v1.sh`).
- `RELEASING.md`: small contributor-docs wording fix.

Stacked on #42 — `render_table_v1.sh` only exists there, and #42 leaves a temporary `render_parity_v1.sh` compat symlink so CI keeps passing until this lands. GitHub will retarget this PR to `main` when #42 merges.
