### PR TITLE
fix(parsers): stop mistral parser leaking [TOOL_CALLS] into content

### DIFF
--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
@@ -17,16 +17,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS], [/TOOL_CALLS] in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &d_4_a
         calls: []
-        normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: not a json array[/TOOL_CALLS]
-      sglang:
-        calls: []
-        normal_text: ''
+        reason: "vLLM's mistral parser splits only on the [TOOL_CALLS] opener and has no [/TOOL_CALLS] concept; on a malformed body its pre-v11 path returns the raw post-opener text as content, leaking the [/TOOL_CALLS] close marker. Dynamo strips the wrapper markers on malformed recovery so nothing leaks (TOOLCALLING.batch.4 impl-defined recovery)."
+      sglang: *d_4_a
   TOOLCALLING.batch.4.b:
     description: Missing close brace in JSON
     ref: dynamo
@@ -34,16 +32,14 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS], [/TOOL_CALLS] in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &d_4_b
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
-      sglang:
-        calls: []
-        normal_text: ''
+        reason: "vLLM splits on the [TOOL_CALLS] opener and, when the JSON body fails both raw_decode and the array-regex fallback, returns the raw post-opener text as content, leaking the body and the [/TOOL_CALLS] close marker. Dynamo strips the wrapper markers on malformed recovery so nothing leaks (TOOLCALLING.batch.4 impl-defined recovery)."
+      sglang: *d_4_b
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
@@ -27,6 +27,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's MistralDetector requires '[TOOL_CALLS] [' with a space before the JSON array; the canonical mistral_common wire format emits '[TOOL_CALLS][' with no space, so it falls to its compact path, finds no [ARGS], and returns no call. Dynamo recovers the call via the empty end-token. Real SGLang divergence on the genuine Mistral format."
   TOOLCALLING.batch.5.b:
     description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
     ref: dynamo
@@ -34,12 +35,20 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's mistral parser leaves [/TOOL_CALLS] in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
-      vllm: *id003
-      sglang: *id003
+        reason: "vLLM requires the [TOOL_CALLS] opener; with only an orphan [/TOOL_CALLS] close it treats the whole string as content and emits no call. Dynamo strips the orphan close marker and recovers the complete call body without leaking markup (TOOLCALLING.batch.5 impl-defined recovery)."
+      sglang:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+        reason: "SGLang's MistralDetector matches no [TOOL_CALLS opener (an orphan [/TOOL_CALLS] close does not match) and returns the text unchanged with no call. Dynamo strips the orphan close marker and recovers the complete call body without leaking markup (TOOLCALLING.batch.5 impl-defined recovery)."
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -78,6 +87,7 @@ cases:
       sglang:
         calls: []
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: "SGLang's MistralDetector requires '[TOOL_CALLS] [' with a space before the JSON array; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it returns no call and keeps the narration prefix. Dynamo recovers both complete calls. Real SGLang divergence on the genuine Mistral format."
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
@@ -29,9 +29,11 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's streaming MistralDetector requires '[TOOL_CALLS] [' with a space; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it never enters the JSON-array path and emits no call. Dynamo buffers the payload and recovers the call. Real SGLang divergence on the genuine Mistral format."
       vllm:
         calls: []
         normal_text: ''
+        reason: "vLLM's streaming Mistral parser (pre-v11 ijson path) emits no call when the entire [TOOL_CALLS] payload arrives in one chunk via the parity harness (no incremental delta_token_ids to drive its coroutine); Dynamo buffers and recovers the call."
   TOOLCALLING.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from TOOLCALLING.batch.1

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
@@ -29,6 +29,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's streaming MistralDetector requires '[TOOL_CALLS] [' with a space; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it never enters the JSON-array path and emits no call. Dynamo recovers the call at stream finalize. Real SGLang divergence on the genuine Mistral format."
       vllm: *id001
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
@@ -74,11 +75,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
-      vllm: *id002
+        reason: "vLLM streaming sees no [TOOL_CALLS] opener in the chunk, so it emits the whole string as content with no call, leaking the orphan [/TOOL_CALLS] markers verbatim. Dynamo strips the orphan close markers at the confirmed end token and recovers the complete call body without leaking markup."
       sglang:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'
-        reason: SGLang strips the trailing ] from each orphan [/TOOL_CALLS] close marker (leaving bracket fragments); Dynamo and vLLM keep the bare body and markers verbatim when the [TOOL_CALLS] opener is absent.
+        reason: "SGLang's streaming MistralDetector matches no [TOOL_CALLS marker and flushes the buffer as normal text, stripping every ']' char via its eot_token replace (leaving bracket fragments). Dynamo strips the orphan close markers at the confirmed end token and recovers the complete call body without leaking markup."

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -441,6 +441,11 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["[TOOL_CALLS]".to_string()],
                 tool_call_end_tokens: vec!["[/TOOL_CALLS]".to_string(), "".to_string()],
+                // On failed-parse recovery, strip the markers instead of leaking
+                // them into normal_text (malformed body, or orphan close with no
+                // opener). Same flag nemotron_deci uses; base_json_parser.rs has
+                // the streaming-path detail.
+                strip_markup_on_recovery: true,
                 ..Default::default()
             }),
             structural_tag_builder: None,

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -528,19 +528,29 @@ pub fn try_tool_call_parse_basic_json(
     }
 
     // Strict recovery (opt-in via `strip_markup_on_recovery`, e.g. nemotron_deci):
-    // every parse above failed, so the fall-through below would return the raw
-    // text verbatim — which leaks the wrapper markers (`<TOOLCALL>` /
-    // `</TOOLCALL>`) into `normal_text`. Instead, strip all configured markers
-    // and retry a strict parse of the remaining payload: recover any well-formed
-    // call (this is what salvages orphan-close framing like
-    // `[{...}]</TOOLCALL>`), otherwise drop the content. Markers never reach the
-    // user either way; `tracing::warn!` records what was recovered or dropped.
-    // Gated on `allow_eof_recovery` so this only runs on finalize / non-streaming
-    // aggregate paths — never on a mid-stream chunk. Firing mid-stream would
-    // claim a "complete" call before the end token arrives (same hazard as
-    // `allow_eof_recovery` itself), which strands the trailing `</TOOLCALL>` as
-    // leaked normal_text on the next chunk.
-    if config.strip_markup_on_recovery && config.allow_eof_recovery {
+    // every parse above failed, so the fall-through below would leak the wrapper
+    // markers verbatim into `normal_text`. Instead, strip the configured markers
+    // and retry a strict parse: recover a well-formed call (salvages orphan-close
+    // framing like `[{...}]</TOOLCALL>`) or drop the content. `tracing::warn!`
+    // records which happened.
+    //
+    // Gated on `allow_eof_recovery` (finalize / batch) so it can't fire on an
+    // incomplete mid-stream chunk and claim a call before the end token arrives.
+    // Mistral also runs it once a complete `[/TOOL_CALLS]` end token is present:
+    // the streaming jail unjails on that marker with `allow_eof_recovery=false`,
+    // and stripping at a *confirmed* end token is safe (a complete region, not a
+    // truncated claim) — without it, orphan-close / malformed-body chunks leak
+    // (TOOLCALLING.stream.4.c). Scoped to mistral via its `[TOOL_CALLS]` start
+    // token so other strip-markup families stay byte-identical.
+    let mistral_end_token_present = config
+        .tool_call_start_tokens
+        .iter()
+        .any(|t| t == "[TOOL_CALLS]")
+        && config
+            .tool_call_end_tokens
+            .iter()
+            .any(|token| !token.is_empty() && trimmed.contains(token.as_str()));
+    if config.strip_markup_on_recovery && (config.allow_eof_recovery || mistral_end_token_present) {
         // Only intervene when a wrapper marker is actually present. Plain text
         // with no tool-call marker is a normal (non-tool) response and MUST
         // pass through unchanged — it must never be dropped or treated as a


### PR DESCRIPTION
#### Overview

The mistral tool-call parser leaked `[TOOL_CALLS]` / `[/TOOL_CALLS]` wrapper markers into user-visible `message.content` whenever the JSON body failed every parse path: malformed args inside a closed wrapper, or an orphan `[/TOOL_CALLS]` close with no opener. Tool-call markup must never reach `content`. The `mistral()` config never opted into `strip_markup_on_recovery` (the marker-stripping mechanism `nemotron_deci` already uses), so the recovery fall-through re-emitted the raw text verbatim. This enables it, plus a small mistral-scoped streaming-end-token extension, so the affected parity cells stop leaking.

#### Details

- `parsers/src/tool_calling/config.rs`: set `strip_markup_on_recovery: true` on `mistral()`.
- `parsers/src/tool_calling/json/base_json_parser.rs`: also run the marker-strip when the payload already carries a complete `[/TOOL_CALLS]` end token (not only on `allow_eof_recovery`), scoped to mistral via its `[TOOL_CALLS]` start token. This covers the streaming early-exit unjail case, which fires on a complete end marker but passes `allow_eof_recovery=false`. Scoped so `nemotron_deci` (the other `strip_markup_on_recovery` user) stays byte-identical.
- `conformance/toolcalling/fixtures/mistral/`: refresh `expected.dynamo` for the de-leaked batch cases (`4.a`/`4.b` to empty, `5.b` recovers `get_weather(NYC)`); classify the vLLM body-leak and SGLang no-space (`[TOOL_CALLS] [` vs `[TOOL_CALLS][`) divergences with a `reason:`. Stream fixtures (`stream.1`/`stream.4`) updated for the rendered table.

#### Before / After

| Case | Before (leaked) | After |
|---|---|---|
| `batch.4.a` | `calls=[] normal_text='[TOOL_CALLS]not a json array[/TOOL_CALLS]'` | `calls=[] normal_text=''` |
| `batch.4.b` | `calls=[] normal_text='[TOOL_CALLS][{"name":"get_weather","arguments":{"location":"NYC"][/TOOL_CALLS]'` | `calls=[] normal_text=''` |
| `batch.5.b` | `calls=[] normal_text='[{"name":"get_weather","arguments":{"location":"NYC"}}][/TOOL_CALLS]'` | `calls=[get_weather(NYC)] normal_text=''` |

#### Cross-impl

vLLM's mistral parser splits only on the `[TOOL_CALLS]` opener and has no `[/TOOL_CALLS]` concept, so on a malformed body it returns the raw post-opener text (leaking the close marker); with only an orphan close it treats the whole string as content. SGLang's `MistralDetector` requires `[TOOL_CALLS] [` with a space, but the canonical `mistral_common` wire format emits `[TOOL_CALLS][` with no space, so it returns no call on genuine Mistral output. Both are documented per-case.

The streaming jail that the end-token extension targets lives in dynamo's `lib/llm` and did not migrate to this crate; v1 conformance here is batch-only, so the batch leak rows are the validated surface (`parity_toolcalling` 606/606).
