### PR TITLE
chore: sync from dynamo @ 8e7c8c6 + align Harmony stream recovery

### DIFF
--- a/conformance/tests/parity_toolcalling_batch_via_stream.rs
+++ b/conformance/tests/parity_toolcalling_batch_via_stream.rs
@@ -66,17 +66,8 @@ fn toolcalling_batch_via_stream_parity() {
     // Batch samples where the streaming parser deliberately differs from the
     // strict batch parser. Removing an entry asserts that stream and batch now
     // agree on that sample.
-    let known_divergences: std::collections::BTreeSet<&str> = [
-        "deepseek_v4:TOOLCALLING.batch.5.g",
-        // fc's v2 stream parser recovers Harmony tool calls at EOF that the
-        // dynamo-synced v1 batch parser no longer emits — dynamo #10366 moved
-        // analysis-channel tool-call recovery to the reasoning parser, so the
-        // v1 batch mirror drops these while v2 keeps recovering them.
-        "harmony:TOOLCALLING.batch.5.a",
-        "harmony:TOOLCALLING.batch.5.d",
-    ]
-    .into_iter()
-    .collect();
+    let known_divergences: std::collections::BTreeSet<&str> =
+        ["deepseek_v4:TOOLCALLING.batch.5.g"].into_iter().collect();
 
     let mut total = 0usize;
     let mut consistent = 0usize;

--- a/conformance/tests/parity_toolcalling_batch_via_stream.rs
+++ b/conformance/tests/parity_toolcalling_batch_via_stream.rs
@@ -67,10 +67,13 @@ fn toolcalling_batch_via_stream_parity() {
     // strict batch parser. Removing an entry asserts that stream and batch now
     // agree on that sample.
     let known_divergences: std::collections::BTreeSet<&str> = [
-        "deepseek_v4:TOOLCALLING.batch.5.a",
-        "deepseek_v4:TOOLCALLING.batch.5.d",
-        "deepseek_v4:TOOLCALLING.batch.5.e",
         "deepseek_v4:TOOLCALLING.batch.5.g",
+        // fc's v2 stream parser recovers Harmony tool calls at EOF that the
+        // dynamo-synced v1 batch parser no longer emits — dynamo #10366 moved
+        // analysis-channel tool-call recovery to the reasoning parser, so the
+        // v1 batch mirror drops these while v2 keeps recovering them.
+        "harmony:TOOLCALLING.batch.5.a",
+        "harmony:TOOLCALLING.batch.5.d",
     ]
     .into_iter()
     .collect();

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
@@ -6,6 +6,7 @@ captured_with:
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    dynamo_note: 'No recovery by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): a Harmony commentary/analysis tool call must carry the <|call|> terminator to be recovered. <|call|> is also the gpt-oss EOS/commit token, so a call missing it was cut off before the model committed; the incomplete envelope is dropped, not recovered or leaked into content.'
     dynamo_rust:
       calls: []
       normal_text: ''
@@ -45,6 +46,7 @@ cases:
       calls: []
       normal_text: ''
   TOOLCALLING.batch.5.d:
+    dynamo_note: 'Trailing call dropped by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): only the commentary call carrying <|call|> (Boston) is recovered; the unterminated trailing call (New York) is dropped, since <|call|> is also the gpt-oss EOS/commit token and its absence means the model was cut off before committing that call.'
     dynamo_rust:
       calls:
       - name: get_weather

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
@@ -7,10 +7,7 @@ captured_with:
 cases:
   TOOLCALLING.batch.5.a:
     dynamo_rust:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
+      calls: []
       normal_text: ''
     vllm_python:
       calls:
@@ -53,9 +50,6 @@ cases:
       - name: get_weather
         arguments:
           location: Boston
-      - name: get_weather
-        arguments:
-          location: New York
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
     vllm_python:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
@@ -97,9 +97,7 @@ cases:
       delta_token_ids: []
       finish_reason: stop
       expected:
-        dynamo_rust:
-        - {index: 0, id: true, name: 'get_weather'}
-        - {index: 0, arguments: '{"location":"NYC"}'}
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
@@ -469,9 +467,7 @@ cases:
       delta_token_ids: []
       finish_reason: tool_calls
       expected:
-        dynamo_rust:
-        - {index: 1, id: true, name: 'get_weather'}
-        - {index: 1, arguments: '{"location":"New York"}'}
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
@@ -17,6 +17,7 @@ captured_with:
 cases:
   TOOLCALLING.streamv2.5.a:
     description: 'Missing <|call|> end marker (bare envelope)'
+    dynamo_note: 'No recovery by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): a Harmony commentary/analysis tool call must carry the <|call|> terminator to be recovered. <|call|> is also the gpt-oss EOS/commit token, so a call missing it was cut off before the model committed; the incomplete envelope is dropped, not recovered or leaked into content.'
     ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
@@ -259,6 +260,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
     description: 'Multi-call, last call missing only end marker (body complete)'
+    dynamo_note: 'Trailing call dropped by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): only the commentary call carrying <|call|> (Boston) is recovered; the unterminated trailing call (New York) is dropped, since <|call|> is also the gpt-oss EOS/commit token and its absence means the model was cut off before committing that call.'
     ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
@@ -21,6 +21,7 @@ captured_with:
 cases:
   TOOLCALLING.streamv2.5.a:
     description: 'Missing <|call|> end marker (bare envelope)'
+    dynamo_note: 'No recovery by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): a Harmony commentary/analysis tool call must carry the <|call|> terminator to be recovered. <|call|> is also the gpt-oss EOS/commit token, so a call missing it was cut off before the model committed; the incomplete envelope is dropped, not recovered or leaked into content.'
     ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
@@ -263,6 +264,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
     description: 'Multi-call, last call missing only end marker (body complete)'
+    dynamo_note: 'Trailing call dropped by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): only the commentary call carrying <|call|> (Boston) is recovered; the unterminated trailing call (New York) is dropped, since <|call|> is also the gpt-oss EOS/commit token and its absence means the model was cut off before committing that call.'
     ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
@@ -101,9 +101,7 @@ cases:
       delta_token_ids: []
       finish_reason: stop
       expected:
-        dynamo_rust:
-        - {index: 0, id: true, name: 'get_weather'}
-        - {index: 0, arguments: '{"location":"NYC"}'}
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
@@ -473,9 +471,7 @@ cases:
       delta_token_ids: []
       finish_reason: tool_calls
       expected:
-        dynamo_rust:
-        - {index: 1, id: true, name: 'get_weather'}
-        - {index: 1, arguments: '{"location":"New York"}'}
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -21,8 +21,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
-        calls: []
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
@@ -33,8 +36,11 @@ cases:
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 
           </｜DSML｜invoke>'
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
-      sglang: *d_5_a
+        reason: "vLLM leaks the DSML envelope into normal_text on missing end-marker recovery; Dynamo recovers the complete <｜DSML｜invoke> call and strips the unterminated outer tag."
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: "SGLang drops the call and emits empty content when </｜DSML｜function_calls> is missing; Dynamo recovers the complete <｜DSML｜invoke> call."
   TOOLCALLING.batch.5.b:
     description: Closing </｜DSML｜function_calls> without matching open
     ref: dynamo
@@ -99,7 +105,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
@@ -133,7 +145,10 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -22,7 +22,10 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
@@ -31,7 +34,7 @@ cases:
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: "vLLM leaks the DSML envelope into normal_text on missing end-marker recovery; Dynamo recovers the complete <｜DSML｜invoke> call and strips the unterminated outer tag."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.5.b:
@@ -99,7 +102,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
@@ -115,7 +124,7 @@ cases:
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
           </｜DSML｜invoke>
-        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path; Dynamo recovers both complete <｜DSML｜invoke> calls (bodies fully closed) and keeps the prefix prose as normal_text."
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -131,7 +140,10 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
@@ -146,7 +158,7 @@ cases:
           </｜DSML｜invoke>
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">New York
-        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path; Dynamo recovers only the complete Boston call and drops the New York call whose <｜DSML｜invoke> was never closed, keeping the prefix prose as normal_text."
   TOOLCALLING.batch.5.f:
     description: Bare valid invoke before a complete wrapped call
     ref: dynamo

--- a/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml
@@ -18,10 +18,7 @@ cases:
             type: string
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: ''
       vllm: &d_5_a
         calls: []
@@ -77,9 +74,6 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls:

--- a/conformance/utils/lib/parsers/REASONING_CASES.md
+++ b/conformance/utils/lib/parsers/REASONING_CASES.md
@@ -7,7 +7,7 @@ DeepSeek V3 think-tag, etc.). Sibling files cover adjacent stages:
 - **Tool-call parsers** (`src/tool_calling/`): see `TOOLCALLING_CASES.md`.
 - **Frontend gating**: see
   `components/src/dynamo/frontend/tests/FRONTEND_CASES.md`.
-- **Pipeline boundary**: tracked in the conformance fixtures and HTML matrix, not a separate local Markdown file.
+- **Pipeline boundary**: see `PIPELINE_CASES.md`.
 
 The reasoning taxonomy mirrors the parser taxonomy on stage / mode /
 format axes:
@@ -187,7 +187,8 @@ carry both `REASONING.batch.2.a` and `TOOLCALLING.harmony.1`.
   call).
 - `FRONTEND.tool_choice` — request-time gating, see
   `FRONTEND_CASES.md`.
