### PR TITLE
ci: pass --git-token to release-plz release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,13 @@ jobs:
 
       - name: Publish to crates.io (trusted publishing)
         if: steps.bump.outputs.bumped == 'true' || github.event_name == 'workflow_dispatch'
-        run: release-plz release
+        # The release-plz binary needs the forge token passed explicitly via
+        # --git-token; unlike release-plz/action it does NOT read GITHUB_TOKEN
+        # from the env. Even with git_release_enable=false, `release` builds a
+        # forge client unconditionally, so a missing token aborts the publish.
+        # Reference the env var (not the ${{ }} expression) so the token value
+        # is never expanded into the echoed command.
+        run: release-plz release --git-token "$GITHUB_TOKEN"
         env:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
           # No CARGO_REGISTRY_TOKEN — trusted publishing via OIDC is used


### PR DESCRIPTION
The publish step calls the release-plz binary directly, but unlike release-plz/action the CLI does not read GITHUB_TOKEN from the env and needs the forge token via --git-token. The 'release' command builds a forge client unconditionally (even with git_release_enable=false), so the missing token aborted publishing with 'git release not configured. Did you specify git-token and forge?'. This regressed in #22 when the release step moved off release-plz/action, leaving crates published versions stuck (e.g. dynamo-parsers bumped to 1.4.0 but never released).