### PR TITLE
chore: trivial sync from dynamo @ c614516

### DIFF
--- a/conformance/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -143,3 +143,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony commentary channels; visible text and downstream tool handoff use model-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use model-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/conformance/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -133,3 +133,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony commentary protocol, so partial commentary-boundary recovery is outside their grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek R1-family parsers
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -163,3 +163,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony commentary channels; visible text and downstream tool handoff use DeepSeek-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use DeepSeek-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -141,3 +141,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V3
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -174,3 +174,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony commentary channels; visible text and downstream tool handoff use DeepSeek-specific think and DSML tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use DeepSeek-specific DSML tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -136,3 +136,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V4
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -192,3 +192,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Gemma 4
+    reason: Gemma 4 uses Gemma thought channels, not Harmony commentary channels; visible text and downstream tool handoff use Gemma-specific markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Gemma 4
+    reason: Gemma 4 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Gemma-specific tool markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Gemma 4
+    reason: Gemma 4 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Gemma thought channels.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -156,3 +156,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Gemma 4
+    reason: Gemma 4 has no configured Harmony commentary boundary; closed-channel handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Gemma 4
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -154,3 +154,15 @@ cases:
         unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Granite
+    reason: Granite does not use Harmony commentary channels; visible text and reasoning are separated by Granite thought-process and response markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Granite
+    reason: Granite does not use Harmony `commentary to=functions.*` envelopes and has no paired Dynamo Harmony tool-call parser fixture.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Granite
+    reason: Granite does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Granite thought-process markers.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Granite
+    reason: Granite has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -121,3 +121,15 @@ cases:
         unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Granite
+    reason: Granite has no configured Harmony commentary boundary; it has no paired Dynamo Harmony tool-call parser fixture.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Granite
+    reason: Granite has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Granite
+    reason: Granite has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Granite
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -156,3 +156,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body◁/think▷answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony commentary channels; visible text and downstream tool handoff use Kimi-specific reasoning and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Kimi-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Kimi-specific reasoning delimiters.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -119,3 +119,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body◁/think▷answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to this Kimi delimiter family
+    reason: This parser family has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -180,3 +180,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 uses Kimi tool-section markers, not Harmony commentary channels; visible text and downstream tool handoff use Kimi-specific markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Kimi tool-section markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Kimi K2.5
+    reason: Kimi K2.5 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -138,3 +138,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 uses Kimi tool-section markers, not Harmony commentary channels; Harmony stream boundary cases are GPT-OSS specific.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `commentary to=functions.*` envelopes, so there is no Harmony stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Kimi K2.5
+    reason: Kimi K2.5 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Kimi K2.5
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -153,3 +153,15 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: '<think>preamble</think>body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony commentary channels; it emits a synthetic normal-text wrapper around model output.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony `commentary to=functions.*` envelopes; downstream tool handoff uses MiniMax-specific output shape when applicable.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony `analysis to=functions.*` envelopes; reasoning-shaped text remains inside the synthetic normal-text wrapper.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -110,3 +110,15 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: '<think>preamble</think>body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no configured Harmony commentary boundary; it emits a synthetic normal-text wrapper around model output.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to MiniMax append-think
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -155,3 +155,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony commentary channels; visible text and downstream tool handoff use Mistral-specific reasoning and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Mistral-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Mistral THINK tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Mistral
+    reason: Mistral reasoning parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/conformance/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -132,3 +132,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Mistral
+    reason: Mistral has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Mistral
+    reason: Mistral has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Mistral
+    reason: Mistral has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Mistral
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -166,3 +166,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony commentary channels; visible text and downstream tool handoff use model-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use model-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/conformance/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -141,3 +141,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no Harmony commentary protocol, so partial commentary-boundary recovery is outside their grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to GLM/Nemotron
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/conformance/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -180,3 +180,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Qwen3
+    reason: Qwen3 does not use Harmony commentary channels; visible text and downstream tool handoff use Qwen-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Qwen3
+    reason: Qwen3 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Qwen-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Qwen3
+    reason: Qwen3 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Qwen3
+    reason: Qwen3 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/conformance/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -137,3 +137,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning, so there is no split downstream boundary to buffer.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning, so partial tool-marker recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Qwen3
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/llm/tests/data/sample-models/mock-special-tokens-only/config.json
+++ b/llm/tests/data/sample-models/mock-special-tokens-only/config.json
@@ -1,0 +1,4 @@
+{
+  "architectures": ["FakeForCausalLM"],
+  "model_type": "fake"
+}