-- `PIPELINE.finish_reason` — pipeline-boundary contract, tracked in the conformance fixtures and HTML matrix.
+- `PIPELINE.finish_reason` — pipeline-boundary contract, see
+  `PIPELINE_CASES.md`.
 
 ---
 

--- a/conformance/utils/lib/parsers/TOOLCALLING_CASES.md
+++ b/conformance/utils/lib/parsers/TOOLCALLING_CASES.md
@@ -6,11 +6,13 @@ Reference taxonomy for unit testing **tool-call** parsers under
 - **Reasoning parsers** (`src/reasoning/`): see `REASONING_CASES.md`.
 - **Frontend gating** (request-time `tool_choice`, etc.): see
   `components/src/dynamo/frontend/tests/FRONTEND_CASES.md`.
-- **Pipeline boundary** (`finish_reason` independence, etc.): tracked in the conformance fixtures and HTML matrix, not a separate local Markdown file.
+- **Pipeline boundary** (`finish_reason` independence, etc.): see
+  `PIPELINE_CASES.md`.
 
 The taxonomy splits on three orthogonal axes:
 
-1. **Stage** — which module is under test (`TOOLCALLING.*` here, `REASONING.*`, `FRONTEND.*`, or pipeline-boundary fixture rows).
+1. **Stage** — which module is under test (`TOOLCALLING.*` here, `REASONING.*`,
+   `FRONTEND.*`, `PIPELINE.*` in their own files).
 2. **Mode** — invocation surface: `batch` (entire model output as one
    string) or `stream` (incremental `delta_text` + `delta_token_ids`).
    Each mode has its own contiguous case numbers; a "single tool call"

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -738,6 +738,19 @@ def _format_output_block_html(block, family: str | None = None) -> str:
     return f"{nt_line}\n{calls_line}"
 
 
