### PR TITLE
feat(parsers-v2): Qwen3-Coder v2 streaming tool-call parser

### DIFF
--- a/conformance/tests/parity_toolcalling_stream.rs
+++ b/conformance/tests/parity_toolcalling_stream.rs
@@ -282,7 +282,10 @@ fn toolcalling_stream_parity() {
                 continue;
             }
         };
-        if !(fx.family == "harmony" || fx.family == "harmony_text" || fx.family == "deepseek_v4")
+        if !(fx.family == "harmony"
+            || fx.family == "harmony_text"
+            || fx.family == "deepseek_v4"
+            || fx.family == "qwen3_coder")
             || !matches!(fx.mode.as_deref(), Some("stream" | "streamv2"))
         {
             continue;

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -16,52 +26,44 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -16,87 +26,73 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> <tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' '
         vllm_rust: ' '
+        sglang_python: ' '
     - delta_text: ' <function=get_weather>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 1
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' <parameter=location> LA'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"location": "LA"'
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - arguments: '{"location":" LA "}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"location": "LA"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -16,45 +26,37 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=unknown_tool>
+    - delta_text: '<tool_call> <function=unknown_tool>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: unknown_tool
-        vllm_rust: []
+        - {index: 0, name: 'unknown_tool'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
-    - delta_text: NYC</parameter> </function> </tool_call>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
+        sglang_python: []
+    - delta_text: 'NYC</parameter> </function> </tool_call>'
+      expected:
+        dynamo_rust:
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: unknown_tool
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (different names)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (different names)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -22,93 +32,79 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> <tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' '
         vllm_rust: ' '
+        sglang_python: ' '
     - delta_text: ' <function=get_time>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 1
-          name: get_time
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' <parameter=timezone> EST'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"timezone": "EST"'
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_rust:
-        - arguments: '{"timezone":" EST "}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"timezone": "EST"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel calls with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel calls with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -122,126 +118,115 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
     - delta_text: 'Both queries:'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: 'Both queries:'
+        vllm_rust: 'Both queries:'
         vllm_python: 'Both queries:'
         sglang_python: 'Both queries:'
-        vllm_rust: 'Both queries:'
     - delta_text: ' <tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' '
+        vllm_rust: ' '
         vllm_python: ' '
         sglang_python: ' '
-        vllm_rust: ' '
     - delta_text: ' <function=get_weather> <parameter=location> NYC'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
     - delta_text: ' <tool_call> <function=get_time>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 1
-          name: get_time
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
       normal_text:
-        sglang_python: ' '
         vllm_rust: ' '
+        sglang_python: ' '
     - delta_text: ' <parameter=timezone> EST </parameter>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"timezone": "EST"'
-        vllm_rust: []
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"timezone": "EST"'}
     - delta_text: ' </function>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ' </tool_call> Results'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"timezone":" EST "}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
+        vllm_python:
+        - {index: 1, arguments: '{'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' Results'
         vllm_rust: ' Results'
+        sglang_python: ' Results'
     - delta_text: ' above.'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '"timezone": "EST"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '"timezone": "EST"'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' above.'
         vllm_rust: ' above.'
+        sglang_python: ' above.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice (id distinctness)
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice (id distinctness)'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -251,87 +236,73 @@ cases:
           location:
             type: string
     - *id001
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> <tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' '
         vllm_rust: ' '
+        sglang_python: ' '
     - delta_text: ' <function=get_weather>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 1
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' <parameter=location> LA'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"location": "LA"'
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - arguments: '{"location":" LA "}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"location": "LA"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -16,49 +26,55 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        dynamo_rust: 'Hello, how'
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' can'
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' I help you'
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' today?'
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with no <function> body
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with no <function> body'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,34 +27,37 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
       vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <tool_call> random
+    - delta_text: '<tool_call> random'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' text'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' without function tag'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </parameter> closing tag
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </parameter> closing tag'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -53,44 +66,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
       vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' NYC </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.f:
-    description: Tool name emitted as an XML tag instead of <function=...>
-    ref: derived from TOOLCALLING.batch.4.f
+    description: 'Tool name emitted as an XML tag instead of <function=...>'
+    ref: 'derived from TOOLCALLING.batch.4.f'
     tools:
     - name: Terminal
       parameters:
@@ -99,28 +107,28 @@ cases:
           command:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
       vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <tool_call> <terminal>
+    - delta_text: '<tool_call> <terminal>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' echo'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' hello </function> </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,45 +27,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
+      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </tool_call> without matching <tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </tool_call> without matching <tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -63,55 +67,51 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <function=get_weather> <parameter=location>
+    - delta_text: '<function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <function=get_weather> <parameter=location>
+        vllm_rust: '<function=get_weather> <parameter=location>'
+        vllm_python: '<function=get_weather> <parameter=location>'
         sglang_python: ' '
-        vllm_rust: <function=get_weather> <parameter=location>
     - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' NYC'
         vllm_rust: ' NYC'
+        vllm_python: ' NYC'
     - delta_text: ' </parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
-        vllm_rust: []
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
       normal_text:
-        vllm_python: ' </parameter> </function> </tool_call>'
-        sglang_python: '
-
-          '
         vllm_rust: ' </parameter> </function> </tool_call>'
+        vllm_python: ' </parameter> </function> </tool_call>'
+        sglang_python: "\n"
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-parameter value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-parameter value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -120,39 +120,35 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
+      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' NY'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -161,150 +157,157 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
+      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        dynamo_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
     - delta_text: ' time! <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' time! '
         vllm_python: ' time! '
         sglang_python: ' time! '
     - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location> Boston'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
         sglang_python: []
     - delta_text: ' </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          arguments: '"location": "Boston"'
+        - {index: 0, arguments: '"location": "Boston"'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "Boston"'
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "Boston"'}
     - delta_text: ' </function> </tool_call> <tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
       normal_text:
         sglang_python: ' '
     - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' New'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' York </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 1
-          arguments: '{'
+        - {index: 1, arguments: '{'}
         sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"location": "New York"'
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"location": "New York"'}
     - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"New York"}'}
         vllm_python:
-        - index: 1
-          arguments: '"location": "New York"'
+        - {index: 1, arguments: '"location": "New York"'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -313,138 +316,147 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
+      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        dynamo_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
     - delta_text: ' time! <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' time! '
         vllm_python: ' time! '
         sglang_python: ' time! '
     - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location> Boston'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
         sglang_python: []
     - delta_text: ' </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 0
-          arguments: '"location": "Boston"'
+        - {index: 0, arguments: '"location": "Boston"'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "Boston"'
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "Boston"'}
     - delta_text: ' </function> </tool_call> <tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
       normal_text:
         sglang_python: ' '
     - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' New'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' York'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - index: 1
-          arguments: '{'
+        - {index: 1, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid function before a complete wrapped call
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid function before a complete wrapped call'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -452,99 +464,88 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <function=get_weather> <parameter=location>
+    - delta_text: '<function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <function=get_weather> <parameter=location>
+        vllm_rust: '<function=get_weather> <parameter=location>'
+        vllm_python: '<function=get_weather> <parameter=location>'
         sglang_python: ' '
-        vllm_rust: <function=get_weather> <parameter=location>
     - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' NYC'
         vllm_rust: ' NYC'
+        vllm_python: ' NYC'
     - delta_text: ' </parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
-        vllm_rust: []
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
       normal_text:
-        vllm_python: ' </parameter> </function> </tool_call>'
-        sglang_python: '
-
-          '
         vllm_rust: ' </parameter> </function> </tool_call>'
+        vllm_python: ' </parameter> </function> </tool_call>'
+        sglang_python: "\n"
     - delta_text: ' <tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
+        vllm_rust: ' '
         vllm_python: ' '
         sglang_python: ' '
-        vllm_rust: ' '
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' Boston </parameter>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"location": "Boston"'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"location": "Boston"'}
     - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "Boston"'
-        sglang_python:
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_rust:
-        - arguments: '{"location":" Boston "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" Boston "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "Boston"'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing </tool_call> without matching <tool_call> open after prefix
-      prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing </tool_call> without matching <tool_call> open after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -552,74 +553,78 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        dynamo_rust: 'I will'
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' check'
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' that. <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
+        dynamo_rust: ' that. '
+        vllm_rust: ' that. <function=get_weather> <parameter=location>'
         vllm_python: ' that. <function=get_weather> <parameter=location>'
         sglang_python: ' that. '
-        vllm_rust: ' that. <function=get_weather> <parameter=location>'
     - delta_text: ' NYC </parameter>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        vllm_rust: []
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
       normal_text:
-        vllm_python: ' NYC </parameter>'
         vllm_rust: ' NYC </parameter>'
+        vllm_python: ' NYC </parameter>'
     - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '}'
-        vllm_rust: []
+        - {index: 0, arguments: '}'}
       normal_text:
+        vllm_rust: ' </function>'
         vllm_python: ' </function>'
         sglang_python: ' '
-        vllm_rust: ' </function>'
     - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' </tool_call>'
         vllm_python: ' </tool_call>'
         sglang_python: ' '
-        vllm_rust: ' </tool_call>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,122 +26,129 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <t
+    - delta_text: '<t'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <t
-    - delta_text: ool
+        vllm_python: '<t'
+    - delta_text: 'ool'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ool
-    - delta_text: _call
+        vllm_python: 'ool'
+    - delta_text: '_call'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: _call
+        vllm_python: '_call'
     - delta_text: '> <function'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: '> <function'
-    - delta_text: =get_weather> <para
+    - delta_text: '=get_weather> <para'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: =get_weather> <para
-    - delta_text: me
+        vllm_python: '=get_weather> <para'
+    - delta_text: 'me'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: me
-    - delta_text: ter
+        vllm_python: 'me'
+    - delta_text: 'ter'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ter
-    - delta_text: =loca
+        vllm_python: 'ter'
+    - delta_text: '=loca'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: =loca
-    - delta_text: tion> NYC <
+        vllm_python: '=loca'
+    - delta_text: 'tion> NYC <'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: tion> NYC <
-    - delta_text: /parameter> </funct
+        vllm_python: 'tion> NYC <'
+    - delta_text: '/parameter> </funct'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        vllm_rust: []
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
       normal_text:
-        vllm_python: /parameter> </funct
-    - delta_text: io
+        vllm_python: '/parameter> </funct'
+    - delta_text: 'io'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: io
+        vllm_python: 'io'
     - delta_text: 'n> '
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '}'
-        vllm_rust: []
+        - {index: 0, arguments: '}'}
       normal_text:
         vllm_python: 'n> '
-    - delta_text: </too
+    - delta_text: '</too'
       expected:
-        vllm_python: []
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
-      normal_text:
-        vllm_python: </too
-    - delta_text: l_call>
-      expected:
         vllm_python: []
         sglang_python: []
-        vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
       normal_text:
-        vllm_python: l_call>
+        vllm_python: '</too'
+    - delta_text: 'l_call>'
+      expected:
+        dynamo_rust: []
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_python: 'l_call>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
@@ -1,106 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Function block with no <parameter>
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Function block with no <parameter>'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_time>
+    - delta_text: '<tool_call> <function=get_time>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-        vllm_rust: []
+        - {index: 0, name: 'get_time'}
     - delta_text: ' </function>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Function block with extra whitespace inside
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Function block with extra whitespace inside'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_time>
+    - delta_text: '<tool_call> <function=get_time>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-        vllm_rust: []
+        - {index: 0, name: 'get_time'}
     - delta_text: '
-
-        </function>'
+</function>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters (existing multi-arg shape)
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters (existing multi-arg shape)'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -20,82 +30,72 @@ cases:
             type: integer
           first_class:
             type: boolean
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=book_flight>
+    - delta_text: '<tool_call> <function=book_flight>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: book_flight
-        vllm_rust: []
+        - {index: 0, name: 'book_flight'}
     - delta_text: ' <parameter=destination>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight', arguments: ''}
+        sglang_python: []
     - delta_text: ' Paris </parameter> <parameter=passengers>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"destination": "Paris"'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"destination": "Paris"'}
     - delta_text: ' 2 </parameter>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"destination": "Paris", "passengers": "2"'
-        sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"destination": "Paris", "passengers": "2"'}
+        sglang_python:
+        - {index: 0, arguments: ', "passengers": 2'}
     - delta_text: ' <parameter=first_class>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' true </parameter>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "first_class": "true"'
-        sglang_python:
-        - index: 0
-          arguments: ', "first_class": true'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "first_class": "true"'}
+        sglang_python:
+        - {index: 0, arguments: ', "first_class": true'}
     - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_rust:
-        - arguments: '{"destination":" Paris ","first_class":true,"passengers":" 2
-            "}'
-          index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight', arguments: '{"destination":" Paris ","first_class":true,"passengers":" 2 "}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in parameter value
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in parameter value'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -103,58 +103,50 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' Tōkyō central </parameter>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "Tōkyō central"'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "Tōkyō central"'}
     - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "Tōkyō central"'
-        sglang_python:
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
         vllm_rust:
-        - arguments: '{"location":" Tōkyō central "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" Tōkyō central "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "Tōkyō central"'}
+        sglang_python:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -162,45 +154,37 @@ cases:
         properties:
           count:
             type: number
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=set_limit>
+    - delta_text: '<tool_call> <function=set_limit>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: set_limit
-        vllm_rust: []
+        - {index: 0, name: 'set_limit'}
     - delta_text: ' <parameter=count>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
-    - delta_text: 9007199254740993</parameter> </function> </tool_call>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"count": 9007199254740992'
-        - index: 0
-          arguments: '}'
+        - {index: 0, id: true, name: 'set_limit', arguments: ''}
+        sglang_python: []
+    - delta_text: '9007199254740993</parameter> </function> </tool_call>'
+      expected:
+        dynamo_rust:
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"count": 9007199254740992'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,87 +26,84 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        dynamo_rust: 'I will'
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' check'
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' the weather. '
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' NYC'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python: []
     - delta_text: ' </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -104,88 +111,82 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python: []
     - delta_text: ' NYC </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> Let'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' Let'
         vllm_rust: ' Let'
+        sglang_python: ' Let'
     - delta_text: ' me'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' me'
         vllm_rust: ' me'
+        sglang_python: ' me'
     - delta_text: ' know if'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' know if'
         vllm_rust: ' know if'
+        sglang_python: ' know if'
     - delta_text: ' you need more.'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' you need more.'
         vllm_python: ' you need more.'
         sglang_python: ' you need more.'
-        vllm_rust: ' you need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -193,125 +194,126 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        dynamo_rust: 'I will'
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' check'
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' the weather. '
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' NYC'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python: []
     - delta_text: ' </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> Let me'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' Let me'
         vllm_rust: ' Let me'
+        sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' know'
         vllm_rust: ' know'
+        sglang_python: ' know'
     - delta_text: ' if you'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' if you'
         vllm_python: ' if you'
         sglang_python: ' if you'
-        vllm_rust: ' if you'
     - delta_text: ' need'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' need'
         vllm_python: ' need'
         sglang_python: ' need'
-        vllm_rust: ' need'
     - delta_text: ' more.'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' more.'
         vllm_python: ' more.'
         sglang_python: ' more.'
-        vllm_rust: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -319,142 +321,134 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        dynamo_rust: 'I will'
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' check'
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: ' the weather. '
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' NYC'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{'}
+        sglang_python: []
     - delta_text: ' </parameter> </function>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"location": "NYC"'
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        - index: 0
-          arguments: '"location": "NYC"'
-        - index: 0
-          arguments: '}'
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"location": "NYC"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' </tool_call> Then check'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust:
-        - arguments: '{"location":" NYC "}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' Then check'
         vllm_rust: ' Then check'
+        sglang_python: ' Then check'
     - delta_text: ' LA'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' LA'
         vllm_rust: ' LA'
+        sglang_python: ' LA'
     - delta_text: ' weather. <tool_call>'
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' weather. '
         vllm_python: ' weather. '
         sglang_python: ' weather. '
-        vllm_rust: ' weather. '
     - delta_text: ' <function=get_weather>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 1
-          name: get_weather
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' <parameter=location> LA'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{'
-        sglang_python: []
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{'}
+        sglang_python: []
     - delta_text: ' </parameter>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '"location": "LA"'
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        - index: 1
-          arguments: '"location": "LA"'
+        dynamo_rust: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '"location": "LA"'}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+        - {index: 1, arguments: '"location": "LA"'}
     - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '}'
-        sglang_python:
-        - index: 1
-          arguments: '}'
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - arguments: '{"location":" LA "}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen3_coder
-model_label: Qwen 3 Coder
+model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  dynamo_rust: 'Dynamo parser v2'
+  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
+  vllm_python: '0.22.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,24 +26,23 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
     - delta_text: ''
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -41,22 +50,22 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
     chunks:
     - delta_text: '   '
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        dynamo_rust: '   '
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/utils/src/parser_families.yaml
+++ b/conformance/utils/src/parser_families.yaml
@@ -31,7 +31,7 @@ families:
   phi4:           {vllm_python: phi4_mini_json, vllm_rust: null,         sglang_python: null,        dynamo_v2: null,        preferred_input: text}
   pythonic:       {vllm_python: pythonic,       vllm_rust: null,         sglang_python: pythonic,    dynamo_v2: null,        preferred_input: text}
   qwen25:         {vllm_python: hermes,         vllm_rust: hermes,       sglang_python: qwen25,      dynamo_v2: null,        preferred_input: text}
-  qwen3_coder:    {vllm_python: qwen3_coder,    vllm_rust: qwen3_coder,  sglang_python: qwen3_coder, dynamo_v2: null,        preferred_input: text}
+  qwen3_coder:    {vllm_python: qwen3_coder,    vllm_rust: qwen3_coder,  sglang_python: qwen3_coder, dynamo_v2: qwen3_coder, preferred_input: text}
   # Harmony (gpt-oss) is driven by the Dynamo token path and captured via the
   # harmony-specific flow, not the peer maps above; listed for registry coverage.
   harmony:        {vllm_python: null,           vllm_rust: null,         sglang_python: null,        dynamo_v2: harmony,      preferred_input: tokens}

--- a/parsers_v2/src/lib.rs
+++ b/parsers_v2/src/lib.rs
@@ -10,4 +10,5 @@ pub use tool_calling::dsml::DeepSeekV4ToolStreamParser;
 pub use tool_calling::harmony::{
     HarmonyToolStreamParser, ToolStreamResult, assemble_tool_calls, decode_harmony, encode_harmony,
 };
+pub use tool_calling::qwen3_coder::Qwen3CoderToolStreamParser;
 pub use tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser, ToolParserInput};

--- a/parsers_v2/src/tool_calling/mod.rs
+++ b/parsers_v2/src/tool_calling/mod.rs
@@ -5,12 +5,14 @@ pub mod dsml;
 pub mod harmony;
 mod harmony_grammar;
 mod harmony_recovery;
+pub mod qwen3_coder;
 pub mod traits;
 
 use traits::{Tool, ToolParser};
 
 use self::dsml::DeepSeekV4ToolStreamParser;
 use self::harmony::HarmonyToolStreamParser;
+use self::qwen3_coder::Qwen3CoderToolStreamParser;
 
 /// Create the Dynamo v2 tool parser for a conformance family.
 pub fn create_tool_parser_for_family(
@@ -20,6 +22,7 @@ pub fn create_tool_parser_for_family(
     match family {
         "harmony" | "harmony_text" => HarmonyToolStreamParser::create(tools),
         "deepseek_v4" => DeepSeekV4ToolStreamParser::create(tools),
+        "qwen3_coder" => Qwen3CoderToolStreamParser::create(tools),
         other => anyhow::bail!("no Dynamo parser v2 for family '{other}'"),
     }
 }

--- a/parsers_v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers_v2/src/tool_calling/qwen3_coder.rs
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Streaming XML tool-call parser for Qwen3-Coder.
+//!
+//! Qwen3-Coder emits tool calls as
+//!   `<tool_call> <function=NAME> <parameter=KEY>value</parameter> ... </function> </tool_call>`
+//! plus a bare `<function=...></function>` back-off form when the outer wrapper
+//! is absent (shared with nemotron_nano).
+//!
+//! The streaming concern (buffering, chunk-split marker safety, normal_text
+//! suppression) is owned here. The per-block value typing is delegated to the v1
+//! batch XML parser `try_tool_call_parse_xml`, so a streamed call matches exactly
+//! what the batch parser produces (the DIS-2209 bar). Arguments are re-serialized
+//! in the source parameter order because the v1 parser builds them from a
+//! `HashMap` whose key order is non-deterministic; streaming fixtures store the
+//! arguments as an exact JSON string, so order has to be pinned to the
+//! model-emitted order (the order vLLM's Rust parser also preserves).
+
+use std::collections::HashSet;
+
+use dynamo_parsers::tool_calling::{ToolDefinition, XmlParserConfig, try_tool_call_parse_xml};
+
+use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
+
+const BLOCK_START: &str = "<tool_call>";
+const BLOCK_END: &str = "</tool_call>";
+const FUNCTION_START: &str = "<function=";
+const FUNCTION_END: &str = "</function>";
+const PARAMETER_START: &str = "<parameter=";
+
+/// Stream parser for Qwen3-Coder XML tool calls.
+pub struct Qwen3CoderToolStreamParser {
+    buffer: String,
+    in_block: bool,
+    suppress_normal_text: bool,
+    next_index: usize,
+    config: XmlParserConfig,
+    tools: Vec<ToolDefinition>,
+}
+
+impl Qwen3CoderToolStreamParser {
+    pub fn new(tools: &[Tool]) -> Self {
+        Self {
+            buffer: String::new(),
+            in_block: false,
+            suppress_normal_text: false,
+            next_index: 0,
+            config: XmlParserConfig::default(),
+            tools: tools
+                .iter()
+                .map(|t| ToolDefinition {
+                    name: t.name.clone(),
+                    parameters: Some(t.parameters.clone()),
+                    strict: t.strict,
+                })
+                .collect(),
+        }
+    }
+
+    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
+        let mut out = ToolParseResult::default();
+
+        loop {
+            if self.in_block {
+                // Close the block once no more complete functions precede its end.
+                if let Some(end) = self.buffer.find(BLOCK_END) {
+                    let function_before_end = self
+                        .buffer
+                        .find(FUNCTION_START)
+                        .is_some_and(|start| start < end);
+                    if !function_before_end {
+                        self.buffer.drain(..end + BLOCK_END.len());
+                        self.in_block = false;
+                        self.suppress_normal_text = true;
+                        continue;
+                    }
+                }
+
+                let Some(start) = self.buffer.find(FUNCTION_START) else {
+                    if flush {
+                        tracing::warn!(
+                            why = "qwen3_coder_block_without_complete_function",
+                            "Qwen3-Coder stream dropped incomplete block at EOF"
+                        );
+                        self.buffer.clear();
+                        self.in_block = false;
+                    }
+                    break;
+                };
+                if start > 0 {
+                    self.buffer.drain(..start);
+                }
+                let Some(end) = self.buffer.find(FUNCTION_END) else {
+                    if flush {
+                        tracing::warn!(
+                            why = "qwen3_coder_incomplete_function",
+                            "Qwen3-Coder stream dropped incomplete function at EOF"
+                        );
+                        self.buffer.clear();
+                        self.in_block = false;
+                    }
+                    break;
+                };
+                let function = self.buffer[..end + FUNCTION_END.len()].to_string();
+                self.buffer.drain(..end + FUNCTION_END.len());
+                if let Some(delta) = self.parse_function_delta(&function)? {
+                    out.calls.push(delta);
+                    self.next_index += 1;
+                    self.suppress_normal_text = true;
+                }
+                continue;
+            }
+
+            let block_start = self.buffer.find(BLOCK_START);
+            let bare_function_start = self.buffer.find(FUNCTION_START);
+            let next_marker = match (block_start, bare_function_start) {
+                (Some(b), Some(f)) if b <= f => Some((b, Marker::Block)),
+                (Some(_), Some(f)) => Some((f, Marker::BareFunction)),
+                (Some(b), None) => Some((b, Marker::Block)),
+                (None, Some(f)) => Some((f, Marker::BareFunction)),
+                (None, None) => None,
+            };
+
+            let Some((start, marker)) = next_marker else {
+                // No marker present: emit buffered text, but hold back a trailing
+                // partial marker (split across this chunk boundary) unless flushing.
+                let keep = if flush {
+                    0
+                } else {
+                    marker_prefix_suffix_len(&self.buffer)
+                };
+                let emit_len = self.buffer.len().saturating_sub(keep);
+                if emit_len > 0 {
+                    if !self.suppress_normal_text {
+                        out.normal_text.push_str(&self.buffer[..emit_len]);
+                    }
+                    self.buffer.drain(..emit_len);
+                }
+                break;
+            };
+
+            if start > 0 {
+                if !self.suppress_normal_text {
+                    out.normal_text.push_str(&self.buffer[..start]);
+                }
+                self.buffer.drain(..start);
+            }
+
+            match marker {
+                Marker::Block => {
+                    self.buffer.drain(..BLOCK_START.len());
+                    self.in_block = true;
+                    self.suppress_normal_text = true;
+                }
+                Marker::BareFunction => {
+                    let Some(end) = self.buffer.find(FUNCTION_END) else {
+                        if flush {
+                            tracing::warn!(
+                                why = "qwen3_coder_incomplete_bare_function",
+                                "Qwen3-Coder stream dropped incomplete bare function at EOF"
+                            );
+                            self.buffer.clear();
+                        }
+                        break;
+                    };
+                    let function = self.buffer[..end + FUNCTION_END.len()].to_string();
+                    self.buffer.drain(..end + FUNCTION_END.len());
+                    if let Some(delta) = self.parse_function_delta(&function)? {
+                        tracing::warn!(
+                            why = "qwen3_coder_bare_function_recovery",
+                            tool_index = delta.tool_index,
+                            "Qwen3-Coder stream recovered a complete bare function"
+                        );
+                        out.calls.push(delta);
+                        self.next_index += 1;
+                        self.suppress_normal_text = true;
+                    }
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Parse one complete `<function=...></function>` block into a delta.
+    ///
+    /// Wraps the function in `<tool_call>` so the v1 parser always takes its
+    /// normal wrapped path, then re-orders the arguments to source order.
+    fn parse_function_delta(&self, function: &str) -> anyhow::Result<Option<ToolCallDelta>> {
+        let wrapped = format!("{BLOCK_START}{function}{BLOCK_END}");
+        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
+        let Some(call) = calls.into_iter().next() else {
+            return Ok(None);
+        };
+        let arguments = reorder_arguments(&call.function.arguments, function);
+        Ok(Some(ToolCallDelta {
+            tool_index: self.next_index,
+            name: Some(call.function.name),
+            arguments,
+        }))
+    }
+}
+
+impl ToolParser for Qwen3CoderToolStreamParser {
+    fn create(tools: &[Tool]) -> anyhow::Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn preserve_special_tokens(&self) -> bool {
+        true
+    }
+
+    fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
+        self.buffer.push_str(chunk);
+        self.drain(false)
+    }
+
+    fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
+        self.drain(true)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Marker {
+    Block,
+    BareFunction,
+}
+
+/// Longest non-empty proper prefix of a start marker that `text` ends with, so a
+/// marker split across chunk boundaries is held back instead of leaked as text.
+fn marker_prefix_suffix_len(text: &str) -> usize {
+    [BLOCK_START, FUNCTION_START]
+        .into_iter()
+        .filter_map(|marker| {
+            marker
+                .char_indices()
+                .map(|(idx, _)| idx)
+                .filter(|idx| *idx > 0)
+                .filter(|idx| *idx < marker.len())
+                .rev()
+                .find(|&len| text.ends_with(&marker[..len]))
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// Re-serialize a v1 arguments JSON object in source `<parameter=...>` order.
+fn reorder_arguments(arguments: &str, function: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
+        return arguments.to_string();
+    };
+    let Some(obj) = value.as_object() else {
+        return arguments.to_string();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for name in source_parameter_order(function) {
+        if let Some(val) = obj.get(&name) {
+            parts.push(format!(
+                "{}:{}",
+                serde_json::to_string(&name).unwrap_or_default(),
+                serde_json::to_string(val).unwrap_or_default()
+            ));
+            seen.insert(name);
+        }
+    }
+    // Append any keys not matched in source order (defensive; normally empty).
+    for (key, val) in obj {
+        if !seen.contains(key) {
+            parts.push(format!(
+                "{}:{}",
+                serde_json::to_string(key).unwrap_or_default(),
+                serde_json::to_string(val).unwrap_or_default()
+            ));
+        }
+    }
+    format!("{{{}}}", parts.join(","))
+}
+
+/// Parameter names in the order they appear in a function block.
+fn source_parameter_order(function: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut cursor = 0;
+    while let Some(rel) = function[cursor..].find(PARAMETER_START) {
+        let start = cursor + rel + PARAMETER_START.len();
+        let Some(header_end) = function[start..].find('>') else {
+            break;
+        };
+        let name = function[start..start + header_end]
+            .trim()
+            .trim_matches('"')
+            .trim();
+        if !name.is_empty() {
+            names.push(name.to_string());
+        }
+        cursor = start + header_end + 1;
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn weather_tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "location": { "type": "string" } }
+            }),
+            strict: None,
+        }]
+    }
+
+    fn parse_chunks(tools: &[Tool], chunks: &[&str]) -> ToolParseResult {
+        let mut parser = Qwen3CoderToolStreamParser::new(tools);
+        let mut out = ToolParseResult::default();
+        for chunk in chunks {
+            out.append(parser.push(chunk).expect("push"));
+        }
+        out.append(parser.finish().expect("finish"));
+        out
+    }
+
+    #[test]
+    fn emits_complete_call_on_close() {
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<tool_call> <function=get_weather>",
+                " <parameter=location>",
+                " NYC </parameter> </function>",
+                " </tool_call>",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        assert_eq!(out.calls.len(), 1);
+        assert_eq!(out.calls[0].tool_index, 0);
+        assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
+        // Value is schema-typed (string) and trimmed, matching the v1 batch parser.
+        assert_eq!(out.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
+    fn preserves_prefix_text_before_block() {
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "I will",
+                " check the weather. <tool_call>",
+                " <function=get_weather>",
+                " <parameter=location>NYC</parameter> </function> </tool_call>",
+            ],
+        );
+        assert_eq!(out.normal_text, "I will check the weather. ");
+        assert_eq!(out.calls.len(), 1);
+    }
+
+    #[test]
+    fn recovers_complete_bare_function() {
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "I will check that. <function=get_weather>",
+                " <parameter=location>NYC</parameter>",
+                " </function>",
+            ],
+        );
+        assert_eq!(out.normal_text, "I will check that. ");
+        assert_eq!(out.calls.len(), 1);
+        assert_eq!(out.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
+    fn suppresses_incomplete_function_at_eof() {
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<tool_call> <function=get_weather>",
+                " <parameter=location> NY",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        assert!(out.calls.is_empty());
+    }
+
+    #[test]
+    fn preserves_source_parameter_order() {
+        // path, old_str, new_str, command is deliberately NOT alphabetical: the
+        // serialized arguments must keep the model-emitted parameter order.
+        let tools = vec![Tool {
+            name: "file_editor".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "old_str": { "type": "string" },
+                    "new_str": { "type": "string" },
+                    "command": { "type": "string" }
+                }
+            }),
+            strict: None,
+        }];
+        let out = parse_chunks(
+            &tools,
+            &[
+                "<tool_call> <function=file_editor>",
+                " <parameter=path>/app/x.go</parameter>",
+                " <parameter=old_str>foo</parameter>",
+                " <parameter=new_str>bar</parameter>",
+                " <parameter=command>str_replace</parameter>",
+                " </function> </tool_call>",
+            ],
+        );
+        assert_eq!(out.calls.len(), 1);
+        assert_eq!(
+            out.calls[0].arguments,
+            r#"{"path":"/app/x.go","old_str":"foo","new_str":"bar","command":"str_replace"}"#
+        );
+    }
+}


### PR DESCRIPTION
#### Overview:

This PR adds the v2 streaming tool-call parser for Qwen3-Coder.

#### Details:

- New `parsers_v2/src/tool_calling/qwen3_coder.rs`: streams the qwen3-coder XML tool-call format (`<tool_call><function=NAME><parameter=KEY>value</parameter></function></tool_call>` plus the bare `<function=>` back-off), emitting the call at block close; per-block typing delegates to the v1 batch parser so streamed output matches batch.
- Wired into `create_tool_parser_for_family`, `parser_families.yaml` (`dynamo_v2: qwen3_coder`), and the stream parity harness; `dynamo_rust` recorded into the 12 `fixtures-stream-v2/qwen3_coder` fixtures.

#### Verification:

`dynamo-parsers-v2` unit tests + stream parity (121/121) green.

#### Where should the reviewer start?

`parsers_v2/src/tool_calling/qwen3_coder.rs`

#### Related Issues:

Relates to DIS-2228

/coderabbit profile chill
