### PR TITLE
fix(parsers): stop qwen25 tool-call parser from leaking <tool_call> markup

### DIFF
--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
@@ -17,12 +17,18 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
         calls: []
-        normal_text: <tool_call>not even json</tool_call>
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id001
+      sglang:
+        reason: 'Malformed body in a complete <tool_call> wrapper: Dynamo discards
+          the unparseable jail region (no leak); SGLang''s Qwen25Detector keys on a
+          "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
+          returns the raw text. Non-parity by design.'
+        calls: []
+        normal_text: <tool_call>not even json</tool_call>
   TOOLCALLING.batch.4.b:
     description: Missing close brace in JSON body
     ref: dynamo
@@ -32,10 +38,16 @@ cases:
     expected:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      dynamo: &id003
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Malformed JSON in a complete <tool_call> wrapper: Dynamo discards the
+          unparseable jail region (no leak); SGLang''s Qwen25Detector keys on a
+          "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
+          returns the raw text. Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-      sglang: *id003
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -43,12 +55,18 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
-        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id004
+      sglang:
+        reason: 'Missing name key in a complete <tool_call> wrapper: Dynamo discards the
+          unparseable jail region (no leak); SGLang''s Qwen25Detector keys on a
+          "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
+          returns the raw text. Non-parity by design.'
+        calls: []
+        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
@@ -34,12 +34,17 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
         calls: []
-        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id002
+      sglang:
+        reason: 'Orphan </tool_call> with no opener: Dynamo strips the stray end marker
+          from normal_text (no leak); SGLang''s Qwen25Detector leaves it in the raw
+          text. Non-parity by design.'
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -68,7 +73,7 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
+      dynamo:
         calls:
         - name: get_weather
           arguments:
@@ -76,7 +81,12 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -88,7 +98,7 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id004
+      dynamo:
         calls:
         - name: get_weather
           arguments:
@@ -96,4 +106,9 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id004
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
@@ -18,14 +18,18 @@ cases:
         type: object
         properties: {}
     expected:
-      dynamo: &id001
+      dynamo:
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id001
+      sglang:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   TOOLCALLING.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -36,14 +40,18 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      sglang:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   TOOLCALLING.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -51,9 +59,17 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id004
+      sglang:
+        reason: 'Name-only call (no arguments key): Dynamo recovers it as get_time({})
+          (matching vLLM/SGLang Hermes detectors); SGLang''s Qwen25Detector keys on a
+          "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
+          returns the raw text. Non-parity by design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
@@ -72,12 +72,9 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        reason: 'Orphan </tool_call> markers with no opener: SGLang strips them, Dynamo keeps them (impl-defined recovery).'
+      dynamo: &d_stream_4_c
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang: *d_stream_4_c

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -64,6 +64,25 @@ pub struct JsonParserConfig {
     /// trailing marker as leaked text on the next chunk.
     #[serde(default)]
     pub strip_markup_on_recovery: bool,
+
+    /// Recover a name-only tool-call object (`{"name": "f"}`, no `arguments`
+    /// or `parameters` key) as an empty-argument call rather than dropping it.
+    /// Matches vLLM's and SGLang's Hermes detectors, which treat a missing
+    /// argument key as `{}`. Default `false` keeps every other family's
+    /// stricter behavior (a name-only object is not a call) unchanged; only
+    /// `qwen25` opts in.
+    #[serde(default)]
+    pub allow_name_only_call: bool,
+
+    /// When a complete `<start>...<end>` wrapper is present but nothing parses
+    /// out of it (non-JSON garbage, missing name), discard the jailed region
+    /// instead of leaving the raw markup in `normal_text`; also strip orphan
+    /// end tokens that appear with no opener. Default `false` preserves every
+    /// other family's impl-defined recovery (which may keep the raw text);
+    /// only `qwen25` opts in, since it must never surface tool-call markup to
+    /// the user.
+    #[serde(default)]
+    pub discard_unparseable_wrapper: bool,
 }
 
 impl Default for JsonParserConfig {
@@ -78,6 +97,8 @@ impl Default for JsonParserConfig {
             bare_json_mode: false,
             allow_eof_recovery: false,
             strip_markup_on_recovery: false,
+            allow_name_only_call: false,
+            discard_unparseable_wrapper: false,
         }
     }
 }
@@ -403,6 +424,21 @@ impl ToolCallConfig {
                 },
             )),
         }
+    }
+
+    /// Qwen 2.5 shares Hermes' `<tool_call>...</tool_call>` wire format but,
+    /// unlike Hermes, must never surface tool-call markup to the user. It uses
+    /// the Hermes config plus two opt-in flags: recover a name-only call as
+    /// empty-arg, and discard an unparseable wrapper / strip orphan end tokens
+    /// rather than leaking them into `normal_text`. (EOF-recovery opt-out for
+    /// qwen25 stays keyed by name in `detect_and_parse_tool_call_with_recovery`.)
+    pub fn qwen25() -> Self {
+        let mut config = Self::hermes();
+        if let ParserConfig::Json(ref mut json) = config.parser_config {
+            json.allow_name_only_call = true;
+            json.discard_unparseable_wrapper = true;
+        }
+        config
     }
 
     /// Default configuration for nemotron tool calls

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -31,6 +31,16 @@ pub struct CalledFunctionArguments {
     pub arguments: Box<RawValue>,
 }
 