--- a/llm/tests/data/sample-models/mock-special-tokens-only/special_tokens_map.json
+++ b/llm/tests/data/sample-models/mock-special-tokens-only/special_tokens_map.json
@@ -1,0 +1,23 @@
+{
+  "bos_token": {
+    "content": "<bos>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  },
+  "eos_token": {
+    "content": "<eos>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  },
+  "pad_token": {
+    "content": "<pad>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  }
+}

--- a/llm/tests/data/sample-models/mock-special-tokens-only/tokenizer.json
+++ b/llm/tests/data/sample-models/mock-special-tokens-only/tokenizer.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "added_tokens": [
+    {"id": 200, "content": "<eos>", "special": true},
+    {"id": 201, "content": "<bos>", "special": true},
+    {"id": 202, "content": "<pad>", "special": true}
+  ],
+  "model": {"type": "BPE", "vocab": {}, "merges": []}
+}

--- a/llm/tests/data/sample-models/mock-tokenizer-config-only/config.json
+++ b/llm/tests/data/sample-models/mock-tokenizer-config-only/config.json
@@ -1,0 +1,4 @@
+{
+  "architectures": ["FakeForCausalLM"],
+  "model_type": "fake"
+}

--- a/llm/tests/data/sample-models/mock-tokenizer-config-only/tokenizer_config.json
+++ b/llm/tests/data/sample-models/mock-tokenizer-config-only/tokenizer_config.json
@@ -1,0 +1,22 @@
+{
+  "bos_token": "<bos>",
+  "eos_token": "<eos>",
+  "added_tokens_decoder": {
+    "100": {
+      "content": "<eos>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "101": {
+      "content": "<bos>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    }
+  }
+}

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -1533,10 +1533,11 @@ NORMAL MODE
             .render(context! { messages => messages.as_array().unwrap() })
             .unwrap();
 
-        // Should produce clean JSON without double-encoding
+        // Should produce clean JSON without double-encoding, with Python
+        // json.dumps separators (what transformers' tojson emits).
         assert_eq!(
             out,
-            r#"{"format":"celsius","location":"San Francisco, CA"}"#
+            r#"{"format": "celsius", "location": "San Francisco, CA"}"#
         );
     }
 

--- a/renderer/src/template/tokcfg.rs
+++ b/renderer/src/template/tokcfg.rs
@@ -111,38 +111,69 @@ pub struct GenerationConfig {
     eos_token_id: Either<u32, Vec<u32>>,
 }
 
+/// Formatter matching Python `json.dumps` default separators (`", "` and
+/// `": "`). serde_json's `CompactFormatter` writes `","`/`":"` instead, and
+/// chat templates embed these strings directly into the prompt, so the
+/// separator choice is model-visible.
+struct PyJsonFormatter;
+
+impl serde_json::ser::Formatter for PyJsonFormatter {
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if !first {
+            writer.write_all(b", ")?;
+        }
+        Ok(())
+    }
+
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if !first {
+            writer.write_all(b", ")?;
+        }
+        Ok(())
+    }
+
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        writer.write_all(b": ")
+    }
+}
+
+/// Mirrors HF transformers' `tojson` filter, not stock Jinja2's. Transformers
+/// overrides Jinja's HTML-safe `tojson` with plain
+/// `json.dumps(x, ensure_ascii=False)` in its chat-template environment, and
+/// vLLM/SGLang render through that — so chat templates (and the models trained
+/// on their output) expect Python separators and **no** HTML escaping
+/// (`'`, `<`, `>`, `&` stay literal). serde_json leaves non-ASCII unescaped by
+/// default, matching `ensure_ascii=False`.
 pub fn tojson(value: Value, kwargs: Kwargs) -> Result<Value, Error> {
-    if let Ok(indent) = kwargs.get("indent") {
-        let mut buf = Vec::new();
+    let mut buf = Vec::new();
+    let result = if let Ok(indent) = kwargs.get("indent") {
+        // Python `json.dumps(indent=n)` separators are `(",", ": ")` with the
+        // item separator followed by newline + indent — PrettyFormatter matches.
         let repeat = b" ".repeat(indent);
         let formatter = serde_json::ser::PrettyFormatter::with_indent(&repeat);
         let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
-        value.serialize(&mut serializer).unwrap();
-        String::from_utf8(buf).map_err(|err| {
-            Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
-        })
+        value.serialize(&mut serializer)
     } else {
-        serde_json::to_string(&value).map_err(|err| {
+        let mut serializer = serde_json::Serializer::with_formatter(&mut buf, PyJsonFormatter);
+        value.serialize(&mut serializer)
+    };
+    result.map_err(|err| {
+        Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
+    })?;
+    String::from_utf8(buf)
+        .map_err(|err| {
             Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
         })
-    }
-    .map_err(|err| {
-        Error::new(ErrorKind::InvalidOperation, "cannot serialize to JSON").with_source(err)
-    })
-    .map(|s| {
-        // When this filter is used the return value is safe for both HTML and JSON
-        let mut rv = String::with_capacity(s.len());
-        for c in s.chars() {
-            match c {
-                '<' => rv.push_str("\\u003c"),
-                '>' => rv.push_str("\\u003e"),
-                '&' => rv.push_str("\\u0026"),
-                '\'' => rv.push_str("\\u0027"),
-                _ => rv.push(c),
-            }
-        }
-        Value::from_safe_string(rv)
-    })
+        .map(Value::from_safe_string)
 }
 
 pub fn strftime_now(format_str: &str) -> Result<Value, Error> {


### PR DESCRIPTION
## Overview

Verbatim one-way mirror of `ai-dynamo/dynamo` into this repo via `scripts/sync-from-dynamo.sh --apply`, at dynamo `c614516`. Brings frontend-crates main back in line with dynamo so the `sync-check` gate goes green.

Drift synced (26 files): `renderer/src/template/{oai,tokcfg}.rs`, tokenizer test fixtures (`llm/tests/data/sample-models/mock-*`), and the reasoning parity fixtures across all families (`conformance/reasoning/fixtures/*/REASONING.{batch,stream}.yaml`).

Mirror only — no local authoring; real review happened upstream. Base PR for the release-plz config fix (#54).
