### PR TITLE
feat(parsers-v2): emit DSv4 DSML tool name eagerly in streaming

### DIFF
--- a/conformance/tests/parity_toolcalling_batch_via_stream.rs
+++ b/conformance/tests/parity_toolcalling_batch_via_stream.rs
@@ -66,8 +66,24 @@ fn toolcalling_batch_via_stream_parity() {
     // Batch samples where the streaming parser deliberately differs from the
     // strict batch parser. Removing an entry asserts that stream and batch now
     // agree on that sample.
-    let known_divergences: std::collections::BTreeSet<&str> =
-        ["deepseek_v4:TOOLCALLING.batch.5.g"].into_iter().collect();
+    //
+    // The DSv4 stream parser emits the function `name` eagerly the moment the
+    // `<｜DSML｜invoke name="...">` header closes (SGLang-style streaming latency).
+    // When the invoke then truncates before `</｜DSML｜invoke>`, that name has
+    // already escaped with empty arguments, while the strict batch parser drops
+    // the incomplete call entirely — so stream and batch diverge by design:
+    //   5.c: invoke header closed, truncated mid-parameter -> stream emits
+    //        ("get_weather", "") ; batch emits nothing.
+    //   5.e: first call complete, second call's header closed then truncated
+    //        mid-arg -> stream emits the extra ("get_weather", "") ; batch drops it.
+    //   5.g: bare invoke after prose, recovered eagerly (pre-existing).
+    let known_divergences: std::collections::BTreeSet<&str> = [
+        "deepseek_v4:TOOLCALLING.batch.5.c",
+        "deepseek_v4:TOOLCALLING.batch.5.e",
+        "deepseek_v4:TOOLCALLING.batch.5.g",
+    ]
+    .into_iter()
+    .collect();
 
     let mut total = 0usize;
     let mut consistent = 0usize;

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
@@ -31,7 +31,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -54,7 +57,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
@@ -31,7 +31,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -54,7 +57,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' <｜DSML｜invoke'
       expected:
@@ -69,7 +71,10 @@ cases:
         - index: 1
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
         vllm_python: []
@@ -94,7 +99,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 1
-          name: get_weather
           arguments: '{"location":"LA"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
@@ -31,7 +31,10 @@ cases:
         - index: 0
           name: unknown_tool
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: unknown_tool
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -54,7 +57,6 @@ cases:
           name: unknown_tool
         dynamo_rust:
         - index: 0
-          name: unknown_tool
           arguments: '{"location":"NYC"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -37,7 +37,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -60,7 +63,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' <｜DSML｜invoke'
       expected:
@@ -75,7 +77,10 @@ cases:
         - index: 1
           name: get_time
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_time
+          arguments: ''
     - delta_text: ' name="timezone" string="true">EST</｜DSML｜parameter>'
       expected:
         vllm_python: []
@@ -100,7 +105,6 @@ cases:
           name: get_time
         dynamo_rust:
         - index: 1
-          name: get_time
           arguments: '{"timezone":"EST"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:
@@ -145,7 +149,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -168,7 +175,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:
@@ -189,7 +195,10 @@ cases:
         - index: 1
           name: get_time
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_time
+          arguments: ''
     - delta_text: ' string="true">'
       expected:
         vllm_python: []
@@ -209,7 +218,6 @@ cases:
         vllm_rust: []
         dynamo_rust:
         - index: 1
-          name: get_time
           arguments: '{"timezone":"EST"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:
@@ -264,7 +272,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' string="true">NYC</｜DSML｜parameter>'
       expected:
         vllm_python: []
@@ -289,7 +300,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' <｜DSML｜invoke name="get_time">'
       expected:
@@ -298,7 +308,10 @@ cases:
         - index: 1
           name: get_time
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_time
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="timezone" string="true">'
       expected:
         vllm_python: []
@@ -329,7 +342,6 @@ cases:
           name: get_time
         dynamo_rust:
         - index: 1
-          name: get_time
           arguments: '{"timezone":"EST"}'
     - delta_text: ' Done.'
       expected:
@@ -370,7 +382,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -393,7 +408,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' <｜DSML｜invoke'
       expected:
@@ -408,7 +422,10 @@ cases:
         - index: 1
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
         vllm_python: []
@@ -433,7 +450,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 1
-          name: get_weather
           arguments: '{"location":"LA"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
@@ -104,7 +104,10 @@ cases:
         sglang_python:
         - index: 0
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -122,7 +125,6 @@ cases:
           arguments: '{}'
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
@@ -32,7 +32,10 @@ cases:
         sglang_python:
         - index: 0
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -50,7 +53,6 @@ cases:
           arguments: '{"location": "NYC"}'
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ''
       finish_reason: stop
@@ -76,7 +78,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
       normal_text:
         vllm_python: <｜DSML｜invoke name="get_weather">
         vllm_rust: <｜DSML｜invoke name="get_weather">
@@ -113,7 +118,6 @@ cases:
         vllm_rust: []
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
       normal_text:
         vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
@@ -150,7 +154,10 @@ cases:
         sglang_python:
         - index: 0
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -274,7 +281,10 @@ cases:
         sglang_python:
         - index: 0
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
@@ -292,7 +302,6 @@ cases:
           arguments: '{"location": "Boston"}'
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"Boston"}'
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
@@ -300,7 +309,10 @@ cases:
         sglang_python:
         - index: 1
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter'
       expected:
         vllm_python: []