+// A tool call may omit both `arguments` and `parameters` when the function
+// takes no inputs (e.g. `{"name": "get_time"}`). vLLM's and SGLang's Hermes
+// detectors treat that as an empty-argument call; this name-only shape is
+// tried as a last resort (after the `parameters` / `arguments` shapes) so the
+// call is recovered with `{}` args rather than dropped and its wrapper leaked.
+#[derive(Debug, serde::Deserialize)]
+pub struct CalledFunctionNameOnly {
+    pub name: String,
+}
+
 // Extract the contents between start and end tokens using regex parsing.
 // Returns a JSON array string if there are multiple matches, otherwise returns the last match directly.
 fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) -> Option<String> {
@@ -326,7 +336,10 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
 /// than re-serializing a parsed `HashMap` / `Value`, which keeps them
 /// byte-identical to what the model emitted (required for KV-cache append-only
 /// prefix matching across multi-step tool use).
-fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
+fn parse_calls(
+    payload: &str,
+    allow_name_only: bool,
+) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
     let mk = |name: String, args: &RawValue| ToolCallResponse {
         id: format!("call-{}", Uuid::new_v4()),
         tp: ToolCallType::Function,
@@ -346,6 +359,12 @@ fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
                 serde_json::from_str::<CalledFunctionParameters>(item_str)
             {
                 calls.push(mk(func_params.name, &func_params.parameters));
+            } else if allow_name_only
+                && let Ok(name_only) = serde_json::from_str::<CalledFunctionNameOnly>(item_str)
+            {
+                // No `arguments`/`parameters` key — treat as an empty-arg call.
+                let empty = RawValue::from_string("{}".to_string())?;
+                calls.push(mk(name_only.name, &empty));
             }
             // Skip malformed entries silently.
         }
@@ -356,6 +375,13 @@ fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
     }
     if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
         return Ok(Some(vec![mk(single.name, &single.arguments)]));
+    }
+    if allow_name_only
+        && let Ok(name_only) = serde_json::from_str::<CalledFunctionNameOnly>(payload)
+    {
+        // No `arguments`/`parameters` key — treat as an empty-arg call.
+        let empty = RawValue::from_string("{}".to_string())?;
+        return Ok(Some(vec![mk(name_only.name, &empty)]));
     }
     Ok(None)
 }
