### PR TITLE
chore: sync from dynamo @ 290609f (protocols nvext)

### DIFF
--- a/protocols/src/types/anthropic.rs
+++ b/protocols/src/types/anthropic.rs
@@ -115,6 +115,11 @@ pub struct AnthropicCreateMessageRequest {
     /// The conversation messages.
     pub messages: Vec<AnthropicMessage>,
 
+    /// Dynamo protocol extension envelope. Protocol parsing keeps this opaque;
+    /// LLM request handling owns extension validation and normalization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<serde_json::Value>,
+
     /// Optional system prompt (string or array of `{"type":"text","text":"..."}` blocks).
     #[serde(
         default,
@@ -869,5 +874,28 @@ fn estimate_block_len(block: &AnthropicContentBlock) -> usize {
         AnthropicContentBlock::WebSearchToolResult { content, .. } => content.to_string().len(),
         AnthropicContentBlock::Image { .. } => 256, // rough estimate for image metadata
         AnthropicContentBlock::Other(v) => v.to_string().len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn messages_request_keeps_nvext_opaque() {
+        let request: AnthropicCreateMessageRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "nvext": {
+                "unknown_future_extension": {"nested": true},
+                "agent_context": {"trajectory_id": 7}
+            }
+        }))
+        .unwrap();
+
+        let nvext = request.nvext.expect("opaque nvext value");
+        assert_eq!(nvext["unknown_future_extension"]["nested"], true);
+        assert_eq!(nvext["agent_context"]["trajectory_id"], 7);
     }
 }


### PR DESCRIPTION
#### Overview
Restores the protocols-crate sync with `ai-dynamo/dynamo@main`, fixing the repo-wide red `sync-check` job. The check shallow-clones dynamo main HEAD and content-diffs `lib/{protocols,tokenizers,renderer}/{src,tests}` against this repo's copies; it has been failing on every PR and the hourly cron since dynamo merged a protocols change this repo had not picked up.

#### Details
- Re-syncs `protocols/src/types/anthropic.rs` from dynamo main (`290609f`) via `scripts/sync-from-dynamo.sh --apply`. One file, +28 lines: adds the opaque `nvext: Option<serde_json::Value>` field to `AnthropicCreateMessageRequest` plus its `messages_request_keeps_nvext_opaque` test.
- Source commit on dynamo: `6fb0d6e` `feat(protocols): move nvext handling to llm (#10784)` (2026-06-18). The field is parsed opaquely; no consumer-side change is needed in this repo (extension validation lives in the `llm` crate, which this repo does not vendor).
- No other `protocols/tokenizers/renderer` `src`/`tests` files drifted; the remaining differences are the intentionally-diverged `Cargo.toml`/`README.md`/`CLAUDE.md`/`AGENTS.md`, which the sync script flags as NOTE-only and never syncs.

#### Verification
- `scripts/sync-from-dynamo.sh /tmp/dynamo-main` now reports no code drift.
- `cargo build -p dynamo-protocols` clean; `cargo test -p dynamo-protocols messages_request_keeps_nvext_opaque` passes; `cargo fmt --all --check` clean.