@@ -323,7 +335,6 @@ cases:
           arguments: '{"location": "New York"}'
         dynamo_rust:
         - index: 1
-          name: get_weather
           arguments: '{"location":"New York"}'
     - delta_text: ''
       finish_reason: stop
@@ -436,7 +447,10 @@ cases:
         sglang_python:
         - index: 0
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
@@ -454,7 +468,6 @@ cases:
           arguments: '{"location": "Boston"}'
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"Boston"}'
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
@@ -462,7 +475,10 @@ cases:
         sglang_python:
         - index: 1
           name: get_weather
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter'
       expected:
         vllm_python: []
@@ -504,7 +520,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
       normal_text:
         vllm_python: <｜DSML｜invoke name="get_weather">
         vllm_rust: <｜DSML｜invoke name="get_weather">
@@ -541,7 +560,6 @@ cases:
         vllm_rust: []
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
       normal_text:
         vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
@@ -562,7 +580,10 @@ cases:
         - index: 1
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -593,7 +614,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 1
-          name: get_weather
           arguments: '{"location":"Boston"}'
     - delta_text: ''
       finish_reason: tool_calls
@@ -642,7 +662,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
       normal_text:
         vllm_python: ' that. <｜DSML｜invoke name="get_weather">'
         vllm_rust: ' that. <｜DSML｜invoke name="get_weather">'
@@ -678,7 +701,6 @@ cases:
         vllm_rust: []
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
       normal_text:
         vllm_python: NYC</｜DSML｜parameter> </｜DSML｜invoke>

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
@@ -74,7 +74,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: arameter name="loca
       expected:
         vllm_python: []
@@ -149,7 +152,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: DSML｜tool_calls>
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
@@ -29,7 +29,10 @@ cases:
         - index: 0
           name: get_time
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_time
+          arguments: ''
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         vllm_python:
@@ -46,7 +49,6 @@ cases:
           name: get_time
         dynamo_rust:
         - index: 0
-          name: get_time
           arguments: '{}'
     - delta_text: ''
       finish_reason: tool_calls
@@ -77,7 +79,10 @@ cases:
         - index: 0
           name: get_time
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_time
+          arguments: ''
     - delta_text: '
 
         </｜DSML｜invoke> </｜DSML｜tool_calls>'
@@ -96,7 +101,6 @@ cases:
           name: get_time
         dynamo_rust:
         - index: 0
-          name: get_time
           arguments: '{}'
     - delta_text: ''
       finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
@@ -35,7 +35,10 @@ cases:
         - index: 0
           name: book_flight
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: book_flight
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="destination" string="true">'
       expected:
         vllm_python: []
