### PR TITLE
fix(parsers): bump openai-harmony 0.0.3 -> 0.0.8 to match dynamo main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "openai-harmony"
-version = "0.0.3"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b7fd6b7d01a317c58d85a22b7cc314e14a2fef0dfdb93b819738d09caece16"
+checksum = "e77e82af451fc95deeb728a40b84db8ee82d341e136c268de415123a560b9b72"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ minijinja = { version = "2.20.0" }
 minijinja-contrib = { version = "2.20.0" }
 moka = { version = "0.12" }
 num-traits = "0.2"
-openai-harmony = "0.0.3"
+openai-harmony = "0.0.8"
 pyo3 = { version = "0.22", features = ["extension-module"] }
 rayon = "1"
 regex = "1"


### PR DESCRIPTION
## Overview

Bumps the workspace `openai-harmony` pin `0.0.3 -> 0.0.8` to match dynamo main.

dynamo main's in-tree `lib/parsers/Cargo.toml` uses `openai-harmony = "0.0.8"`, but this repo's workspace `Cargo.toml` still pinned `0.0.3` (the parser `src/` is mirrored from dynamo, but `Cargo.toml` isn't synced). As a result the published `dynamo-parsers 1.4.0` requires `^0.0.3`, so cutting dynamo over to the published crate (`ai-dynamo/dynamo#10423`) **downgrades** `openai-harmony 0.0.8 -> 0.0.3` — losing StreamableParser invalid-UTF-8 handling and malformed-message recovery.

Bumping here makes the next published `dynamo-parsers` carry `0.0.8`, so the cutover no longer regresses it.

`fix:` prefix so release-plz cuts a new release (1.4.1). Verified: `cargo test -p dynamo-parsers` builds against 0.0.8 and 606 tests pass.

## Scope

Workspace `Cargo.toml` + `Cargo.lock` only.
