### PR TITLE
fix(parsers): align hermes tool-call parser to never leak markup

### DIFF
--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
@@ -55,6 +55,9 @@ cases:
             timezone: EST
         normal_text: 'Both:'
       vllm:
+        reason: 'vLLM preserves the trailing space before the first <tool_call> in
+          normal_text; Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by
+          design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.4.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
-        reason: "Dynamo's hermes parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id001
+        reason: 'vLLM and SGLang leave the raw <tool_call> wrapper in normal_text on
+          non-JSON garbage; Dynamo discards the unparseable wrapper (no leak). Non-parity
+          by design.'
         calls: []
         normal_text: <tool_call>not even json</tool_call>
-      vllm: *id001
       sglang: *id001
   TOOLCALLING.batch.4.b:
     description: Missing close brace in JSON body
@@ -36,12 +40,13 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
+      vllm: &id006
+        reason: 'vLLM and SGLang drop the call and leak the raw wrapper when the JSON
+          body is missing its closing brace; Dynamo''s JSON-repair recovers the call.
+          Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+      sglang: *id006
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -50,13 +55,14 @@ cases:
     - *id002
     expected:
       dynamo: &id003
-        reason: "Dynamo's hermes parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
-        calls: []
-        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
-      vllm: *id003
-      sglang:
         calls: []
         normal_text: ''
+      sglang: *id003
+      vllm:
+        reason: 'vLLM leaks the raw wrapper when the name key is missing; Dynamo and
+          SGLang discard the unparseable wrapper (no leak). Non-parity by design.'
+        calls: []
+        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.5.yaml
@@ -32,11 +32,15 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's hermes parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm: &id003
+        reason: 'vLLM and SGLang leave the orphan </tool_call> in normal_text when the
+          opening <tool_call> marker is missing; Dynamo strips the stray end marker
+          (no leak). Non-parity by design.'
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON
@@ -45,11 +49,15 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
-        reason: "Dynamo's hermes parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id004
+        reason: 'vLLM and SGLang surface the truncated <tool_call> body as raw text;
+          Dynamo suppresses the unterminated call (open <tool_call>, no close, nothing
+          salvaged) so no markup leaks. Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-      vllm: *id004
       sglang: *id004
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
@@ -65,7 +73,10 @@ cases:
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm:
+      vllm: &id005
+        reason: 'vLLM and SGLang recover the trailing call whose body is complete but
+          end marker is missing; Dynamo drops the unterminated trailing call and keeps
+          the first complete call. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -74,15 +85,7 @@ cases:
           arguments:
             location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      sglang:
-        calls:
-        - name: get_weather
-          arguments:
-            location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang: *id005
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -97,13 +100,20 @@ cases:
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm:
+      vllm: &id007
+        reason: 'vLLM and SGLang leak the whole text when the trailing call is truncated
+          mid-arg-value; Dynamo recovers the first complete call and drops the truncated
+          trailer (no leak). Non-parity by design.'
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
           "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
           "New York'
-      sglang:
-        calls: []
-        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
-          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
-          "New York'
+      sglang: *id007
+  TOOLCALLING.batch.5.f:
+    description: Bare valid call before a complete wrapped call — n/a for this family's syntax
+    reason: |-
+      TOOLCALLING.batch.5.f tests recovery of a leading bare (unwrapped) call body that precedes a properly-wrapped call. It applies only to families that admit a bare-body call form (deepseek_v4, gemma4, glm47, kimi_k2, minimax_m2, qwen3_coder). Hermes uses paired <tool_call>...</tool_call> fences with no bare-body form, so this case is not applicable; truncation/orphan coverage for this family lives in 5.a-5.e.
+  TOOLCALLING.batch.5.g:
+    description: Orphan close marker after prefix prose — n/a for this family's syntax
+    reason: |-
+      TOOLCALLING.batch.5.g tests prefix prose followed by a bare (unwrapped) call body terminated by an orphan close marker. It applies only to families that admit a bare-body call form (deepseek_v4, gemma4, glm47, kimi_k2, minimax_m2, qwen3_coder). Hermes uses paired <tool_call>...</tool_call> fences with no bare-body form, so this case is not applicable; orphan-close coverage for this family lives in 5.b.

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.6.yaml
@@ -44,12 +44,13 @@ cases:
     - *id002
     expected:
       dynamo: &id004
