### PR TITLE
feat: jamba never-leaks tool-call markup on malformed input

### DIFF
--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
@@ -56,6 +56,7 @@ cases:
             timezone: EST
         normal_text: 'Both:'
       vllm:
+        reason: "Cosmetic whitespace only: Dynamo trims the single space between the leading narration and the <tool_calls> fence; vLLM preserves it. Calls are identical."
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.4.yaml
@@ -17,11 +17,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
-        reason: "Dynamo's jamba parser leaves <tool_calls> envelope in normal_text on malformed input (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: "vLLM's jamba detector leaves the raw <tool_calls> envelope in normal_text when the wrapped payload is not a valid JSON array. Dynamo discards the unparseable wrapper (discard_unparseable_wrapper) so no tool-call markup reaches the user."
         calls: []
         normal_text: <tool_calls>not a json array</tool_calls>
-      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.4.b:
@@ -31,11 +33,13 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's jamba parser leaves <tool_calls> envelope in normal_text on malformed input (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: "vLLM's jamba detector leaves the raw <tool_calls> envelope in normal_text when the JSON body is malformed (missing close brace). Dynamo discards the unparseable wrapper so no tool-call markup reaches the user."
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
-      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.4.c:
@@ -49,6 +53,7 @@ cases:
         calls: []
         normal_text: ''
       vllm:
+        reason: "vLLM's jamba detector leaves the raw <tool_calls> envelope in normal_text when no call carries a name key. Dynamo discards it so no tool-call markup reaches the user."
         calls: []
         normal_text: '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>'
       sglang:
@@ -67,6 +72,7 @@ cases:
             location: NYC
         normal_text: ''
       vllm:
+        reason: "vLLM's jamba detector requires the closing </tool_calls> marker and leaves the unterminated wrapper in normal_text. Dynamo recovers the complete call body (strip_markup_on_recovery) and emits no markup."
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
       sglang:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.5.yaml
@@ -24,6 +24,7 @@ cases:
             location: NYC
         normal_text: ''
       vllm:
+        reason: "vLLM's jamba detector requires the closing </tool_calls> marker and leaves the unterminated wrapper in normal_text. Dynamo recovers the complete call body (strip_markup_on_recovery) and emits no markup."
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
       sglang:
@@ -35,11 +36,16 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
-        reason: "Dynamo's jamba parser leaves closing </tool_calls> envelope plus the JSON array in normal_text when opening <tool_calls> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: "vLLM's jamba detector leaves the orphan closing </tool_calls> plus the JSON array in normal_text when the opening marker is missing. Dynamo strips the orphan close tag and recovers the call body (discard_unparseable_wrapper) so no tool-call markup reaches the user."
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
-      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.5.c:
@@ -49,11 +55,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
-        reason: "Dynamo's jamba parser leaves closing </tool_calls> envelope plus the JSON array in normal_text when opening <tool_calls> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: "vLLM's jamba detector leaves the truncated <tool_calls> wrapper in normal_text. Dynamo strips the markup on recovery and drops the incomplete body so no tool-call markup reaches the user."
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
-      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.5.d:
@@ -74,6 +82,7 @@ cases:
             location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
+        reason: "vLLM's jamba detector requires the closing </tool_calls> marker and leaves the unterminated wrapper in normal_text. Dynamo recovers the complete multi-call body and emits no markup."
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name":
           "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
@@ -97,6 +106,7 @@ cases:
             location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
+        reason: "vLLM's jamba detector leaves the truncated multi-call wrapper in normal_text. Dynamo recovers the two complete call bodies and drops the truncated tail, emitting no markup."
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name":
           "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.6.yaml
@@ -49,6 +49,7 @@ cases:
         calls: []
         normal_text: ''
       vllm:
+        reason: "vLLM's jamba detector leaves the raw <tool_calls> envelope in normal_text when a call object has no arguments key. Dynamo discards it so no tool-call markup reaches the user."
         calls: []
         normal_text: '<tool_calls>[{"name": "get_time"}]</tool_calls>'
       sglang:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
@@ -24,6 +24,7 @@ cases:
             location: NYC
         normal_text: I will check the weather.
       vllm:
+        reason: "Cosmetic whitespace only: Dynamo trims the trailing space between the narration and the <tool_calls> fence; vLLM preserves it. Calls are identical."
         calls:
         - name: get_weather
           arguments:
@@ -63,6 +64,7 @@ cases:
             location: NYC
         normal_text: I will check the weather.
       vllm:
+        reason: "Cosmetic whitespace only: Dynamo trims the trailing space between the narration and the <tool_calls> fence; vLLM preserves it. Calls are identical."
         calls:
         - name: get_weather
           arguments:
@@ -82,6 +84,7 @@ cases:
         calls: []
         normal_text: I will check the weather.
       vllm:
+        reason: "Known Dynamo limitation: the jamba framed parser spans from the first <tool_calls> opener to the last </tool_calls> closer, so narration between two separate fences lands inside the captured region and breaks the JSON parse, dropping both calls and keeping only the leading narration. vLLM extracts the first call. Multiple-disjoint-fence support is a base JSON-parser change tracked as a follow-up, out of scope for the never-leak fix."
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.1.yaml
@@ -29,6 +29,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "vLLM's streaming jamba detector emits the call name but drops the arguments to an empty object. Dynamo's streaming jail surfaces the full arguments."
         calls:
         - name: get_weather
           arguments: {}
@@ -54,6 +55,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "vLLM's streaming jamba detector emits the call name but drops the arguments to an empty object. Dynamo's streaming jail surfaces the full arguments."
         calls:
         - name: get_weather
           arguments: {}

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.2.yaml
@@ -53,6 +53,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "vLLM's streaming jamba detector leaks the first partial wrapper chunk (<tool_cal) into normal_text and leaves the second call's arguments as an unterminated JSON fragment. Dynamo's streaming jail buffers across chunk boundaries and emits both complete calls with no leaked markup."
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.3.yaml
@@ -40,6 +40,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "vLLM's streaming jamba detector leaks the partial opening wrapper (<tool_call) into normal_text and drops the arguments to an empty object when the grammar token is split across chunks. Dynamo's streaming jail buffers the split token and emits the complete call with no leaked markup."
         calls:
         - name: get_weather
           arguments: {}

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.4.yaml
@@ -29,6 +29,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "vLLM's streaming jamba detector drops the arguments to an empty object on a truncated (finish_reason=stop) stream. Dynamo's streaming jail recovers the complete in-flight call body with full arguments."
         calls:
         - name: get_weather
           arguments: {}
@@ -55,6 +56,7 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
+        reason: "Streaming-jail case, not covered by the batch parser fix: vLLM emits the call with empty arguments on mid-body truncation, while Dynamo's streaming jail currently leaves the truncated <tool_calls> wrapper in normal_text. Aligning the jail to discard the partial wrapper (matching the batch parser's strip_markup_on_recovery) is tracked as a follow-up dynamo jail PR."
         calls:
         - name: get_weather
           arguments: {}

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.stream.4.yaml
@@ -52,11 +52,11 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
       vllm:
-        reason: "Streaming-jail case, not covered by the batch parser fix: vLLM emits the call with empty arguments on mid-body truncation, while Dynamo's streaming jail currently leaves the truncated <tool_calls> wrapper in normal_text. Aligning the jail to discard the partial wrapper (matching the batch parser's strip_markup_on_recovery) is tracked as a follow-up dynamo jail PR."
+        reason: "vLLM emits the call with empty arguments on mid-body truncation; Dynamo's streaming jail suppresses the truncated <tool_calls> wrapper, emitting no call and no markup (aligned by ai-dynamo/dynamo#10847)."
         calls:
         - name: get_weather
           arguments: {}
@@ -77,9 +77,12 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      vllm:
+        reason: "vLLM's streaming jamba detector leaves the orphan </tool_calls> close markers in normal_text. Dynamo's streaming jail strips every </tool_calls> occurrence and keeps the inner JSON body (aligned by ai-dynamo/dynamo#10847)."
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls></tool_calls></tool_calls>'
-      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -595,6 +595,13 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["<tool_calls>".to_string()],
                 tool_call_end_tokens: vec!["</tool_calls>".to_string()],
+                // Jamba never surfaces tool-call markup to the user: discard an
+                // unparseable wrapper / strip an orphan close tag rather than
+                // leaking the raw `<tool_calls>` envelope into normal_text, and
+                // strip the markers on truncation-recovery instead of leaving the
+                // partial fence. Same intent as hermes/qwen25 and nemotron_deci.
+                strip_markup_on_recovery: true,
+                discard_unparseable_wrapper: true,
                 ..Default::default()
             }),
             structural_tag_builder: None,