+def _dynamo_note_sections(case: dict) -> list[tuple[str, str]]:
+    """A baseline-side rationale for the Dynamo Rust output, rendered as its own
+    tooltip section. `_tooltip_for` only explains PEER divergences (it skips the
+    baseline), so a deliberate Dynamo behavior — e.g. dropping an unterminated
+    Harmony tool call per dynamo #10366 — has no other surface. Sourced from a
+    case-level `dynamo_note:` in the fc-local v2 fixtures; include a full URL so
+    `linkify_text_html` makes the PR reference clickable."""
+    note = case.get("dynamo_note")
+    if not note:
+        return []
+    return [("Dynamo recovery contract", linkify_text_html(str(note)))]
+
+
 def _build_tooltip_html(case: dict, dyn, output_kind: str = "batch") -> str:
     """Rich HTML hover tooltip: head, input (colorized), per-engine output,
     divergence reasons. Returns the full `<div class="ttip">...</div>`.
@@ -835,6 +848,7 @@ def _build_tooltip_html(case: dict, dyn, output_kind: str = "batch") -> str:
         divergent_reasons=reasons or None,
         leak_label="↯ Dynamo tool call leaks",
         leak_text=str(dyn_leak) if dyn_leak else None,
+        extra_sections=_dynamo_note_sections(case),
         chart=chart,
         refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
     )
@@ -1898,6 +1912,7 @@ def _build_sob_tooltip(case: dict, marker_context: str | None = None) -> str:
         input_html=input_html,
         output_sections=sections,
         divergent_reasons_html="<br>".join(reason_parts) if reason_parts else None,
+        extra_sections=_dynamo_note_sections(case),
         chart=chart,
         refs=[("Ref", case.get("ref"))],
         html_section_labels=True,
@@ -1989,6 +2004,9 @@ def _build_stream_on_batch_cases(batch_cases: dict) -> dict:
             "description": bcase.get("description"),
             "model_text": bcase.get("model_text"),
             "ref": bcase.get("ref"),
+            # Baseline rationale lives in the fc-local overlay (sync-safe); fall
+            # back to the synced v1 batch fixture if it ever carries one upstream.
+            "dynamo_note": overlay_case.get("dynamo_note") or bcase.get("dynamo_note"),
             "expected": _stream_on_batch_expected(
                 overlay_case, has_batch_text="model_text" in bcase
             ),

--- a/conformance/utils/tests/parity/common.py
+++ b/conformance/utils/tests/parity/common.py
@@ -191,9 +191,7 @@ def parity_cell_class(marker: str) -> str:
         return "na"
     if marker in {"D", "·"}:
         return "donly"
-    if "!" in marker:
-        return "err"
-    if "✗" in marker:
+    if "!" in marker or "✗" in marker:
         return "err"
     if "↯" in marker:
         return "leak"

--- a/conformance/utils/tests/parity/parity_table.html.j2
+++ b/conformance/utils/tests/parity/parity_table.html.j2
@@ -232,7 +232,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 <p class="legend summary-only">
   <strong>Overview:</strong>
   <span class="summary-key ok" aria-hidden="true"></span>green = selected implementation output is clean ·
-  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has an expected error ·
+  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has a parser exception ·
   <span class="summary-key na" aria-hidden="true"></span>gray = not applicable, unavailable, or missing fixture.
 </p>
 <p class="legend details-only">
@@ -251,8 +251,8 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   (e.g. V?, S? — diverges with no <code>reason:</code> yet) ·
   <span style="color:#b00">↯</span> Dynamo leaks tool call markup into <code>normal_text</code>
   (<code>expected.dynamo.reason:</code> carries the explanation) ·
-  <span style="color:#b00">!</span> expected-error suffix
-  (e.g. V!, S! — engine crashes by design) ·
+  <span style="color:#b00">✗</span> parser exception
+  (e.g. V✗, S✗ — Python parser raised) ·
   <span style="color:#aaa">n/a</span> not applicable ·
   <span style="color:#8a6d3b">—</span> missing fixture coverage ·
   <span class="parser-suffix">†</span> = no vLLM peer tool calling parser for this family ·

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -517,11 +517,7 @@ def _overview_status(case: dict[str, Any] | None, family: str | None, impl: str)
     if case is None:
         return "na"
     if "expected" not in case:
-        return (
-            "problem"
-            if impl in _python_exception_impls(case, family)
-            else "na"
-        )
+        return "problem" if impl in _python_exception_impls(case, family) else "na"
     block = case.get("expected", {}).get(impl)
     if not isinstance(block, dict) or "unavailable" in block:
         return "na"
@@ -797,6 +793,12 @@ def _python_exception_impls(
     case: dict[str, Any] | None,
     family: str | None,
 ) -> tuple[str, ...]:
+    """Impls whose Python parser would raise on this input-less n/a stub.
+
+    A no-`expected` n/a stub carries no `model_text`/`chunks`, so feeding it to
+    the vLLM/SGLang Python parser raises ``KeyError: 'model_text'``. Surface that
+    as a parser exception for any family that has a Python peer parser.
+    """
     if not case or "expected" in case or not _is_na_stub(case):
         return ()
     if _case_has_parser_input(case):
@@ -811,7 +813,9 @@ def _python_exception_marker(
     family: str | None,
 ) -> str:
     letters = {"vllm": "V", "sglang": "S"}
-    return "".join(f"{letters[impl]}✗" for impl in _python_exception_impls(case, family))
+    return "".join(
+        f"{letters[impl]}✗" for impl in _python_exception_impls(case, family)
+    )
 
 
 def _python_exception_tooltip_lines(
@@ -2181,8 +2185,8 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
         "(e.g. V?, S? — diverges with no <code>reason:</code> yet) · "
         '<span style="color:#b00">↯</span> Dynamo leaks reasoning markup '
         "or final-answer text · "
-        '<span style="color:#b00">✗</span> Python parser exception '
-        "(e.g. V✗, S✗ — parser raised while running this fixture) · "
+        '<span style="color:#b00">✗</span> parser exception '
+        "(e.g. V✗, S✗ — Python parser raised) · "
         '<span style="color:#aaa">n/a</span> not applicable'
         f"{missing_text}."
         "<br>"

--- a/conformance/utils/tests/parity/toolcalling/table.py
+++ b/conformance/utils/tests/parity/toolcalling/table.py
@@ -26,8 +26,8 @@ Cell markers (per peer, vllm + sglang):
   V/S   peer is a concrete inline block AND has `reason:` (intentional)
   V?/S? peer is a concrete inline block AND has no `reason:` yet
         (research-needed; we observed it but haven't classified it)
-  V!/S! peer has `error: <substring>` (expected to crash)
-  VS, V?S, VS!, etc. — combinations
+  V✗/S✗ peer has `error: <substring>` (Python parser raised)
+  VS, V?S, VS✗, etc. — combinations
   ·     Dynamo-only fixture; both peer blocks are `unavailable`
   n/a   family/case doesn't apply
   —     no fixture entry exists for this family/case yet
@@ -718,7 +718,7 @@ def _parser_marker(case: dict | None, impl: str) -> str:
     if not isinstance(block, dict) or "unavailable" in block:
         return "n/a"
     if "error" in block:
-        return "!"
+        return "✗"
     if _block_tool_call_leaks(block):
         return "↯"
     if impl == "dynamo":
@@ -753,11 +753,11 @@ def cell_for(case: dict | None) -> str:
     if v_kind == "div":
         parts.append("V?" if v_unknown else "V")
     elif v_kind == "err":
-        parts.append("V!")
+        parts.append("V✗")
     if s_kind == "div":
         parts.append("S?" if s_unknown else "S")
     elif s_kind == "err":
-        parts.append("S!")
+        parts.append("S✗")
 
     # `reason:` on the `expected.dynamo` block flags Dynamo's own output as
     # leaking tool call markup only when Dynamo also leaves residual
@@ -799,7 +799,7 @@ _LEGEND_MD = (
     "`?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · "
     "`↯` Dynamo leaks tool call markup into `normal_text` "
     "(`expected.dynamo.reason:` carries the explanation) · "
-    "`!` expected-error suffix (e.g. V!, S! — engine crashes by design) · "
+    "`✗` parser exception (e.g. V✗, S✗ — Python parser raised) · "
     "`n/a` not applicable · "
     "`—` missing fixture coverage · "
     "`†` (tool calling parser column) = no vLLM peer parser for this family · "
@@ -949,7 +949,7 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
     Each non-matching, non-unavailable peer contributes one line:
       vllm: <reason>                        # `reason:` field present
       vllm: UNKNOWN — divergent ...         # divergent, no reason
-      vllm: expected error matching '...'   # `error:` field present
+      vllm: parser exception matching '...' # `error:` field present
     """
     parts: list[str] = []
     n_dyn = {
@@ -964,7 +964,7 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
             continue
         name = _IMPL_DISPLAY.get(impl, impl)
         if "error" in block:
-            parts.append(f"{name}: expected error matching {block['error']!r}")
+            parts.append(f"{name}: parser exception matching {block['error']!r}")
             continue
         # Don't rely on PyYAML preserving anchor identity (the `block is dyn`
         # check above is the fast path; value equality is the safety net).
@@ -1480,7 +1480,7 @@ def _compute_stats(
                 s["parity"] += 1
             elif text in {"D", "·"}:
                 s["dynamo_only"] += 1
-            elif "!" in text:
+            elif "!" in text or "✗" in text:
                 s["errors"] += 1
             elif "↯" in text:
                 s["documented"] += 1

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -447,22 +447,21 @@ mod tests {
     //   - TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 N/A — Harmony-only.
     //
     // EOF recovery:
-    //   - TOOLCALLING.stream.4.a  Stream finalization sets
-    //             `allow_eof_recovery=true` and recovers complete
-    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even when the
-    //             outer close fence is absent at EOS. Streaming early-exit and
-    //             batch/non-streaming aggregate paths keep recovery disabled so
-    //             they do not claim DSML calls before `</｜DSML｜tool_calls>`
-    //             actually arrives.
+    //   - TOOLCALLING.stream.4.a / TOOLCALLING.batch.5  Both the stream-finalize
+    //             and batch/non-streaming finalize paths set
+    //             `allow_eof_recovery=true` (via
+    //             `detect_and_parse_tool_call_with_recovery`) and recover every
+    //             complete <｜DSML｜invoke>...</｜DSML｜invoke> pair even when the
+    //             outer close fence is absent at EOS, keeping the pre-block prose
+    //             as normal_text and dropping any trailing invoke that was never
+    //             closed. Only streaming early-exit keeps recovery disabled so it
+    //             does not claim DSML calls before `</｜DSML｜tool_calls>` actually
+    //             arrives (see test_parse_deepseek_v4_missing_end_token_without_recovery).
     //
     // TODO — bugs pinned, parser still needs to be fixed:
-    //   - TOOLCALLING.batch.5  BUG: parser drops all calls when </｜DSML｜tool_calls> is
-    //             absent (max_tokens / EOS before close). Same class as
-    //             Kimi K2 pre-PR #8208. Fix: scan for complete
-    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even without the
-    //             outer close fence (see kimi_k2_parser.rs for precedent).
-    //             Pinning tests below assert the current silent-drop;
-    //             flip them once the parser is fixed.
+    //   - (TOOLCALLING.batch.5  FIXED: batch/non-streaming finalize now recovers
+    //     complete invokes when </｜DSML｜tool_calls> is absent, matching the
+    //     stream-finalize path. Same class as Kimi K2 pre-PR #8208.)
     //   - (TOOLCALLING.batch.4 missing-parameter-close & middle-invoke-truncation now
     //     pinned: see test_parse_deepseek_v4_missing_parameter_close_loses_param,
     //     test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next.)

--- a/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -17,12 +17,10 @@ static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static FINAL_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static MESSAGE_CALL_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
-static COMMENTARY_BLOCK_EOF_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
-/// input — alternative on this path is silent-drop. Normal streaming requires
-/// `<|call|>`; finalize recovery may treat EOF as the close only when the
-/// directed commentary call has complete JSON arguments.
+/// input — alternative on this path is silent-drop. Worst case is missing
+/// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
 ///
 /// Matches tool calls on either `commentary` or `analysis` channel: the model
 /// emits ~47% of tool calls on the `analysis` channel with a bare `code`
@@ -39,15 +37,6 @@ fn commentary_block_regex() -> &'static Regex {
             r"(?s)(?:<\|start\|>assistant)?<\|channel\|>(?:commentary|analysis) to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
-    })
-}
-
-fn commentary_block_eof_regex() -> &'static Regex {
-    COMMENTARY_BLOCK_EOF_REGEX.get_or_init(|| {
-        Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|(?P<eof>\z))",
-        )
-        .expect("commentary block EOF regex")
     })
 }
 
