### PR TITLE
test(conformance): align hermes stream 4.b/4.c with fixed dynamo jail

### DIFF
--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
@@ -46,20 +46,19 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
         reason: 'On a stream truncated mid-body, SGLang''s finalizer recovers a no-arg
-          get_weather({}); Dynamo''s streaming jail surfaces the partial <tool_call>
-          body as text. Streaming-finalize recovery is tracked separately from the
-          batch path (the batch case 5.c suppresses to empty). Non-parity by design.'
+          get_weather({}); Dynamo suppresses the unterminated call (open <tool_call>,
+          no close, nothing salvaged) so no markup leaks. Non-parity by design.'
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
       vllm:
         reason: 'On a stream truncated mid-body, vLLM''s finalizer emits get_weather
-          with the partial ''{"loc'' argument fragment; Dynamo''s streaming jail surfaces
-          the partial <tool_call> body as text. Non-parity by design.'
+          with the partial ''{"loc'' argument fragment; Dynamo suppresses the
+          unterminated call so no markup leaks. Non-parity by design.'
         calls:
         - name: get_weather
           arguments: '{"loc'
@@ -82,11 +81,11 @@ cases:
     expected:
       dynamo: &id002
         calls: []
-        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
-      vllm: *id002
-      sglang:
-        reason: 'SGLang strips the orphan </tool_call> run and keeps the inner JSON
-          body as text; Dynamo''s streaming jail leaves the trailing close-marker run
-          in normal_text. Non-parity by design.'
-        calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      sglang: *id002
+      vllm:
+        reason: 'vLLM leaves the orphan </tool_call> run in normal_text; Dynamo and
+          SGLang strip the stray end markers and keep the inner JSON body as text.
+          Non-parity by design.'
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge ai-dynamo/dynamo#10833 first.** This fixture asserts the streaming-jail markup-suppression output that #10833 introduces. Landing this PR before #10833 would make the parity dashboard assert behavior that shipping dynamo does not have yet (a false green).

#### Overview
The hermes TC-stream cells 4.b/4.c were red because this conformance fixture recorded Dynamo leaking `<tool_call>` markup into content on truncated/orphan streams. ai-dynamo/dynamo#10833 fixes the streaming jail to suppress that markup; this updates the fixture's `expected.dynamo` to the fixed output, turning both cells green and completing the hermes row (batch landed in #63).

#### Details
- 4.b (truncated mid-body): `expected.dynamo` -> `calls: [], normal_text: ''` (Dynamo suppresses the unterminated call). vLLM/SGLang keep their real partial-call recoveries; their `reason:` strings now describe Dynamo suppressing rather than leaking.
- 4.c (orphan close spam): `expected.dynamo` -> `{...}` with the trailing `</tool_call>` runs stripped. SGLang is now value-identical, so it aliases dynamo; vLLM still leaks the full run and is documented via `reason:`.

#### Before / After
Dashboard hermes TC-stream row:
```
before: 4.b RED, 4.c RED   (Dynamo leaks markup)
after:  4.b green, 4.c green (documented; Dynamo markup-free)
```

#### Cross-impl
- 4.b: Dynamo suppresses; vLLM recovers `get_weather("{\"loc")`; SGLang recovers `get_weather({})`; documented non-parity.
- 4.c: Dynamo and SGLang strip the orphan close to `{...}`; vLLM leaks the full `</tool_call>` run; documented non-parity.
