### PR TITLE
chore: trivial parser sync from dynamo @ 9322f28

### DIFF
--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
@@ -38,6 +38,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -55,7 +56,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both: '
       vllm:
         calls:
         - name: get_weather
@@ -68,6 +69,7 @@ cases:
       sglang:
         calls: []
         normal_text: 'Both:'
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -90,6 +92,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.b:
     description: Two back-to-back fence pairs — not applicable to this family
     reason: |-

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
@@ -75,6 +75,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.4.e:
     description: Malformed-prefix recovery — n/a for this family's syntax
     reason: |-

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
@@ -48,12 +48,12 @@ cases:
     - *id002
     expected:
       dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS] in normal_text on missing/orphan end marker (impl-defined recovery)"
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"loc'
+        reason: vLLM leaves the truncated post-marker JSON body in content; Dynamo suppresses the unterminated [TOOL_CALLS] call and emits empty content.
       sglang:
         calls: []
         normal_text: ''
@@ -91,14 +91,13 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments":
           {"location": "New York'
+        reason: vLLM leaves the raw truncated body in content; Dynamo recovers the complete leading call (Boston) and drops the truncated trailing call without fabricating it.
       sglang:
         calls: []
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: SGLang emits no call and keeps the narration prefix; Dynamo recovers the complete leading call (Boston) and drops the truncated trailing call.

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.6.yaml
@@ -24,6 +24,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -40,6 +41,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.6.c:
     description: No arguments key
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514
@@ -55,4 +57,5 @@ cases:
         - name: get_time
           arguments: {}
         normal_text: ''
+        reason: vLLM's mistral_tool_parser fabricates an empty arguments object {} when the 'arguments' key is absent; Dynamo and SGLang drop the call because the required key is missing
       sglang: *id004

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.7.yaml
@@ -33,6 +33,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -55,6 +56,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -77,6 +79,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -106,6 +109,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.e:
     description: Large / deep JSON-edge argument payload
     ref: dynamo
@@ -164,6 +168,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.f:
     description: Numeric precision edge preserves integer-like number literal
     ref: inferhub live capture on nvidia/mistralai/mixtral-8x22b-instruct-v01

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
@@ -22,7 +22,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather
@@ -32,6 +32,7 @@ cases:
       sglang:
         calls: []
         normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -50,6 +51,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
@@ -63,7 +65,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather
@@ -73,6 +75,7 @@ cases:
       sglang:
         calls: []
         normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -81,10 +84,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
+      dynamo:
         calls: []
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         error: 'ValueError: Only one BOT token should have been outputted'
         reason: vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes
-      sglang: *id003
+      sglang:
+        calls: []
+        normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits; it also trims the boundary whitespace Dynamo now preserves.

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.yaml
@@ -156,6 +156,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.30.c:
     description: Mistral wrapper marker `[TOOL_CALLS]...[/TOOL_CALLS]` text inside one argument string value
     ref: dynamo
@@ -183,6 +184,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.31.a:
     description: Multi-call JSON array with call separator `,` inside the first argument string
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
@@ -264,6 +266,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.13.a:
     description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
@@ -44,13 +44,20 @@ cases:
       finish_reason: tool_calls
     tools: *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the call.
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: '[/TOOL_CALLS]'
-      sglang:
-        calls: []
-        normal_text: ''
-      vllm: *id002
+        reason: vLLM's streaming Mistral parser leaks the trailing [/TOOL_CALLS] close marker into content; Dynamo now keeps the jail open until the marker arrives and consumes it, so normal_text is empty.

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.2.yaml
@@ -49,10 +49,12 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: '[/TOOL_CALLS]'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the calls.
       vllm:
         calls: []
         normal_text: '[TOOL_CAL'
+        reason: vLLM leaks the partial start marker prefix into content when [TOOL_CALLS] is split across chunks and emits no call; Dynamo buffers the marker fragments and recovers the calls with empty normal_text.

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.3.yaml
@@ -36,10 +36,12 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: '[/TOOL_CALLS]'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the call.
       vllm:
         calls: []
         normal_text: '[TOOL_CALL'
+        reason: vLLM leaks the partial start marker prefix into content when [TOOL_CALLS] is split across chunks and emits no call; Dynamo buffers the marker fragments and recovers the call with empty normal_text.

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
@@ -48,7 +48,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
@@ -57,6 +57,7 @@ cases:
         - name: get_weather
           arguments: '{"loc'
         normal_text: ''
+        reason: vLLM emits a malformed partial call with the incomplete argument fragment as arguments; Dynamo suppresses the unterminated call and emits empty content.
   TOOLCALLING.stream.4.c:
     description: Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by
       repeated close markers
@@ -80,3 +81,4 @@ cases:
       sglang:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'
+        reason: SGLang strips the trailing ] from each orphan [/TOOL_CALLS] close marker (leaving bracket fragments); Dynamo and vLLM keep the bare body and markers verbatim when the [TOOL_CALLS] opener is absent.

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
@@ -7,17 +7,21 @@ cases:
   TOOLCALLING.batch.2.a:
     description: Parallel calls (back-to-back tool_call wrappers)
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-      "arguments": {"timezone": "EST"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_time", "arguments": {"timezone": "EST"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +29,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -36,20 +40,24 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
+      sglang: *id001
+  TOOLCALLING.batch.2.b:
+    description: Two back-to-back fence pairs - not applicable to this family
+    reason: Multi-call is covered by 2.a/2.c/2.d; no back-to-back fence pattern for this family.
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
     ref: dynamo
-    model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-      "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+    model_text: |-
+      Both: <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_time", "arguments": {"timezone": "EST"}}
+      </tool_call> Done.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -60,20 +68,21 @@ cases:
         normal_text: 'Both:'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+      sglang: *id004
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-      "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -84,11 +93,4 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-  TOOLCALLING.batch.2.b:
-    description: Two back-to-back fence pairs — not applicable to this family
-    reason: |-
-      qwen25's multi-call form is exercised by TOOLCALLING.batch.2.a / 2.c / 2.d; no back-to-back fence/wrapper pattern applies to this family's parser syntax.
+      sglang: *id005

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
@@ -18,7 +18,6 @@ cases:
             type: string
     expected:
       dynamo: &id001
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
         calls: []
         normal_text: <tool_call>not even json</tool_call>
       vllm:
@@ -31,17 +30,12 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
+      dynamo: &id003
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -49,13 +43,12 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      sglang: *id004
   TOOLCALLING.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
@@ -63,22 +56,19 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
       sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.4.e:
-    description: Malformed-prefix recovery — n/a for this family's syntax
-    reason: |-
-      TOOLCALLING.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in TOOLCALLING.batch.4.a through 4.d.
+    description: Malformed-prefix recovery - n/a for this family's syntax
+    reason: 'n/a: llama3_json-specific raw-JSON-prefix resync; this family uses a framed grammar (see 4.a-4.d).'
   TOOLCALLING.batch.4.f:
     description: Tool-name XML tag case - n/a for this family's syntax
-    reason: |-
-      TOOLCALLING.batch.4.f is specific to Qwen3-Coder XML syntax, where the model may emit a tool-name tag such as <terminal> inside <tool_call> instead of the required <function=Terminal> opener. This family does not use Qwen3-Coder's <function=...> opener.
+    reason: 'n/a: Qwen3-Coder <function=...> XML syntax, not this family''s format.'

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
@@ -17,15 +17,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
       sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.5.b:
@@ -36,7 +35,6 @@ cases:
     - *id001
     expected:
       dynamo: &id002
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
       vllm:
@@ -49,22 +47,28 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
-    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
-      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York"}}'
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>
+      {"name": "get_weather", "arguments": {"location": "Boston"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "New York"}}
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -72,20 +76,19 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
-          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
-          "New York"}}'
+      sglang: *id003
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
-    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
-      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York'
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>
+      {"name": "get_weather", "arguments": {"location": "Boston"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "New York
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -93,8 +96,4 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
-          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
-          "New York'
+      sglang: *id004

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
@@ -7,52 +7,53 @@ cases:
   TOOLCALLING.batch.6.a:
     description: 'Canonical "arguments": {}'
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_time", "arguments": {}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_time", "arguments": { }}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.6.c:
     description: No arguments key
     ref: dynamo
     model_text: '<tool_call>{"name": "get_time"}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on minimal/no-body case"
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id002
+      sglang: *id004

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.7.yaml
@@ -7,8 +7,10 @@ cases:
   TOOLCALLING.batch.7.a:
     description: Standard scalar types
     ref: dynamo
-    model_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
-      true}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}
+      </tool_call>
     tools:
     - name: book_flight
       parameters:
@@ -21,7 +23,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -31,14 +33,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
-          true}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}
+      </tool_call>
     tools:
     - name: get_weather
       parameters:
@@ -47,7 +49,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
@@ -55,13 +57,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+      sglang: *id002
   TOOLCALLING.batch.7.c:
-    description: Schema mismatch — string value where schema declares integer
+    description: Schema mismatch - string value where schema declares integer
     ref: dynamo
-    model_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "set_temperature", "arguments": {"celsius": "20"}}
+      </tool_call>
     tools:
     - name: set_temperature
       parameters:
@@ -70,7 +73,7 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
@@ -78,13 +81,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.7.d:
     description: Nested object + array
     ref: dynamo
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}
+      </tool_call>
     tools:
     - name: process_data
       parameters:
@@ -95,7 +99,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -108,14 +112,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+      sglang: *id004
   TOOLCALLING.batch.7.e:
     description: Large / deep JSON-edge argument payload
     ref: dynamo
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
-      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}
+      </tool_call>
     tools:
     - name: process_data
       parameters:
@@ -124,7 +128,7 @@ cases:
           payload:
             type: object
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: process_data
           arguments:
@@ -147,14 +151,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
-          2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+      sglang: *id005
   TOOLCALLING.batch.7.f:
     description: Numeric precision edge preserves integer-like number literal
     ref: https://qwen.readthedocs.io/en/v2.5/framework/function_call.html