-        reason: "Dynamo's hermes parser leaves <tool_call> tag in normal_text on minimal/no-body case"
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
-      vllm: *id004
-      sglang:
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
+      sglang: *id004
+      vllm:
+        reason: 'vLLM leaks the raw wrapper when the arguments key is absent; Dynamo
+          and SGLang recover it as a no-arg call get_time({}). Non-parity by design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
@@ -24,6 +24,8 @@ cases:
             location: NYC
         normal_text: I will check the weather.
       vllm:
+        reason: 'vLLM preserves the trailing space before <tool_call> in normal_text;
+          Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -61,6 +63,8 @@ cases:
             location: NYC
         normal_text: I will check the weather.
       vllm:
+        reason: 'vLLM preserves the trailing space before <tool_call> in normal_text;
+          Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -85,6 +89,8 @@ cases:
             location: LA
         normal_text: I will check the weather.
       vllm:
+        reason: 'vLLM preserves the trailing space before <tool_call> in normal_text;
+          Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
@@ -48,11 +48,18 @@ cases:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
       sglang:
+        reason: 'On a stream truncated mid-body, SGLang''s finalizer recovers a no-arg
+          get_weather({}); Dynamo''s streaming jail surfaces the partial <tool_call>
+          body as text. Streaming-finalize recovery is tracked separately from the
+          batch path (the batch case 5.c suppresses to empty). Non-parity by design.'
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
       vllm:
+        reason: 'On a stream truncated mid-body, vLLM''s finalizer emits get_weather
+          with the partial ''{"loc'' argument fragment; Dynamo''s streaming jail surfaces
+          the partial <tool_call> body as text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments: '{"loc'
@@ -78,5 +85,8 @@ cases:
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
       vllm: *id002
       sglang:
+        reason: 'SGLang strips the orphan </tool_call> run and keeps the inner JSON
+          body as text; Dynamo''s streaming jail leaves the trailing close-marker run
+          in normal_text. Non-parity by design.'
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -70,7 +70,7 @@ pub struct JsonParserConfig {
     /// Matches vLLM's and SGLang's Hermes detectors, which treat a missing
     /// argument key as `{}`. Default `false` keeps every other family's
     /// stricter behavior (a name-only object is not a call) unchanged; only
-    /// `qwen25` opts in.
+    /// `qwen25` and `hermes` opt in.
     #[serde(default)]
     pub allow_name_only_call: bool,
 
@@ -79,8 +79,8 @@ pub struct JsonParserConfig {
     /// instead of leaving the raw markup in `normal_text`; also strip orphan
     /// end tokens that appear with no opener. Default `false` preserves every
     /// other family's impl-defined recovery (which may keep the raw text);
-    /// only `qwen25` opts in, since it must never surface tool-call markup to
-    /// the user.
+    /// only `qwen25` and `hermes` opt in, since they must never surface
+    /// tool-call markup to the user.
     #[serde(default)]
     pub discard_unparseable_wrapper: bool,
 }
@@ -408,6 +408,14 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["<tool_call>".to_string()],
                 tool_call_end_tokens: vec!["</tool_call>".to_string()],
+                // Hermes never surfaces tool-call markup to the user: recover a
+                // name-only call as empty-arg, and discard an unparseable
+                // wrapper / strip orphan end tokens rather than leaking them
+                // into `normal_text`. Unterminated-call suppression (open
+                // `<tool_call>`, no close) is keyed by name in
+                // `detect_and_parse_tool_call_with_recovery`, shared with qwen25.
+                allow_name_only_call: true,
+                discard_unparseable_wrapper: true,
                 ..Default::default()
             }),
             structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
