### PR TITLE
fix(parsers): drop tool calls truncated mid-parameter-value

### DIFF
--- a/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.5.yaml
@@ -68,10 +68,7 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NY
+        calls: []
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
@@ -136,9 +133,6 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:

--- a/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -84,13 +84,15 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id003
         calls:
         - name: get_weather
           arguments:
             location: NY
         normal_text: ''
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
@@ -160,24 +162,24 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
         - name: get_weather
           arguments:
             location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *id005
-      sglang:
-        calls:
-        - name: get_weather
-          arguments:
-            location: Boston
-        normal_text: |
-          I'll start by fetching the weather for both Boston and New York at the same time!
         reason: |-
-          Same root cause as 5.d: SGLang's `<tool_call>(.*?)</tool_call>` regex
-          requires the closing sentinel, so the trailing call truncated mid-arg
-          value is dropped. Dynamo/vLLM recover the partial value
-          (location='New York') and emit the call.
+          vLLM recovers the partial value (location='New York') from the call
+          truncated mid-arg-value before its closing sentinel. Dynamo (the
+          truncation guard) and SGLang require the value to be terminated, so
+          they drop the truncated call.
+      sglang: *id005
   TOOLCALLING.batch.5.f:
     description: Bare valid function before a complete wrapped call
     ref: dynamo

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -363,6 +363,30 @@ fn parse_tool_call_block(
             continue;
         }
 
+        // Truncation guard: when a function block is recovered without its
+        // `</function>` close (EOF / max_tokens cut) and its trailing
+        // `<parameter=...>` value runs to raw end-of-input with no following
+        // close marker, the value was cut off mid-stream. The lenient recovery
+        // regex would capture the partial value via its `$` fallback, but an
+        // unterminated value can't be trusted (e.g. "New York" may be a truncated
+        // "New York City"), so drop the whole call rather than emit a guessed
+        // argument. A value bounded by *any* close marker — `</parameter>`,
+        // `</function>` (function terminated), or `</tool_call>` — is complete and
+        // still recovered.
+        let function_terminated = func_cap
+            .get(0)
+            .is_some_and(|m| m.as_str().contains(config.function_end_token.as_str()));
+        if !function_terminated {
+            if let Some(open_idx) = function_body.rfind(config.parameter_start_token.as_str()) {
+                let after_value = &function_body[open_idx..];
+                let value_bounded = after_value.contains(config.parameter_end_token.as_str())
+                    || after_value.contains(config.tool_call_end_token.as_str());
+                if !value_bounded {
+                    continue;
+                }
+            }
+        }
+
         // Get parameter config for this function
         let param_config = get_arguments_config(function_name, tools);
 
@@ -1210,10 +1234,27 @@ NYC
     }
 
     #[test]
-    fn test_parse_qwen3_bare_function_partial_with_recovery_recovers() {
-        // Finalize path: recovery ON allows truncated function block to
-        // surface a (potentially incomplete) call rather than being dropped.
+    fn test_parse_qwen3_bare_function_truncated_value_dropped() {
+        // Finalize path with recovery ON: a parameter value that runs to raw
+        // end-of-input with NO close marker (`</parameter>` / `</tool_call>`) was
+        // cut off mid-stream ("NY" might be a truncated "NYC"/"NY..."), so the
+        // call is dropped rather than emitting a guessed argument.
         let input = "<function=get_weather>\n<parameter=city>\nNY";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            allow_eof_recovery: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_complete_value_recovers() {
+        // Counterpart to the truncation guard: the value IS terminated
+        // (`</parameter>` present); only the `</function>` wrapper is missing.
+        // The value is complete, so the call is still recovered.
+        let input = "<function=get_weather>\n<parameter=city>\nNY</parameter>";
         let config = XmlParserConfig {
             backoff_when_no_wrapper: true,
             allow_eof_recovery: true,
@@ -1222,6 +1263,8 @@ NYC
         let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NY");
     }
 
     // Qwen3-Coder-style XML treats text after the first parsed tool call as

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -376,14 +376,14 @@ fn parse_tool_call_block(
         let function_terminated = func_cap
             .get(0)
             .is_some_and(|m| m.as_str().contains(config.function_end_token.as_str()));
-        if !function_terminated {
-            if let Some(open_idx) = function_body.rfind(config.parameter_start_token.as_str()) {
-                let after_value = &function_body[open_idx..];
-                let value_bounded = after_value.contains(config.parameter_end_token.as_str())
-                    || after_value.contains(config.tool_call_end_token.as_str());
-                if !value_bounded {
-                    continue;
-                }
+        if !function_terminated
+            && let Some(open_idx) = function_body.rfind(config.parameter_start_token.as_str())
+        {
+            let after_value = &function_body[open_idx..];
+            let value_bounded = after_value.contains(config.parameter_end_token.as_str())
+                || after_value.contains(config.tool_call_end_token.as_str());
+            if !value_bounded {
+                continue;
             }
         }
 


### PR DESCRIPTION
#### Overview:

This PR drops tool calls truncated mid-parameter-value instead of emitting a guessed argument. It is the complete v1 fix (the shared XML-parser guard plus the batch fixtures that guard forces), ported from the now-closed dynamo#10733 after `lib/parsers` was cut over into the `dynamo-parsers` crate by dynamo#10423. Rebased onto current `main`.

#### Details:

- `parse_tool_call_block` now drops a recovered function whose trailing `<parameter=...>` value runs to raw end-of-input with no `</parameter>` / `</function>` / `</tool_call>` boundary. The lenient `$`-fallback recovery regex would otherwise capture the partial value and emit a guessed argument (e.g. `New York` for a truncated `New York City`). A value bounded by any close marker (only the wrapper missing) is still recovered.
- The guard is shared across all XML-config families, so it forces both `qwen3_coder` and `nemotron_nano` batch `5.c` (-> `[]`) and `5.e` (-> `[get_weather(Boston)]`) to be rebaselined together; the `5.e` `reason:` is updated (vLLM still over-recovers). minimax_m2 is strict-match, so the guard is inert there.
- Independent of #53 (the v2 streaming parser) — no file overlap. qwen3_coder's batch path is still v1, so its v1 batch fixture is rebaselined here, not in #53; the two PRs can land in any order.

#### Verification:

`dynamo-parsers` xml unit tests (114) and the conformance batch / batch-via-stream / stream tool-calling parity suites pass on the rebased base; `cargo fmt` clean.

#### Where should the reviewer start?

`parsers/src/tool_calling/xml/parser.rs` (the truncation guard in `parse_tool_call_block`)

#### Related Issues:

Relates to DIS-2238. Supersedes the closed dynamo#10733.

/coderabbit profile chill