-    model_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "set_limit", "arguments": {"count": 9007199254740993}}
+      </tool_call>
     tools:
     - name: set_limit
       parameters:
@@ -163,7 +167,7 @@ cases:
           count:
             type: number
     expected:
-      dynamo:
+      dynamo: &id006
         calls:
         - name: set_limit
           arguments:
@@ -171,7 +175,4 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        reason: SGLang's Qwen2.5 detector requires newline-delimited '<tool_call>\n...\n</tool_call>' blocks; this fixture uses Dynamo's compact inline '<tool_call>{...}</tool_call>' form, so SGLang treats it as normal text.
-        calls: []
-        normal_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}</tool_call>'
+      sglang: *id006

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
@@ -7,9 +7,12 @@ cases:
   TOOLCALLING.batch.8.a:
     description: Narration before tool call only
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +20,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,18 +28,18 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you need
-      more.'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -44,19 +47,18 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you
-          need more.'
+      sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-      Let me know if you need more.'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -64,19 +66,20 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-          Let me know if you need more.'
+      sglang: *id004
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-      Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Then check LA weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -87,7 +90,4 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-          Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
+      sglang: *id005

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.yaml
@@ -7,9 +7,12 @@ mode: batch
 cases:
   TOOLCALLING.batch.1:
     description: Single tool call (happy path)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +20,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,21 +28,19 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id002
+      sglang: *id003
   TOOLCALLING.batch.9.a:
     description: Empty model text
     model_text: ''
@@ -81,12 +82,16 @@ cases:
         normal_text: '   '
   TOOLCALLING.batch.10:
     description: Duplicate calls (same name twice)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-      "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -97,22 +102,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-  TOOLCALLING.batch.30:
-    description: Separator-character case not applicable
-    reason: |-
-      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
-  TOOLCALLING.batch.31:
-    description: Multi-call separator-character case not applicable
-    reason: |-
-      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
+      sglang: *id004
   TOOLCALLING.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
-    model_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "unknown_tool", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
     - name: get_weather
       parameters:
@@ -121,19 +118,24 @@ cases:
           location:
             type: string
     expected:
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
       dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
       sglang:
+        reason: SGLang drops tool calls whose name is absent from the supplied tools; Dynamo forwards the call regardless.
         calls: []
-        normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
-        reason: SGLang treats the unknown qwen25 tool call as ordinary content rather than forwarding it by default.
+        normal_text: ''
   TOOLCALLING.batch.13.c:
     description: Mixed known and unknown calls not applicable
-    reason: |-
-      This case is not applicable to qwen25 because vLLM has no peer parser and SGLang treats this family as ordinary content.
+    reason: 'n/a: no vLLM peer; SGLang treats unknown calls as content.'
+  TOOLCALLING.batch.30:
+    description: Separator-character case not applicable
+    reason: 'n/a: this family wraps each call in <tool_call>, not a delimiter-separated body.'
+  TOOLCALLING.batch.31:
+    description: Multi-call separator-character case not applicable
+    reason: 'n/a: this family wraps each call in <tool_call>, not a delimiter-separated body.'

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.1.yaml
@@ -9,10 +9,13 @@ cases:
     description: Complete tool-call payload delivered in one content chunk
     ref: derived from TOOLCALLING.batch.1
     chunks:
-    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: |-
+        <tool_call>
+        {"name": "get_weather", "arguments": {"location": "NYC"}}
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
-    tools: &id001
+    tools: &id002
     - name: get_weather
       parameters:
         type: object
@@ -20,37 +23,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id001
   TOOLCALLING.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from TOOLCALLING.batch.1
     chunks:
-    - delta_text: <tool_call>
+    - delta_text: |
+        <tool_call>
     - delta_text: '{"name": "get_weather", '
     - delta_text: '"arguments": {"location": "NYC"}}'
-    - delta_text: </tool_call>
+    - delta_text: |2-
+
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
-    tools: *id001
+    tools: *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id003

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.2.yaml
@@ -9,23 +9,21 @@ cases:
     description: Multiple tool calls split across multiple content chunks
     ref: derived from TOOLCALLING.batch.2.a
     chunks:
-    - delta_text: <tool_cal
-    - delta_text: l>{"nam
+    - delta_text: |-
+        <tool_call>
+        {"nam
     - delta_text: 'e": "get_weat'
-    - delta_text: her",
-    - delta_text: ' "arguments": {"l'
-    - delta_text: oca
-    - delta_text: 'tion": "N'
-    - delta_text: YC"}}</
-    - delta_text: tool_call><to
-    - delta_text: ol_ca
-    - delta_text: 'll>{"name": "get_'
-    - delta_text: tim
-    - delta_text: e", "argu
-    - delta_text: 'ments":'
-    - delta_text: ' {"timezone":'
-    - delta_text: ' "EST'
-    - delta_text: '"}}</tool_call>'
+    - delta_text: 'her", "arguments": {"location": "NYC"}}'
+    - delta_text: |2-
+
+        </tool_call><to
+    - delta_text: |-
+        ol_call>
+        {"name": "get_time"
+    - delta_text: ', "arguments": {"timezone": "EST"}}'
+    - delta_text: |2-
+
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
     tools:
@@ -42,15 +40,15 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo:
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'ol_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name": "get_time",
-          "arguments": {"timezone": "EST"}}'
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.3.yaml
@@ -11,14 +11,17 @@ cases:
     chunks:
     - delta_text: <t
     - delta_text: ool
-    - delta_text: _call
-    - delta_text: '>{"name": "'
+    - delta_text: |-
+        _call>
+        {"name": "
     - delta_text: get_weather", "argu
     - delta_text: me
     - delta_text: nts
     - delta_text: '": {"'
     - delta_text: 'location": '
-    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: |-
+        "NYC"}}
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
     tools:
@@ -29,14 +32,12 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id001

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
@@ -20,17 +20,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c
@@ -47,12 +46,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-      sglang: *id001
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
   TOOLCALLING.stream.4.c:
     description: Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by
       repeated close markers
@@ -75,5 +78,6 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
+        reason: 'Orphan </tool_call> markers with no opener: SGLang strips them, Dynamo keeps them (impl-defined recovery).'
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'

--- a/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -9,6 +9,7 @@ use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding
 use regex::{Captures, Regex};
 use serde_json::Value;
 use std::sync::OnceLock;
+use uuid::Uuid;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -290,9 +291,8 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
             continue;
         }
         let args_json = serialize_harmony_arguments(raw_args);