@@ -426,19 +434,14 @@ impl ToolCallConfig {
         }
     }
 
-    /// Qwen 2.5 shares Hermes' `<tool_call>...</tool_call>` wire format but,
-    /// unlike Hermes, must never surface tool-call markup to the user. It uses
-    /// the Hermes config plus two opt-in flags: recover a name-only call as
-    /// empty-arg, and discard an unparseable wrapper / strip orphan end tokens
-    /// rather than leaking them into `normal_text`. (EOF-recovery opt-out for
-    /// qwen25 stays keyed by name in `detect_and_parse_tool_call_with_recovery`.)
+    /// Qwen 2.5 shares Hermes' `<tool_call>...</tool_call>` wire format and the
+    /// same "never surface tool-call markup" config — `hermes()` now opts into
+    /// both `allow_name_only_call` and `discard_unparseable_wrapper`, so the
+    /// configs are identical. The only behavioral difference is the EOF-recovery
+    /// opt-out, keyed by name in `detect_and_parse_tool_call_with_recovery`:
+    /// qwen25 drops an unterminated complete-body call where hermes salvages it.
     pub fn qwen25() -> Self {
-        let mut config = Self::hermes();
-        if let ParserConfig::Json(ref mut json) = config.parser_config {
-            json.allow_name_only_call = true;
-            json.discard_unparseable_wrapper = true;
-        }
-        config
+        Self::hermes()
     }
 
     /// Default configuration for nemotron tool calls

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -175,16 +175,20 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     };
     let (calls, normal_text) = try_tool_call_parse(message, &cfg, tools).await?;
 
-    // An unterminated qwen25 call (open <tool_call>, no close, nothing parsed)
-    // drops its partial markup instead of leaking it. Deliberate non-parity
-    // with SGLang, which surfaces the raw text.
-    if parser_key == "qwen25"
+    // An unterminated qwen25/hermes call (open <tool_call>, no close, nothing
+    // parsed) drops its partial markup instead of leaking it. Deliberate
+    // non-parity with vLLM/SGLang, which surface the raw text. Hermes keeps
+    // `allow_eof_recovery` on (so a complete-but-unclosed body still recovers),
+    // so this only fires on a genuinely truncated body that salvaged nothing.
+    // Keep any prose that preceded the wrapper (trailing whitespace trimmed, to
+    // match the wrapped-call extraction) rather than wiping the whole message.
+    if matches!(parser_key, "qwen25" | "hermes")
         && calls.is_empty()
         && let Some(text) = normal_text.as_deref()
-        && text.contains("<tool_call>")
+        && let Some(idx) = text.find("<tool_call>")
         && !text.contains("</tool_call>")
     {
-        return Ok((calls, Some(String::new())));
+        return Ok((calls, Some(text[..idx].trim_end().to_string())));
     }
 
     Ok((calls, normal_text))
@@ -2007,6 +2011,30 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let args: serde_json::Value =
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
+    }
+
+    /// An unterminated hermes/qwen25 call (open `<tool_call>`, no close, nothing
+    /// salvaged) drops the partial markup without leaking it, but keeps the prose
+    /// that preceded the wrapper instead of wiping the whole message. Trailing
+    /// whitespace before the wrapper is trimmed, matching the wrapped-call path.
+    /// Not a TOOLCALLING.* fixture — the conformance cases for this shape have no
+    /// prefix prose, so this guards the prefix-preservation branch directly.
+    #[tokio::test]
+    async fn test_unterminated_call_preserves_prefix_prose() {
+        let input =
+            "I'll check the weather. <tool_call>{\"name\": \"get_weather\", \"arguments\": {\"loc";
+        for parser_name in ["hermes", "qwen25"] {
+            let (tool_calls, normal_text) =
+                detect_and_parse_tool_call_with_recovery(input, Some(parser_name), None)
+                    .await
+                    .expect("Failed to parse");
+            assert!(tool_calls.is_empty(), "{parser_name}: expected no calls");
+            assert_eq!(
+                normal_text,
+                Some("I'll check the weather.".to_string()),
+                "{parser_name}: prefix prose should be preserved (trailing space trimmed)"
+            );
+        }
     }
 
     /// Alias registration: verifies `deepseek-v4` and `deepseekv4` route to the same parser as `deepseek_v4`. Not a TOOLCALLING.*; covers registry plumbing.