@@ -94,7 +97,6 @@ cases:
           name: book_flight
         dynamo_rust:
         - index: 0
-          name: book_flight
           arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
     - delta_text: ''
       finish_reason: tool_calls
@@ -127,7 +129,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -158,7 +163,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"Tōkyō central"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:
@@ -197,7 +201,10 @@ cases:
         - index: 0
           name: set_limit
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: set_limit
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="count" string="false">'
       expected:
         vllm_python: []
@@ -220,7 +227,6 @@ cases:
           name: set_limit
         dynamo_rust:
         - index: 0
-          name: set_limit
           arguments: '{"count":9007199254740993}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -57,7 +57,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter'
       expected:
         vllm_python: []
@@ -86,7 +89,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ''
       finish_reason: tool_calls
@@ -119,7 +121,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -142,7 +147,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:
@@ -231,7 +235,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter'
       expected:
         vllm_python: []
@@ -260,7 +267,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' Let'
       expected:
@@ -349,7 +355,10 @@ cases:
         - index: 0
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 0
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter'
       expected:
         vllm_python: []
@@ -378,7 +387,6 @@ cases:
           name: get_weather
         dynamo_rust:
         - index: 0
-          name: get_weather
           arguments: '{"location":"NYC"}'
     - delta_text: ' Then'
       expected:
@@ -411,7 +419,10 @@ cases:
         - index: 1
           name: get_weather
         vllm_rust: []
-        dynamo_rust: []
+        dynamo_rust:
+        - index: 1
+          name: get_weather
+          arguments: ''
     - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python: []
@@ -431,7 +442,6 @@ cases:
         vllm_rust: []
         dynamo_rust:
         - index: 1
-          name: get_weather
           arguments: '{"location":"LA"}'
     - delta_text: ' </｜DSML｜tool_calls>'
       expected:

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -15,11 +15,21 @@ const PARAMETER_PREFIX: &str = "<｜DSML｜parameter name=";
 const PARAMETER_END: &str = "</｜DSML｜parameter>";
 
 /// Stream parser for DeepSeek V4 DSML tool calls.
+///
+/// Emits eagerly to match SGLang's streaming latency: the function `name` is
+/// emitted as a delta the moment the `<｜DSML｜invoke name="...">` header closes,
+/// before any parameter body has streamed. The complete JSON `arguments` are
+/// emitted in a second delta once `</｜DSML｜invoke>` arrives. Consumers coalesce
+/// the two deltas by `tool_index` (name on the first, args on the second). This
+/// is the same wire shape Harmony uses (`name`-first, then arguments fragment).
 pub struct DeepSeekV4ToolStreamParser {
     buffer: String,
     in_block: bool,
     suppress_normal_text: bool,
     next_index: usize,
+    /// Set to `Some(tool_index)` after the invoke header (and its `name`) has
+    /// been emitted, while we wait for `</｜DSML｜invoke>` to emit the arguments.
+    open_invoke: Option<usize>,
 }
 
 impl DeepSeekV4ToolStreamParser {
@@ -29,6 +39,7 @@ impl DeepSeekV4ToolStreamParser {
             in_block: false,
             suppress_normal_text: false,
             next_index: 0,
+            open_invoke: None,
         }
     }
 