-        let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
-            id: format!("call-{call_idx}"),
+            id: format!("call-{}", Uuid::new_v4()),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -381,7 +381,6 @@ pub async fn parse_tool_calls_harmony_complete(
     };
 
     let mut res = Vec::with_capacity(messages.len());
-    let mut call_idx = 0; // Index of the tool call
     let mut normal_text = String::new();
     let has_tool_call_stop = text.contains("<|call|>");
     let has_recipientless_commentary_call = contains_recipientless_commentary_call(text);
@@ -420,9 +419,8 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            call_idx += 1;
             res.push(ToolCallResponse {
-                id: format!("call-{}", call_idx),
+                id: format!("call-{}", Uuid::new_v4()),
                 tp: ToolCallType::Function,
                 function: CalledFunction {
                     name: fname.to_string(),
@@ -916,6 +914,39 @@ mod tests {
         assert_eq!(name1, "get_weather");
         assert_eq!(args0["city"], "NYC");
         assert_eq!(args1["city"], "LA");
+    }
+
+    /// Regression test: the harmony parser must produce ids that are unique
+    /// not just within a single invocation but also across multiple invocations.
+    /// `jail.rs` slices the raw stream at each `<|call|>` boundary and invokes
+    /// the parser once per section. With index-based ids ("call-1", "call-2", ...)
+    /// each per-section invocation would restart from "call-1", and the
+    /// downstream OpenAI Chat Completions response would carry duplicate ids,
+    /// which clients (and Dynamo's own E2E harness) reject as
+    /// `duplicate_tool_ids`. Using `Uuid::new_v4()` at construction guarantees
+    /// uniqueness independent of how many times the parser is invoked.
+    #[tokio::test]
+    async fn test_parse_tool_calls_harmony_unique_ids_across_invocations() {
+        // Two independent invocations, each on a single tool-call section —
+        // matches the jail's per-<|call|> emission pattern.
+        let chunk_a = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>"#;
+        let chunk_b = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NY"}<|call|>"#;
+
+        let (calls_a, _) = parse_tool_calls_harmony_complete(chunk_a, &Default::default(), None)
+            .await
+            .unwrap();
+        let (calls_b, _) = parse_tool_calls_harmony_complete(chunk_b, &Default::default(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(calls_a.len(), 1, "first chunk should produce 1 call");
+        assert_eq!(calls_b.len(), 1, "second chunk should produce 1 call");
+        assert_ne!(
+            calls_a[0].id, calls_b[0].id,
+            "Tool call ids must be unique across separate parser invocations \
+             (jail invokes the parser once per <|call|> boundary; identical ids \
+             would surface as duplicate_tool_ids in the OpenAI response)",
+        );
     }
 }
 

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -215,10 +215,54 @@ pub(crate) fn try_repair_truncated_json(s: &str) -> Option<String> {
     Some(repaired)
 }
 
+/// Recover the complete leading tool-call objects from an unterminated mistral
+/// JSON array body (e.g. `[{...complete...}, {...truncated`). Parses top-level
+/// `{...}` objects left-to-right with a streaming deserializer and stops at the
+/// first incomplete one, keeping every complete leading call and dropping the
+/// truncated tail. Unlike `try_repair_truncated_json`, it performs no
+/// brace-balancing fabrication, so a half-emitted trailing call is discarded
+/// rather than invented. Returns the verbatim byte spans of the complete
+/// objects (empty when none completed).
+fn recover_leading_complete_objects(json: &str) -> Vec<String> {
+    let trimmed = json.trim();
+    let body = trimmed.strip_prefix('[').unwrap_or(trimmed);
+    let mut out: Vec<String> = Vec::new();
+    let mut remaining = body.trim_start();
+    while !remaining.is_empty() {
+        let mut stream = serde_json::Deserializer::from_str(remaining).into_iter::<Box<RawValue>>();
+        match stream.next() {
+            Some(Ok(rv)) => {
+                let raw = rv.get();
+                if raw.is_empty() || !raw.trim_start().starts_with('{') {
+                    break;
+                }
+                out.push(raw.to_string());
+                remaining = remaining[raw.len()..].trim_start();
+                match remaining.strip_prefix(',') {
+                    Some(rest) => remaining = rest.trim_start(),
+                    None => break,
+                }
+            }
+            _ => break,
+        }
+    }
+    out
+}
+
 fn try_parse_normal_text(input: &str, start_token: &str) -> String {
     // If input contains start token, just take the part before it
     if let Some(idx) = input.find(start_token) {
-        return input[..idx].trim().to_string();
+        let prefix = &input[..idx];
+        // The mistral family ([TOOL_CALLS]) keeps the boundary space before the
+        // marker to match vLLM; every other JSON family trims it. Keyed on the
+        // family's distinctive start token rather than a config field so the
+        // exported `JsonParserConfig` gains no new public member (downstream
+        // struct-literal constructors stay source-compatible).
+        return if start_token == "[TOOL_CALLS]" {
+            prefix.to_string()
+        } else {
+            prefix.trim().to_string()
+        };
     }
 
     // No start token found, return empty string
@@ -436,6 +480,33 @@ pub fn try_tool_call_parse_basic_json(
     // through to truncation recovery.
     if let Some(calls) = parse_calls(json)? {
         return Ok((calls, Some(normal_text)));
+    }
+
+    // mistral optional-close form: an unterminated call (a `[TOOL_CALLS]`
+    // opener with no `[/TOOL_CALLS]` close) whose JSON array did not parse
+    // cleanly above. Recover only the complete leading objects, dropping the
+    // truncated tail with no brace-balancing fabrication; if nothing complete
+    // remains, suppress entirely so the raw `[TOOL_CALLS]...` markup never
+    // leaks into normal_text (consistent incomplete-call handling, matching
+    // hermes). Gated on `allow_eof_recovery` so it only runs at finalize /
+    // batch, never mid-stream, and scoped to mistral via its start token so
+    // other JSON families keep their existing recovery.
+    if config.allow_eof_recovery
+        && config
+            .tool_call_start_tokens
+            .iter()
+            .any(|t| t == "[TOOL_CALLS]")
+        && trimmed.contains("[TOOL_CALLS]")
+        && !trimmed.contains("[/TOOL_CALLS]")
+    {
+        let recovered = recover_leading_complete_objects(json);
+        if !recovered.is_empty()
+            && let Some(calls) = parse_calls(&format!("[{}]", recovered.join(",")))?
+            && !calls.is_empty()
+        {
+            return Ok((calls, Some(normal_text)));
+        }
+        return Ok((vec![], Some(normal_text)));
     }
 
     // Truncation recovery: balance unclosed strings/braces (common

--- a/parsers/src/tool_calling/json/mod.rs
+++ b/parsers/src/tool_calling/json/mod.rs
@@ -51,7 +51,7 @@ pub fn find_tool_call_end_position_json(
     config: &JsonParserConfig,
 ) -> usize {
     match parser {
-        "hermes" | "nemotron_deci" => {
+        "hermes" | "nemotron_deci" | "qwen25" => {
             let start_token = config.tool_call_start_tokens.first().map(|s| s.as_str());
             if let Some(end_token) = config.tool_call_end_tokens.first() {
                 let Some(first_end) = chunk.find(end_token.as_str()) else {
@@ -189,6 +189,33 @@ mod tests {
             pos_inc, first_end,
             "should stop at end of first complete call when second is incomplete"
         );
+    }
+
+    // qwen25 aliases the hermes config and must share its jail behavior: two
+    // parallel <tool_call> blocks must be captured as one region, otherwise the
+    // second call's opener leaks into normal_text when split across stream
+    // chunks (e.g. `ol_call>...`). Regression for the qwen25 streaming leak.
+    #[test] // TOOLCALLING.stream.2: qwen25 parallel-call end-position
+    fn test_find_tool_call_end_position_parallel_calls_qwen25() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<tool_call>".to_string()],
+            tool_call_end_tokens: vec!["</tool_call>".to_string()],
+            ..Default::default()
+        };
+
+        // Two parallel calls in the qwen2.5 newline-delimited form.
+        let two_calls = concat!(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"NYC\"}}\n</tool_call>\n",
+            "<tool_call>\n{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"EST\"}}\n</tool_call>",
+            "trailing"
+        );
+        let pos = find_tool_call_end_position_json(two_calls, "qwen25", &config);
+        assert!(
+            two_calls[..pos].ends_with("</tool_call>"),
+            "qwen25 should end at last </tool_call>, got: {:?}",
+            &two_calls[..pos]
+        );
+        assert_eq!(&two_calls[pos..], "trailing");
     }
 
     // Bare DeepSeek inner calls (no outer <｜tool▁calls▁begin｜> wrapper) arriving

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -58,7 +58,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
         map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
-        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes
+        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
         map
     })
 }
@@ -148,7 +148,10 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     let recovery_config = match &base.parser_config {
         ParserConfig::Json(c) => {
             let mut c = c.clone();
-            c.allow_eof_recovery = true;
+            // qwen25 opts out of EOF recovery so unterminated calls are dropped,
+            // not salvaged. Keyed by name (not a config field) to keep the
+            // exported JsonParserConfig stable for downstream callers.
+            c.allow_eof_recovery = parser_key != "qwen25";
             ParserConfig::Json(c)
         }
         ParserConfig::Xml(c) => {
@@ -170,7 +173,21 @@ pub async fn detect_and_parse_tool_call_with_recovery(
         parser_config: recovery_config,
         structural_tag_builder: None,
     };
-    try_tool_call_parse(message, &cfg, tools).await
+    let (calls, normal_text) = try_tool_call_parse(message, &cfg, tools).await?;
+
+    // An unterminated qwen25 call (open <tool_call>, no close, nothing parsed)
+    // drops its partial markup instead of leaking it. Deliberate non-parity
+    // with SGLang, which surfaces the raw text.
+    if parser_key == "qwen25"
+        && calls.is_empty()
+        && let Some(text) = normal_text.as_deref()
+        && text.contains("<tool_call>")
+        && !text.contains("</tool_call>")
+    {
+        return Ok((calls, Some(String::new())));
+    }
+
+    Ok((calls, normal_text))
 }
 
 /// Deprecated compatibility shim retained for the published `dynamo-parsers`
@@ -270,6 +287,64 @@ pub fn find_tool_call_end_position(chunk: &str, parser_str: Option<&str>) -> Opt
                 } else {
                     parser_key
                 };
+                // mistral's `[/TOOL_CALLS]` close marker is optional, so the
+                // streaming jail can't simply split at the JSON array `]`: if a
+                // `[/TOOL_CALLS]` arrives in a later chunk it would be stranded
+                // as leaked normal_text (TOOLCALLING.stream.1.b / .2 / .3). But
+                // it also can't just wait for the marker, because the bare
+                // `[TOOL_CALLS][...]` form is frequently followed by ordinary
+                // trailing prose that must still stream as content. Decide based
+                // on what trails the JSON body. Guarded to mistral so phi4
+                // (empty end token) and the marker-required families
+                // (hermes / nemotron_deci) keep their existing behavior.
+                // Only the framed form (an explicit `[TOOL_CALLS]` opener) can
+                // strand a later `[/TOOL_CALLS]`; the bare `[{...}]` form keeps
+                // the normal immediate-split behavior so trailing prose still
+                // streams as its own chunk.
+                let has_open_marker = json_config
+                    .tool_call_start_tokens
+                    .iter()
+                    .any(|t| !t.is_empty() && chunk.contains(t.as_str()));
+                if effective_parser == "mistral"
+                    && has_open_marker
+                    && let Some(marker) = json_config
+                        .tool_call_end_tokens
+                        .iter()
+                        .find(|t| !t.is_empty())
+                {
+                    // Full close marker already present: consume through it so
+                    // it is part of the jailed region, never leaked. Advance
+                    // past any consecutive close markers separated only by
+                    // whitespace (e.g. `[/TOOL_CALLS][/TOOL_CALLS]`) so a
+                    // repeated marker isn't stranded as trailing normal_text.
+                    // Mirrors the consecutive-block loop in the hermes branch of
+                    // `find_tool_call_end_position_json`.
+                    if let Some(pos) = chunk.find(marker.as_str()) {
+                        let mut cursor = pos + marker.len();
+                        loop {
+                            let rest = &chunk[cursor..];
+                            let trimmed = rest.trim_start();
+                            if !trimmed.starts_with(marker.as_str()) {
+                                break;
+                            }
+                            let trim_offset = rest.len() - trimmed.len();
+                            cursor += trim_offset + marker.len();
+                        }
+                        return Some(cursor);
+                    }
+                    let json_end =
+                        find_tool_call_end_position_json(chunk, effective_parser, json_config);
+                    let tail = chunk.get(json_end..).unwrap_or("").trim_start();
+                    // Tail empty, or a partial `[/TOOL_CALLS]` still arriving:
+                    // keep the jail open so the marker is consumed once complete
+                    // (or the call is recovered by `finalize()` if the stream
+                    // ends here). Real non-marker prose: split at the JSON body
+                    // end so the trailing content streams normally.
+                    if tail.is_empty() || marker.starts_with(tail) {
+                        return None;
+                    }
+                    return Some(json_end);
+                }
                 Some(find_tool_call_end_position_json(
                     chunk,
                     effective_parser,
@@ -924,7 +999,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // mistral preserves the boundary space before `[TOOL_CALLS]` (matches vLLM).
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -977,7 +1053,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // mistral preserves the boundary space before `[TOOL_CALLS]` (matches vLLM).
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());


### PR DESCRIPTION
Verbatim one-way mirror of `ai-dynamo/dynamo` `lib/parsers/src/` into this repo's `parsers/src/` via `scripts/manual-sync-parsers.sh --apply`, at dynamo `9322f28`.

Brings the drift since the last parser sync:
- `tool_calling/parsers.rs`, `tool_calling/json/base_json_parser.rs` — mistral repeated-close-marker fix + EOF recovery ([ai-dynamo/dynamo#10443](https://github.com/ai-dynamo/dynamo/pull/10443)), and `tool_call.id` renumbering ([ai-dynamo/dynamo#10608](https://github.com/ai-dynamo/dynamo/pull/10608))
- `tool_calling/harmony/harmony_parser.rs`, `tool_calling/json/mod.rs` — accumulated drift

Mirror only — no local authoring; real review happened upstream. `cargo test -p dynamo-parsers` 606 pass, clippy clean.
