### PR TITLE
chore: trivial sync from dynamo @ 2982d50

### DIFF
--- a/llm/tests/data/sample-models/mock-tokenizer-json-fallback/config.json
+++ b/llm/tests/data/sample-models/mock-tokenizer-json-fallback/config.json
@@ -1,0 +1,5 @@
+{
+  "architectures": ["JinaEmbeddingsV5OmniModel"],
+  "model_type": "jina_embeddings_v5_omni",
+  "special_token_ids": [151652, 151653, 151655, 151656, 151669, 151670, 151671]
+}

--- a/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer.json
+++ b/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer.json
@@ -1,0 +1,6 @@
+{
+  "added_tokens": [
+    {"id": 151643, "content": "<|endoftext|>", "special": true},
+    {"id": 151645, "content": "<|im_end|>", "special": true}
+  ]
+}

--- a/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer_config.json
+++ b/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer_config.json
@@ -1,0 +1,10 @@
+{
+  "add_prefix_space": false,
+  "bos_token": null,
+  "clean_up_tokenization_spaces": false,
+  "eos_token": "<|im_end|>",
+  "model_max_length": 131072,
+  "pad_token": "<|endoftext|>",
+  "tokenizer_class": "Qwen2Tokenizer",
+  "unk_token": null
+}


### PR DESCRIPTION
Mirrors a new tokenizer test fixture from `ai-dynamo/dynamo` @ `2982d50` so `sync-check` passes again. Fixtures only — no code or logic changes. Generated by `scripts/sync-from-dynamo.sh --apply`.

`dynamo lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/` -> `llm/tests/data/sample-models/mock-tokenizer-json-fallback/` (`config.json`, `tokenizer.json`, `tokenizer_config.json`)

/coderabbit profile chill