@@ -478,7 +504,7 @@ pub fn try_tool_call_parse_basic_json(
     // `arguments`, or an array of either). A recognized shape returns here —
     // including an empty array, which is a valid empty result and must not fall
     // through to truncation recovery.
-    if let Some(calls) = parse_calls(json)? {
+    if let Some(calls) = parse_calls(json, config.allow_name_only_call)? {
         return Ok((calls, Some(normal_text)));
     }
 
@@ -501,7 +527,10 @@ pub fn try_tool_call_parse_basic_json(
     {
         let recovered = recover_leading_complete_objects(json);
         if !recovered.is_empty()
-            && let Some(calls) = parse_calls(&format!("[{}]", recovered.join(",")))?
+            && let Some(calls) = parse_calls(
+                &format!("[{}]", recovered.join(",")),
+                config.allow_name_only_call,
+            )?
             && !calls.is_empty()
         {
             return Ok((calls, Some(normal_text)));
@@ -515,7 +544,7 @@ pub fn try_tool_call_parse_basic_json(
     // call while the model is still emitting JSON tokens.
     if config.allow_eof_recovery
         && let Some(repaired) = try_repair_truncated_json(json)
-        && let Some(calls) = parse_calls(repaired.as_str())?
+        && let Some(calls) = parse_calls(repaired.as_str(), config.allow_name_only_call)?
         && !calls.is_empty()
     {
         return Ok((calls, Some(normal_text)));
@@ -592,7 +621,7 @@ pub fn try_tool_call_parse_basic_json(
             }
             let payload = payload.trim();
 
-            let calls = parse_calls(payload)?.unwrap_or_default();
+            let calls = parse_calls(payload, config.allow_name_only_call)?.unwrap_or_default();
 
             if !calls.is_empty() {
                 tracing::warn!(
@@ -608,6 +637,53 @@ pub fn try_tool_call_parse_basic_json(
                 "Dropping unparseable tool-call content; wrapper markers stripped, no valid tool call recovered"
             );
             return Ok((vec![], Some(String::new())));
+        }
+    }
+
+    // No parseable tool call was produced. Families that opt into
+    // `discard_unparseable_wrapper` (qwen25) must never surface tool-call
+    // markup, so decide what (if anything) of the raw text may pass through as
+    // `normal_text`. Every other family keeps its impl-defined recovery (the
+    // raw text passes through unchanged below). Two distinct leak shapes:
+    if config.discard_unparseable_wrapper {
+        let has_start = config
+            .tool_call_start_tokens
+            .iter()
+            .any(|t| !t.is_empty() && trimmed.contains(t.as_str()));
+        let has_end = config
+            .tool_call_end_tokens
+            .iter()
+            .any(|t| !t.is_empty() && trimmed.contains(t.as_str()));
+
+        if has_start && has_end {
+            // A complete `<start>...</end>` wrapper was present but nothing
+            // parsed out of it (non-JSON garbage, missing name, etc.). Discard
+            // the whole jailed region rather than leaking the wrapper markup;
+            // `normal_text` already holds the pre-wrapper prefix.
+            return Ok((vec![], Some(normal_text)));
+        }
+        if has_end {
+            // Orphan end token(s) with no matching opener (e.g.
+            // `{..}</tool_call>` or repeated `</tool_call>` runs at `length`).
+            // Strip the trailing stray end markers so the marker never reaches
+            // user-visible content, but keep the surrounding text the model
+            // produced outside any call.
+            let mut cleaned = trimmed;
+            loop {
+                let t = cleaned.trim_end();
+                match config
+                    .tool_call_end_tokens
+                    .iter()
+                    .filter(|tok| !tok.is_empty())
+                    .find_map(|tok| t.strip_suffix(tok.as_str()))
+                {
+                    Some(rest) => cleaned = rest,
+                    None => break,
+                }
+            }
+            if cleaned.len() != trimmed.len() {
+                return Ok((vec![], Some(cleaned.trim().to_string())));
+            }
         }
     }
 

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -58,7 +58,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
         map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
-        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
+        map.insert("qwen25", ToolCallConfig::qwen25()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes but never leaks markup; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
         map
     })
 }


### PR DESCRIPTION
#### Overview

The qwen25 tool-call parser leaked raw `<tool_call>` / `</tool_call>` markup into user-visible `message.content` on several malformed or partial inputs. Six cases on the qwen25 parity row were flagged as leaks. qwen25 shares Hermes' `<tool_call>...</tool_call>` wire format, but unlike Hermes it must never surface tool-call markup to the user. This change makes qwen25 discard or strip that markup so it never reaches content, and recover a no-argument call instead of dropping it. The behavior is opted into by qwen25 only; every other family that runs through the shared JSON parser is byte-for-byte unchanged.

#### Details

- `parsers/src/tool_calling/config.rs`: add `allow_name_only_call` and `discard_unparseable_wrapper` flags and a `qwen25()` config (Hermes wire format plus both opt-ins) instead of aliasing the hermes config.
- `parsers/src/tool_calling/json/base_json_parser.rs`: add a name-only call shape (`{"name":"f"}` with no `arguments`/`parameters` key), tried last and gated behind `allow_name_only_call`. When `discard_unparseable_wrapper` is set, a complete `<tool_call>...</tool_call>` wrapper that fails to parse is discarded instead of leaking the raw text, and an orphan `</tool_call>` end marker with no opener is stripped.
- `parsers/src/tool_calling/parsers.rs`: qwen25 maps to `ToolCallConfig::qwen25()` instead of `ToolCallConfig::hermes()`.
- `conformance/toolcalling/fixtures/qwen25/`: refresh `expected.dynamo` for the changed batch cases (`4.a/4.b/4.c` discarded, `5.b` marker stripped, `6.c` recovers `get_time({})`) and record SGLang outputs with a `reason:` on each documented divergence. Stream fixture (`stream.4`) updated for the rendered table.

#### Before / After

```
batch.4.a  <tool_call>not even json</tool_call>
  before: content leaks    after: content="" (discarded)
batch.5.b  {"name":...}</tool_call>   (orphan close)
  before: leaks marker      after: marker stripped
batch.6.c  <tool_call>{"name":"get_time"}</tool_call>
  before: calls=[], leak     after: calls=[get_time({})]
```

#### Cross-impl

vLLM is n/a because the parity harness has no qwen25-to-hermes mapping (vLLM serves Qwen2.5 tool calls through its hermes parser per its own docs; adding that mapping is a sensible follow-up). Each SGLang divergence carries a reason in the fixture (its `Qwen25Detector` keys on a `<tool_call>\n` prefix and so detects nothing on the compact wrapper), so the qwen25 row shows zero leaks and zero unclassified divergences.

Note: dynamo's original change also touched `lib/llm/.../jail.rs` for the streaming finalize / trailing-content path. That has no home in frontend-crates (the jail is not in this crate; v1 conformance is batch-only; v2 streaming lives in `parsers_v2/`). All validated batch leak fixes here come from the parser-crate changes; the jail/streaming portion is dynamo-`lib/llm`-only and is intentionally not part of this PR.