@@ -222,10 +211,6 @@ fn serialize_harmony_arguments(raw_args: &str) -> String {
     }
 }
 
-fn args_are_complete_json(raw_args: &str) -> bool {
-    serde_json::from_str::<Value>(raw_args.trim()).is_ok()
-}
-
 fn push_harmony_text(out: &mut String, content: &[Content]) {
     for item in content {
         if let Content::Text(text) = item {
@@ -290,19 +275,11 @@ fn contains_recipientless_commentary_call(text: &str) -> bool {
 /// Returns (calls, residual_text) where residual_text is everything not
 /// consumed by a matched commentary block — preserved so non-tool user-visible
 /// spans aren't dropped.
-fn extract_calls_via_regex(
-    text: &str,
-    allow_eof_recovery: bool,
-) -> (Vec<ToolCallResponse>, String) {
+fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    let regex = if allow_eof_recovery {
-        commentary_block_eof_regex()
-    } else {
-        commentary_block_regex()
-    };
-    for cap in regex.captures_iter(text) {
+    for cap in commentary_block_regex().captures_iter(text) {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -311,18 +288,6 @@ fn extract_calls_via_regex(
         let raw_args = cap.name("args").map(|x| x.as_str().trim()).unwrap_or("{}");
         if name.is_empty() {
             continue;
-        }
-        if cap.name("eof").is_some() {
-            if !args_are_complete_json(raw_args) {
-                continue;
-            }
-            tracing::warn!(
-                family = "harmony",
-                reason = "eof_recovered_complete_call_without_call_marker",
-                function = name,
-                recovered_bytes = raw_args.len(),
-                "recovered complete Harmony tool call at EOF"
-            );
         }
         let args_json = serialize_harmony_arguments(raw_args);
         let call_idx = out.len() + 1;
@@ -377,7 +342,7 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    config: &JsonParserConfig,
+    _config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
@@ -398,9 +363,12 @@ pub async fn parse_tool_calls_harmony_complete(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
             // Recovery: harmony rejects parallel commentary blocks even when
-            // every call is explicitly closed. EOF recovery is gated so
-            // streaming jails do not claim a call before the model is done.
-            let (calls, residual) = extract_calls_via_regex(text, config.allow_eof_recovery);
+            // every call is explicitly closed. Only EOF/truncated recovery is
+            // gated, so streaming jails do not synthesize incomplete calls.
+            // Harmony differs from generic JSON/XML recovery: a tool call is
+            // complete only once `<|call|>` is present. Do not synthesize a
+            // call from EOF; that would diverge from vLLM/openai_harmony.
+            let (calls, residual) = extract_calls_via_regex(text);
             if !calls.is_empty() {
                 let normal_text =
                     strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");
@@ -431,8 +399,7 @@ pub async fn parse_tool_calls_harmony_complete(
         // `commentary` (canonical) and `analysis` (malformed-but-common) channels.
         let is_tool_channel = channel == Some("commentary") || channel == Some("analysis");
         if is_tool_channel && recipient.starts_with("functions.") {
-            let can_recover_at_eof = channel == Some("commentary") && config.allow_eof_recovery;
-            if !has_tool_call_stop && !can_recover_at_eof {
+            if !has_tool_call_stop {
                 continue;
             }
 
@@ -452,24 +419,6 @@ pub async fn parse_tool_calls_harmony_complete(
             }) else {
                 continue;
             };
-            if !has_tool_call_stop {
-                let Some(raw_args) = message.content.first().and_then(|content| match content {
-                    Content::Text(text) => Some(text.text.as_str()),
-                    _ => None,
-                }) else {
-                    continue;
-                };
-                if !args_are_complete_json(raw_args) {
-                    continue;
-                }
-                tracing::warn!(
-                    family = "harmony",
-                    reason = "eof_recovered_complete_call_without_call_marker",
-                    function = fname.as_str(),
-                    recovered_bytes = raw_args.len(),
-                    "recovered complete Harmony tool call at EOF"
-                );
-            }
 
             call_idx += 1;
             res.push(ToolCallResponse {
@@ -764,12 +713,12 @@ mod tests {
         assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
-    // Bare-envelope TOOLCALLING.batch.5.a: no preceding `analysis` block, no
-    // `<|call|>` at the end. Finalize recovery may accept EOF as the close when
-    // the function recipient and JSON arguments are complete.
+    // Bare-envelope TOOLCALLING.batch.5: no preceding `analysis` block, no `<|call|>`
+    // at the end. Harmony requires the explicit call stop token, so fallback
+    // must not accept EOS as a synthetic close.
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml.
     #[tokio::test] // TOOLCALLING.batch.5 — gpt-oss
-    async fn test_parse_harmony_bare_envelope_no_call_token_recovers_at_eof() {
+    async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
         let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
@@ -781,11 +730,8 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(tool_calls.is_empty());
         assert_eq!(normal, Some("".to_string()));
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args, serde_json::json!({"location": "NYC"}));
     }
 
     // The regex fallback must preserve user-visible non-tool spans (prose before

--- a/parsers/src/tool_calling/mod.rs
+++ b/parsers/src/tool_calling/mod.rs
@@ -54,9 +54,11 @@ pub use structural_tag::{
     DsmlToolCallsConfig, StructuralTagBuilder, StructuralTagSchemaMode, TOOL_NAME_PLACEHOLDER,
     ToolCallFormatBuildContext, TriggeredTagsConfig,
 };
+#[allow(deprecated)]
+pub use tools::try_tool_call_parse_aggregate_stream_finalize;
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
-    try_tool_call_parse_aggregate_stream_finalize, try_tool_call_parse_stream,
+    try_tool_call_parse_stream,
 };
 pub use xml::try_tool_call_parse_kimi_k2;
 pub use xml::try_tool_call_parse_xml;

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -116,38 +116,22 @@ pub async fn try_tool_call_parse(
 }
 
 /// Same as [`detect_and_parse_tool_call`] but flips `allow_eof_recovery=true`
-/// on parser configs with EOF recovery so finalize / non-streaming aggregate paths
-/// recover from missing-end-token / truncated-JSON instead of silently
+/// on the JSON / XML / DSML configs so finalize / non-streaming aggregate
+/// paths recover from missing-end-token / truncated-JSON instead of silently
 /// dropping the call. Streaming jails MUST keep using the non-recovery
 /// variant — otherwise `should_exit_jail_early` fires before the end-token
 /// has actually arrived (see jail.rs).
+///
+/// DSML recovery covers DeepSeek V4: when the outer `</｜DSML｜tool_calls>`
+/// wrapper never arrives (EOS / max_tokens), still recover every complete
+/// `<｜DSML｜invoke>...</｜DSML｜invoke>` pair and keep the pre-block prose as
+/// `normal_text`, while dropping any trailing invoke that was never closed.
+/// This is best-effort recovery from the bytes already received, so the same
+/// behavior applies on both batch/non-streaming and stream-finalize paths.
 pub async fn detect_and_parse_tool_call_with_recovery(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, false).await
-}
-
-/// Stream-end finalize variant of [`detect_and_parse_tool_call_with_recovery`].
-///
-/// DeepSeek V4's vLLM streaming parser emits a tool call once a complete
-/// `<｜DSML｜invoke>...</｜DSML｜invoke>` arrives, even if the outer
-/// `</｜DSML｜tool_calls>` wrapper never appears before EOS. Keep that recovery
-/// scoped to stream finalization so batch/non-streaming parity remains strict.
-pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
-    message: &str,
-    parser_str: Option<&str>,
-    tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, true).await
-}
-
-async fn detect_and_parse_tool_call_with_recovery_options(
-    message: &str,
-    parser_str: Option<&str>,
-    tools: Option<&[ToolDefinition]>,
-    recover_dsml_eof: bool,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let parser_map = get_tool_parser_map();
     let parser_key = match parser_str {
@@ -172,12 +156,7 @@ async fn detect_and_parse_tool_call_with_recovery_options(
             c.allow_eof_recovery = true;
             ParserConfig::Xml(c)
         }
-        ParserConfig::Harmony(c) => {
-            let mut c = c.clone();
-            c.allow_eof_recovery = true;
-            ParserConfig::Harmony(c)
-        }
-        ParserConfig::Dsml(c) if recover_dsml_eof => {
+        ParserConfig::Dsml(c) => {
             let mut c = c.clone();
             c.allow_eof_recovery = true;
             ParserConfig::Dsml(c)
@@ -192,6 +171,20 @@ async fn detect_and_parse_tool_call_with_recovery_options(
         structural_tag_builder: None,
     };
     try_tool_call_parse(message, &cfg, tools).await
+}
+
+/// Deprecated compatibility shim retained for the published `dynamo-parsers`
+/// API. Batch/non-streaming and stream-end finalize now share one recovery
+/// path; call [`detect_and_parse_tool_call_with_recovery`] directly.
+#[deprecated(
+    note = "batch and stream finalize now share one recovery path; use detect_and_parse_tool_call_with_recovery"
+)]
+pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await
 }
 
 // Base Detector to call for all tool parsing
@@ -1914,8 +1907,12 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
     }
+    /// Both the batch/non-streaming finalize and stream-finalize paths now run
+    /// `detect_and_parse_tool_call_with_recovery`, which enables DSML EOF
+    /// recovery: a complete `<｜DSML｜invoke>...</｜DSML｜invoke>` is recovered
+    /// even when the outer `</｜DSML｜tool_calls>` wrapper never arrives.
     #[tokio::test]
-    async fn test_deepseek_v4_common_recovery_stays_strict_without_outer_close() {
+    async fn test_deepseek_v4_recovery_recovers_without_outer_close() {
         let input = r#"<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_datetime">
 <｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
@@ -1925,25 +1922,6 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             detect_and_parse_tool_call_with_recovery(input, Some("deepseek_v4"), None)
                 .await
                 .expect("Failed to parse");
-
-        assert!(tool_calls.is_empty());
-        assert_eq!(normal_text, Some("".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_deepseek_v4_stream_finalize_recovery_recovers_without_outer_close() {
-        let input = r#"<｜DSML｜tool_calls>
-<｜DSML｜invoke name="get_datetime">
-<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
-</｜DSML｜invoke>"#;
-
-        let (tool_calls, normal_text) = detect_and_parse_tool_call_with_stream_finalize_recovery(
-            input,
-            Some("deepseek_v4"),
-            None,
-        )
-        .await
-        .expect("Failed to parse");
 
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_datetime");

--- a/parsers/src/tool_calling/tools.rs
+++ b/parsers/src/tool_calling/tools.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
-pub use super::parsers::{
-    detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery,
-    detect_and_parse_tool_call_with_stream_finalize_recovery,
-};
+#[allow(deprecated)]
+pub use super::parsers::detect_and_parse_tool_call_with_stream_finalize_recovery;
+pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
 pub use super::response::{
     CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
 };
@@ -37,11 +36,11 @@ pub async fn try_tool_call_parse_aggregate(
 }
 
 /// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
-/// the common EOF recovery paths (missing outer end-token, truncated JSON args).
-/// Use this from non-streaming aggregator paths — never from streaming jail
-/// early-exit logic. Stream-end jail finalization uses
-/// [`try_tool_call_parse_aggregate_stream_finalize`] so DSML can salvage
-/// completed invokes without changing batch/non-streaming behavior.
+/// the common EOF recovery paths (missing outer end-token, truncated JSON
+/// args, and — for DSML/DeepSeek V4 — a missing outer `</｜DSML｜tool_calls>`
+/// wrapper). Use this from finalize paths: both non-streaming aggregate and
+/// stream-end jail finalization. Never use it from streaming jail early-exit
+/// logic, which must keep `allow_eof_recovery=false`.
 pub async fn try_tool_call_parse_aggregate_finalize(
     message: &str,
     parser_str: Option<&str>,
@@ -55,23 +54,18 @@ pub async fn try_tool_call_parse_aggregate_finalize(
     Ok((parsed, content))
 }
 
-/// Stream-end variant of [`try_tool_call_parse_aggregate_finalize`].
-///
-/// It keeps the normal finalize recovery for JSON/XML and additionally lets
-/// DSML recover complete invokes from an unterminated outer wrapper. This is
-/// intentionally not used by batch/non-streaming aggregate paths.
+/// Deprecated compatibility shim retained for the published `dynamo-parsers`
+/// API. Batch/non-streaming and stream-end finalize now share one recovery
+/// path; call [`try_tool_call_parse_aggregate_finalize`] directly.
+#[deprecated(
+    note = "batch and stream finalize now share one recovery path; use try_tool_call_parse_aggregate_finalize"
+)]
 pub async fn try_tool_call_parse_aggregate_stream_finalize(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    let (parsed, content) =
-        detect_and_parse_tool_call_with_stream_finalize_recovery(message, parser_str, tools)
-            .await?;
-    if parsed.is_empty() {
-        return Ok((vec![], content));
-    }
-    Ok((parsed, content))
+    try_tool_call_parse_aggregate_finalize(message, parser_str, tools).await
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.

--- a/parsers_v2/src/tool_calling/harmony.rs
+++ b/parsers_v2/src/tool_calling/harmony.rs
@@ -153,7 +153,12 @@ impl HarmonyToolStreamParser {
                 }
             }
         }
-        let snapshot = parse_harmony_snapshot(&self.scan_buffer, true);
+        // Match the v1 batch parser: do NOT recover commentary calls missing the
+        // closing <|call|> token at EOF. dynamo #10366 moved analysis-channel
+        // tool-call recovery to the reasoning parser, so the batch tool-call
+        // parser drops these — the stream parser stays consistent with it
+        // (batch.5.a -> no call, batch.5.d -> only the fenced call).
+        let snapshot = parse_harmony_snapshot(&self.scan_buffer, false);
         self.emit_snapshot_delta_from_snapshot(snapshot, true)
     }
 
@@ -554,16 +559,18 @@ mod tests {
     }
 
     #[test]
-    fn missing_call_marker_with_complete_json_recovers_batch_case_5_a() {
+    fn missing_call_marker_drops_batch_case_5_a() {
+        // A complete commentary call missing the closing <|call|> at EOF is NOT
+        // recovered — stream matches the v1 batch parser (analysis-channel
+        // recovery lives in the reasoning parser now; see dynamo #10366).
         let text = "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"location\":\"NYC\"}";
         let mut parser = HarmonyToolStreamParser::new().expect("new");
         let result = parse_complete_for_test(&mut parser, text);
         assert_eq!(result.normal_text, "");
-        assert_eq!(result.calls.len(), 1);
-        assert_eq!(result.calls[0].name.as_deref(), Some("get_weather"));
-        let args: serde_json::Value =
-            serde_json::from_str(&result.calls[0].arguments).expect("args");
-        assert_eq!(args, serde_json::json!({"location": "NYC"}));
+        assert!(
+            result.calls.is_empty(),
+            "missing <|call|> must not be recovered (batch parity): {result:?}"
+        );
     }
 
     #[test]
@@ -579,7 +586,9 @@ mod tests {
     }
 
     #[test]
-    fn complete_trailing_call_recovers_batch_case_5_d() {
+    fn unfenced_trailing_call_drops_batch_case_5_d() {
+        // The trailing call is missing its <|call|>; only the fenced Boston call
+        // is recovered — stream matches the v1 batch parser.
         let text = concat!(
             "I'll start by fetching the weather for both Boston and New York at the same time!",
             "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"location\":\"Boston\"}<|call|>",
@@ -591,15 +600,11 @@ mod tests {
             result.normal_text,
             "I'll start by fetching the weather for both Boston and New York at the same time!"
         );
-        assert_eq!(result.calls.len(), 2);
+        assert_eq!(result.calls.len(), 1);
         assert_eq!(result.calls[0].name.as_deref(), Some("get_weather"));
-        assert_eq!(result.calls[1].name.as_deref(), Some("get_weather"));
-        let first: serde_json::Value =
-            serde_json::from_str(&result.calls[0].arguments).expect("first args");
-        let second: serde_json::Value =
-            serde_json::from_str(&result.calls[1].arguments).expect("second args");
-        assert_eq!(first, serde_json::json!({"location": "Boston"}));
-        assert_eq!(second, serde_json::json!({"location": "New York"}));
+        let args: serde_json::Value =
+            serde_json::from_str(&result.calls[0].arguments).expect("args");
+        assert_eq!(args, serde_json::json!({"location": "Boston"}));
     }
 
     #[test]

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -9,29 +9,29 @@ use either::Either;
 use minijinja::{Environment, Value, context};
 use serde_json::json;
 
+/// Renders the `default` template with the given `messages` and
+/// `add_generation_prompt=false`, returning the output (empty string on any
+/// error). Shared probe used by the load-time template-capability detectors
+/// (`detect_content_array_usage`, `detect_passthrough_template`).
+fn render_default_probe(env: &Environment, messages: serde_json::Value) -> String {
+    let ctx = context! {
+        messages => messages,
+        add_generation_prompt => false,
+    };
+    env.get_template("default")
+        .and_then(|t| t.render(&ctx))
+        .unwrap_or_default()
+}
+
 /// Detects if a template requires content as arrays (multimodal) vs strings (text-only).
 /// Returns true if the template only works with array format.
 fn detect_content_array_usage(env: &Environment) -> bool {
-    // Test with array format
-    let array_msg = context! {
-        messages => json!([{"role": "user", "content": [{"type": "text", "text": "template_test"}]}]),
-        add_generation_prompt => false,
-    };
-
-    // Test with string format
-    let string_msg = context! {
-        messages => json!([{"role": "user", "content": "template_test"}]),
-        add_generation_prompt => false,
-    };
-
-    let out_array = env
-        .get_template("default")
-        .and_then(|t| t.render(&array_msg))
-        .unwrap_or_default();
-    let out_string = env
-        .get_template("default")
-        .and_then(|t| t.render(&string_msg))
-        .unwrap_or_default();
+    let out_array = render_default_probe(
+        env,
+        json!([{"role": "user", "content": [{"type": "text", "text": "template_test"}]}]),
+    );
+    let out_string =
+        render_default_probe(env, json!([{"role": "user", "content": "template_test"}]));
 
     // If array works but string doesn't, template requires arrays
     out_array.contains("template_test") && !out_string.contains("template_test")
@@ -66,7 +66,55 @@ fn detect_image_placeholder_template(env: &Environment) -> Option<&'static str> 
     if src.contains("USER:") && src.contains("ASSISTANT:") {
         return Some("<image>");
     }
+    // Pure pass-through templates (e.g. NVIDIA-Nemotron-Parse's
+    // `{% for message in messages %}{{ message['content'] }}{% endfor %}`)
+    // emit `message.content` verbatim with no role markers or special tokens.
+    // These are typically encoder-decoder document models where the image is
+    // consumed by the vision encoder out-of-band and contributes NO token to
+    // the decoder prompt (the prompt is just the control tokens, e.g.
+    // `</s><s><predict_bbox>...`). A mixed text+image content array would
+    // otherwise be JSON-serialized into the prompt by `{{ message.content }}`,
+    // producing garbage. The empty placeholder makes the flatten path drop the
+    // image part from the text while preserving the text parts — exactly what
+    // these models expect.
+    if detect_passthrough_template(env) {
+        return Some("");
+    }
     None
+}
+
+/// Detects a pure pass-through chat template: one that emits `message.content`
+/// verbatim with no role markers, BOS/EOS, or other decoration, AND does not
+/// render content arrays natively. Callers use this to pick an empty image
+/// placeholder (drop images from the rendered text; the vision encoder consumes
+/// them out-of-band — see Nemotron-Parse).
+///
+/// Two probes against the `default` template (`add_generation_prompt=false`,
+/// mirroring `detect_content_array_usage`), both with a control-char sentinel
+/// that cannot collide with literal template text:
+///  1. string content must round-trip verbatim (the pass-through property), and
+///  2. a mixed text+image array must NOT be rendered natively. A pure
+///     pass-through stringifies `{{ content }}` on the array (retaining the
+///     serialized dict structure); a template with a native array branch emits
+///     the text value plus its own image marker. The latter handles images
+///     itself, so it must keep the array (return `false` here) rather than get
+///     the empty placeholder that would drop the image before its branch runs.
+fn detect_passthrough_template(env: &Environment) -> bool {
+    const PROBE: &str = "\u{1}dynamo_passthrough_probe\u{1}";
+    // (1) String content must pass through verbatim. `.trim()` tolerates a
+    // trailing newline some pass-through templates emit.
+    let out_string = render_default_probe(env, json!([{"role": "user", "content": PROBE}]));
+    if out_string.trim() != PROBE {
+        return false;
+    }
+    // (2) A mixed text+image array must not be rendered natively: a pure
+    // pass-through stringifies it (output keeps the `[ ... "type" ...` structure),
+    // whereas a native array branch emits the text value + its own image marker.
+    let out_mixed = render_default_probe(
+        env,
+        json!([{"role": "user", "content": [{"type": "text", "text": PROBE}, {"type": "image"}]}]),
+    );
+    out_mixed.contains('[') && out_mixed.contains("type")
 }
 
 /// Remove known non-standard Jinja2 tags from chat templates
@@ -386,6 +434,14 @@ impl HfTokenizerConfigJsonFormatter {
 mod tests {
     use super::*;
 
+    /// Builds the same `default`-template env the production renderer uses
+    /// (`JinjaEnvironment::default()`), with `src` registered as `default`.
+    fn env_with_default(src: &str) -> Environment<'static> {
+        let mut env = JinjaEnvironment::default().env();
+        env.add_template_owned("default", src.to_string()).unwrap();
+        env
+    }
+
     #[test]
     fn test_remove_known_non_jinja2_tags() {
         let template =
@@ -406,6 +462,68 @@ mod tests {
         let template = "Start {% generation %}Part 1{% endgeneration %} middle {% generation %}Part 2{% endgeneration %}";
         let result = remove_known_non_jinja2_tags(template);
         assert_eq!(result, "Start Part 1 middle Part 2");
+    }
+
+    /// NVIDIA-Nemotron-Parse ships a pure pass-through chat template
+    /// (`{% for message in messages %}{{ message['content'] }}{% endfor %}`).
+    /// It must be detected as: (a) not requiring content arrays, and
+    /// (b) using an empty image placeholder, so a mixed text+image request
+    /// flattens to the text-only control-token prompt instead of being
+    /// JSON-serialized into the prompt.
+    #[test]
+    fn test_detect_nemotron_parse_passthrough_template() {
+        let env =
+            env_with_default("{% for message in messages %}{{ message['content'] }}{% endfor %}");
+
+        assert!(
+            detect_passthrough_template(&env),
+            "pure pass-through template should be detected"
+        );
+        assert!(
+            !detect_content_array_usage(&env),
+            "pass-through template renders string content fine, so does not require arrays"
+        );
+        assert_eq!(
+            detect_image_placeholder_template(&env),
+            Some(""),
+            "pass-through template should flatten images to an empty placeholder"
+        );
+    }
+
+    /// A decorated template (role markers / special tokens added around
+    /// content) is NOT a pass-through and must not get the empty placeholder.
+    #[test]
+    fn test_decorated_template_is_not_passthrough() {
+        let env = env_with_default(
+            "{% for message in messages %}<|{{ message['role'] }}|>{{ message['content'] }}<|end|>{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}",
+        );
+
+        assert!(
+            !detect_passthrough_template(&env),
+            "template that wraps content in role markers is not pass-through"
+        );
+    }
+
+    /// A template that passes *string* content through verbatim but also has a
+    /// native *array* branch emitting an image marker must NOT be treated as
+    /// pass-through: its array branch renders images itself, so flattening to an
+    /// empty placeholder would drop the image before that branch runs. The
+    /// mixed-array probe distinguishes it from a pure pass-through.
+    #[test]
+    fn test_string_passthrough_with_native_array_branch_is_not_passthrough() {
+        let env = env_with_default(
+            "{% for message in messages %}{% if message['content'] is string %}{{ message['content'] }}{% else %}{% for part in message['content'] %}{% if part['type'] == 'image' %}<image>{% else %}{{ part['text'] }}{% endif %}{% endfor %}{% endif %}{% endfor %}",
+        );
+
+        assert!(
+            !detect_passthrough_template(&env),
+            "template with a native content-array branch is not pass-through"
+        );
+        assert_eq!(
+            detect_image_placeholder_template(&env),
+            None,
+            "template that natively renders image markers must keep the content array"
+        );
     }
 
     #[test]

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -167,6 +167,11 @@ fn may_be_fix_msg_content(
                             // Mixed text+image array for a string-content
                             // template — flatten with model-family image
                             // placeholders inlined where the image parts were.
+                            // An empty `placeholder_tpl` ("") drops the image
+                            // parts entirely while keeping the text — used by
+                            // pure pass-through / encoder-decoder templates
+                            // (Nemotron-Parse) whose vision encoder consumes the
+                            // image out-of-band, so no text token represents it.
                             // The `is_empty` guard preserves a literal `[]`
                             // content (matches pre-PR behavior); flattening
                             // an empty array to `""` would silently change
@@ -202,7 +207,10 @@ fn may_be_fix_msg_content(
 ///
 /// Used in `may_be_fix_msg_content` when `preserve_arrays=false` and the
 /// template knows a placeholder convention — currently Phi-3-vision
-/// (`<|image_{n}|>`) and LLaVA-1.5 (`<image>`).
+/// (`<|image_{n}|>`), LLaVA-1.5 (`<image>`), and pure pass-through /
+/// encoder-decoder templates (`""`, image emits nothing — Nemotron-Parse).
+/// With an empty `placeholder_tpl` the non-text parts contribute no characters,
+/// so the result is the concatenated text parts only.
 ///
 /// **Caveat — non-text index slot:** `img_idx` increments for every non-text
 /// part, not just images. The current supported families (Phi-3, LLaVA-1.5)
@@ -1160,6 +1168,81 @@ mod tests {
 
         let content = messages[0]["content"].as_str().expect("content flattened");
         assert_eq!(content, "Describe: <image>");
+    }
+
+    /// Nemotron-Parse pass-through path: a mixed text+image array with an
+    /// empty placeholder (`""`) flattens to the text parts only — the image
+    /// contributes nothing because the vision encoder consumes it out-of-band.
+    /// Without this, `{{ message.content }}` would JSON-serialize the array
+    /// into the prompt (the gibberish failure mode).
+    #[test]
+    fn test_may_be_fix_msg_content_flattens_empty_placeholder() {
+        let json_str = r#"{
+            "model": "nvidia/NVIDIA-Nemotron-Parse-v1.2",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                    ]
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, Some(""))).unwrap();
+
+        let content = messages[0]["content"].as_str().expect("content flattened");
+        assert_eq!(
+            content,
+            "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
+        );
+    }
+
+    /// End-to-end render through the Nemotron-Parse pass-through chat template:
+    /// a text+image chat request must produce exactly the control-token prompt,
+    /// with the image dropped from the rendered text. The renderer is agnostic
+    /// to the control tokens themselves (they are just the text part, passed
+    /// through verbatim), so both `predict_no_text_in_pic` and
+    /// `predict_text_in_pic` prompts round-trip identically.
+    #[test]
+    fn test_render_nemotron_parse_passthrough() {
+        use super::super::tokcfg::ChatTemplate;
+        use super::{ContextMixins, HfTokenizerConfigJsonFormatter};
+
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+        }))
+        .unwrap();
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        for prompt in [
+            "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>",
+            "</s><s><predict_bbox><predict_classes><output_markdown><predict_text_in_pic>",
+        ] {
+            let request: NvCreateChatCompletionRequest =
+                serde_json::from_value(serde_json::json!({
+                    "model": "nvidia/NVIDIA-Nemotron-Parse-v1.2",
+                    "messages": [{
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": prompt},
+                            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                        ]
+                    }]
+                }))
+                .unwrap();
+
+            let rendered = formatter.render(&request).unwrap();
+            assert_eq!(
+                rendered, prompt,
+                "rendered prompt must be the control tokens only, with no JSON-serialized image array"
+            );
+        }
     }
 
     /// Tests that content arrays containing only non-text types remain as arrays,

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -18,6 +18,20 @@ pub fn may_be_fix_tool_schema(tools: serde_json::Value) -> Option<Value> {
     if let Some(arr) = tools.as_array() {
         for tool in arr {
             let mut tool = tool.clone();
+            if let Some(function) = tool.get_mut("function") {
+                // Backfill a missing/null `description`. It's optional in the
+                // OpenAI tool schema, but some chat templates (e.g. gpt-oss
+                // harmony) concatenate it unconditionally and fail on an
+                // `undefined`/null value.
+                if let Some(obj) = function.as_object_mut()
+                    && !matches!(obj.get("description"), Some(serde_json::Value::String(_)))
+                {
+                    obj.insert(
+                        "description".to_string(),
+                        serde_json::Value::String(String::new()),
+                    );
+                }
+            }
             if let Some(function) = tool.get_mut("function")
                 && let Some(parameters) = function.get_mut("parameters")
             {
@@ -886,6 +900,96 @@ mod tests {
             serde_json::Value::Object(Default::default())
         );
         assert_eq!(tools[0]["function"]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_missing_description() {
+        // `description` is optional in the OpenAI tool schema, but some chat
+        // templates (e.g. gpt-oss harmony) concatenate it unconditionally and
+        // fail on an `undefined`/null value. It must be backfilled to "".
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "noop",
+                        "parameters": {
+                            "type": "object",
+                            "properties": { "x": { "type": "string" } },
+                            "required": ["x"],
+                            "additionalProperties": false
+                        },
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert_eq!(
+            tools[0]["function"]["description"],
+            serde_json::Value::String(String::new())
+        );
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_null_description() {
+        // An explicit null `description` must also be normalized to "".
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "noop",
+                        "description": null,
+                        "parameters": {"type": "object", "properties": {}},
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert_eq!(
+            tools[0]["function"]["description"],
+            serde_json::Value::String(String::new())
+        );
+    }
+
+    #[test]
+    fn test_may_be_fix_tool_schema_preserves_description() {
+        // A present `description` must be left untouched.
+        let json_str = r#"{
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {"type": "object", "properties": {}},
+                        "strict": null
+                    }
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let tools = serde_json::to_value(request.tools()).unwrap();
+
+        assert_eq!(
+            tools[0]["function"]["description"],
+            "Get the current weather in a given location"
+        );
     }
 
     /// Tests that content arrays (containing only text parts) are correctly concatenated.

--- a/scripts/sync-from-dynamo.sh
+++ b/scripts/sync-from-dynamo.sh
@@ -133,11 +133,6 @@ for fam in toolcalling reasoning; do
   [ -d "$pfx_src" ] || continue
   echo "--- parity fixtures ($fam) ---"
   fixture_excludes=()
-  if [ "$fam" = "toolcalling" ]; then
-    # frontend-crates carries Harmony EOF recovery for batch case 5 ahead of
-    # the Dynamo mirror. Remove this once Dynamo's fixture has the same output.
-    fixture_excludes+=(--exclude "harmony/TOOLCALLING.batch.5.yaml")
-  fi
   if [ "$APPLY" = "1" ]; then
     mkdir -p "$pfx_dst"
     rsync -a --delete --checksum "${fixture_excludes[@]}" "$pfx_src/" "$pfx_dst/"


### PR DESCRIPTION
One-way sync from `ai-dynamo/dynamo` main @ `8e7c8c6`, plus aligning the v2 Harmony **streaming** parser's recovery with upstream batch behavior and documenting the contract in the matrix.

**Sync:** `renderer/src` (incl. a tool-schema `description` backfill for gpt-oss harmony templates, re-synced to current main), the v1 parser mirror `parsers/src/tool_calling/*`, parity modules + case docs under `conformance/utils/`, and `deepseek_v3_2` / `deepseek_v4` / `harmony` batch fixtures.

**Streaming recovery — `TOOLCALLING.5` (missing end-token recovery):** dynamo #10366 moved Harmony analysis-channel tool-call recovery to the reasoning parser, so the batch parser now drops a commentary call missing `<|call|>` at EOF. The v2 stream parser hadn't followed — `finish_tool_call_stream` now uses `allow_eof_recovery=false` to match:
- **`TOOLCALLING.5.a`** (missing closing tag): before → recovered `get_weather(NYC)`; after → no call.
- **`TOOLCALLING.5.d`** (multi-call, trailing call missing end marker): before → `[Boston, New York]`; after → `[Boston]`.

Regenerated the affected stream + batch-on-stream fixtures and dropped the stale Harmony entries from the divergence allowlist (`deepseek_v4:5.g` remains).

**Documented the contract:** the matrix showed 5.a/5.d dropping calls with no explanation of why (the popup only explains peer divergences). Added a case-level `dynamo_note:` to the fc-local v2 fixtures, rendered as a "Dynamo recovery contract" popup section (linkified #10366) in both v2 tabs: *a Harmony tool call must carry `<|call|>` to be recovered; `<|call|>` is also the gpt-oss EOS/commit token, so its absence means the call was never committed.* v2 only — the synced v1 fixture is untouched.

Note: this is a `chore:` sync (no auto-release). `renderer/src` + `parsers/src` changed — retitle to `sync(...)`/`fix(...)` if you want those crates republished.

/coderabbit profile chill