### PR DESCRIPTION
#### Overview:
AI21 Jamba reuses the generic JSON base parser but had opted into none of the never-leak recovery flags, so malformed or unterminated `<tool_calls>` input left the raw envelope in `normal_text`. In the Dynamo per-engine view this showed up as live leaks on batch cases 4.a, 4.b, 5.b and 5.c (and the streaming-jail equivalents 4.b/4.c). This change enables the same discard/strip recovery that hermes, qwen25 and nemotron_deci already use, so jamba never surfaces tool-call markup to the user, and classifies the remaining vLLM-only divergences with a `reason:` so the parity matrix has no unexplained `research` cells.

#### Details:
- `config.rs` `jamba()`: enable `discard_unparseable_wrapper` and `strip_markup_on_recovery`, matching the hermes/qwen25 and nemotron_deci never-leak configs.
- `batch.4` / `batch.5`: flip `expected.dynamo` for the four leak cases to a clean discard (4.a, 4.b, 5.c) or a recovered call (5.b, where the orphan close tag is stripped and the bare array parses), and document vLLM's leak with a `reason:`.
- `batch.4.c`/`4.d`, `batch.5.a`/`5.d`/`5.e`, `batch.6.c`: add a `reason:` for the cases where Dynamo already discards or recovers and only vLLM leaks.
- `batch.2.c`, `batch.8.a`/`8.c`: add a `reason:` for the cosmetic trailing-whitespace difference (Dynamo trims the space adjacent to the fence, vLLM keeps it; calls are identical).
- `batch.8.d`: document the multiple-disjoint-fence limitation (the framed parser spans from the first opener to the last closer, so narration between two fences breaks the JSON parse). Multi-fence support is a base-parser change tracked as a follow-up.
- `stream.1` through `stream.4`: add a `reason:` for the vLLM streaming detector artifacts (it drops arguments to `{}` and leaks partial wrapper chunks). `stream.4.b`/`4.c` assert the suppressed streaming-jail output (empty for the truncated body, close-markers stripped for the orphan case) aligned by ai-dynamo/dynamo#10847.

#### Before / After:
```
batch.4.a expected.dynamo
  before: {calls: [], normal_text: "<tool_calls>not a json array</tool_calls>"}
  after : {calls: [], normal_text: ""}
batch.4.b expected.dynamo
  before: {calls: [], normal_text: "<tool_calls>[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"NYC\"]</tool_calls>"}
  after : {calls: [], normal_text: ""}
batch.5.b expected.dynamo
  before: {calls: [], normal_text: "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"NYC\"}}]</tool_calls>"}
  after : {calls: [get_weather(location=NYC)], normal_text: ""}
batch.5.c expected.dynamo
  before: {calls: [], normal_text: "<tool_calls>[{\"name\": \"get_weather\", \"arguments\": {\"loc"}
  after : {calls: [], normal_text: ""}
stream.4.b expected.dynamo
  before: {calls: [], normal_text: "<tool_calls>[{\"name\": \"get_weather\", \"arguments\": {\"loc"}
  after : {calls: [], normal_text: ""}
stream.4.c expected.dynamo
  before: {calls: [], normal_text: "[{...NYC}}]</tool_calls></tool_calls></tool_calls>"}
  after : {calls: [], normal_text: "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"NYC\"}}]"}
```

#### Cross-impl:
```
4.a    Dynamo: leak -> discard ("")            vLLM: still leaks (documented)
4.b    Dynamo: leak -> discard ("")            vLLM: still leaks (documented)
5.b    Dynamo: leak -> recover call            vLLM: still leaks (documented)
5.c    Dynamo: leak -> discard ("")            vLLM: still leaks (documented)
s4.b   Dynamo: leak -> suppressed ("")         vLLM: partial call, empty args (documented)
s4.c   Dynamo: leak -> close markers stripped  vLLM: still leaks markers (documented)
       SGLang: n/a (no jamba detector) for all cases
```

Note: the `stream.4.b`/`4.c` fixtures assert the streaming-jail behavior from ai-dynamo/dynamo#10847, so this PR should merge after that one. Jamba stream fixtures are declarative (not parser-executed here), so CI does not gate on the ordering, but the dashboard would briefly show green ahead of the jail fix otherwise.
