### PR TITLE
fix: strip dangling reasoning end marker for non-ASCII delimiter families (Kimi unicode)

### DIFF
--- a/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -51,13 +51,15 @@ cases:
       sglang: *d_3
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
-    dynamo_leak: true
+    reason: Dangling-end recovery treats the prefix as implicit reasoning and
+      strips the closer, matching the ASCII REASONING.batch.4 behavior. The
+      unicode marker must never leak into normal_text (lossless-split contract).
     ref: dynamo
     model_text: normal◁/think▷answer
     expected:
       dynamo: &d_4
-        reasoning_text: ''
-        normal_text: normal◁/think▷answer
+        reasoning_text: normal
+        normal_text: answer
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
       sglang: *d_4

--- a/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -51,18 +51,22 @@ cases:
       sglang: *d_3
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
-    reason: Dangling-end recovery treats the prefix as implicit reasoning and
-      strips the closer, matching the ASCII REASONING.batch.4 behavior. The
-      unicode marker must never leak into normal_text (lossless-split contract).
     ref: dynamo
+    spec_ref: tests/parity/README.md
     model_text: normal◁/think▷answer
     expected:
-      dynamo: &d_4
+      dynamo:
         reasoning_text: normal
         normal_text: answer
+        reason: 'Lossless split: a dangling close marker with no opener triggers
+          recovery. The prefix becomes implicit reasoning and the parser-owned
+          marker is stripped, matching the ASCII REASONING.batch.4 behavior. The
+          unicode marker must never leak into normal_text.'
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
-      sglang: *d_4
+      sglang:
+        reasoning_text: ''
+        normal_text: normal◁/think▷answer
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
     ref: dynamo

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -108,13 +108,16 @@ impl ReasoningParser for BasicReasoningParser {
         // REASONING.batch.4: dangling end marker without an opener. Treat the
         // prefix as reasoning.
         // Models in this family normally emit `<think>...</think>final_answer`;
-        // when the opener is absent but a `</think>` is present, the natural
+        // when the opener is absent but the end marker is present, the natural
         // reading is that the opener was implicit (chat template or tokenizer
-        // consumed it). Without this, the `</think>` markup leaks into
-        // normal_text. Matches vLLM's `partition()`-based behavior for the
-        // same input.
-        let supports_dangling_end_recovery =
-            self.think_start_token == "<think>" && self.think_end_token == "</think>";
+        // consumed it). Without this, the end marker leaks into normal_text.
+        // Matches vLLM's `partition()`-based behavior for the same input.
+        //
+        // This applies to any configured delimiter pair, not just the ASCII
+        // `<think>`/`</think>` tags: the lossless-split contract (parser-owned
+        // markup must never reach normal_text) is family-agnostic, so Kimi's
+        // unicode `◁think▷`/`◁/think▷` delimiters get the same recovery.
+        let supports_dangling_end_recovery = !self.think_end_token.is_empty();
         let has_dangling_end = supports_dangling_end_recovery
             && !has_think_tag
             && text.contains(&self.think_end_token);
@@ -647,13 +650,24 @@ mod tests {
         assert_eq!(result.reasoning_text, "normal text");
     }
 
-    #[test] // REASONING.batch.4 — Kimi Unicode delimiters keep stray closer as normal text.
-    fn test_kimi_unicode_stray_closing_tag_passes_through() {
+    #[test] // REASONING.batch.4 — Kimi unicode dangling closer recovers, no markup leak.
+    fn test_kimi_unicode_dangling_close_marker_recovers() {
+        // A stray `◁/think▷` with no opener must trigger dangling-end recovery
+        // the same way ASCII `</think>` does (test_malformed_stray_closing_tag):
+        // prefix becomes reasoning, the marker is stripped, the rest is normal.
+        // Previously the recovery was gated to ASCII tags and the unicode marker
+        // leaked verbatim into normal_text.
         let mut parser =
             BasicReasoningParser::new("◁think▷".to_string(), "◁/think▷".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("normal◁/think▷answer", &[]);
-        assert_eq!(result.normal_text, "normal◁/think▷answer");
-        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.reasoning_text, "normal");
+        assert_eq!(result.normal_text, "answer");
+        assert!(
+            !result.normal_text.contains('◁') && !result.reasoning_text.contains('◁'),
+            "unicode marker must be stripped, not leaked; got normal={:?} reasoning={:?}",
+            result.normal_text,
+            result.reasoning_text
+        );
     }
 
     #[test] // REASONING.batch.4

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -670,6 +670,25 @@ mod tests {
         );
     }
 
+    #[test] // REASONING.batch.4 — dangling-end recovery is delimiter-agnostic, not ASCII-only.
+    fn test_dangling_end_recovery_is_family_agnostic() {
+        // Scope lock for the `!think_end_token.is_empty()` guard: recovery must
+        // fire for ANY configured delimiter pair, not just `<think>`/`</think>`
+        // or Kimi's unicode tags. A future narrowing of the guard back to a
+        // specific family would re-leak the closer for everyone else and fail
+        // here. Uses an arbitrary custom pair to prove the contract is generic.
+        let mut parser =
+            BasicReasoningParser::new("<R>".to_string(), "</R>".to_string(), false, true);
+        let result = parser.detect_and_parse_reasoning("prefix</R>tail", &[]);
+        assert_eq!(result.reasoning_text, "prefix");
+        assert_eq!(result.normal_text, "tail");
+        assert!(
+            !result.normal_text.contains("</R>"),
+            "custom closer must be stripped, not leaked; got normal={:?}",
+            result.normal_text
+        );
+    }
+
     #[test] // REASONING.batch.4
     fn test_malformed_multiple_opening_tags() {
         let mut parser =


### PR DESCRIPTION
#### Overview:
The BasicReasoningParser dangling-end recovery (a stray close marker with no opener, REASONING.batch.4) was gated to the literal ASCII pair `<think>`/`</think>`. Parsers configured with other delimiters skipped recovery and leaked the raw close marker into `normal_text`. The Kimi unicode parser (`--dyn-reasoning-parser kimi`, `◁think▷`/`◁/think▷`) hit this: `normal◁/think▷answer` returned the whole string as `normal_text` with the `◁/think▷` markup intact, violating the lossless-split contract that parser-owned markup must never reach `normal_text`.

#### Details:
- `parsers/src/reasoning/base_parser.rs`: replace the ASCII literal guard on `supports_dangling_end_recovery` with a non-empty end-token check, so recovery applies to any configured delimiter pair. Only the `kimi` parser (force_reasoning=false, non-ASCII delimiters) changes behavior in practice; every ASCII parser already qualified, so there is no behavior change there.
- `parsers/src/reasoning/base_parser.rs`: rename `test_kimi_unicode_stray_closing_tag_passes_through` to `test_kimi_unicode_dangling_close_marker_recovers` and assert recovery instead of the leak.
- `conformance/reasoning/fixtures/kimi/REASONING.batch.yaml` (batch.4): drop `dynamo_leak: true`, update `expected.dynamo` to the recovered split, and add a `reason:` note. SGLang keeps its `*d_4` anchor; vLLM stays unavailable.

#### Before / After:
`conformance/reasoning/fixtures/kimi/REASONING.batch.yaml`, REASONING.batch.4 (model_text: `normal◁/think▷answer`)

before:
```
dynamo_leak: true
expected.dynamo:
  reasoning_text: ''
  normal_text: normal◁/think▷answer   # leak
```

after:
```
expected.dynamo:
  reasoning_text: normal
  normal_text: answer
reason: dangling-end recovery strips the closer; marker must never leak
```

#### Cross-impl:
Case REASONING.batch.4, dangling close marker
```
Dynamo:  ""/"normal◁/think▷answer"  ->  "normal"/"answer"  (leak fixed)
vLLM:    unavailable (no Kimi ◁..▷ parser)
SGLang:  *d_4 anchor (mirrors Dynamo)
```