### PR DESCRIPTION
#### Overview
Hermes tool-call parsing leaked `<tool_call>` markup into `message.content` on malformed/truncated input, leaving 16 batch + 2 stream cells red on the conformance dashboard. This aligns hermes with the same "never surface tool-call markup" contract qwen25 already uses. All 18 hermes cells are now green.

#### Details
- `config.rs`: `hermes()` opts into `allow_name_only_call` (recover `{"name":"f"}` as `f({})`, matching the vLLM/SGLang detectors) and `discard_unparseable_wrapper` (discard a complete wrapper that parses nothing; strip orphan end tokens). `qwen25()` is now `Self::hermes()` since the configs are identical; the only qwen25-vs-hermes difference is the name-keyed EOF-recovery opt-out. Field docs updated to note hermes opts in.
- `parsers.rs`: added `hermes` to the unterminated-call suppression (open `<tool_call>`, no close, nothing salvaged) shared with qwen25. Hermes keeps `allow_eof_recovery` on, so a complete-but-unclosed body still recovers; only a genuinely truncated body is suppressed. The suppression preserves prose preceding the wrapper (trailing-trimmed) instead of wiping the whole message.
- Fixtures: updated `expected.dynamo` for the 5 now-clean batch cells (4.a/4.c/5.b/5.c/6.c), added `reason:` docs to diverging peer blocks on 7 batch + 2 stream cells, and added n/a stubs for the bare-body cases 5.f/5.g (n/a for paired-fence hermes).

#### Before / After

No-arguments-key call `<tool_call>{"name": "get_time"}</tool_call>`:

Before:
```
dynamo: calls=[]                normal_text='<tool_call>{"name": "get_time"}</tool_call>'
vllm:   calls=[]                normal_text='<tool_call>{"name": "get_time"}</tool_call>'
sglang: calls=[get_time({})]    normal_text=''
```
After:
```
dynamo: calls=[get_time({})]    normal_text=''
vllm:   calls=[]                normal_text='<tool_call>{"name": "get_time"}</tool_call>'
sglang: calls=[get_time({})]    normal_text=''
```

Non-JSON garbage in a complete wrapper `<tool_call>not even json</tool_call>`:

Before:
```
dynamo: calls=[]    normal_text='<tool_call>not even json</tool_call>'
vllm:   calls=[]    normal_text='<tool_call>not even json</tool_call>'
sglang: calls=[]    normal_text='<tool_call>not even json</tool_call>'
```
After:
```
dynamo: calls=[]    normal_text=''
vllm:   calls=[]    normal_text='<tool_call>not even json</tool_call>'
sglang: calls=[]    normal_text='<tool_call>not even json</tool_call>'
```

Dashboard hermes row: 16 batch become 0 (all ok/documented/na).

#### Cross-impl
- vLLM/SGLang hermes parsers leak the raw wrapper on malformed input; Dynamo now discards it (documented as intentional Dynamo-stricter non-parity via peer `reason:`).
- 4.c/6.c: Dynamo now matches SGLang (discard / recover no-arg call); vLLM still leaks (documented).
- `allow_name_only_call` mirrors vLLM's and SGLang's treatment of a missing `arguments` key as `{}`.
