### PR TITLE
ci: fix release-plz config so parser-sync commits publish (demo-server flag + chore trigger)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,10 +7,14 @@
 semver_check = true
 
 # Only commits matching this regex count toward "is there anything to release".
-# Excludes chore:/ci:/build:/test:/docs: from triggering bumps. (Excluded
-# commits still appear in the changelog if their parser group is configured
-# below — they just don't drive a release on their own.)
-release_commits = "^(feat|fix|perf|refactor|sync)(\\(.+\\))?!?:"
+# TEMPORARY (transition only): `chore` is included so `chore: trivial parser
+# sync from dynamo` commits — how parser updates land during the
+# dynamo -> frontend-crates migration — actually trigger a version bump and
+# publish. Without it those syncs propose no bump, so the workflow's publish
+# step (gated on `bumped == 'true'`) is skipped and the synced fixes never
+# reach crates.io. REMOVE `chore` after the transition completes; it also lets
+# unrelated chore: commits (incl. dependabot `chore(deps):`) drive releases.
+release_commits = "^(feat|fix|perf|refactor|sync|chore)(\\(.+\\))?!?:"
 
 # Default tag format: per-crate, e.g. dynamo-protocols-v0.1.1
 git_tag_enable = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,6 +30,11 @@ name = "dynamo-conformance-fixtures-v2"
 publish = false
 release = false
 
+# `dynamo-demo-server` is `publish = false` in its Cargo.toml; mirror BOTH
+# `publish = false` and `release = false` here. release-plz fails the whole
+# `release` run if its config's publish flag (default true) disagrees with the
+# package's `publish = false` in Cargo.toml, so `release = false` alone is not
+# enough — the publish flag must match too.
 [[package]]
 name = "dynamo-demo-server"
 publish = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -78,7 +78,12 @@ commit_parsers = [
     { message = "^refactor", group = "Refactoring" },
     { message = "^doc", group = "Documentation" },
     { message = "^sync", group = "Upstream sync" },
-    { message = "^chore", skip = true },
+    # TEMPORARY (transition): render `chore` in the changelog instead of
+    # skipping it, since `chore` now triggers releases (see `release_commits`
+    # above) — a chore-driven release would otherwise have an empty changelog.
+    # Remove together with the `release_commits` chore entry after the
+    # dynamo -> frontend-crates transition.
+    { message = "^chore", group = "Miscellaneous" },
     { message = "^ci", skip = true },
     { message = "^build", skip = true },
     { message = "^test", skip = true },


### PR DESCRIPTION
## Overview

Two `release-plz.toml` config fixes so parser updates actually publish to crates.io. `dynamo-parsers v1.4.0` was version-bumped on `main` but never reached crates.io (no tag, crates.io still at 1.3.0).

## Fix 1 — `dynamo-demo-server`: add `publish = false` (removes a fatal abort)

release-plz tracks two per-package flags: `publish` (may it go to crates.io?) and `release` (should release-plz manage it?). The block set `release = false` only; `publish` was left to its default of `true`. That contradicts the package manifest (`examples/dynamo-demo-server/Cargo.toml` is `publish = false`), and release-plz rejects the contradiction during config validation **at startup** — exiting 1 before any crate is processed:

```
ERROR Package `dynamo-demo-server` has `publish = false` ... in the Cargo.toml,
      but it has `publish = true` in the release-plz configuration.
```

Because the abort is global (not per-crate), it blocked `dynamo-parsers` from publishing too. Setting `publish = false` makes the config agree with the manifest, so release-plz gets past validation and runs. (This is the error the last release run — on the #51 App-token merge — died on.)

## Fix 2 — include `chore` in `release_commits` (so syncs trigger a publish)

`release.yml`'s publish step is gated on `steps.bump.outputs.bumped == 'true'`, which is only true when `release-plz update` proposes a bump — and `update` only counts commits matching `release_commits`. Parser updates land as `chore: trivial parser sync from dynamo`; with `chore` excluded, those syncs propose no bump → `bumped=false` → publish step skipped → the synced fixes never publish.

Adding `chore` makes sync commits count, so they trigger a bump and the publish runs. **Transitional** — remove `chore` after the dynamo→frontend-crates migration completes (it also lets unrelated `chore:`/`chore(deps):` commits drive releases).

## Scope

`release-plz.toml` only. No code, no crate version edits.

Note: for the already-pending `1.4.0` (Cargo.toml already bumped, no new bump to propose), a one-time `workflow_dispatch` of `release.yml` after this merges publishes it directly — the publish step's `if` includes `workflow_dispatch`, which bypasses the `bumped` gate.