@@ -36,6 +47,38 @@ impl DeepSeekV4ToolStreamParser {
         let mut out = ToolParseResult::default();
 
         loop {
+            // An invoke header (with its name) has already been emitted; we are
+            // now waiting for the closing marker to emit the complete arguments.
+            if let Some(tool_index) = self.open_invoke {
+                let Some(end) = self.buffer.find(INVOKE_END) else {
+                    if flush {
+                        // Eager name already escaped; the truncated body cannot
+                        // produce arguments, so the call lands with empty args.
+                        tracing::warn!(
+                            why = "dsv4_incomplete_invoke",
+                            tool_index,
+                            "DSML stream truncated after eager name emit; arguments dropped"
+                        );
+                        self.buffer.clear();
+                        self.in_block = false;
+                        self.open_invoke = None;
+                    }
+                    break;
+                };
+                let body = self.buffer[..end].to_string();
+                self.buffer.drain(..end + INVOKE_END.len());
+                let arguments = serde_json::to_string(&parse_parameters(&body)?)?;
+                out.calls.push(ToolCallDelta {
+                    tool_index,
+                    name: None,
+                    arguments,
+                });
+                self.next_index += 1;
+                self.open_invoke = None;
+                self.suppress_normal_text = true;
+                continue;
+            }
+
             if self.in_block {
                 if let Some(end) = self.buffer.find(BLOCK_END) {
                     let invoke_before_end = self
@@ -64,23 +107,17 @@ impl DeepSeekV4ToolStreamParser {
                 if start > 0 {
                     self.buffer.drain(..start);
                 }
-                let Some(end) = self.buffer.find(INVOKE_END) else {
+                if self.open_invoke_header(&mut out)?.is_none() {
+                    // Header not fully streamed yet; wait for more input.
                     if flush {
                         tracing::warn!(
                             why = "dsv4_incomplete_invoke",
-                            "DSML stream dropped incomplete invoke at EOF"
+                            "DSML stream dropped incomplete invoke header at EOF"
                         );
                         self.buffer.clear();
                         self.in_block = false;
                     }
                     break;
-                };
-                let invoke = self.buffer[..end + INVOKE_END.len()].to_string();
-                self.buffer.drain(..end + INVOKE_END.len());
-                if let Some(delta) = self.parse_invoke_delta(&invoke)? {
-                    out.calls.push(delta);
-                    self.next_index += 1;
-                    self.suppress_normal_text = true;
                 }
                 continue;
             }
@@ -124,8 +161,15 @@ impl DeepSeekV4ToolStreamParser {
                     self.in_block = true;
                     self.suppress_normal_text = true;
                 }
-                Marker::BareInvoke => {
-                    let Some(end) = self.buffer.find(INVOKE_END) else {
+                Marker::BareInvoke => match self.open_invoke_header(&mut out)? {
+                    Some(tool_index) => {
+                        tracing::warn!(
+                            why = "dsv4_bare_invoke_recovery",
+                            tool_index,
+                            "DSML stream recovering a bare invoke (eager name emit)"
+                        );
+                    }
+                    None => {
                         if flush {
                             tracing::warn!(
                                 why = "dsv4_incomplete_bare_invoke",
@@ -134,52 +178,48 @@ impl DeepSeekV4ToolStreamParser {
                             self.buffer.clear();
                         }
                         break;
-                    };
-                    let invoke = self.buffer[..end + INVOKE_END.len()].to_string();
-                    self.buffer.drain(..end + INVOKE_END.len());
-                    if let Some(delta) = self.parse_invoke_delta(&invoke)? {
-                        tracing::warn!(
-                            why = "dsv4_bare_invoke_recovery",
-                            tool_index = delta.tool_index,
-                            "DSML stream recovered a complete bare invoke"
-                        );
-                        out.calls.push(delta);
-                        self.next_index += 1;
-                        self.suppress_normal_text = true;
                     }
-                }
+                },
             }
         }
 
         Ok(out)
     }
 
-    fn parse_invoke_delta(&self, invoke: &str) -> anyhow::Result<Option<ToolCallDelta>> {
-        let Some(after_prefix) = invoke.strip_prefix(INVOKE_START_PREFIX) else {
+    /// Given `self.buffer` positioned at an `INVOKE_START_PREFIX`, parse the
+    /// invoke header. If the header is complete (its closing `>` has streamed),
+    /// emit a name-only delta, consume the header bytes, mark `open_invoke`, and
+    /// return `Some(tool_index)`. If the header is still partial, leave the
+    /// buffer intact and return `None` so the caller can wait for more input.
+    fn open_invoke_header(&mut self, out: &mut ToolParseResult) -> anyhow::Result<Option<usize>> {
+        let Some((name, header_len)) = parse_invoke_header(&self.buffer) else {
             return Ok(None);
         };
-        let Some(after_quote) = after_prefix.strip_prefix('"') else {
-            return Ok(None);
-        };
-        let Some(name_end) = after_quote.find('"') else {
-            return Ok(None);
-        };
-        let name = after_quote[..name_end].trim().to_string();
-        let Some(header_end) = after_quote[name_end..].find('>') else {
-            return Ok(None);
-        };
-        let body_start = name_end + header_end + 1;
-        let Some(body_end) = after_quote[body_start..].find(INVOKE_END) else {
-            return Ok(None);
-        };
-        let body = &after_quote[body_start..body_start + body_end];
-        let arguments = serde_json::to_string(&parse_parameters(body)?)?;
-        Ok(Some(ToolCallDelta {
-            tool_index: self.next_index,
+        self.buffer.drain(..header_len);
+        let tool_index = self.next_index;
+        out.calls.push(ToolCallDelta {
+            tool_index,
             name: Some(name),
-            arguments,
-        }))
+            arguments: String::new(),
+        });
+        self.open_invoke = Some(tool_index);
+        self.suppress_normal_text = true;
+        Ok(Some(tool_index))
     }
+}
+
+/// Parse a complete invoke header `<｜DSML｜invoke name="X">` from the front of
+/// `s`. Returns `(name, header_byte_len)` where `header_byte_len` covers through
+/// the closing `>`. Returns `None` if the header has not fully streamed yet.
+fn parse_invoke_header(s: &str) -> Option<(String, usize)> {
+    let after_prefix = s.strip_prefix(INVOKE_START_PREFIX)?;
+    let after_quote = after_prefix.strip_prefix('"')?;
+    let name_end = after_quote.find('"')?;
+    let name = after_quote[..name_end].trim().to_string();
+    let rest = &after_quote[name_end + 1..];
+    let gt = rest.find('>')?;
+    let header_len = INVOKE_START_PREFIX.len() + 1 + name_end + 1 + gt + 1;
+    Some((name, header_len))
 }
 
 impl Default for DeepSeekV4ToolStreamParser {
@@ -281,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn emits_complete_invoke_on_close() {
+    fn emits_name_eagerly_then_args_on_close() {
         let out = parse_chunks(&[
             "<｜DSML｜tool_calls> <｜DSML｜invoke",
             " name=\"get_weather\">",
@@ -290,10 +330,33 @@ mod tests {
             " </｜DSML｜tool_calls>",
         ]);
         assert_eq!(out.normal_text, "");
-        assert_eq!(out.calls.len(), 1);
+        // Two deltas: name-only first, then arguments-only on close.
+        assert_eq!(out.calls.len(), 2);
         assert_eq!(out.calls[0].tool_index, 0);
         assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
-        assert_eq!(out.calls[0].arguments, r#"{"location":"NYC"}"#);
+        assert_eq!(out.calls[0].arguments, "");
+        assert_eq!(out.calls[1].tool_index, 0);
+        assert_eq!(out.calls[1].name, None);
+        assert_eq!(out.calls[1].arguments, r#"{"location":"NYC"}"#);
+
+        // Coalesced wire shape matches the complete call.
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
+    fn emits_name_before_any_arguments() {
+        // The name delta must precede the arguments delta on the wire.
+        let out = parse_chunks(&[
+            "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weather\">",
+            " <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter> </｜DSML｜invoke>",
+        ]);
+        let first_named = out.calls.iter().position(|c| c.name.is_some());
+        let first_args = out.calls.iter().position(|c| !c.arguments.is_empty());
+        assert_eq!(first_named, Some(0));
+        assert!(first_named <= first_args, "name must stream before args");
     }
 
     #[test]
@@ -305,7 +368,7 @@ mod tests {
             " <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter> </｜DSML｜invoke>",
         ]);
         assert_eq!(out.normal_text, "I will check the weather. ");
-        assert_eq!(out.calls.len(), 1);
+        assert_eq!(out.coalesce_calls().calls.len(), 1);
     }
 
     #[test]
@@ -316,16 +379,30 @@ mod tests {
             " </｜DSML｜invoke> </｜DSML｜tool_calls>",
         ]);
         assert_eq!(out.normal_text, "I will check that. ");
-        assert_eq!(out.calls.len(), 1);
-        assert_eq!(out.calls[0].arguments, r#"{"location":"NYC"}"#);
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
     }
 
     #[test]
-    fn suppresses_incomplete_invoke_at_eof() {
+    fn eager_name_escapes_when_invoke_truncates_at_eof() {
+        // The header closed, so the name was already emitted eagerly. The
+        // truncated parameter body never closes, so arguments stay empty.
         let out = parse_chunks(&[
             "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weather\">",
             " <｜DSML｜parameter name=\"location\" string=\"true\">NY",
         ]);
+        assert_eq!(out.normal_text, "");
+        assert_eq!(out.calls.len(), 1);
+        assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(out.calls[0].arguments, "");
+    }
+
+    #[test]
+    fn suppresses_invoke_header_truncated_mid_header() {
+        // The header itself never closes, so nothing is emitted at all.
+        let out = parse_chunks(&["<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weat"]);
         assert_eq!(out.normal_text, "");
         assert!(out.calls.is_empty());
     }


### PR DESCRIPTION
#### Overview:

This PR makes Dynamo's DeepSeek-V4 DSML streaming parser emit the tool **name as soon as the invoke header arrives**, instead of holding the whole call back until it finishes. That matches how vLLM and SGLang already stream (name first, arguments after), so consumers see the tool name earlier and Dynamo's stream lines up with the other engines.

#### What changed (and why):

- One behavior change in `parsers_v2/src/tool_calling/dsml.rs`: when `` `<｜DSML｜invoke name="...">` `` closes, emit a `name`-only delta immediately; emit the `arguments` as a second delta when `` `</｜DSML｜invoke>` `` closes. The two deltas coalesce by `tool_index` back into the exact same call as before — only the on-the-wire timing/splitting changed.
- Why: name-first streaming is what SGLang/vLLM do, and emitting the name early lets callers show "calling `get_weather`…" without waiting for the arguments to finish.
- The 10 `deepseek_v4` stream fixtures were regenerated to record the new emit sequence. One edge case is now an intentional stream-vs-batch divergence (allowlisted in the parity test): if a call truncates after the header but before close, the eager `name` has already been emitted (with empty args) while the strict batch parser drops the incomplete call — `` `batch.5.c` `` / `` `batch.5.e` ``.

#### Before / after (from the conformance chart — `deepseek_v4` → `TOOLCALLING.streamv2.1`, happy path):

Per-chunk emit of the Dynamo Rust stream parser, with SGLang shown for reference (note "after" now mirrors SGLang):

| input chunk | SGLang | Dynamo **before** | Dynamo **after** |
|---|---|---|---|
| `` `<｜DSML｜invoke` `` | — | — | — |
| `` ` name="get_weather">` `` | `name=get_weather` | — (nothing yet) | `name=get_weather, arguments=""` |
| `` ` <｜DSML｜parameter …>` `` | — | — | — |
| `` `NYC</｜DSML｜parameter> </｜DSML｜invoke>` `` | `arguments={"location":"NYC"}` | `name=get_weather, arguments={"location":"NYC"}` | `arguments={"location":"NYC"}` |

Before: Dynamo emitted nothing until the call fully closed, then sent name + arguments in one delta. After: it emits the name on the header chunk (like SGLang), then the arguments on the closing chunk.

#### Verification:

`cargo test -p dynamo-parsers-v2 -p dynamo-conformance-fixtures-v2` -> 27 passed, 0 failed (includes the batch-via-stream parity test). Conformance chart regenerated.

#### Where should the reviewer start?

`parsers_v2/src/tool_calling/dsml.rs`, then `conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml`

Related: [DIS-2237](https://linear.app/nvidia/issue/DIS-2237) — DSML parser work. This is the eager-streaming refinement, distinct from the wrapper-strict change tracked there.

/coderabbit profile chill
