### PR TITLE
chore(conformance): bump v2 fixtures to vLLM 0.23.0 / SGLang 0.5.12.post1

### DIFF
--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.2.yaml
@@ -1,68 +1,69 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.2.b:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
-  TOOLCALLING.batch.2.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
       normal_text: 'Both: '
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.4.yaml
@@ -1,56 +1,55 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
       normal_text: nonsense
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: ''
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -14,10 +17,16 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+
+        ```json
+
+        {"location": "NYC"}
+
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
     vllm_python:
       calls: []
       normal_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
@@ -31,26 +40,18 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-
-        ```json
-
-        {"location": "NYC"}
-
-        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls:
       - name: get_weather
         arguments: {}
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -59,10 +60,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -71,6 +71,3 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.6.yaml
@@ -1,39 +1,39 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.7.yaml
@@ -1,84 +1,76 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: book_flight
         arguments: {}
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
       normal_text: ''
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls:
-      - arguments:
-          location: Tōkyō "central"
-        name: get_weather
+      - name: set_temperature
+        arguments:
+          celsius: '20'
       normal_text: ''
-  TOOLCALLING.batch.7.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_temperature
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
-      normal_text: ''
   TOOLCALLING.batch.7.d:
-    vllm_python:
-      calls: []
-    sglang_python:
+    vllm_rust:
       calls:
       - name: process_data
-        arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          config:
-            nested: true
+        arguments:
           items:
           - 1
           - 2
           - 3
-        name: process_data
+          config:
+            nested: true
       normal_text: ''
-  TOOLCALLING.batch.7.e:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: process_data
         arguments: {}
+  TOOLCALLING.batch.7.e:
     vllm_rust:
       calls:
-      - arguments:
+      - name: process_data
+        arguments:
           payload:
-            empty: {}
-            flags:
-              enabled: true
-              retry: null
             regions:
             - name: west
               scores:
@@ -90,18 +82,27 @@ cases:
               - 4
               - 5
               - 6
-        name: process_data
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: process_data
+        arguments: {}
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_limit
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.8.yaml
@@ -1,59 +1,60 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3/TOOLCALLING.batch.yaml
@@ -1,98 +1,99 @@
 family: deepseek_v3
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       calls: []
       normal_text: '   '
-    vllm_rust:
-      calls: []
-      normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: unknown_tool
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.2.yaml
@@ -1,68 +1,69 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time
         arguments: {}
+  TOOLCALLING.batch.2.b:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
       normal_text: ''
-  TOOLCALLING.batch.2.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time
         arguments: {}
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      normal_text: ''
-  TOOLCALLING.batch.2.c:
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time
         arguments: {}
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Both: '
-  TOOLCALLING.batch.2.d:
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.4.yaml
@@ -1,38 +1,40 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
       normal_text: nonsense
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: ''
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls:
       - name: get_weather
@@ -41,19 +43,17 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.5.yaml
@@ -1,24 +1,28 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     vllm_python:
       calls: []
       normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
@@ -26,10 +30,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -38,10 +41,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -50,10 +52,9 @@ cases:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -62,6 +63,3 @@ cases:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.6.yaml
@@ -1,39 +1,39 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.7.yaml
@@ -1,84 +1,76 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: book_flight
         arguments: {}
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
       normal_text: ''
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls:
-      - arguments:
-          location: Tōkyō "central"
-        name: get_weather
+      - name: set_temperature
+        arguments:
+          celsius: '20'
       normal_text: ''
-  TOOLCALLING.batch.7.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_temperature
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
-      normal_text: ''
   TOOLCALLING.batch.7.d:
-    vllm_python:
-      calls: []
-    sglang_python:
+    vllm_rust:
       calls:
       - name: process_data
-        arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          config:
-            nested: true
+        arguments:
           items:
           - 1
           - 2
           - 3
-        name: process_data
+          config:
+            nested: true
       normal_text: ''
-  TOOLCALLING.batch.7.e:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: process_data
         arguments: {}
+  TOOLCALLING.batch.7.e:
     vllm_rust:
       calls:
-      - arguments:
+      - name: process_data
+        arguments:
           payload:
-            empty: {}
-            flags:
-              enabled: true
-              retry: null
             regions:
             - name: west
               scores:
@@ -90,18 +82,27 @@ cases:
               - 4
               - 5
               - 6
-        name: process_data
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: process_data
+        arguments: {}
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_limit
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.8.yaml
@@ -1,50 +1,57 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
-  TOOLCALLING.batch.8.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.8.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: 'I will check the weather. '
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
@@ -52,9 +59,3 @@ cases:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
           Then check LA weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_1/TOOLCALLING.batch.yaml
@@ -1,98 +1,99 @@
 family: deepseek_v3_1
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       calls: []
       normal_text: '   '
-    vllm_rust:
-      calls: []
-      normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: unknown_tool
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -22,16 +32,13 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -40,6 +47,9 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
+      normal_text: '
+
+        '
     sglang_python:
       calls:
       - name: get_weather
@@ -48,13 +58,16 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
     vllm_python:
       calls:
       - name: get_weather
@@ -63,7 +76,7 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-      normal_text: 'Both: '
+      normal_text: 'Both:  Done.'
     sglang_python:
       calls:
       - name: get_weather
@@ -72,16 +85,16 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Both: '
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -98,12 +111,3 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.4.yaml
@@ -1,53 +1,54 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls:
       - name: get_weather
-        arguments: {}
+        arguments: '{"location":"NYC\n</｜DSML｜invoke>\n</｜DSML｜function_calls>'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -16,15 +19,18 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜function_calls>'
     vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
+      calls: []
       normal_text: '<｜DSML｜invoke name="get_weather">
 
         <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
@@ -37,26 +43,20 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      calls: []
-      normal_text: '<｜DSML｜invoke name="get_weather">
-
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
-        </｜DSML｜invoke>
-
-        </｜DSML｜function_calls>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
-      calls: []
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NY'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -77,15 +77,16 @@ cases:
       - name: get_weather
         arguments:
           location: New York
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: Boston
+      - name: get_weather
+        arguments: '{"location":"New York'
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
         at the same time!
 
@@ -97,6 +98,3 @@ cases:
           location: Boston
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.6.yaml
@@ -1,11 +1,17 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
@@ -14,29 +20,24 @@ cases:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
-    vllm_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments: {}
-        name: get_time
+      - name: get_time
+        arguments: {}
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -20,53 +29,51 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
-    vllm_rust:
-      calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
-      normal_text: ''
   TOOLCALLING.batch.7.b:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: Tōkyō central
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
@@ -77,9 +84,3 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740993
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -17,48 +24,49 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
+      normal_text: I will check the weather.  Let me know if you need more.
     sglang_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -67,7 +75,7 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-      normal_text: 'I will check the weather. '
+      normal_text: 'I will check the weather.  Then check LA weather. '
     sglang_python:
       calls:
       - name: get_weather
@@ -76,9 +84,3 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v3_2/TOOLCALLING.batch.yaml
@@ -1,116 +1,117 @@
 family: deepseek_v3_2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
-    vllm_python:
-      calls:
-      - name: unknown_tool
-        arguments:
-          location: NYC
-    sglang_python:
-      calls:
-      - name: unknown_tool
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: unknown_tool
+        arguments:
           location: NYC
-        name: unknown_tool
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+    sglang_python:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.2.yaml
@@ -1,12 +1,30 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -16,23 +34,6 @@ cases:
         arguments:
           timezone: EST
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -41,6 +42,21 @@ cases:
         arguments:
           timezone: EST
   TOOLCALLING.batch.2.b:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -49,21 +65,10 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
+      normal_text: '
+
+        '
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -72,6 +77,24 @@ cases:
         arguments:
           timezone: EST
   TOOLCALLING.batch.2.c:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
     vllm_python:
       calls:
       - name: get_weather
@@ -80,25 +103,8 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-      normal_text: 'Both: '
+      normal_text: 'Both:  Done.'
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Both: '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -107,6 +113,24 @@ cases:
         arguments:
           timezone: EST
   TOOLCALLING.batch.2.d:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -116,23 +140,6 @@ cases:
         arguments:
           location: LA
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
@@ -1,62 +1,65 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    dynamo_rust:
+      calls: []
+      normal_text: ''
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
-      calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
-    dynamo_rust:
       calls: []
   TOOLCALLING.batch.4.c:
+    dynamo_rust:
+      calls: []
+      normal_text: ''
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
-      calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
-    dynamo_rust:
       calls: []
   TOOLCALLING.batch.4.d:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls:
       - name: get_weather
-        arguments: {}
+        arguments: '{"location":"NYC\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>'
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments: {}
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -1,48 +1,37 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.5.b:
-    vllm_python:
+    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: '<｜DSML｜invoke name="get_weather">
-
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
-        </｜DSML｜invoke>
-
-        </｜DSML｜tool_calls>'
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
+      normal_text: ''
     vllm_rust:
       calls: []
       normal_text: '<｜DSML｜invoke name="get_weather">
@@ -52,24 +41,51 @@ cases:
         </｜DSML｜invoke>
 
         </｜DSML｜tool_calls>'
-    dynamo_rust:
+    vllm_python:
+      calls: []
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>'
+    sglang_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.5.c:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments: ''
+      normal_text: ''
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
-      calls: []
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NY'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
-    dynamo_rust:
-      calls: []
   TOOLCALLING.batch.5.d:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -83,17 +99,6 @@ cases:
 
         '
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Boston
-      - name: get_weather
-        arguments:
-          location: New York
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -102,11 +107,26 @@ cases:
         arguments:
           location: New York
   TOOLCALLING.batch.5.e:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments: ''
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!
+
+        '
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: Boston
+      - name: get_weather
+        arguments: '{"location":"New York'
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
         at the same time!
 
@@ -118,20 +138,32 @@ cases:
           location: Boston
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+  TOOLCALLING.batch.5.f:
     dynamo_rust:
       calls:
       - name: get_weather
         arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
           location: Boston
-  TOOLCALLING.batch.5.f:
-    vllm_python:
+      normal_text: ''
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
-          location: NYC
+          location: Boston
+      normal_text: '<｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>
+
+        '
+    vllm_python:
+      calls:
       - name: get_weather
         arguments:
           location: Boston
@@ -145,28 +177,6 @@ cases:
 
         '
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: Boston
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Boston
-        name: get_weather
-      normal_text: '<｜DSML｜invoke name="get_weather">
-
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
-        </｜DSML｜invoke>
-
-        </｜DSML｜tool_calls>
-
-        '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -175,23 +185,12 @@ cases:
         arguments:
           location: Boston
   TOOLCALLING.batch.5.g:
-    vllm_python:
+    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check that. <｜DSML｜invoke name="get_weather">
-
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
-        </｜DSML｜invoke>
-
-        </｜DSML｜tool_calls>'
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
+      normal_text: 'I will check that. '
     vllm_rust:
       calls: []
       normal_text: 'I will check that. <｜DSML｜invoke name="get_weather">
@@ -201,7 +200,16 @@ cases:
         </｜DSML｜invoke>
 
         </｜DSML｜tool_calls>'
-    dynamo_rust:
+    vllm_python:
+      calls: []
+      normal_text: 'I will check that. <｜DSML｜invoke name="get_weather">
+
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+
+        </｜DSML｜invoke>
+
+        </｜DSML｜tool_calls>'
+    sglang_python:
       calls:
       - name: get_weather
         arguments:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.6.yaml
@@ -1,51 +1,53 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    dynamo_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
         arguments: {}
     sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_time
         arguments: {}
   TOOLCALLING.batch.6.b:
-    vllm_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
     dynamo_rust:
       calls:
       - name: get_time
         arguments: {}
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.7.yaml
@@ -1,12 +1,28 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    dynamo_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -21,82 +37,69 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
-    vllm_rust:
-      calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
-      normal_text: ''
+  TOOLCALLING.batch.7.b:
     dynamo_rust:
       calls:
-      - name: book_flight
+      - name: get_weather
         arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-  TOOLCALLING.batch.7.b:
+          location: Tōkyō central
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: Tōkyō central
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Tōkyō central
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: Tōkyō central
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    dynamo_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
         arguments:
           count: '9007199254740993'
     sglang_python:
-      calls:
-      - name: set_limit
-        arguments:
-          count: 9007199254740993
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: set_limit
         arguments:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.8.yaml
@@ -1,12 +1,24 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -14,67 +26,74 @@ cases:
           location: NYC
       normal_text: 'I will check the weather. '
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.8.b:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
+      normal_text: ' Let me know if you need more.'
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.8.c:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
+      normal_text: I will check the weather.  Let me know if you need more.
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.8.d:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather. '
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -83,22 +102,8 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-      normal_text: 'I will check the weather. '
+      normal_text: 'I will check the weather.  Then check LA weather. '
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.yaml
@@ -1,75 +1,97 @@
 family: deepseek_v4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.3:
-    vllm_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    sglang_python:
+    dynamo_rust:
       calls: []
       normal_text: Hello, how can I help you today?
     vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
-    dynamo_rust:
-      calls: []
-  TOOLCALLING.batch.9.a:
     vllm_python:
       calls: []
+      normal_text: Hello, how can I help you today?
     sglang_python:
       calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    dynamo_rust:
+      calls: []
+      normal_text: ''
     vllm_rust:
       calls: []
       normal_text: ''
-    dynamo_rust:
+    vllm_python:
+      calls: []
+    sglang_python:
       calls: []
   TOOLCALLING.batch.9.b:
+    dynamo_rust:
+      calls: []
+      normal_text: '   '
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       calls: []
       normal_text: '   '
-    vllm_rust:
-      calls: []
-      normal_text: '   '
-    dynamo_rust:
-      calls: []
   TOOLCALLING.batch.10:
+    dynamo_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -79,23 +101,6 @@ cases:
         arguments:
           location: LA
     sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: get_weather
         arguments:
@@ -104,37 +109,38 @@ cases:
         arguments:
           location: LA
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    dynamo_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: unknown_tool
         arguments:
           location: NYC
     sglang_python:
-      calls:
-      - name: unknown_tool
-        arguments:
-          location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
-    dynamo_rust:
       calls:
       - name: unknown_tool
         arguments:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -16,19 +26,8 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.2.c:
-    vllm_python:
-      calls: []
-    sglang_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
@@ -37,35 +36,37 @@ cases:
         arguments:
           timezone: EST
       normal_text: 'Both:  Done.'
-    vllm_rust:
+    vllm_python:
+      calls: []
+    sglang_python:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
       normal_text: 'Both:  Done.'
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weatherget_weather
         arguments: '{"location": "NYC"}{"location": "LA"}'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.4.yaml
@@ -1,37 +1,37 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -41,20 +41,17 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -15,20 +18,19 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     vllm_python:
       calls: []
       normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     sglang_python:
-      calls: []
-      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-    vllm_rust:
       calls: []
       normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -37,10 +39,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls:
       - name: ''
@@ -52,10 +53,9 @@ cases:
         arguments: '{"location": "Boston"}{"location": "New York"}'
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls:
       - name: ''
@@ -68,10 +68,13 @@ cases:
           location: Boston
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.5.f:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     vllm_python:
       calls: []
     sglang_python:
@@ -80,19 +83,13 @@ cases:
         arguments:
           location: Boston
       normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Boston
-        name: get_weather
-      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
   TOOLCALLING.batch.5.g:
+    vllm_rust:
+      calls: []
+      normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     vllm_python:
       calls: []
       normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     sglang_python:
-      calls: []
-      normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-    vllm_rust:
       calls: []
       normal_text: I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.6.yaml
@@ -1,35 +1,39 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Gemma4 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -15,15 +24,13 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
       normal_text: ''
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls: []
     sglang_python:
@@ -31,13 +38,13 @@ cases:
       - name: get_weather
         arguments:
           location: Tōkyō central
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls:
-      - arguments:
-          location: Tōkyō central
-        name: get_weather
+      - name: set_temperature
+        arguments:
+          celsius: '20'
       normal_text: ''
-  TOOLCALLING.batch.7.c:
     vllm_python:
       calls: []
     sglang_python:
@@ -45,13 +52,18 @@ cases:
       - name: set_temperature
         arguments:
           celsius: '20'
+  TOOLCALLING.batch.7.d:
     vllm_rust:
       calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
       normal_text: ''
-  TOOLCALLING.batch.7.d:
     vllm_python:
       calls: []
     sglang_python:
@@ -64,18 +76,28 @@ cases:
           - 3
           config:
             nested: true
+  TOOLCALLING.batch.7.e:
     vllm_rust:
       calls:
-      - arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-        name: process_data
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
       normal_text: ''
-  TOOLCALLING.batch.7.e:
     vllm_python:
       calls: []
     sglang_python:
@@ -98,10 +120,13 @@ cases:
               enabled: true
               retry: 'null'
             empty: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -109,9 +134,3 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740993
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
     sglang_python:
@@ -13,14 +20,14 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
     vllm_python:
       calls: []
     sglang_python:
@@ -28,14 +35,14 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: ' Let me know if you need more.'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: ' Let me know if you need more.'
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
     vllm_python:
       calls: []
     sglang_python:
@@ -44,26 +51,20 @@ cases:
         arguments:
           location: NYC
       normal_text: I will check the weather.  Let me know if you need more.
+  TOOLCALLING.batch.8.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      normal_text: I will check the weather.  Let me know if you need more.
-  TOOLCALLING.batch.8.d:
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weatherget_weather
         arguments: '{"location": "NYC"}{"location": "LA"}'
-      normal_text: 'I will check the weather.  Then check LA weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
       normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/gemma4/TOOLCALLING.batch.yaml
@@ -1,11 +1,18 @@
 family: gemma4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -13,57 +20,57 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       calls: []
       normal_text: '   '
-    vllm_rust:
-      calls: []
-      normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weatherget_weather
         arguments: '{"location": "NYC"}{"location": "LA"}'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.30.a:
+    vllm_rust:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a,b:and{brace}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -71,13 +78,13 @@ cases:
       - name: run_query
         arguments:
           sql: SELECT a,b:and{brace}
-    vllm_rust:
-      calls:
-      - arguments:
-          sql: SELECT a,b:and{brace}
-        name: run_query
-      normal_text: ''
   TOOLCALLING.batch.30.b:
+    vllm_rust:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT value WHERE note has brace } and bracket ]
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -85,13 +92,13 @@ cases:
       - name: run_query
         arguments:
           sql: SELECT value WHERE note has brace } and bracket ]
-    vllm_rust:
-      calls:
-      - arguments:
-          sql: SELECT value WHERE note has brace } and bracket ]
-        name: run_query
-      normal_text: ''
   TOOLCALLING.batch.30.c:
+    vllm_rust:
+      calls:
+      - name: run_query
+        arguments:
+          sql: literal <|tool_call marker> call:get_time{} stays text
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -99,13 +106,16 @@ cases:
       - name: run_query
         arguments:
           sql: literal <|tool_call marker> call:get_time{} stays text
-    vllm_rust:
-      calls:
-      - arguments:
-          sql: literal <|tool_call marker> call:get_time{} stays text
-        name: run_query
-      normal_text: ''
   TOOLCALLING.batch.31.a:
+    vllm_rust:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT a,b:and{brace}
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -116,16 +126,16 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      calls:
-      - arguments:
-          sql: SELECT a,b:and{brace}
-        name: run_query
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.31.b:
+    vllm_rust:
+      calls:
+      - name: run_query
+        arguments:
+          sql: SELECT value WHERE note has brace } and bracket ]
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -136,16 +146,13 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
+  TOOLCALLING.batch.13.a:
     vllm_rust:
       calls:
-      - arguments:
-          sql: SELECT value WHERE note has brace } and bracket ]
-        name: run_query
-      - arguments:
-          timezone: EST
-        name: get_time
+      - name: unknown_tool
+        arguments:
+          location: NYC
       normal_text: ''
-  TOOLCALLING.batch.13.a:
     vllm_python:
       calls: []
     sglang_python:
@@ -153,13 +160,16 @@ cases:
       - name: unknown_tool
         arguments:
           location: NYC
+  TOOLCALLING.batch.13.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: unknown_tool
+      - name: unknown_tool
+        arguments:
+          location: LA
       normal_text: ''
-  TOOLCALLING.batch.13.c:
     vllm_python:
       calls: []
     sglang_python:
@@ -170,12 +180,3 @@ cases:
       - name: unknown_tool
         arguments:
           location: LA
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: unknown_tool
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -19,16 +29,16 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
-      normal_text: ''
-  TOOLCALLING.batch.2.c:
+      normal_text: 'Checking: '
     vllm_python:
       calls:
       - name: get_weather
@@ -44,42 +54,33 @@ cases:
         arguments:
           location: NYC
       normal_text: 'Checking: '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Checking: '
   TOOLCALLING.batch.2.d:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.4.yaml
@@ -1,18 +1,21 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls:
       - name: get_weather
@@ -22,33 +25,31 @@ cases:
       calls:
       - name: get_weather
         arguments: '{"location": "NYC}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete GLM MoE tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -14,20 +17,19 @@ cases:
       calls:
       - name: get_weather
         arguments: '{"location": "NYC"'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     vllm_python:
       calls: []
       normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     sglang_python:
       calls: []
       normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-    vllm_rust:
-      calls: []
-      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete GLM MoE tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -36,10 +38,9 @@ cases:
       calls:
       - name: get_weather
         arguments: '{"location": "N'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete GLM MoE tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -56,10 +57,9 @@ cases:
           location: Boston
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete GLM MoE tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -76,10 +76,13 @@ cases:
           location: Boston
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
   TOOLCALLING.batch.5.f:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     vllm_python:
       calls:
       - name: get_weather
@@ -92,19 +95,13 @@ cases:
         arguments:
           location: Boston
       normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Boston
-        name: get_weather
-      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
   TOOLCALLING.batch.5.g:
+    vllm_rust:
+      calls: []
+      normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     vllm_python:
       calls: []
       normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     sglang_python:
       calls: []
       normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-    vllm_rust:
-      calls: []
-      normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.6.yaml
@@ -1,38 +1,39 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -20,53 +29,51 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
-    vllm_rust:
-      calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
-      normal_text: ''
   TOOLCALLING.batch.7.b:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: Tōkyō central
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
@@ -77,9 +84,3 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740993
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -18,13 +25,13 @@ cases:
         arguments:
           location: NYC
       normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
-  TOOLCALLING.batch.8.b:
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -36,13 +43,13 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
+  TOOLCALLING.batch.8.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      normal_text: ''
-  TOOLCALLING.batch.8.c:
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -55,13 +62,13 @@ cases:
         arguments:
           location: NYC
       normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: 'I will check the weather. '
-  TOOLCALLING.batch.8.d:
     vllm_python:
       calls:
       - name: get_weather
@@ -76,10 +83,4 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/glm47/TOOLCALLING.batch.yaml
@@ -1,100 +1,107 @@
 family: glm47
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: unknown_tool
@@ -105,9 +112,3 @@ cases:
       - name: unknown_tool
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.2.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
@@ -14,6 +15,9 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -41,6 +45,8 @@ cases:
         arguments:
           timezone: EST
       normal_text: I need both.  Done.
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -61,6 +67,9 @@ cases:
       - name: get_weather
         arguments:
           location: LA
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -79,6 +88,8 @@ cases:
           location: LA
       normal_text: ''
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.4.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
@@ -10,6 +11,9 @@ cases:
       calls:
       - name: get_weather
         arguments: not json at all
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -22,6 +26,9 @@ cases:
       calls:
       - name: get_weather
         arguments: '{"location":"NYC'
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -32,22 +39,31 @@ cases:
   TOOLCALLING.batch.4.c:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: ''
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.5.yaml
@@ -1,15 +1,17 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
-    dynamo_note: 'No recovery by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): a Harmony commentary/analysis tool call must carry the <|call|> terminator to be recovered. <|call|> is also the gpt-oss EOS/commit token, so a call missing it was cut off before the model committed; the incomplete envelope is dropped, not recovered or leaked into content.'
     dynamo_rust:
       calls: []
       normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -24,6 +26,9 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -38,6 +43,9 @@ cases:
   TOOLCALLING.batch.5.c:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -46,7 +54,6 @@ cases:
       calls: []
       normal_text: ''
   TOOLCALLING.batch.5.d:
-    dynamo_note: 'Trailing call dropped by design (dynamo #10366: https://github.com/ai-dynamo/dynamo/pull/10366): only the commentary call carrying <|call|> (Boston) is recovered; the unterminated trailing call (New York) is dropped, since <|call|> is also the gpt-oss EOS/commit token and its absence means the model was cut off before committing that call.'
     dynamo_rust:
       calls:
       - name: get_weather
@@ -54,6 +61,8 @@ cases:
           location: Boston
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -71,6 +80,8 @@ cases:
           location: Boston
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.6.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
@@ -10,6 +11,9 @@ cases:
       calls:
       - name: get_time
         arguments: {}
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_time
@@ -24,6 +28,9 @@ cases:
       calls:
       - name: get_time
         arguments: {}
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_time
@@ -36,6 +43,9 @@ cases:
   TOOLCALLING.batch.6.c:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.7.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
@@ -13,6 +14,9 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: book_flight
@@ -34,6 +38,9 @@ cases:
       - name: get_weather
         arguments:
           location: Tōkyō "central"
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -51,6 +58,9 @@ cases:
       - name: set_temperature
         arguments:
           celsius: '20'
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: set_temperature
@@ -73,6 +83,9 @@ cases:
           - 3
           config:
             nested: true
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: process_data
@@ -115,6 +128,9 @@ cases:
               enabled: true
               retry: null
             empty: {}
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: process_data
@@ -162,6 +178,9 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740993
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: set_limit

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.8.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
@@ -12,6 +13,8 @@ cases:
         arguments:
           location: NYC
       normal_text: I will check the weather.
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -27,6 +30,8 @@ cases:
         arguments:
           location: NYC
       normal_text: Let me know if you need more.
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -45,6 +50,8 @@ cases:
         arguments:
           location: NYC
       normal_text: I will check the weather.  Let me know if you need more.
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -63,6 +70,8 @@ cases:
         arguments:
           location: LA
       normal_text: I will check the weather.  Then check LA weather.
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/harmony/TOOLCALLING.batch.yaml
@@ -1,8 +1,9 @@
 family: harmony
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
   dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
@@ -11,6 +12,9 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -25,6 +29,9 @@ cases:
   TOOLCALLING.batch.3:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -33,6 +40,9 @@ cases:
   TOOLCALLING.batch.9.a:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -41,6 +51,9 @@ cases:
   TOOLCALLING.batch.9.b:
     dynamo_rust:
       calls: []
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls: []
     sglang_python:
@@ -55,6 +68,9 @@ cases:
       - name: get_weather
         arguments:
           location: LA
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: get_weather
@@ -73,11 +89,15 @@ cases:
           location: LA
       normal_text: ''
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
@@ -88,6 +108,9 @@ cases:
       - name: unknown_tool
         arguments:
           location: NYC
+      normal_text: ''
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       calls:
       - name: unknown_tool
@@ -97,6 +120,8 @@ cases:
       calls: []
       normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'harmony'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -18,16 +28,16 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
-      normal_text: ''
-  TOOLCALLING.batch.2.c:
+      normal_text: 'Both:  Done.'
     vllm_python:
       calls:
       - name: get_weather
@@ -40,16 +50,16 @@ cases:
     sglang_python:
       calls: []
       normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Both:  Done.'
-  TOOLCALLING.batch.2.d:
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -62,19 +72,10 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.4.yaml
@@ -1,36 +1,39 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
         arguments: '{"location": "NYC"'
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes
+
+        expected `name`'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: expected `name`'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -40,20 +43,17 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -15,20 +18,19 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     vllm_python:
       calls: []
       normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     sglang_python:
       calls: []
       normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    vllm_rust:
-      calls: []
-      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -37,10 +39,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -55,10 +56,9 @@ cases:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -72,6 +72,17 @@ cases:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
+  TOOLCALLING.batch.5.f:
     vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      unavailable: No batch model_text for this case.
+    vllm_python:
+      unavailable: No batch model_text for this case.
+    sglang_python:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.5.g:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
+    vllm_python:
+      unavailable: No batch model_text for this case.
+    sglang_python:
+      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.6.yaml
@@ -1,11 +1,17 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
@@ -14,26 +20,12 @@ cases:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
-    vllm_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments: {}
-        name: get_time
+      - name: get_time
+        arguments: {}
       normal_text: ''
-  TOOLCALLING.batch.6.c:
     vllm_python:
       calls:
       - name: get_time
@@ -42,6 +34,14 @@ cases:
       calls:
       - name: get_time
         arguments: {}
+  TOOLCALLING.batch.6.c:
     vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      error: 'tool parser parsing failed: invalid Hermes'
+    vllm_python:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -17,15 +26,13 @@ cases:
       calls:
       - name: book_flight
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
-      normal_text: ''
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -35,13 +42,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Tōkyō "central"
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_temperature
@@ -51,13 +58,18 @@ cases:
       calls:
       - name: set_temperature
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
-      normal_text: ''
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -72,18 +84,28 @@ cases:
       calls:
       - name: process_data
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-        name: process_data
-      normal_text: ''
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -108,28 +130,13 @@ cases:
       calls:
       - name: process_data
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          payload:
-            empty: {}
-            flags:
-              enabled: true
-              retry: null
-            regions:
-            - name: west
-              scores:
-              - 1
-              - 2
-              - 3
-            - name: east
-              scores:
-              - 4
-              - 5
-              - 6
-        name: process_data
-      normal_text: ''
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
@@ -139,9 +146,3 @@ cases:
       calls:
       - name: set_limit
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -15,13 +22,13 @@ cases:
     sglang_python:
       calls: []
       normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
-  TOOLCALLING.batch.8.b:
+      normal_text: ' Let me know if you need more.'
     vllm_python:
       calls:
       - name: get_weather
@@ -31,29 +38,32 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ' Let me know if you need more.'
   TOOLCALLING.batch.8.c:
-    vllm_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
-    sglang_python:
-      calls: []
-      normal_text: 'I will check the weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: I will check the weather.  Let me know if you need more.
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang_python:
+      calls: []
+      normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -66,12 +76,3 @@ cases:
     sglang_python:
       calls: []
       normal_text: 'I will check the weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/hermes/TOOLCALLING.batch.yaml
@@ -1,11 +1,18 @@
 family: hermes
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -15,41 +22,44 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -62,16 +72,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.13.a:
     vllm_rust:
       calls:
-      - arguments:
+      - name: unknown_tool
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
       normal_text: ''
-  TOOLCALLING.batch.13.a:
     vllm_python:
       calls:
       - name: unknown_tool
@@ -79,13 +86,16 @@ cases:
           location: NYC
     sglang_python:
       calls: []
+  TOOLCALLING.batch.13.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: unknown_tool
+      - name: unknown_tool
+        arguments:
+          location: LA
       normal_text: ''
-  TOOLCALLING.batch.13.c:
     vllm_python:
       calls:
       - name: get_weather
@@ -98,26 +108,17 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.2.yaml
@@ -1,25 +1,35 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.4.yaml
@@ -1,35 +1,49 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.5.yaml
@@ -1,31 +1,43 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
       normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.6.yaml
@@ -1,20 +1,28 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.7.yaml
@@ -1,35 +1,49 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.8.yaml
@@ -1,25 +1,35 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/jamba/TOOLCALLING.batch.yaml
@@ -1,67 +1,93 @@
 family: jamba
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.3:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.9.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.10:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.30.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.30.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.30.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.31.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.31.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.13.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'jamba'.
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'jamba'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -18,16 +28,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -40,13 +47,16 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'I will check both. '
     vllm_python:
       calls:
       - name: get_weather
@@ -60,16 +70,16 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'I will check both. '
-  TOOLCALLING.batch.2.d:
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -82,12 +92,3 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.4.yaml
@@ -1,18 +1,21 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Kimi K2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -21,17 +24,16 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls:
       - name: get_weather
@@ -40,19 +42,17 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,18 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -15,13 +22,10 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     vllm_python:
       calls: []
       normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
@@ -29,10 +33,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Kimi K2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -41,10 +44,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Kimi K2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -59,10 +61,9 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Kimi K2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -76,10 +77,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
   TOOLCALLING.batch.5.f:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     vllm_python:
       calls:
       - name: get_weather
@@ -90,13 +94,10 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Boston
-        name: get_weather
-      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
   TOOLCALLING.batch.5.g:
+    vllm_rust:
+      calls: []
+      normal_text: I will check that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     vllm_python:
       calls: []
       normal_text: I will check that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
@@ -104,6 +105,3 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: I will check that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.6.yaml
@@ -1,11 +1,17 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
@@ -14,30 +20,24 @@ cases:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
-    vllm_python:
-      calls:
-      - name: get_time
-        arguments: {}
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
     vllm_rust:
       calls:
-      - arguments: {}
-        name: get_time
+      - name: get_time
+        arguments: {}
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_time
+        arguments: {}
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Kimi K2 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -17,15 +26,13 @@ cases:
       calls:
       - name: book_flight
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
-      normal_text: ''
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -35,13 +42,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Tōkyō "central"
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_temperature
@@ -51,13 +58,18 @@ cases:
       calls:
       - name: set_temperature
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
-      normal_text: ''
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -72,18 +84,28 @@ cases:
       calls:
       - name: process_data
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-        name: process_data
-      normal_text: ''
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -108,28 +130,13 @@ cases:
       calls:
       - name: process_data
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          payload:
-            empty: {}
-            flags:
-              enabled: true
-              retry: null
-            regions:
-            - name: west
-              scores:
-              - 1
-              - 2
-              - 3
-            - name: east
-              scores:
-              - 4
-              - 5
-              - 6
-        name: process_data
-      normal_text: ''
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
@@ -139,9 +146,3 @@ cases:
       calls:
       - name: set_limit
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      normal_text: 'I''ll check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -16,29 +23,29 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Dallas
-        name: get_weather
-      normal_text: 'I''ll check the weather. '
   TOOLCALLING.batch.8.b:
-    vllm_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
           location: Dallas
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Dallas
-        name: get_weather
       normal_text: ''
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      normal_text: 'I''ll check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -49,13 +56,13 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.8.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: Dallas
-        name: get_weather
-      normal_text: 'I''ll check the weather. '
-  TOOLCALLING.batch.8.d:
+      normal_text: 'First check Dallas. '
     vllm_python:
       calls:
       - name: get_weather
@@ -69,9 +76,3 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Dallas
-        name: get_weather
-      normal_text: 'First check Dallas. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/kimi_k2/TOOLCALLING.batch.yaml
@@ -1,11 +1,18 @@
 family: kimi_k2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -15,41 +22,44 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -62,30 +72,27 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: unknown_tool
@@ -95,16 +102,10 @@ cases:
       calls:
       - name: unknown_tool
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.2.yaml
@@ -1,49 +1,50 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}}'
-  TOOLCALLING.batch.2.c:
     vllm_python:
       calls: []
-      normal_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls: []
       normal_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
-  TOOLCALLING.batch.2.d:
     vllm_python:
       calls: []
+      normal_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}};{"name": "get_weather", "arguments": {"location": "LA"}}'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.4.yaml
@@ -1,55 +1,58 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      calls: []
+      normal_text: <|python_tag|>not even json
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.4.b:
     vllm_rust:
       calls: []
-      normal_text: <|python_tag|>not even json
-  TOOLCALLING.batch.4.b:
+      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "NYC"'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "NYC"'
   TOOLCALLING.batch.4.c:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Llama JSON
+
+        expected `parameters`'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: expected `parameters`'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.5.yaml
@@ -1,32 +1,38 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}'
-  TOOLCALLING.batch.5.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.5.c:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York"}'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -36,12 +42,12 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York"}'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -51,15 +57,10 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "Boston"}};{"name": "get_weather", "arguments": {"location": "New York'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.6.yaml
@@ -1,37 +1,38 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_time
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_time", "arguments": {}}'
-  TOOLCALLING.batch.6.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
+  TOOLCALLING.batch.6.b:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_time", "arguments": { }}'
-  TOOLCALLING.batch.6.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
+  TOOLCALLING.batch.6.c:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_time"}'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_time
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.7.yaml
@@ -1,73 +1,74 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls: []
+      normal_text: '<|python_tag|>{"name": "book_flight", "arguments": {"destination":
+        "Paris", "passengers": 2, "first_class": true}}'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: book_flight
         arguments: {}
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls: []
-      normal_text: '<|python_tag|>{"name": "book_flight", "arguments": {"destination":
-        "Paris", "passengers": 2, "first_class": true}}'
-  TOOLCALLING.batch.7.b:
+      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "Tōkyō \"central\""}}'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls: []
-      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "Tōkyō \"central\""}}'
-  TOOLCALLING.batch.7.c:
+      normal_text: '<|python_tag|>{"name": "set_temperature", "arguments": {"celsius":
+        "20"}}'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_temperature
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: '<|python_tag|>{"name": "set_temperature", "arguments": {"celsius":
-        "20"}}'
   TOOLCALLING.batch.7.d:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: process_data
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "process_data", "arguments": {"items":
         [1,2,3], "config": {"nested": true}}}'
-  TOOLCALLING.batch.7.e:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: process_data
         arguments: {}
+  TOOLCALLING.batch.7.e:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "process_data", "arguments": {"payload":
         {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores":
         [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: process_data
+        arguments: {}
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls: []
+      normal_text: '<|python_tag|>{"name": "set_limit", "arguments": {"count": 9007199254740993}}'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: set_limit
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: '<|python_tag|>{"name": "set_limit", "arguments": {"count": 9007199254740993}}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.8.yaml
@@ -1,35 +1,40 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
-    vllm_python:
-      calls: []
-      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
-        "arguments": {"location": "NYC"}}'
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
         "arguments": {"location": "NYC"}}'
-  TOOLCALLING.batch.8.b:
     vllm_python:
       calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}}'
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.8.b:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}} Let me know if you need more.'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}} Let me know if you need more.'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
@@ -38,11 +43,12 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
-        "arguments": {"location": "NYC"}} Let me know if you need more.'
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
+        "arguments": {"location": "NYC"}} Then check LA weather. <|python_tag|>{"name":
+        "get_weather", "arguments": {"location": "LA"}}'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
@@ -52,8 +58,3 @@ cases:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check the weather. <|python_tag|>{"name": "get_weather",
-        "arguments": {"location": "NYC"}} Then check LA weather. <|python_tag|>{"name":
-        "get_weather", "arguments": {"location": "LA"}}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/llama3_json/TOOLCALLING.batch.yaml
@@ -1,133 +1,134 @@
 family: llama3_json
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls:
-      - name: get_weather
-        arguments: {}
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}}'
-  TOOLCALLING.batch.3:
-    vllm_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
-      calls: []
-      normal_text: Hello, how can I help you today?
-  TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
-    vllm_rust:
-      calls: []
-      normal_text: ''
-  TOOLCALLING.batch.9.b:
-    vllm_python:
-      calls: []
-      normal_text: '   '
-    sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
-      calls: []
-      normal_text: '   '
-  TOOLCALLING.batch.10:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    vllm_python:
+      calls: []
+      normal_text: Hello, how can I help you today?
+    sglang_python:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  TOOLCALLING.batch.9.a:
+    vllm_rust:
+      calls: []
+      normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
+  TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
+    vllm_python:
+      calls: []
+      normal_text: '   '
+    sglang_python:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
         "NYC"}};{"name": "get_weather", "arguments": {"location": "LA"}}'
-  TOOLCALLING.batch.30.a:
     vllm_python:
       calls: []
     sglang_python:
       calls:
-      - name: run_query
+      - name: get_weather
         arguments: {}
+  TOOLCALLING.batch.30.a:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT
         a; SELECT b"}}'
-  TOOLCALLING.batch.30.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: run_query
         arguments: {}
+  TOOLCALLING.batch.30.b:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT
         value WHERE note has brace } and bracket ]"}}'
-  TOOLCALLING.batch.30.c:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: run_query
         arguments: {}
+  TOOLCALLING.batch.30.c:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "literal
         <|python_tag marker|>{name:x} stays text"}}'
-  TOOLCALLING.batch.31.a:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: run_query
         arguments: {}
+  TOOLCALLING.batch.31.a:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT
         a; SELECT b"}};{"name": "get_time", "arguments": {"timezone": "EST"}}'
-  TOOLCALLING.batch.31.b:
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: run_query
         arguments: {}
+  TOOLCALLING.batch.31.b:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT
         value WHERE note has brace } and bracket ]"}};{"name": "get_time", "arguments":
         {"timezone": "EST"}}'
-  TOOLCALLING.batch.13.a:
     vllm_python:
       calls: []
     sglang_python:
-      calls: []
+      calls:
+      - name: run_query
+        arguments: {}
+  TOOLCALLING.batch.13.a:
     vllm_rust:
       calls: []
       normal_text: '<|python_tag|>{"name": "unknown_tool", "arguments": {"location":
         "NYC"}}'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      calls: []
+      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
+        "NYC"}};{"name": "unknown_tool", "arguments": {"location": "LA"}}'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      calls: []
-      normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location":
-        "NYC"}};{"name": "unknown_tool", "arguments": {"location": "LA"}}'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -23,9 +33,13 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -43,9 +57,16 @@ cases:
       - name: get_time
         arguments:
           timezone: EST
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
     vllm_python:
       calls:
       - name: get_weather
@@ -65,9 +86,16 @@ cases:
         arguments:
           timezone: EST
       normal_text: 'Both: '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -84,5 +112,3 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.4.yaml
@@ -1,51 +1,52 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete MiniMax M2 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: '{"location": "NYC"'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete MiniMax M2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -16,9 +19,16 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'
     vllm_python:
       calls: []
       normal_text: '<invoke name="get_weather">
@@ -29,15 +39,6 @@ cases:
 
         </minimax:tool_call>'
     sglang_python:
-      calls: []
-      normal_text: '<invoke name="get_weather">
-
-        <parameter name="location">NYC</parameter>
-
-        </invoke>
-
-        </minimax:tool_call>'
-    vllm_rust:
       calls: []
       normal_text: '<invoke name="get_weather">
 
@@ -47,15 +48,17 @@ cases:
 
         </minimax:tool_call>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete MiniMax M2 tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete MiniMax M2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -80,9 +83,9 @@ cases:
         at the same time!
 
         '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete MiniMax M2 tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -103,9 +106,21 @@ cases:
         at the same time!
 
         '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.5.f:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '<invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>
+
+        '
     vllm_python:
       calls:
       - name: get_weather
@@ -137,9 +152,16 @@ cases:
         </minimax:tool_call>
 
         '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.5.g:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check that. <invoke name="get_weather">
+
+        <parameter name="location">NYC</parameter>
+
+        </invoke>
+
+        </minimax:tool_call>'
     vllm_python:
       calls: []
       normal_text: 'I will check that. <invoke name="get_weather">
@@ -150,15 +172,6 @@ cases:
 
         </minimax:tool_call>'
     sglang_python:
-      calls: []
-      normal_text: 'I will check that. <invoke name="get_weather">
-
-        <parameter name="location">NYC</parameter>
-
-        </invoke>
-
-        </minimax:tool_call>'
-    vllm_rust:
       calls: []
       normal_text: 'I will check that. <invoke name="get_weather">
 

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.6.yaml
@@ -1,11 +1,17 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
@@ -14,9 +20,12 @@ cases:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
@@ -25,12 +34,10 @@ cases:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -20,9 +29,13 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -33,30 +46,34 @@ cases:
       - name: get_weather
         arguments:
           location: Tōkyō central
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls:
       - name: set_limit
@@ -67,5 +84,3 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740992
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -18,9 +25,13 @@ cases:
         arguments:
           location: NYC
       normal_text: 'I will check the weather. '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -31,9 +42,13 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -46,9 +61,13 @@ cases:
         arguments:
           location: NYC
       normal_text: 'I will check the weather. '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -67,5 +86,3 @@ cases:
         arguments:
           location: LA
       normal_text: 'I will check the weather. '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/minimax_m2/TOOLCALLING.batch.yaml
@@ -1,11 +1,18 @@
 family: minimax_m2
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -16,44 +23,51 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -70,26 +84,24 @@ cases:
       - name: get_weather
         arguments:
           location: LA
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.2.yaml
@@ -1,43 +1,44 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.2.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-      normal_text: 'Both: '
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls: []
       normal_text: 'Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]
         Done.'
-  TOOLCALLING.batch.2.d:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+      normal_text: 'Both: '
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.4.yaml
@@ -1,36 +1,41 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
-  TOOLCALLING.batch.4.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.4.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"][/TOOL_CALLS]'
-  TOOLCALLING.batch.4.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.4.c:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
+        "NYC"}}]'
     vllm_python:
       calls:
       - name: get_weather
@@ -38,21 +43,17 @@ cases:
           location: NYC
     sglang_python:
       calls: []
-    vllm_rust:
-      calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
-        "NYC"}}]'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,16 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
+        "NYC"}}]'
     vllm_python:
       calls:
       - name: get_weather
@@ -13,31 +18,32 @@ cases:
           location: NYC
     sglang_python:
       calls: []
+  TOOLCALLING.batch.5.b:
     vllm_rust:
       calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
-        "NYC"}}]'
-  TOOLCALLING.batch.5.b:
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     vllm_python:
       calls: []
       normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     sglang_python:
       calls: []
       normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS'
+  TOOLCALLING.batch.5.c:
     vllm_rust:
       calls: []
-      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.5.c:
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
     vllm_python:
       calls:
       - name: get_weather
         arguments: '{"loc'
     sglang_python:
       calls: []
+  TOOLCALLING.batch.5.d:
     vllm_rust:
       calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
-  TOOLCALLING.batch.5.d:
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time![TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
     vllm_python:
       calls:
       - name: get_weather
@@ -48,12 +54,12 @@ cases:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
+  TOOLCALLING.batch.5.e:
     vllm_rust:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
         at the same time![TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
-        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
-  TOOLCALLING.batch.5.e:
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
     vllm_python:
       calls:
       - name: get_weather
@@ -64,8 +70,3 @@ cases:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
-    vllm_rust:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time![TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
-        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.6.yaml
@@ -1,27 +1,31 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.6.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.6.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_time", "arguments": { }}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]'
     vllm_python:
       calls:
       - name: get_time
@@ -29,6 +33,3 @@ cases:
       normal_text: '[/TOOL_CALLS]'
     sglang_python:
       calls: []
-    vllm_rust:
-      calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.7.yaml
@@ -1,61 +1,62 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "book_flight", "arguments": {"destination":
         "Paris", "passengers": 2, "first_class": true}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "Tōkyō \"central\""}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.7.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "set_temperature", "arguments": {"celsius":
         "20"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.7.d:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.7.d:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1,2,3],
         "config": {"nested": true}}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.7.e:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.7.e:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"payload":
         {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores":
         [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.7.f:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.7.f:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "set_limit", "arguments": {"count": 9007199254740993}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.8.yaml
@@ -1,47 +1,48 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
-      normal_text: 'I will check the weather. '
     vllm_rust:
       calls: []
       normal_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather",
         "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.8.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}][/TOOL_CALLS] Let me know if you need more.'
-  TOOLCALLING.batch.8.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-      normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.c:
     vllm_rust:
       calls: []
       normal_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather",
         "arguments": {"location": "NYC"}}][/TOOL_CALLS] Let me know if you need more.'
-  TOOLCALLING.batch.8.d:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: 'I will check the weather. '
+  TOOLCALLING.batch.8.d:
     vllm_rust:
       calls: []
       normal_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather",
         "arguments": {"location": "NYC"}}][/TOOL_CALLS] Then check LA weather. [TOOL_CALLS][{"name":
         "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
+      normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/mistral/TOOLCALLING.batch.yaml
@@ -1,117 +1,118 @@
 family: mistral
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
-  TOOLCALLING.batch.9.b:
     vllm_python:
       calls: []
-      normal_text: '   '
     sglang_python:
       calls: []
-      normal_text: '   '
+  TOOLCALLING.batch.9.b:
     vllm_rust:
       calls: []
       normal_text: '   '
-  TOOLCALLING.batch.10:
     vllm_python:
       calls: []
+      normal_text: '   '
     sglang_python:
       calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.30.a:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.30.a:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT
         a, SELECT b"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.30.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.30.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT
         value WHERE note has brace } and bracket ]"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.30.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.30.c:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "literal
         [TOOL_CALLS marker][][/TOOL_CALLS marker] stays text"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.31.a:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.31.a:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT
         a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.31.b:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.31.b:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT
         value WHERE note has brace } and bracket ]"}}, {"name": "get_time", "arguments":
         {"timezone": "EST"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.13.a:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.13.a:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "unknown_tool", "arguments": {"location":
         "NYC"}}][/TOOL_CALLS]'
-  TOOLCALLING.batch.13.c:
     vllm_python:
       calls: []
     sglang_python:
       calls: []
+  TOOLCALLING.batch.13.c:
     vllm_rust:
       calls: []
       normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location":
         "NYC"}}, {"name": "unknown_tool", "arguments": {"location": "LA"}}][/TOOL_CALLS]'
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.2.yaml
@@ -1,33 +1,39 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
         {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
-        {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name":
+        "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name":
         "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name":
-        "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>'
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      calls: []
+      normal_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>
+        Done.'
     vllm_python:
       calls: []
       normal_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location":
@@ -35,19 +41,14 @@ cases:
         Done.'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location":
-        "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>
-        Done.'
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
         {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
-        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.4.yaml
@@ -1,57 +1,58 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      calls: []
+      normal_text: <TOOLCALL>not a json array</TOOLCALL>
     vllm_python:
       calls: []
       normal_text: <TOOLCALL>not a json array</TOOLCALL>
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: <TOOLCALL>not a json array</TOOLCALL>
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.5.yaml
@@ -1,38 +1,44 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -40,12 +46,12 @@ cases:
         "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
-        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      calls: []
+      normal_text: 'I''ll start by fetching the weather for both Boston and New York
+        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
+        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -53,8 +59,3 @@ cases:
         "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<TOOLCALL>[{"name": "get_weather", "arguments": {"location":
-        "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.6.yaml
@@ -1,34 +1,35 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>'
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.7.yaml
@@ -1,55 +1,61 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination":
+        "Paris", "passengers": 2, "first_class": true}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination":
         "Paris", "passengers": 2, "first_class": true}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination":
-        "Paris", "passengers": 2, "first_class": true}}]</TOOLCALL>'
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō
+        \"central\""}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō
         \"central\""}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō
-        \"central\""}}]</TOOLCALL>'
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius":
+        "20"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius":
         "20"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius":
-        "20"}}]</TOOLCALL>'
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3],
+        "config": {"nested": true}}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3],
         "config": {"nested": true}}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3],
-        "config": {"nested": true}}}]</TOOLCALL>'
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions":
+        [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5,
+        6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions":
@@ -57,15 +63,10 @@ cases:
         6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions":
-        [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5,
-        6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.8.yaml
@@ -1,44 +1,50 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
         {"location": "NYC"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
-        {"location": "NYC"}}]</TOOLCALL>'
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
+        Let me know if you need more.'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
         Let me know if you need more.'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
-        Let me know if you need more.'
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL> Let me know if you need more.'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
         {"location": "NYC"}}]</TOOLCALL> Let me know if you need more.'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
-        {"location": "NYC"}}]</TOOLCALL> Let me know if you need more.'
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls: []
+      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
+        {"location": "NYC"}}]</TOOLCALL> Then check LA weather. <TOOLCALL>[{"name":
+        "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
@@ -46,8 +52,3 @@ cases:
         "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments":
-        {"location": "NYC"}}]</TOOLCALL> Then check LA weather. <TOOLCALL>[{"name":
-        "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_deci/TOOLCALLING.batch.yaml
@@ -1,85 +1,86 @@
 family: nemotron_deci
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.3:
-    vllm_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    sglang_python:
-      unavailable: No SGLang parser for family 'nemotron_deci'.
     vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
-  TOOLCALLING.batch.9.a:
     vllm_python:
       calls: []
+      normal_text: Hello, how can I help you today?
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
+  TOOLCALLING.batch.9.a:
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      unavailable: No SGLang parser for family 'nemotron_deci'.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
+        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
         {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}},
-        {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "unknown_tool", "arguments": {"location":
+        "NYC"}}]</TOOLCALL>'
     vllm_python:
       calls: []
       normal_text: '<TOOLCALL>[{"name": "unknown_tool", "arguments": {"location":
         "NYC"}}]</TOOLCALL>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_deci'.
-    vllm_rust:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "unknown_tool", "arguments": {"location":
-        "NYC"}}]</TOOLCALL>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.2.yaml
@@ -1,39 +1,37 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'Both: '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.4.yaml
@@ -1,51 +1,50 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.5.yaml
@@ -1,19 +1,32 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>'
     vllm_python:
       calls: []
       normal_text: '<function=get_weather>
@@ -29,28 +42,16 @@ cases:
         </tool_call>'
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      calls: []
-      normal_text: '<function=get_weather>
-
-        <parameter=location>
-
-        NYC
-
-        </parameter>
-
-        </function>
-
-        </tool_call>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -59,10 +60,9 @@ cases:
         '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -71,6 +71,3 @@ cases:
         '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.6.yaml
@@ -1,30 +1,29 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.7.yaml
@@ -1,52 +1,50 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.8.yaml
@@ -1,42 +1,39 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/nemotron_nano/TOOLCALLING.batch.yaml
@@ -1,78 +1,76 @@
 family: nemotron_nano
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.3:
-    vllm_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    sglang_python:
-      unavailable: No SGLang parser for family 'nemotron_nano'.
     vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
-  TOOLCALLING.batch.9.a:
     vllm_python:
       calls: []
+      normal_text: Hello, how can I help you today?
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
+  TOOLCALLING.batch.9.a:
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      unavailable: No SGLang parser for family 'nemotron_nano'.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      calls: []
-      normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'nemotron_nano'.
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.2.yaml
@@ -1,25 +1,35 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.4.yaml
@@ -1,35 +1,49 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.5.yaml
@@ -1,30 +1,42 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.6.yaml
@@ -1,20 +1,28 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.7.yaml
@@ -1,35 +1,49 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.8.yaml
@@ -1,25 +1,35 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/phi4/TOOLCALLING.batch.yaml
@@ -1,65 +1,91 @@
 family: phi4
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.3:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.9.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.10:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.30.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.30.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.30.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.31.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.31.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.13.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:
       unavailable: No SGLang parser for family 'phi4'.
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'phi4'.
     vllm_python:
       calls: []
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.2.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -22,6 +26,8 @@ cases:
         arguments:
           timezone: EST
   TOOLCALLING.batch.2.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")]
@@ -36,6 +42,8 @@ cases:
           timezone: EST
       normal_text: 'Both: '
   TOOLCALLING.batch.2.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -53,6 +61,8 @@ cases:
         arguments:
           location: LA
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.4.yaml
@@ -1,37 +1,51 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: '[not a valid python call]'
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
       calls: []
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: '[get_weather(location="NYC"]'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.5.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -13,6 +17,8 @@ cases:
     sglang_python:
       calls: []
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: get_weather(location="NYC")]
@@ -20,6 +26,8 @@ cases:
       calls: []
       normal_text: get_weather(location="NYC")]
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -27,6 +35,8 @@ cases:
     sglang_python:
       calls: []
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York
@@ -37,6 +47,8 @@ cases:
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: I'll start by fetching the weather for both Boston and New York

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.6.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_time
@@ -14,6 +18,8 @@ cases:
       - name: get_time
         arguments: {}
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_time
@@ -22,6 +28,8 @@ cases:
       calls: []
       normal_text: '[get_time( )]'
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.7.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: book_flight
@@ -20,6 +24,8 @@ cases:
           passengers: 2
           first_class: true
   TOOLCALLING.batch.7.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -31,6 +37,8 @@ cases:
         arguments:
           location: Tōkyō "central"
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: set_temperature
@@ -42,6 +50,8 @@ cases:
         arguments:
           celsius: '20'
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: process_data
@@ -63,6 +73,8 @@ cases:
           config:
             nested: true
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: process_data
@@ -104,6 +116,8 @@ cases:
               retry: null
             empty: {}
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.8.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: I will check the weather. [get_weather(location="NYC")]
@@ -15,6 +19,8 @@ cases:
           location: NYC
       normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
@@ -23,6 +29,8 @@ cases:
         arguments:
           location: NYC
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: I will check the weather. [get_weather(location="NYC")] Let me
@@ -34,6 +42,8 @@ cases:
           location: NYC
       normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: I will check the weather. [get_weather(location="NYC")] Then check

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/pythonic/TOOLCALLING.batch.yaml
@@ -1,10 +1,14 @@
 family: pythonic
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -16,6 +20,8 @@ cases:
         arguments:
           location: NYC
   TOOLCALLING.batch.3:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
@@ -23,11 +29,15 @@ cases:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
       calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
       normal_text: '   '
@@ -35,6 +45,8 @@ cases:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather
@@ -52,6 +64,8 @@ cases:
         arguments:
           location: LA
   TOOLCALLING.batch.30.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: run_query
@@ -63,6 +77,8 @@ cases:
         arguments:
           sql: SELECT a, SELECT b
   TOOLCALLING.batch.30.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
@@ -70,6 +86,8 @@ cases:
       normal_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket
         ]'
   TOOLCALLING.batch.30.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: run_query
@@ -81,6 +99,8 @@ cases:
         arguments:
           sql: literal [get_time marker] stays text
   TOOLCALLING.batch.31.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: run_query
@@ -98,6 +118,8 @@ cases:
         arguments:
           timezone: EST
   TOOLCALLING.batch.31.b:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls: []
     sglang_python:
@@ -105,6 +127,8 @@ cases:
       normal_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket
         ]'
   TOOLCALLING.batch.13.a:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: unknown_tool
@@ -113,6 +137,8 @@ cases:
     sglang_python:
       calls: []
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No vLLM Rust parser for family 'pythonic'.
     vllm_python:
       calls:
       - name: get_weather

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,21 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
@@ -15,19 +25,26 @@ cases:
         arguments:
           timezone: EST
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
-        "get_time", "arguments": {"timezone": "EST"}}'
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
+    vllm_python:
+      unavailable: No batch model_text for this case.
+    sglang_python:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
-      normal_text: ''
-  TOOLCALLING.batch.2.c:
+      normal_text: 'Both:  Done.'
     vllm_python:
       calls:
       - name: get_weather
@@ -38,44 +55,28 @@ cases:
           timezone: EST
       normal_text: 'Both: '
     sglang_python:
-      calls: []
-      normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location":
-        "NYC"}}<tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}} Done.'
-    vllm_rust:
       calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: 'Both:  Done.'
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.2.d:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
-        "get_weather", "arguments": {"location": "LA"}}'
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: ''
-  TOOLCALLING.batch.2.b:
     vllm_python:
-      unavailable: No batch model_text for this case.
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.4.yaml
@@ -1,20 +1,22 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: <tool_call>not even json
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -22,18 +24,19 @@ cases:
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes
+
+        expected `name`'
     vllm_python:
       calls: []
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"arguments": {"location": "NYC"}}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: expected `name`'
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -42,20 +45,17 @@ cases:
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -14,20 +17,19 @@ cases:
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     vllm_python:
       calls: []
       normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     sglang_python:
       calls: []
       normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    vllm_rust:
-      calls: []
-      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -35,10 +37,9 @@ cases:
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -50,15 +51,12 @@ cases:
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
     sglang_python:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<tool_call>{"name": "get_weather", "arguments": {"location":
-        "Boston"}}<tool_call>{"name": "get_weather", "arguments": {"location": "New
-        York"}}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Hermes tool call'
     vllm_python:
       calls:
       - name: get_weather
@@ -69,11 +67,6 @@ cases:
       normal_text: I'll start by fetching the weather for both Boston and New York
         at the same time!
     sglang_python:
-      calls: []
-      normal_text: 'I''ll start by fetching the weather for both Boston and New York
-        at the same time!<tool_call>{"name": "get_weather", "arguments": {"location":
-        "Boston"}}<tool_call>{"name": "get_weather", "arguments": {"location": "New
-        York'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      calls:
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.6.yaml
@@ -1,37 +1,42 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
         arguments: {}
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_time", "arguments": {}}'
-    vllm_rust:
       calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_time
         arguments: {}
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_time", "arguments": { }}'
-    vllm_rust:
       calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
+      - name: get_time
+        arguments: {}
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: invalid Hermes'
     vllm_python:
       calls:
       - name: get_time
@@ -39,6 +44,3 @@ cases:
     sglang_python:
       calls: []
       normal_text: '<tool_call>{"name": "get_time"}'
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: book_flight
@@ -14,50 +23,53 @@ cases:
           passengers: 2
           first_class: true
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination":
-        "Paris", "passengers": 2, "first_class": true}}'
+      calls:
+      - name: book_flight
+        arguments: {}
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
       normal_text: ''
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: Tōkyō "central"
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō
-        \"central\""}}'
+      calls:
+      - name: get_weather
+        arguments: {}
+  TOOLCALLING.batch.7.c:
     vllm_rust:
       calls:
-      - arguments:
-          location: Tōkyō "central"
-        name: get_weather
+      - name: set_temperature
+        arguments:
+          celsius: '20'
       normal_text: ''
-  TOOLCALLING.batch.7.c:
     vllm_python:
       calls:
       - name: set_temperature
         arguments:
           celsius: '20'
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius":
-        "20"}}'
-    vllm_rust:
       calls:
-      - arguments:
-          celsius: '20'
-        name: set_temperature
-      normal_text: ''
+      - name: set_temperature
+        arguments: {}
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -69,21 +81,31 @@ cases:
           config:
             nested: true
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3],
-        "config": {"nested": true}}}'
-    vllm_rust:
       calls:
-      - arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-        name: process_data
-      normal_text: ''
+      - name: process_data
+        arguments: {}
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      calls:
+      - name: process_data
+        arguments:
+          payload:
+            regions:
+            - name: west
+              scores:
+              - 1
+              - 2
+              - 3
+            - name: east
+              scores:
+              - 4
+              - 5
+              - 6
+            flags:
+              enabled: true
+              retry: null
+            empty: {}
+      normal_text: ''
     vllm_python:
       calls:
       - name: process_data
@@ -105,43 +127,22 @@ cases:
               retry: null
             empty: {}
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions":
-        [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5,
-        6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}'
+      calls:
+      - name: process_data
+        arguments: {}
+  TOOLCALLING.batch.7.f:
     vllm_rust:
       calls:
-      - arguments:
-          payload:
-            empty: {}
-            flags:
-              enabled: true
-              retry: null
-            regions:
-            - name: west
-              scores:
-              - 1
-              - 2
-              - 3
-            - name: east
-              scores:
-              - 4
-              - 5
-              - 6
-        name: process_data
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
       normal_text: ''
-  TOOLCALLING.batch.7.f:
     vllm_python:
       calls:
       - name: set_limit
         arguments:
           count: 9007199254740993
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}'
-    vllm_rust:
       calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''
+      - name: set_limit
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -13,49 +20,52 @@ cases:
           location: NYC
       normal_text: 'I will check the weather. '
     sglang_python:
-      calls: []
-      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
-        {"location": "NYC"}}'
-    vllm_rust:
       calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: 'I will check the weather. '
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.b:
-    vllm_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-    sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}
-        Let me know if you need more.'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: ' Let me know if you need more.'
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.c:
-    vllm_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
-    sglang_python:
-      calls: []
-      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
-        {"location": "NYC"}} Let me know if you need more.'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: I will check the weather.  Let me know if you need more.
+    vllm_python:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+    sglang_python:
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.8.d:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: 'I will check the weather.  Then check LA weather. '
     vllm_python:
       calls:
       - name: get_weather
@@ -66,16 +76,6 @@ cases:
           location: LA
       normal_text: 'I will check the weather. '
     sglang_python:
-      calls: []
-      normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments":
-        {"location": "NYC"}} Then check LA weather. <tool_call>{"name": "get_weather",
-        "arguments": {"location": "LA"}}'
-    vllm_rust:
       calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: 'I will check the weather.  Then check LA weather. '
+      - name: get_weather
+        arguments: {}

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen25/TOOLCALLING.batch.yaml
@@ -1,90 +1,84 @@
 family: qwen25
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: get_weather
         arguments:
           location: NYC
     sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    vllm_rust:
       calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
+    vllm_python:
+      calls: []
+    sglang_python:
+      calls: []
   TOOLCALLING.batch.9.b:
+    vllm_rust:
+      calls: []
+      normal_text: '   '
     vllm_python:
       calls: []
       normal_text: '   '
     sglang_python:
-      calls: []
-      normal_text: '   '
-    vllm_rust:
       calls: []
       normal_text: '   '
   TOOLCALLING.batch.10:
-    vllm_python:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-    sglang_python:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name":
-        "get_weather", "arguments": {"location": "LA"}}'
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: ''
-  TOOLCALLING.batch.30:
     vllm_python:
-      unavailable: No batch model_text for this case.
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
-  TOOLCALLING.batch.31:
-    vllm_python:
-      unavailable: No batch model_text for this case.
-    sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
+      calls:
+      - name: get_weather
+        arguments: {}
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls:
       - name: unknown_tool
@@ -92,18 +86,24 @@ cases:
           location: NYC
     sglang_python:
       calls: []
-      normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location":
-        "NYC"}}'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.30:
     vllm_rust:
+      unavailable: No batch model_text for this case.
+    vllm_python:
+      unavailable: No batch model_text for this case.
+    sglang_python:
+      unavailable: No batch model_text for this case.
+  TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
+    vllm_python:
+      unavailable: No batch model_text for this case.
+    sglang_python:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.2.yaml
@@ -1,11 +1,23 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.2.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: '
+
+        '
     vllm_python:
       calls: []
     sglang_python:
@@ -19,18 +31,16 @@ cases:
       normal_text: '
 
         '
+  TOOLCALLING.batch.2.c:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_time
+        arguments:
           timezone: EST
-        name: get_time
-      normal_text: '
-
-        '
-  TOOLCALLING.batch.2.c:
+      normal_text: "Both queries: \n Results above."
     vllm_python:
       calls: []
       normal_text: 'Both queries: '
@@ -43,16 +53,18 @@ cases:
         arguments:
           timezone: EST
       normal_text: "Both queries: \n Results above."
+  TOOLCALLING.batch.2.d:
     vllm_rust:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
-          timezone: EST
-        name: get_time
-      normal_text: "Both queries: \n Results above."
-  TOOLCALLING.batch.2.d:
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: '
+
+        '
     vllm_python:
       calls: []
     sglang_python:
@@ -66,21 +78,10 @@ cases:
       normal_text: '
 
         '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      - arguments:
-          location: LA
-        name: get_weather
-      normal_text: '
-
-        '
   TOOLCALLING.batch.2.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.4.yaml
@@ -1,18 +1,21 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.4.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls: []
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
@@ -20,35 +23,33 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '
   TOOLCALLING.batch.4.b:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.4.f:
+    vllm_rust:
+      error: 'tool parser parsing failed: '
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: ''
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -1,11 +1,14 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.5.a:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Qwen Coder tool call'
     vllm_python:
       calls: []
     sglang_python:
@@ -13,10 +16,20 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
   TOOLCALLING.batch.5.b:
+    vllm_rust:
+      calls: []
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>'
     vllm_python:
       calls: []
       normal_text: '<function=get_weather>
@@ -40,30 +53,18 @@ cases:
 
 
         '
-    vllm_rust:
-      calls: []
-      normal_text: '<function=get_weather>
-
-        <parameter=location>
-
-        NYC
-
-        </parameter>
-
-        </function>
-
-        </tool_call>'
   TOOLCALLING.batch.5.c:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Qwen Coder tool call'
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_weather
         arguments: {}
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
   TOOLCALLING.batch.5.d:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Qwen Coder tool call'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -83,10 +84,9 @@ cases:
 
 
         '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
   TOOLCALLING.batch.5.e:
+    vllm_rust:
+      error: 'tool parser parsing failed: incomplete Qwen Coder tool call'
     vllm_python:
       calls: []
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
@@ -105,10 +105,25 @@ cases:
 
 
         '
-    vllm_rust:
-      unavailable: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Qwen Coder tool call'
   TOOLCALLING.batch.5.f:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: '<function=get_weather>
+
+        <parameter=location>
+
+        NYC
+
+        </parameter>
+
+        </function>
+
+        </tool_call>
+
+        '
     vllm_python:
       calls: []
       normal_text: '<function=get_weather>
@@ -138,12 +153,10 @@ cases:
 
 
         '
+  TOOLCALLING.batch.5.g:
     vllm_rust:
-      calls:
-      - arguments:
-          location: Boston
-        name: get_weather
-      normal_text: '<function=get_weather>
+      calls: []
+      normal_text: 'I will check that. <function=get_weather>
 
         <parameter=location>
 
@@ -153,10 +166,7 @@ cases:
 
         </function>
 
-        </tool_call>
-
-        '
-  TOOLCALLING.batch.5.g:
+        </tool_call>'
     vllm_python:
       calls: []
       normal_text: 'I will check that. <function=get_weather>
@@ -176,16 +186,3 @@ cases:
         arguments:
           location: NYC
       normal_text: "I will check that. \n\n\n"
-    vllm_rust:
-      calls: []
-      normal_text: 'I will check that. <function=get_weather>
-
-        <parameter=location>
-
-        NYC
-
-        </parameter>
-
-        </function>
-
-        </tool_call>'

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.6.yaml
@@ -1,38 +1,39 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.6.a:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.b:
+    vllm_rust:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
       calls:
       - name: get_time
         arguments: {}
-    vllm_rust:
-      calls:
-      - arguments: {}
-        name: get_time
-      normal_text: ''
   TOOLCALLING.batch.6.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.7.yaml
@@ -1,11 +1,20 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.7.a:
+    vllm_rust:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -15,15 +24,13 @@ cases:
           destination: Paris
           passengers: 2
           first_class: true
+  TOOLCALLING.batch.7.b:
     vllm_rust:
       calls:
-      - arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-        name: book_flight
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
       normal_text: ''
-  TOOLCALLING.batch.7.b:
     vllm_python:
       calls: []
     sglang_python:
@@ -31,34 +38,34 @@ cases:
       - name: get_weather
         arguments:
           location: Tōkyō central
-    vllm_rust:
-      calls:
-      - arguments:
-          location: Tōkyō central
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.7.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.d:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.e:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.7.f:
+    vllm_rust:
+      calls:
+      - name: set_limit
+        arguments:
+          count: 9007199254740993
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -66,9 +73,3 @@ cases:
       - name: set_limit
         arguments:
           count: 9007199254740992
-    vllm_rust:
-      calls:
-      - arguments:
-          count: 9007199254740993
-        name: set_limit
-      normal_text: ''

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.8.yaml
@@ -1,11 +1,18 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.8.a:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. '
@@ -14,14 +21,14 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: 'I will check the weather. '
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ' Let me know if you need more.'
     vllm_python:
       calls: []
     sglang_python:
@@ -29,14 +36,14 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: ' Let me know if you need more.'
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
       normal_text: ' Let me know if you need more.'
   TOOLCALLING.batch.8.c:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.  Let me know if you need more.
     vllm_python:
       calls: []
       normal_text: 'I will check the weather. '
@@ -46,17 +53,8 @@ cases:
         arguments:
           location: NYC
       normal_text: I will check the weather.  Let me know if you need more.
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: I will check the weather.  Let me know if you need more.
   TOOLCALLING.batch.8.d:
-    vllm_python:
-      calls: []
-      normal_text: 'I will check the weather. '
-    sglang_python:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
@@ -65,12 +63,15 @@ cases:
         arguments:
           location: LA
       normal_text: 'I will check the weather.  Then check LA weather. '
-    vllm_rust:
+    vllm_python:
+      calls: []
+      normal_text: 'I will check the weather. '
+    sglang_python:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: 'I will check the weather.  Then check LA weather. '

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/qwen3_coder/TOOLCALLING.batch.yaml
@@ -1,11 +1,18 @@
 family: qwen3_coder
 mode: batch-on-stream
 captured_with:
-  vllm_python: 0.22.0
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  dynamo_rust: Dynamo parser v2
 cases:
   TOOLCALLING.batch.1:
+    vllm_rust:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -13,44 +20,36 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: get_weather
-      normal_text: ''
   TOOLCALLING.batch.3:
+    vllm_rust:
+      calls: []
+      normal_text: Hello, how can I help you today?
     vllm_python:
       calls: []
       normal_text: Hello, how can I help you today?
     sglang_python:
-      calls: []
-      normal_text: Hello, how can I help you today?
-    vllm_rust:
       calls: []
       normal_text: Hello, how can I help you today?
   TOOLCALLING.batch.9.a:
-    vllm_python:
-      calls: []
-    sglang_python:
-      calls: []
     vllm_rust:
       calls: []
       normal_text: ''
-  TOOLCALLING.batch.9.b:
     vllm_python:
       calls: []
-      normal_text: '   '
     sglang_python:
       calls: []
-      normal_text: '   '
+  TOOLCALLING.batch.9.b:
     vllm_rust:
       calls: []
       normal_text: '   '
-  TOOLCALLING.batch.10:
     vllm_python:
       calls: []
+      normal_text: '   '
     sglang_python:
+      calls: []
+      normal_text: '   '
+  TOOLCALLING.batch.10:
+    vllm_rust:
       calls:
       - name: get_weather
         arguments:
@@ -61,32 +60,40 @@ cases:
       normal_text: '
 
         '
-    vllm_rust:
+    vllm_python:
+      calls: []
+    sglang_python:
       calls:
-      - arguments:
+      - name: get_weather
+        arguments:
           location: NYC
-        name: get_weather
-      - arguments:
+      - name: get_weather
+        arguments:
           location: LA
-        name: get_weather
       normal_text: '
 
         '
   TOOLCALLING.batch.30:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.
   TOOLCALLING.batch.31:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
       unavailable: No batch model_text for this case.
-    vllm_rust:
-      unavailable: No batch model_text for this case.
   TOOLCALLING.batch.13:
+    vllm_rust:
+      calls:
+      - name: unknown_tool
+        arguments:
+          location: NYC
+      normal_text: ''
     vllm_python:
       calls: []
     sglang_python:
@@ -94,16 +101,10 @@ cases:
       - name: unknown_tool
         arguments:
           location: NYC
-    vllm_rust:
-      calls:
-      - arguments:
-          location: NYC
-        name: unknown_tool
-      normal_text: ''
   TOOLCALLING.batch.13.c:
+    vllm_rust:
+      unavailable: No batch model_text for this case.
     vllm_python:
       unavailable: No batch model_text for this case.
     sglang_python:
-      unavailable: No batch model_text for this case.
-    vllm_rust:
       unavailable: No batch model_text for this case.

--- a/conformance/toolcalling/fixtures-stream-v2/README.md
+++ b/conformance/toolcalling/fixtures-stream-v2/README.md
@@ -15,8 +15,8 @@ Each stream fixture records chunks under `cases.<case>.chunks`. Each chunk has i
 ```yaml
 captured_with:
   dynamo_rust: Dynamo parser v2
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  vllm_python: 0.22.0
+  vllm_rust: v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75
+  vllm_python: 0.23.0
   sglang_python: 0.5.12.post1
 cases:
   TOOLCALLING.streamv2.1.a:
@@ -76,7 +76,7 @@ conformance/utils/capture.sh dynamo-stream \
 conformance/utils/capture.sh stream \
   --vllm-container vllm-localdev \
   --sglang-container sglang-localdev \
-  --vllm-rust-source ~/dynamo/vllm-0.22.0
+  --vllm-rust-source ~/dynamo/vllm-0.23.0
 ```
 
 Use `capture.sh stream` for all-family captures; do not add a second wrapper for the same workflow.

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,40 +26,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,63 +26,73 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-    - delta_text: function<｜tool▁sep｜>get_weather
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'function<｜tool▁sep｜>get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location": "LA"}'
+    - delta_text: '
+```json
+{"location": "LA"}'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": "LA"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,40 +26,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'unknown_tool ```json {"location":'
+    - delta_text: 'unknown_tool
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'unknown_tool'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
+        - {index: 0, id: true, name: 'unknown_tool'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: unknown_tool
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'unknown_tool'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls in single fence pair
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls in single fence pair'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,69 +32,79 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-    - delta_text: function<｜tool▁sep｜>get_time
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'function<｜tool▁sep｜>get_time'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"timezone": "EST"}'
+    - delta_text: '
+```json
+{"timezone": "EST"}'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone": "EST"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
+        - {index: 1, id: true, name: 'get_time'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, name: 'get_time'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back fence pairs
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back fence pairs'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -100,73 +119,82 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>get_time ```json
+    - delta_text: 'function<｜tool▁sep｜>get_time
+```json'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
+        - {index: 1, id: true, name: 'get_time'}
         sglang_python: []
-    - delta_text: ' {"timezone":'
+    - delta_text: '
+{"timezone":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' "EST"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "EST"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, name: 'get_time'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -181,81 +209,91 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: 'Both: '
         vllm_python: 'Both: '
-    - delta_text: <｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>get_weather ```json
+    - delta_text: 'function<｜tool▁sep｜>get_weather
+```json'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' {"location": "NYC"}'
+    - delta_text: '
+{"location": "NYC"}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-    - delta_text: 'get_time ```json {"timezone":'
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'get_time
+```json
+{"timezone":'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
+        - {index: 1, id: true, name: 'get_time'}
         sglang_python: []
     - delta_text: ' "EST"}'
       expected:
+        vllm_rust:
+        - {index: 1, arguments: ' "EST"}'}
         vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone": "EST"}'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
+        - {index: 1, name: 'get_time'}
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
         vllm_python: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -266,63 +304,73 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-    - delta_text: function<｜tool▁sep｜>get_weather
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'function<｜tool▁sep｜>get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location": "LA"}'
+    - delta_text: '
+```json
+{"location": "LA"}'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": "LA"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Garbage between calls fences
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Garbage between calls fences'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,24 +26,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    - delta_text: '<｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: nonsense
+        vllm_python: 'nonsense'
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace inside fenced JSON
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace inside fenced JSON'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -43,46 +51,43 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC" ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"
+```<｜tool▁call▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
+        - {index: 0, arguments: '{"location": "NYC"'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing function name token
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing function name token'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -91,38 +96,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location": "NYC"}'
+    - delta_text: '
+```json
+{"location": "NYC"}'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
+        - {index: 0}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.streamv2.4.d:
-    description: Missing fenced JSON block (no ```json)
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing fenced JSON block (no ```json)'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -131,24 +136,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather {"location": "NYC"}<｜tool▁call▁end｜>'
+    - delta_text: 'get_weather
+{"location": "NYC"}<｜tool▁call▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <｜tool▁calls▁end｜>
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing calls_end / call_end markers
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing calls_end / call_end markers'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,44 +26,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```'
+    - delta_text: ' "NYC"}
+```'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.streamv2.5.b:
-    description: Closing tool_calls_end without matching tool_calls_begin
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing tool_calls_end without matching tool_calls_begin'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -63,54 +68,60 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
-        vllm_rust: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
-    - delta_text: get_weather
+        vllm_rust: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
+        vllm_python: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
+    - delta_text: 'get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: get_weather
-        vllm_rust: get_weather
-    - delta_text: ' ```json {"location": "NYC"}'
+        vllm_rust: 'get_weather'
+        vllm_python: 'get_weather'
+    - delta_text: '
+```json
+{"location": "NYC"}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' ```json {"location": "NYC"}'
-        vllm_rust: ' ```json {"location": "NYC"}'
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        vllm_rust: '
+```json
+{"location": "NYC"}'
+        vllm_python: '
+```json
+{"location": "NYC"}'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
-        vllm_rust: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        vllm_rust: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        vllm_python: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON inside fenced block
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arguments JSON inside fenced block'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -119,36 +130,33 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather ```json {"loc
+    - delta_text: 'get_weather
+```json
+{"loc'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -157,18 +165,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -218,68 +224,67 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <｜tool▁calls▁begin｜>'
+    - delta_text: ' time!
+<｜tool▁calls▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: <｜tool▁call▁begin｜>
+        vllm_python: ' time!
+'
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>get_weather
+    - delta_text: 'function<｜tool▁sep｜>get_weather'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json'
+    - delta_text: '
+```json'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' {"location": "Boston"} ```<｜tool▁call▁end｜>'
+    - delta_text: '
+{"location": "Boston"}
+```<｜tool▁call▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: get_weather
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: 'get_weather'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location":'
+    - delta_text: '
+```json
+{"location":'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "New York"} ```'
+    - delta_text: ' "New York"}
+```'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: '{"location": "New York"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: '{"location": "New York"}'}
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -288,18 +293,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -349,49 +352,50 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <｜tool▁calls▁begin｜>'
+    - delta_text: ' time!
+<｜tool▁calls▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: <｜tool▁call▁begin｜>
+        vllm_python: ' time!
+'
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>get_weather
+    - delta_text: 'function<｜tool▁sep｜>get_weather'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json'
+    - delta_text: '
+```json'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' {"location": "Boston"} ```<｜tool▁call▁end｜>'
+    - delta_text: '
+{"location": "Boston"}
+```<｜tool▁call▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: get_weather
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: 'get_weather'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location":'
+    - delta_text: '
+```json
+{"location":'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: ' "New York'
       expected:
@@ -401,6 +405,5 @@ cases:
       finish_reason: tool_calls
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": "New York'
+        - {index: 1, arguments: '{"location": "New York'}
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,81 +26,79 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜
+    - delta_text: '<｜'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: <｜
-        sglang_python: <｜
-    - delta_text: too
+        vllm_python: '<｜'
+        sglang_python: '<｜'
+    - delta_text: 'too'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: too
-        sglang_python: too
-    - delta_text: l▁cal
+        vllm_python: 'too'
+        sglang_python: 'too'
+    - delta_text: 'l▁cal'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: l▁cal
-        sglang_python: l▁cal
-    - delta_text: ls▁begin｜><
+        vllm_python: 'l▁cal'
+        sglang_python: 'l▁cal'
+    - delta_text: 'ls▁begin｜><'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ls▁begin｜><
-        sglang_python: ls▁begin｜><
-    - delta_text: ｜tool▁call▁begin｜>f
+        vllm_python: 'ls▁begin｜><'
+        sglang_python: 'ls▁begin｜><'
+    - delta_text: '｜tool▁call▁begin｜>f'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ｜tool▁call▁begin｜>f
-        sglang_python: ｜tool▁call▁begin｜>f
-    - delta_text: un
+        vllm_python: '｜tool▁call▁begin｜>f'
+        sglang_python: '｜tool▁call▁begin｜>f'
+    - delta_text: 'un'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: un
-        sglang_python: un
-    - delta_text: cti
+        vllm_python: 'un'
+        sglang_python: 'un'
+    - delta_text: 'cti'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: cti
-        sglang_python: cti
-    - delta_text: on<｜t
+        vllm_python: 'cti'
+        sglang_python: 'cti'
+    - delta_text: 'on<｜t'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: on<｜t
-        sglang_python: on<｜t
-    - delta_text: ool▁sep｜>ge
+        vllm_python: 'on<｜t'
+        sglang_python: 'on<｜t'
+    - delta_text: 'ool▁sep｜>ge'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ool▁sep｜>ge
-        sglang_python: ool▁sep｜>ge
-    - delta_text: t_weather ```json {
+        vllm_python: 'ool▁sep｜>ge'
+        sglang_python: 'ool▁sep｜>ge'
+    - delta_text: 't_weather ```json {'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: t_weather ```json {
-        sglang_python: t_weather json {
+        vllm_python: 't_weather ```json {'
+        sglang_python: 't_weather json {'
     - delta_text: '"l'
       expected:
         vllm_python: []
@@ -100,20 +106,20 @@ cases:
       normal_text:
         vllm_python: '"l'
         sglang_python: '"l'
-    - delta_text: oca
+    - delta_text: 'oca'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: oca
-        sglang_python: oca
-    - delta_text: tion"
+        vllm_python: 'oca'
+        sglang_python: 'oca'
+    - delta_text: 'tion"'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: tion"
-        sglang_python: tion"
+        vllm_python: 'tion"'
+        sglang_python: 'tion"'
     - delta_text: ': "NYC"} ``'
       expected:
         vllm_python: []
@@ -128,34 +134,34 @@ cases:
       normal_text:
         vllm_python: '`<｜tool▁call▁end｜><'
         sglang_python: '`<'
-    - delta_text: ｜t
+    - delta_text: '｜t'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ｜t
-        sglang_python: ｜t
-    - delta_text: ool
+        vllm_python: '｜t'
+        sglang_python: '｜t'
+    - delta_text: 'ool'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ool
-        sglang_python: ool
-    - delta_text: ▁call
+        vllm_python: 'ool'
+        sglang_python: 'ool'
+    - delta_text: '▁call'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ▁call
-        sglang_python: ▁call
-    - delta_text: s▁end｜>
+        vllm_python: '▁call'
+        sglang_python: '▁call'
+    - delta_text: 's▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: s▁end｜>
-        sglang_python: s▁end｜>
+        vllm_python: 's▁end｜>'
+        sglang_python: 's▁end｜>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.6.yaml
@@ -1,122 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Canonical empty {} in fenced code block
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Canonical empty {} in fenced code block'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: get_time ```json {}
+    - delta_text: 'get_time
+```json
+{}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
+        - {index: 0, id: true, name: 'get_time'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{}'
+        - {index: 0, arguments: '{}'}
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside empty { } (newlines)
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside empty { } (newlines)'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: get_time ```json {
+    - delta_text: 'get_time
+```json
+{'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
+        - {index: 0, id: true, name: 'get_time'}
         sglang_python: []
-    - delta_text: ' } ```<｜tool▁call▁end｜>'
+    - delta_text: '
+}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '
+}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_time'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{ }'
+        - {index: 0, arguments: '{
+}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.6.c:
-    description: No fenced JSON block (function name only)
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No fenced JSON block (function name only)'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    - delta_text: 'get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,60 +30,66 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'book_flight ```json {"destination":'
+    - delta_text: 'book_flight
+```json
+{"destination":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'book_flight'}
+        - {index: 0, arguments: '{"destination":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
+        - {index: 0, id: true, name: 'book_flight'}
         sglang_python: []
     - delta_text: ' "Paris", "passengers":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "Paris", "passengers":'}
         vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris", "passengers":'
+        - {index: 0, arguments: '{"destination": "Paris", "passengers":'}
         sglang_python: []
     - delta_text: ' 2,'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' 2,'}
         vllm_python:
-        - index: 0
-          arguments: ' 2,'
+        - {index: 0, arguments: ' 2,'}
         sglang_python: []
     - delta_text: ' "first_class": true}'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "first_class": true}'}
         vllm_python:
-        - index: 0
-          arguments: ' "first_class": true}'
+        - {index: 0, arguments: ' "first_class": true}'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"destination": "Paris", "passengers": 2, "first_class": true}'
+        - {index: 0, arguments: '{"destination": "Paris", "passengers": 2, "first_class": true}'}
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -83,52 +98,57 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: ' "Tōkyō \"central\""}'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "Tōkyō \"central\""}'}
         vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō \"central\""}'
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō \"central\""}'
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -137,46 +157,51 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'set_temperature ```json {"celsius":'
+    - delta_text: 'set_temperature
+```json
+{"celsius":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'set_temperature'}
+        - {index: 0, arguments: '{"celsius":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
+        - {index: 0, id: true, name: 'set_temperature'}
         sglang_python: []
-    - delta_text: ' "20"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "20"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "20"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: set_temperature
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'set_temperature'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
+        - {index: 0, arguments: '{"celsius": "20"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array (existing)
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array (existing)'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -187,64 +212,72 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'process_data ```json {"items":'
+    - delta_text: 'process_data
+```json
+{"items":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"items":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: process_data
+        - {index: 0, id: true, name: 'process_data'}
         sglang_python: []
     - delta_text: ' [1, 2,'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' [1, 2,'}
         vllm_python:
-        - index: 0
-          arguments: '{"items": [1, 2,'
+        - {index: 0, arguments: '{"items": [1, 2,'}
         sglang_python: []
     - delta_text: ' 3]'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' 3]'}
         vllm_python:
-        - index: 0
-          arguments: ' 3]'
+        - {index: 0, arguments: ' 3]'}
         sglang_python: []
     - delta_text: ', "config":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ', "config":'}
         vllm_python:
-        - index: 0
-          arguments: ', "config":'
+        - {index: 0, arguments: ', "config":'}
         sglang_python: []
-    - delta_text: ' {"nested": true}} ```<｜tool▁call▁end｜>'
+    - delta_text: ' {"nested": true}}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' {"nested": true}}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: process_data
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'process_data'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'
+        - {index: 0, arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -253,122 +286,136 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'process_data ```json {"payload":'
+    - delta_text: 'process_data
+```json
+{"payload":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"payload":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: process_data
+        - {index: 0, id: true, name: 'process_data'}
         sglang_python: []
     - delta_text: ' {"regions": [{"name":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' {"regions": [{"name":'}
         vllm_python:
-        - index: 0
-          arguments: '{"payload": {"regions": [{"name":'
+        - {index: 0, arguments: '{"payload": {"regions": [{"name":'}
         sglang_python: []
     - delta_text: ' "west",'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "west",'}
         vllm_python:
-        - index: 0
-          arguments: ' "west",'
+        - {index: 0, arguments: ' "west",'}
         sglang_python: []
     - delta_text: ' "scores": [1,'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "scores": [1,'}
         vllm_python:
-        - index: 0
-          arguments: ' "scores": [1,'
+        - {index: 0, arguments: ' "scores": [1,'}
         sglang_python: []
     - delta_text: ' 2, 3]},'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' 2, 3]},'}
         vllm_python:
-        - index: 0
-          arguments: ' 2, 3]},'
+        - {index: 0, arguments: ' 2, 3]},'}
         sglang_python: []
     - delta_text: ' {"name":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' {"name":'}
         vllm_python:
-        - index: 0
-          arguments: ' {"name":'
+        - {index: 0, arguments: ' {"name":'}
         sglang_python: []
     - delta_text: ' "east", "scores":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "east", "scores":'}
         vllm_python:
-        - index: 0
-          arguments: ' "east", "scores":'
+        - {index: 0, arguments: ' "east", "scores":'}
         sglang_python: []
     - delta_text: ' [4,'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' [4,'}
         vllm_python:
-        - index: 0
-          arguments: ' [4,'
+        - {index: 0, arguments: ' [4,'}
         sglang_python: []
     - delta_text: ' 5, 6]'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' 5, 6]'}
         vllm_python:
-        - index: 0
-          arguments: ' 5, 6]'
+        - {index: 0, arguments: ' 5, 6]'}
         sglang_python: []
     - delta_text: '}]'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '}]'}
         vllm_python:
-        - index: 0
-          arguments: '}]'
+        - {index: 0, arguments: '}]'}
         sglang_python: []
     - delta_text: ', "flags": {"enabled":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ', "flags": {"enabled":'}
         vllm_python:
-        - index: 0
-          arguments: ', "flags": {"enabled":'
+        - {index: 0, arguments: ', "flags": {"enabled":'}
         sglang_python: []
     - delta_text: ' true, "retry":'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' true, "retry":'}
         vllm_python:
-        - index: 0
-          arguments: ' true, "retry":'
+        - {index: 0, arguments: ' true, "retry":'}
         sglang_python: []
     - delta_text: ' null},'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' null},'}
         vllm_python:
-        - index: 0
-          arguments: ' null},'
+        - {index: 0, arguments: ' null},'}
         sglang_python: []
     - delta_text: ' "empty": {}}}'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "empty": {}}}'}
         vllm_python:
-        - index: 0
-          arguments: ' "empty": {}}}'
+        - {index: 0, arguments: ' "empty": {}}}'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: process_data
+        - {index: 0, name: 'process_data'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]},
-            {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry":
-            null}, "empty": {}}}'
+        - {index: 0, arguments: '{"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}'}
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -377,36 +424,39 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: set_limit ```json {"count":9007199254740993}
+    - delta_text: 'set_limit
+```json
+{"count":9007199254740993}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'set_limit'}
+        - {index: 0, arguments: '{"count":9007199254740993}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
+        - {index: 0, id: true, name: 'set_limit'}
         sglang_python: []
-    - delta_text: ' ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: '
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"count":9007199254740993}'
+        - {index: 0, arguments: '{"count":9007199254740993}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,62 +26,72 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather
+    - delta_text: 'get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location":'
+    - delta_text: '
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -81,40 +100,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -122,6 +146,7 @@ cases:
         sglang_python: ' Let me'
     - delta_text: ' know if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -129,6 +154,7 @@ cases:
         sglang_python: ' know if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -136,6 +162,7 @@ cases:
         sglang_python: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -144,11 +171,12 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -157,62 +185,73 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather
+    - delta_text: 'get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location":'
+    - delta_text: '
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -220,6 +259,7 @@ cases:
         sglang_python: ' me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -227,6 +267,7 @@ cases:
         sglang_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -234,6 +275,7 @@ cases:
         sglang_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -242,11 +284,12 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -255,62 +298,73 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather
+    - delta_text: 'get_weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' ```json {"location":'
+    - delta_text: '
+```json
+{"location":'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "NYC"} ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    - delta_text: ' "NYC"}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' Then'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -318,6 +372,7 @@ cases:
         sglang_python: ' check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -325,33 +380,38 @@ cases:
         sglang_python: ' weather.'
     - delta_text: ' <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: function<｜tool▁sep｜>
+    - delta_text: 'function<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 'get_weather ```json {"location":'
+    - delta_text: 'get_weather
+```json
+{"location":'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
-    - delta_text: ' "LA"} ```<｜tool▁call▁end｜>'
+    - delta_text: ' "LA"}
+```<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3
-model_label: DeepSeek V3
+model_label: 'DeepSeek V3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,38 +26,31 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,50 +26,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_weather
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_weather'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 1, arguments: '{"location":"LA"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"LA"}'
-        vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
+        - {index: 0, arguments: '{"location":"LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,38 +26,31 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: unknown_tool<｜tool▁sep｜>
+    - delta_text: 'unknown_tool<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python:
-        - index: 0
-          name: unknown_tool
         vllm_rust:
-        - index: 0
-          name: unknown_tool
+        - {index: 0, name: 'unknown_tool'}
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool'}
+        sglang_python:
+        - {index: 0, name: 'unknown_tool'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls in single fence pair
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls in single fence pair'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,56 +32,45 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_time
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_time'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python: []
     - delta_text: '{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"timezone":"EST"}'
-        vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
+        - {index: 0, arguments: '{"timezone":"EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back fence pairs
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back fence pairs'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -87,63 +85,54 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <｜tool▁call▁begin｜>get_time<｜tool▁sep｜>
-      expected:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
+        - {index: 0, arguments: '{"location":"NYC"}'}
+    - delta_text: '<｜tool▁call▁begin｜>get_time<｜tool▁sep｜>'
+      expected:
         vllm_rust: []
+        vllm_python: []
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: '{"timezone":"EST"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        vllm_rust: []
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -158,66 +147,59 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: 'Both: '
         vllm_rust: 'Both: '
-    - delta_text: <｜tool▁call▁begin｜>
+        vllm_python: 'Both: '
+    - delta_text: '<｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: 'get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        vllm_python: []
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜>'
+      expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        vllm_python: []
+        sglang_python:
+        - {index: 0, arguments: '{"timezone":"EST"}'}
+    - delta_text: '<｜tool▁calls▁end｜>'
+      expected:
         vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{"timezone":"EST"}'
-        vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-    - delta_text: <｜tool▁calls▁end｜>
-      expected:
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' Results.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Results.'
         sglang_python: ' Results.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice (id distinctness)
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice (id distinctness)'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -228,50 +210,39 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_weather
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_weather'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 1, arguments: '{"location":"LA"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"LA"}'
-        vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
+        - {index: 0, arguments: '{"location":"LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Garbage between calls fences (no tool_sep / args)
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Garbage between calls fences (no tool_sep / args)'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,24 +26,23 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    - delta_text: '<｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: nonsense
+        vllm_python: 'nonsense'
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Unterminated JSON string in args
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Unterminated JSON string in args'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -43,38 +51,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC'
+        - {index: 0, arguments: '{"location":"NYC'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing function name (no token before tool_sep)
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing function name (no token before tool_sep)'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -83,33 +85,31 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <｜tool▁sep｜>
+    - delta_text: '<｜tool▁sep｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
+        - {index: 0}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Mismatched fences (calls_end without call_end)
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Mismatched fences (calls_end without call_end)'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -118,31 +118,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁calls▁end｜>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}<｜tool▁calls▁end｜>'
+        - {index: 0, arguments: '{"location":"NYC"}<｜tool▁calls▁end｜>'}
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}<｜tool▁calls▁end｜>'
+        - {index: 0, arguments: '{"location":"NYC"}<｜tool▁calls▁end｜>'}
     - delta_text: ''
       finish_reason: stop
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing tool_calls_end (truncation)
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing tool_calls_end (truncation)'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,44 +26,37 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing tool_calls_end without matching tool_calls_begin
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing tool_calls_end without matching tool_calls_begin'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -63,46 +65,43 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
-        vllm_rust: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+        vllm_rust: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
+        vllm_python: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}
       normal_text:
-        vllm_python: '{"location":"NYC"}<｜tool▁call▁end｜>'
         vllm_rust: '{"location":"NYC"}<｜tool▁call▁end｜>'
-    - delta_text: <｜tool▁calls▁end｜>
+        vllm_python: '{"location":"NYC"}<｜tool▁call▁end｜>'
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <｜tool▁calls▁end｜>
-        vllm_rust: <｜tool▁calls▁end｜>
+        vllm_rust: '<｜tool▁calls▁end｜>'
+        vllm_python: '<｜tool▁calls▁end｜>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arguments JSON'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -111,40 +110,33 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"loc'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
         sglang_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -153,18 +145,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -218,46 +208,37 @@ cases:
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
-    - delta_text: get_weather<｜tool▁sep｜>
+        - {index: 0, arguments: '{"location":"Boston"}'}
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: '{"location":"New York"}'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"New York"}'
+        - {index: 1, arguments: '{"location":"New York"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":"New York"}'
+        - {index: 1, arguments: '{"location":"New York"}'}
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -266,18 +247,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -331,40 +310,31 @@ cases:
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
-    - delta_text: get_weather<｜tool▁sep｜>
+        - {index: 0, arguments: '{"location":"Boston"}'}
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: '{"location":"New York'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"New York'
+        - {index: 1, arguments: '{"location":"New York'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":"New York'
+        - {index: 1, arguments: '{"location":"New York'}
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,136 +26,133 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜
+    - delta_text: '<｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <｜
-        sglang_python: <｜
-    - delta_text: too
+        vllm_python: '<｜'
+        sglang_python: '<｜'
+    - delta_text: 'too'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: too
-        sglang_python: too
-    - delta_text: l▁cal
+        vllm_python: 'too'
+        sglang_python: 'too'
+    - delta_text: 'l▁cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: l▁cal
-        sglang_python: l▁cal
-    - delta_text: ls▁begin｜><
+        vllm_python: 'l▁cal'
+        sglang_python: 'l▁cal'
+    - delta_text: 'ls▁begin｜><'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ls▁begin｜><
-        sglang_python: ls▁begin｜><
-    - delta_text: ｜tool▁call▁begin｜>g
+        vllm_python: 'ls▁begin｜><'
+        sglang_python: 'ls▁begin｜><'
+    - delta_text: '｜tool▁call▁begin｜>g'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ｜tool▁call▁begin｜>g
-        sglang_python: ｜tool▁call▁begin｜>g
-    - delta_text: et
+        vllm_python: '｜tool▁call▁begin｜>g'
+        sglang_python: '｜tool▁call▁begin｜>g'
+    - delta_text: 'et'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: et
-        sglang_python: et
-    - delta_text: _we
+        vllm_python: 'et'
+        sglang_python: 'et'
+    - delta_text: '_we'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: _we
-        sglang_python: _we
-    - delta_text: ather
+        vllm_python: '_we'
+        sglang_python: '_we'
+    - delta_text: 'ather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ather
-        sglang_python: ather
-    - delta_text: <｜tool▁sep｜
+        vllm_python: 'ather'
+        sglang_python: 'ather'
+    - delta_text: '<｜tool▁sep｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <｜tool▁sep｜
-        sglang_python: <｜tool▁sep｜
+        vllm_python: '<｜tool▁sep｜'
+        sglang_python: '<｜tool▁sep｜'
     - delta_text: '>{"location":"NYC"}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":"NYC"}'
-          index: 0
       normal_text:
         vllm_python: '>{"location":"NYC"}'
         sglang_python: '>{"location":"NYC"}'
-    - delta_text: <｜
+    - delta_text: '<｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <｜
-        sglang_python: <｜
-    - delta_text: too
+        vllm_python: '<｜'
+        sglang_python: '<｜'
+    - delta_text: 'too'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: too
-        sglang_python: too
-    - delta_text: l▁cal
+        vllm_python: 'too'
+        sglang_python: 'too'
+    - delta_text: 'l▁cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: l▁cal
-        sglang_python: l▁cal
-    - delta_text: l▁end｜><｜to
+        vllm_python: 'l▁cal'
+        sglang_python: 'l▁cal'
+    - delta_text: 'l▁end｜><｜to'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: l▁end｜><｜to
-        sglang_python: l▁end｜><｜to
-    - delta_text: ol▁calls▁end｜>
+        vllm_python: 'l▁end｜><｜to'
+        sglang_python: 'l▁end｜><｜to'
+    - delta_text: 'ol▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ol▁calls▁end｜>
-        sglang_python: ol▁calls▁end｜>
+        vllm_python: 'ol▁calls▁end｜>'
+        sglang_python: 'ol▁calls▁end｜>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.6.yaml
@@ -1,122 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Canonical empty {} after tool_sep
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Canonical empty {} after tool_sep'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_time<｜tool▁sep｜>
+    - delta_text: 'get_time<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: '{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        vllm_rust:
-        - arguments: '{}'
-          index: 0
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside empty { }
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside empty { }'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_time<｜tool▁sep｜>
+    - delta_text: 'get_time<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: '{ }<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{ }'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{ }'
-        vllm_rust:
-        - arguments: '{ }'
-          index: 0
+        - {index: 0, arguments: '{ }'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.c:
-    description: No tool_sep / args section
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No tool_sep / args section'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek V3.1 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek V3.1 tool call'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: get_time<｜tool▁call▁end｜>
+    - delta_text: 'get_time<｜tool▁call▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <｜tool▁calls▁end｜>
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,44 +30,37 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: book_flight<｜tool▁sep｜>
+    - delta_text: 'book_flight<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust:
-        - index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight'}
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
     - delta_text: '{"destination":"Paris","passengers":2,"first_class":true}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-        vllm_rust:
-        - arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-          index: 0
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -67,44 +69,37 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"Tōkyō \"central\""}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"Tōkyō \"central\""}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Tōkyō \"central\""}'
-        vllm_rust:
-        - arguments: '{"location":"Tōkyō \"central\""}'
-          index: 0
+        - {index: 0, arguments: '{"location":"Tōkyō \"central\""}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -113,44 +108,37 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: set_temperature<｜tool▁sep｜>
+    - delta_text: 'set_temperature<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python:
-        - index: 0
-          name: set_temperature
         vllm_rust:
-        - index: 0
-          name: set_temperature
+        - {index: 0, name: 'set_temperature'}
+        vllm_python:
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python:
+        - {index: 0, name: 'set_temperature'}
     - delta_text: '{"celsius":"20"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"celsius":"20"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"celsius":"20"}'
-        vllm_rust:
-        - arguments: '{"celsius":"20"}'
-          index: 0
+        - {index: 0, arguments: '{"celsius":"20"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array (existing)
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array (existing)'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -161,44 +149,37 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: process_data<｜tool▁sep｜>
+    - delta_text: 'process_data<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust:
-        - index: 0
-          name: process_data
+        - {index: 0, name: 'process_data'}
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: '{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"items":[1,2,3],"config":{"nested":true}}'
-        vllm_rust:
-        - arguments: '{"items":[1,2,3],"config":{"nested":true}}'
-          index: 0
+        - {index: 0, arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -207,55 +188,45 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: process_data<｜tool▁sep｜>
+    - delta_text: 'process_data<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust:
-        - index: 0
-          name: process_data
+        - {index: 0, name: 'process_data'}
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
-        sglang_python:
-        - index: 0
-          arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
         vllm_rust:
-        - arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
-          index: 0
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'}
+        vllm_python:
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'}
+        sglang_python:
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'}
     - delta_text: ',"flags":{"enabled":true,"retry":null},"empty":{}}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'
-        vllm_rust:
-        - arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'
-          index: 0
+        - {index: 0, arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -264,38 +235,31 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: set_limit<｜tool▁sep｜>
+    - delta_text: 'set_limit<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust:
-        - index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit'}
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
     - delta_text: '{"count":9007199254740993}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"count":9007199254740993}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"count":9007199254740993}'
-        vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
+        - {index: 0, arguments: '{"count":9007199254740993}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,67 +26,62 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+        vllm_python: ' the weather. '
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 0, arguments: '{"location":"NYC"}'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -86,76 +90,69 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+    - delta_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather<｜tool▁sep｜>
+    - delta_text: 'get_weather<｜tool▁sep｜>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜> Let'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' me know'
         sglang_python: ' me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' if'
         sglang_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' you need'
         sglang_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' more.'
         sglang_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -164,94 +161,89 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+        vllm_python: ' the weather. '
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <｜tool▁calls▁end｜> Let
+        - {index: 0, arguments: '{"location":"NYC"}'}
+    - delta_text: '<｜tool▁calls▁end｜> Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Let'
         sglang_python: ' Let'
     - delta_text: ' me know if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' me know if'
         sglang_python: ' me know if'
     - delta_text: ' you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' you'
         sglang_python: ' you'
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' need more.'
         sglang_python: ' need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -260,98 +252,91 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+        vllm_python: ' the weather. '
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"NYC"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <｜tool▁calls▁end｜> Then
+        - {index: 0, arguments: '{"location":"NYC"}'}
+    - delta_text: '<｜tool▁calls▁end｜> Then'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Then'
         sglang_python: ' Then'
     - delta_text: ' check LA weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' check LA weather.'
         sglang_python: ' check LA weather.'
     - delta_text: ' <｜tool▁calls▁begin｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' '
-    - delta_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>
+    - delta_text: '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
     - delta_text: '{"location":"LA"}<｜tool▁call▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"LA"}'
-        vllm_rust: []
-    - delta_text: <｜tool▁calls▁end｜>
+        - {index: 1, arguments: '{"location":"LA"}'}
+    - delta_text: '<｜tool▁calls▁end｜>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_1
-model_label: DeepSeek V3.1
+model_label: 'DeepSeek V3.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,81 +26,76 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
-        - index: 1
-          arguments: '"location": "LA"}'
-        vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="unknown_tool">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: unknown_tool
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, name: 'unknown_tool'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: unknown_tool
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Two invokes inside one function_calls wrapper
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Two invokes inside one function_calls wrapper'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,87 +32,82 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ' name="get_time"> <｜DSML｜parameter'
+    - delta_text: ' name="get_time">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' name="timezone" string="true">EST</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone":"EST"'}
         sglang_python:
-        - index: 1
-          arguments: '"timezone": "EST"}'
-        vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"timezone": "EST"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back function_calls wrappers
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back function_calls wrappers'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -118,87 +122,90 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: ' <｜DSML｜function_calls> <｜DSML｜invoke'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
-      expected:
-        vllm_python: []
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
         sglang_python:
-        - index: 1
-          name: get_time
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: '
+<｜DSML｜function_calls>
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_python: '
+'
+    - delta_text: ' name="get_time">
+<｜DSML｜parameter name="timezone"'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-    - delta_text: EST</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 1, arguments: '{"timezone":"'}
+        sglang_python: []
+    - delta_text: 'EST</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: 'EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -213,97 +220,94 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <｜DSML｜function_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: 'Both: '
         vllm_rust: 'Both: '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: 'Both: '
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter name="location"'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter name="location"'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' string="true">NYC</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"NYC"'}
         sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
+        - {index: 0, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜invoke name="get_time">'
-      expected:
-        vllm_python: []
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="timezone" string="true">'
+        - {index: 0, arguments: '"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_time">'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: '
+<｜DSML｜parameter name="timezone" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"timezone":"'}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: EST</｜DSML｜parameter>
+    - delta_text: 'EST</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: 'EST"'}
         sglang_python:
-        - index: 1
-          arguments: '"timezone": "EST"}'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"timezone": "EST"}'}
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -314,81 +318,76 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
-        - index: 1
-          arguments: '"location": "LA"}'
-        vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Function_calls wrapper with garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Function_calls wrapper with garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,11 +26,11 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜function_calls> not
+    - delta_text: '<｜DSML｜function_calls>
+not'
       expected:
         vllm_python: []
         sglang_python: []
@@ -29,7 +38,8 @@ cases:
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' valid invoke </｜DSML｜function_calls>'
+    - delta_text: ' valid invoke
+</｜DSML｜function_calls>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -39,8 +49,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Invoke without name attribute
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Invoke without name attribute'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -49,15 +59,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke>
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' <｜DSML｜parameter'
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
@@ -65,7 +76,9 @@ cases:
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -75,8 +88,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </｜DSML｜parameter> end tag
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </｜DSML｜parameter> end tag'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -85,37 +98,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-    - delta_text: NYC </｜DSML｜invoke>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{}'
-        sglang_python:
-        - index: 0
-          arguments: '{}'
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC
+</｜DSML｜invoke>'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: 'NYC\n</｜DSML｜invoke>'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_python:
+        - {index: 0, arguments: '\n</｜DSML｜function_calls>'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </｜DSML｜function_calls> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </｜DSML｜function_calls> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,43 +26,41 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </｜DSML｜function_calls> without matching open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </｜DSML｜function_calls> without matching open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -62,60 +69,61 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜invoke name="get_weather">
+    - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <｜DSML｜invoke name="get_weather">
-        vllm_rust: <｜DSML｜invoke name="get_weather">
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_rust: '<｜DSML｜invoke name="get_weather">'
+        vllm_python: '<｜DSML｜invoke name="get_weather">'
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' <｜DSML｜parameter'
-        vllm_rust: ' <｜DSML｜parameter'
+        vllm_rust: '
+<｜DSML｜parameter'
+        vllm_python: '
+<｜DSML｜parameter'
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
+        - {index: 0, arguments: '{'}
       normal_text:
-        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
         vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
+        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
         vllm_rust: []
+        vllm_python: []
+        sglang_python:
+        - {index: 0, arguments: '"location": "NYC"}'}
       normal_text:
-        vllm_python: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
-        vllm_rust: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
+        vllm_rust: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+        vllm_python: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-parameter value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-parameter value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -124,39 +132,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: NY
+    - delta_text: 'NY'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: 'NY'}
         sglang_python:
-        - index: 0
-          arguments: '{'
+        - {index: 0, arguments: '{'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -165,18 +174,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -226,68 +233,69 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <｜DSML｜function_calls>'
+    - delta_text: ' time!
+<｜DSML｜function_calls>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: ' <｜DSML｜parameter'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: New York</｜DSML｜parameter> </｜DSML｜invoke>
+    - delta_text: 'New York</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: 'New York"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: '{"location": "New York"}'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -296,18 +304,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -357,56 +363,60 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <｜DSML｜function_calls>'
+    - delta_text: ' time!
+<｜DSML｜function_calls>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: ' <｜DSML｜parameter'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: New York
+    - delta_text: 'New York'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: 'New York'}
         sglang_python:
-        - index: 1
-          arguments: '{'
+        - {index: 1, arguments: '{'}
     - delta_text: ''
       finish_reason: stop
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,135 +26,129 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜
+    - delta_text: '<｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: DSM
+    - delta_text: 'DSM'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: L｜fun
+    - delta_text: 'L｜fun'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ction_calls
+    - delta_text: 'ction_calls'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '> <｜DSML｜invoke nam'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: e=
+    - delta_text: 'e='
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '"ge'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: t_wea
+    - delta_text: 't_wea'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ther"> <｜DS
+    - delta_text: 'ther"> <｜DS'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: ML｜parameter name="
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'ML｜parameter name="'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: lo
+    - delta_text: 'lo'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: cat
+    - delta_text: 'cat'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: 'ion" '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: string="tru
+    - delta_text: 'string="tru'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: e">NYC</｜DSML｜param
+    - delta_text: 'e">NYC</｜DSML｜param'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: et
+        - {index: 0, arguments: '{'}
+    - delta_text: 'et'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: er>
+    - delta_text: 'er>'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"'}
+        sglang_python: []
     - delta_text: ' </｜D'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: SML｜invoke>
+    - delta_text: 'SML｜invoke>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: ' </｜DSML｜function_c'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: al
+    - delta_text: 'al'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ls>
+    - delta_text: 'ls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.6.yaml
@@ -1,98 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Invoke with no <parameter>
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Invoke with no <parameter>'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_time">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{}'
+        - {index: 0, name: 'get_time'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Invoke with extra newline
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Invoke with extra newline'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_time">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: '
 
-        </｜DSML｜invoke> </｜DSML｜function_calls>'
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
-        sglang_python:
-        - index: 0
-          arguments: '{}'
         vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,80 +30,80 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="book_flight">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="destination" string="true">'
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
+    - delta_text: '
+<｜DSML｜parameter name="destination" string="true">'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"destination":"'}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: Paris</｜DSML｜parameter> <｜DSML｜parameter
+    - delta_text: 'Paris</｜DSML｜parameter>
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'Paris"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
     - delta_text: ' name="passengers"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' string="false">2</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '"destination": "Paris"'
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="first_class" string="false">'
+        vllm_python:
+        - {index: 0, arguments: ',"passengers":"2"'}
+        sglang_python:
+        - {index: 0, arguments: '"destination": "Paris"'}
+    - delta_text: '
+<｜DSML｜parameter name="first_class" string="false">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: true</｜DSML｜parameter>
+    - delta_text: 'true</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2'
         vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜function_calls>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: '{"destination": "Paris", "passengers": "2", "first_class": "true"}'
+        - {index: 0, arguments: ',"first_class":"true"'}
         sglang_python:
-        - index: 0
-          arguments: ', "first_class": true}'
+        - {index: 0, arguments: ', "passengers": 2'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"destination":"Paris","first_class":true,"passengers":2}'
-          index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: ', "first_class": true}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in parameter
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in parameter'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -103,61 +112,59 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: Tōkyō central</｜DSML｜parameter>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Tōkyō central"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '"location": "Tōkyō central"}'
-        vllm_rust:
-        - arguments: '{"location":"Tōkyō central"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'Tōkyō central</｜DSML｜parameter>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'Tōkyō central"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '"location": "Tōkyō central"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -166,48 +173,45 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="set_limit">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="count" string="false">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: 9007199254740993</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-          arguments: '{"count": "9007199254740993"}'
+        - {index: 0, id: true, name: 'set_limit', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
-          name: set_limit
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, name: 'set_limit'}
+    - delta_text: '
+<｜DSML｜parameter name="count" string="false">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: '9007199254740993</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count":"9007199254740993"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,75 +26,73 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜function_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜function_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -94,74 +101,80 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜function_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' Let me'
     - delta_text: ' know if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' know if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -170,100 +183,108 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜function_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜function_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -272,117 +293,124 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜function_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜function_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Then'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ' <｜DSML｜function_calls> <｜DSML｜invoke'
+      normal_text:
+        vllm_python: ' weather.'
+    - delta_text: ' <｜DSML｜function_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
+      normal_text:
+        vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-    - delta_text: LA</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        vllm_rust: []
-    - delta_text: ' </｜DSML｜function_calls>'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'LA</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: 'LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜function_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v3_2
-model_label: DeepSeek V3.2
+model_label: 'DeepSeek V3.2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,57 +25,47 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,47 +26,49 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,99 +25,77 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
-        - index: 1
-          arguments: '"location": "LA"}'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
-        dynamo_rust:
-        - index: 1
-          arguments: '{"location":"LA"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,47 +26,49 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather">
-<｜DSML｜parameter'
+    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
@@ -73,29 +76,32 @@ cases:
         - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
         - {index: 1, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
         - {index: 1, arguments: '}'}
         sglang_python:
         - {index: 1, arguments: '"location": "LA"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,47 +26,49 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="unknown_tool">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'unknown_tool', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python:
         - {index: 0, name: 'unknown_tool'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,57 +25,47 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="unknown_tool">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: unknown_tool
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: unknown_tool
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, name: 'unknown_tool'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: unknown_tool
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -31,47 +32,49 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_time">
-<｜DSML｜parameter'
+    - delta_text: ' name="get_time"> <｜DSML｜parameter'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
@@ -79,29 +82,32 @@ cases:
         - {index: 1, name: 'get_time'}
     - delta_text: ' name="timezone" string="true">EST</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"timezone":"EST"'}
         sglang_python:
         - {index: 1, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust:
         - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
         - {index: 1, arguments: '}'}
         sglang_python:
         - {index: 1, arguments: '"timezone": "EST"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -121,57 +127,57 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: '
-'
-    - delta_text: ' name="get_time">
-<｜DSML｜parameter name="timezone"'
+        vllm_python: ' '
+    - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
@@ -179,27 +185,30 @@ cases:
         - {index: 1, name: 'get_time'}
     - delta_text: ' string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"timezone":"'}
         sglang_python: []
-    - delta_text: 'EST</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'EST</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: 'EST"}'}
         sglang_python:
         - {index: 1, arguments: '{"timezone": "EST"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -219,26 +228,27 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'Both: '
         vllm_rust: 'Both: '
         vllm_python: 'Both: '
-    - delta_text: '
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather">
-<｜DSML｜parameter name="location"'
+    - delta_text: ' name="get_weather"> <｜DSML｜parameter name="location"'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -246,46 +256,50 @@ cases:
         - {index: 0, name: 'get_weather'}
     - delta_text: ' string="true">NYC</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"NYC"'}
         sglang_python:
         - {index: 0, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '"location": "NYC"}'}
-    - delta_text: '
-<｜DSML｜invoke name="get_time">'
+    - delta_text: ' <｜DSML｜invoke name="get_time">'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_time'}
-    - delta_text: '
-<｜DSML｜parameter name="timezone" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="timezone" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"timezone":"'}
         sglang_python: []
     - delta_text: 'EST</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: 'EST"'}
         sglang_python:
         - {index: 1, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust:
         - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
@@ -294,6 +308,7 @@ cases:
         - {index: 1, arguments: '"timezone": "EST"}'}
     - delta_text: ' Done.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -302,6 +317,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -317,47 +333,49 @@ cases:
           location:
             type: string
     - *id001
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather">
-<｜DSML｜parameter'
+    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
@@ -365,29 +383,32 @@ cases:
         - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
         - {index: 1, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
         - {index: 1, arguments: '}'}
         sglang_python:
         - {index: 1, arguments: '"location": "LA"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Two invokes inside one tool_calls wrapper
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Two invokes inside one tool_calls wrapper'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,105 +31,83 @@ cases:
         properties:
           timezone:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' name="get_time"> <｜DSML｜parameter'
+    - delta_text: ' name="get_time">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_time
-          arguments: ''
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' name="timezone" string="true">EST</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone":"EST"'}
         sglang_python:
-        - index: 1
-          arguments: '"timezone": "EST"}'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
-        dynamo_rust:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"timezone": "EST"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back tool_calls wrappers
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back tool_calls wrappers'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -135,106 +121,91 @@ cases:
         properties:
           timezone:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
-      expected:
-        vllm_python: []
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
         sglang_python:
-        - index: 1
-          name: get_time
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
+      expected:
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_time
-          arguments: ''
+        vllm_python: []
+        sglang_python: []
+    - delta_text: '
+<｜DSML｜tool_calls>
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_python: '
+'
+    - delta_text: ' name="get_time">
+<｜DSML｜parameter name="timezone"'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: EST</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: '{"timezone":"'}
+        sglang_python: []
+    - delta_text: 'EST</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: 'EST"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -248,117 +219,95 @@ cases:
         properties:
           timezone:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: 'Both: '
         vllm_rust: 'Both: '
-        dynamo_rust: 'Both: '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: 'Both: '
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter name="location"'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter name="location"'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' string="true">NYC</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"NYC"'}
         sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
+        - {index: 0, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' <｜DSML｜invoke name="get_time">'
-      expected:
-        vllm_python: []
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_time
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="timezone" string="true">'
+        - {index: 0, arguments: '"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_time">'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: '
+<｜DSML｜parameter name="timezone" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"timezone":"'}
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: EST</｜DSML｜parameter>
+    - delta_text: 'EST</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, arguments: 'EST"'}
         sglang_python:
-        - index: 1
-          arguments: '"timezone": "EST"}'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
-        dynamo_rust:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"timezone": "EST"}'}
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' Done.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -368,99 +317,77 @@ cases:
           location:
             type: string
     - *id001
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' <｜DSML｜invoke'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+<｜DSML｜invoke'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location" string="true">LA</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, arguments: '{"location":"LA"'}
         sglang_python:
-        - index: 1
-          arguments: '"location": "LA"}'
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
-        dynamo_rust:
-        - index: 1
-          arguments: '{"location":"LA"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.3.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,48 +26,55 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Hello, how'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'Hello, how'
         vllm_rust: 'Hello, how'
         vllm_python: 'Hello, how'
         sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' can'
         vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
     - delta_text: ' I help you'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' I help you'
         vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
     - delta_text: ' today?'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' today?'
         vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.3.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,55 +25,48 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
-        dynamo_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
-        dynamo_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
-        dynamo_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
-        dynamo_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -26,26 +27,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-not'
+    - delta_text: '<｜DSML｜tool_calls> not'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' a'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' valid invoke
-</｜DSML｜tool_calls>'
+    - delta_text: ' valid invoke </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
@@ -59,32 +61,32 @@ not'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke>'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
@@ -98,41 +100,44 @@ not'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC
-</｜DSML｜invoke>'
+    - delta_text: 'NYC </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{}'}
         vllm_python:
-        - {index: 0, arguments: 'NYC\n</｜DSML｜invoke>'}
+        - {index: 0, arguments: 'NYC </｜DSML｜invoke>'}
         sglang_python:
         - {index: 0, arguments: '{}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - {index: 0, arguments: '\n</｜DSML｜tool_calls>'}
+        - {index: 0, arguments: ' </｜DSML｜tool_calls>'}
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_calls wrapper with garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_calls wrapper with garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -18,32 +26,31 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜tool_calls> not
+    - delta_text: '<｜DSML｜tool_calls>
+not'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' a'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' valid invoke </｜DSML｜tool_calls>'
+    - delta_text: ' valid invoke
+</｜DSML｜tool_calls>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.4.c:
-    description: Invoke without name attribute
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Invoke without name attribute'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -52,37 +59,37 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke>
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' <｜DSML｜parameter'
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </｜DSML｜parameter> end tag
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </｜DSML｜parameter> end tag'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -91,49 +98,41 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        dynamo_rust: []
-    - delta_text: NYC </｜DSML｜invoke>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC
+</｜DSML｜invoke>'
+      expected:
+        vllm_python:
+        - {index: 0, arguments: 'NYC\n</｜DSML｜invoke>'}
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        dynamo_rust:
-        - index: 0
-          arguments: '{}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, arguments: '{}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: '\n</｜DSML｜tool_calls>'}
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -26,29 +27,31 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
@@ -56,6 +59,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
@@ -68,11 +72,11 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -80,19 +84,18 @@ cases:
       normal_text:
         vllm_rust: '<｜DSML｜invoke name="get_weather">'
         vllm_python: '<｜DSML｜invoke name="get_weather">'
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-<｜DSML｜parameter'
-        vllm_python: '
-<｜DSML｜parameter'
+        vllm_rust: ' <｜DSML｜parameter'
+        vllm_python: ' <｜DSML｜parameter'
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -100,24 +103,21 @@ cases:
       normal_text:
         vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
         vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '"location": "NYC"}'}
       normal_text:
-        vllm_rust: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
-        vllm_python: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+        vllm_rust: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
+        vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -132,28 +132,30 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
     - delta_text: 'NY'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: 'NY'}
         sglang_python:
@@ -161,6 +163,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
@@ -174,116 +177,137 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!
-<｜DSML｜tool_calls>'
+    - delta_text: ' time! <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time!
-'
-    - delta_text: '
-<｜DSML｜invoke'
+        dynamo_rust: ' time! '
+        vllm_python: ' time! '
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather">
-<｜DSML｜parameter'
+    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "Boston"}'}
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'New York</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'New York</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"location":"New York"}'}
         vllm_python:
         - {index: 1, arguments: 'New York"}'}
         sglang_python:
@@ -291,6 +315,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
@@ -304,115 +329,136 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!
-<｜DSML｜tool_calls>'
+    - delta_text: ' time! <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time!
-'
-    - delta_text: '
-<｜DSML｜invoke'
+        dynamo_rust: ' time! '
+        vllm_python: ' time! '
+    - delta_text: ' <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather">
-<｜DSML｜parameter'
+    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "Boston"}'}
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{"location":"'}
         sglang_python: []
     - delta_text: 'New York'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: 'New York'}
         sglang_python:
@@ -420,6 +466,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
@@ -432,11 +479,11 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -444,19 +491,18 @@ cases:
       normal_text:
         vllm_rust: '<｜DSML｜invoke name="get_weather">'
         vllm_python: '<｜DSML｜invoke name="get_weather">'
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-<｜DSML｜parameter'
-        vllm_python: '
-<｜DSML｜parameter'
+        vllm_rust: ' <｜DSML｜parameter'
+        vllm_python: ' <｜DSML｜parameter'
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -464,58 +510,54 @@ cases:
       normal_text:
         vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
         vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '"location": "NYC"}'}
       normal_text:
-        vllm_rust: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
-        vllm_python: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
-    - delta_text: '
-<｜DSML｜tool_calls>'
+        vllm_rust: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
+        vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
+    - delta_text: ' <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-'
-        vllm_python: '
-'
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+        vllm_rust: ' '
+        vllm_python: ' '
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
     - delta_text: 'Boston</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: 'Boston"'}
         sglang_python:
         - {index: 1, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"location":"Boston"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
@@ -525,6 +567,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -538,81 +581,83 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' that. <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
+        dynamo_rust: ' that. '
         vllm_rust: ' that. <｜DSML｜invoke name="get_weather">'
         vllm_python: ' that. <｜DSML｜invoke name="get_weather">'
-    - delta_text: '
-<｜DSML｜parameter name="location"'
+    - delta_text: ' <｜DSML｜parameter name="location"'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-<｜DSML｜parameter name="location"'
-        vllm_python: '
-<｜DSML｜parameter name="location"'
+        vllm_rust: ' <｜DSML｜parameter name="location"'
+        vllm_python: ' <｜DSML｜parameter name="location"'
     - delta_text: ' string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_rust: ' string="true">'
         vllm_python: ' string="true">'
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_rust: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
-        vllm_python: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
-    - delta_text: '
-</｜DSML｜tool_calls>'
+        vllm_rust: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
+        vllm_python: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-</｜DSML｜tool_calls>'
-        vllm_python: '
-</｜DSML｜tool_calls>'
+        vllm_rust: ' </｜DSML｜tool_calls>'
+        vllm_python: ' </｜DSML｜tool_calls>'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </｜DSML｜tool_calls> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </｜DSML｜tool_calls> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -18,120 +26,41 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </｜DSML｜tool_calls> without matching open
-    ref: derived from TOOLCALLING.batch.5.b
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    chunks:
-    - delta_text: <｜DSML｜invoke name="get_weather">
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-      normal_text:
-        vllm_python: <｜DSML｜invoke name="get_weather">
-        vllm_rust: <｜DSML｜invoke name="get_weather">
-    - delta_text: ' <｜DSML｜parameter'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-      normal_text:
-        vllm_python: ' <｜DSML｜parameter'
-        vllm_rust: ' <｜DSML｜parameter'
-    - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-        dynamo_rust: []
-      normal_text:
-        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
-        vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-      expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-      normal_text:
-        vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-        vllm_rust: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-  TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-parameter value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Closing </｜DSML｜tool_calls> without matching open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -140,45 +69,103 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜invoke name="get_weather">'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+      normal_text:
+        vllm_rust: '<｜DSML｜invoke name="get_weather">'
+        vllm_python: '<｜DSML｜invoke name="get_weather">'
+    - delta_text: '
+<｜DSML｜parameter'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: '
+<｜DSML｜parameter'
+        vllm_python: '
+<｜DSML｜parameter'
+    - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python:
+        - {index: 0, arguments: '{'}
+      normal_text:
+        vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
+        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python:
+        - {index: 0, arguments: '"location": "NYC"}'}
+      normal_text:
+        vllm_rust: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+        vllm_python: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+  TOOLCALLING.streamv2.5.c:
+    description: 'Truncation mid-parameter value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
+    chunks:
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: NY
+    - delta_text: 'NY'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, arguments: 'NY'}
         sglang_python:
-        - index: 0
-          arguments: '{'
-        dynamo_rust: []
+        - {index: 0, arguments: '{'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -187,164 +174,128 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        dynamo_rust: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' by'
         sglang_python: ' by'
-        dynamo_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        dynamo_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' for both'
         sglang_python: ' for both'
-        dynamo_rust: ' for both'
     - delta_text: ' Boston'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        dynamo_rust: ' Boston'
     - delta_text: ' and New'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' and New'
         sglang_python: ' and New'
-        dynamo_rust: ' and New'
     - delta_text: ' York at the'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        dynamo_rust: ' York at the'
     - delta_text: ' same'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-        dynamo_rust: ' same'
-    - delta_text: ' time! <｜DSML｜tool_calls>'
+    - delta_text: ' time!
+<｜DSML｜tool_calls>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' time! '
-        dynamo_rust: ' time! '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"Boston"}'
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: New York</｜DSML｜parameter> </｜DSML｜invoke>
+    - delta_text: 'New York</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: 'New York"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New York"}'
-        dynamo_rust:
-        - index: 1
-          arguments: '{"location":"New York"}'
+        - {index: 1, arguments: '{"location": "New York"}'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -353,158 +304,127 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        DeepSeek DSML tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete DeepSeek DSML tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        dynamo_rust: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' by'
         sglang_python: ' by'
-        dynamo_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        dynamo_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' for both'
         sglang_python: ' for both'
-        dynamo_rust: ' for both'
     - delta_text: ' Boston'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        dynamo_rust: ' Boston'
     - delta_text: ' and New'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' and New'
         sglang_python: ' and New'
-        dynamo_rust: ' and New'
     - delta_text: ' York at the'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        dynamo_rust: ' York at the'
     - delta_text: ' same'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-        dynamo_rust: ' same'
-    - delta_text: ' time! <｜DSML｜tool_calls>'
+    - delta_text: ' time!
+<｜DSML｜tool_calls>'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' time! '
-        dynamo_rust: ' time! '
-    - delta_text: ' <｜DSML｜invoke'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<｜DSML｜invoke'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' name="get_weather"> <｜DSML｜parameter'
+    - delta_text: ' name="get_weather">
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location"'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
+    - delta_text: ' string="true">Boston</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"Boston"}'
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-        dynamo_rust: []
-    - delta_text: New York
+    - delta_text: 'New York'
       expected:
-        vllm_python: []
+        vllm_python:
+        - {index: 1, arguments: 'New York'}
         sglang_python:
-        - index: 1
-          arguments: '{'
-        dynamo_rust: []
+        - {index: 1, arguments: '{'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid invoke before a complete wrapped call
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid invoke before a complete wrapped call'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -512,119 +432,105 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜invoke name="get_weather">
+    - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <｜DSML｜invoke name="get_weather">
-        vllm_rust: <｜DSML｜invoke name="get_weather">
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_rust: '<｜DSML｜invoke name="get_weather">'
+        vllm_python: '<｜DSML｜invoke name="get_weather">'
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' <｜DSML｜parameter'
-        vllm_rust: ' <｜DSML｜parameter'
+        vllm_rust: '
+<｜DSML｜parameter'
+        vllm_python: '
+<｜DSML｜parameter'
     - delta_text: ' name="location" string="true">NYC</｜DSML｜parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-        dynamo_rust: []
+        - {index: 0, arguments: '{'}
       normal_text:
-        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
         vllm_rust: ' name="location" string="true">NYC</｜DSML｜parameter>'
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
+        vllm_python: ' name="location" string="true">NYC</｜DSML｜parameter>'
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"}'
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        vllm_python: []
+        sglang_python:
+        - {index: 0, arguments: '"location": "NYC"}'}
       normal_text:
-        vllm_python: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-        vllm_rust: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-    - delta_text: ' <｜DSML｜tool_calls>'
+        vllm_rust: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+        vllm_python: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+    - delta_text: '
+<｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' '
-        vllm_rust: ' '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_rust: '
+'
+        vllm_python: '
+'
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: Boston</｜DSML｜parameter>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          arguments: '{'
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          arguments: '"location": "Boston"}'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'Boston</｜DSML｜parameter>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'Boston"'}
+        sglang_python:
+        - {index: 1, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"Boston"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 1
-          arguments: '{"location":"Boston"}'
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '"location": "Boston"}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing </｜DSML｜tool_calls> without matching open after prefix prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing </｜DSML｜tool_calls> without matching open after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -632,92 +538,81 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
-        dynamo_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
-        dynamo_rust: ' check'
     - delta_text: ' that. <｜DSML｜invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: ' that. <｜DSML｜invoke name="get_weather">'
         vllm_rust: ' that. <｜DSML｜invoke name="get_weather">'
-        dynamo_rust: ' that. '
-    - delta_text: ' <｜DSML｜parameter name="location"'
+        vllm_python: ' that. <｜DSML｜invoke name="get_weather">'
+    - delta_text: '
+<｜DSML｜parameter name="location"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' <｜DSML｜parameter name="location"'
-        vllm_rust: ' <｜DSML｜parameter name="location"'
+        vllm_rust: '
+<｜DSML｜parameter name="location"'
+        vllm_python: '
+<｜DSML｜parameter name="location"'
     - delta_text: ' string="true">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' string="true">'
         vllm_rust: ' string="true">'
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
+        vllm_python: ' string="true">'
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        vllm_rust: []
+        vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_python: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-        vllm_rust: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-    - delta_text: ' </｜DSML｜tool_calls>'
+        vllm_rust: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+        vllm_python: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' </｜DSML｜tool_calls>'
-        vllm_rust: ' </｜DSML｜tool_calls>'
+        vllm_rust: '
+</｜DSML｜tool_calls>'
+        vllm_python: '
+</｜DSML｜tool_calls>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,51 +26,59 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<｜'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'DSM'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'L｜too'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'l_calls> <｜'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'DSML｜invoke name="g'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'et'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: '_we'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'ather'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: '"> <｜DSML｜p'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -77,26 +86,31 @@ cases:
         - {index: 0, name: 'get_weather'}
     - delta_text: 'arameter name="loca'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'ti'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'on"'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' stri'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'ng="true">N'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"N'}
@@ -104,6 +118,7 @@ cases:
         - {index: 0, arguments: '{'}
     - delta_text: 'YC</｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: 'YC'}
@@ -111,22 +126,27 @@ cases:
         - {index: 0, arguments: '"location": "N'}
     - delta_text: '> '
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '"'}
         sglang_python: []
     - delta_text: '</｜'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'DSML｜'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'invoke> </｜'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -135,12 +155,14 @@ cases:
         - {index: 0, arguments: 'YC"}'}
     - delta_text: 'DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
@@ -1,16 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,151 +25,122 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜
+    - delta_text: '<｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: DSM
+    - delta_text: 'DSM'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: L｜too
+    - delta_text: 'L｜too'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: l_calls> <｜
+    - delta_text: 'l_calls> <｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: DSML｜invoke name="g
+    - delta_text: 'DSML｜invoke name="g'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: et
+    - delta_text: 'et'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: _we
+    - delta_text: '_we'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ather
+    - delta_text: 'ather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: '"> <｜DSML｜p'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: arameter name="loca
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'arameter name="loca'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ti
+    - delta_text: 'ti'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: on"
+    - delta_text: 'on"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' stri'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ng="true">N
+    - delta_text: 'ng="true">N'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: YC</｜DSML｜parameter
+        vllm_python:
+        - {index: 0, arguments: '{"location":"N'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+    - delta_text: 'YC</｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '"location": "N'
         vllm_rust: []
-        dynamo_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'YC'}
+        sglang_python:
+        - {index: 0, arguments: '"location": "N'}
     - delta_text: '> '
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: </｜
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: DSML｜
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: invoke> </｜
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: YC"}
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: DSML｜tool_calls>
+        - {index: 0, arguments: '"'}
+        sglang_python: []
+    - delta_text: '</｜'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: 'DSML｜'
+      expected:
         vllm_rust: []
-        dynamo_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: 'invoke> </｜'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: 'YC"}'}
+    - delta_text: 'DSML｜tool_calls>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -23,26 +24,26 @@ cases:
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_time'}
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{}'}
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -52,6 +53,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -63,27 +65,27 @@ cases:
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_time'}
     - delta_text: '
-
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+</｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{}'}
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -93,6 +95,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
@@ -1,111 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Invoke with no <parameter>
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Invoke with no <parameter>'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_time">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_time
-          arguments: ''
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
-        dynamo_rust:
-        - index: 0
-          arguments: '{}'
-    - delta_text: ''
-      finish_reason: tool_calls
+        - {index: 0, name: 'get_time'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Invoke with extra newline
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Invoke with extra newline'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_time">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_time
-          arguments: ''
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: '
 
-        </｜DSML｜invoke> </｜DSML｜tool_calls>'
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
-        sglang_python:
-        - index: 0
-          arguments: '{}'
         vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
-        dynamo_rust:
-        - index: 0
-          arguments: '{}'
+        - {index: 0, name: 'get_time', arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -29,32 +30,32 @@ cases:
             type: integer
           first_class:
             type: boolean
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="book_flight">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'book_flight', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'book_flight', arguments: ''}
         sglang_python:
         - {index: 0, name: 'book_flight'}
-    - delta_text: '
-<｜DSML｜parameter name="destination" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="destination" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"destination":"'}
         sglang_python: []
-    - delta_text: 'Paris</｜DSML｜parameter>
-<｜DSML｜parameter'
+    - delta_text: 'Paris</｜DSML｜parameter> <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: 'Paris"'}
@@ -62,33 +63,36 @@ cases:
         - {index: 0, arguments: '{'}
     - delta_text: ' name="passengers"'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' string="false">2</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: ',"passengers":"2"'}
         sglang_python:
         - {index: 0, arguments: '"destination": "Paris"'}
-    - delta_text: '
-<｜DSML｜parameter name="first_class" string="false">'
+    - delta_text: ' <｜DSML｜parameter name="first_class" string="false">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: 'true</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: ',"first_class":"true"'}
         sglang_python:
         - {index: 0, arguments: ', "passengers": 2'}
-    - delta_text: '
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_rust:
         - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_python:
@@ -98,6 +102,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -111,54 +116,57 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
     - delta_text: 'Tōkyō central</｜DSML｜parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: 'Tōkyō central"'}
         sglang_python:
         - {index: 0, arguments: '{'}
-    - delta_text: '
-</｜DSML｜invoke>'
+    - delta_text: ' </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"Tōkyō central"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '"location": "Tōkyō central"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -172,46 +180,48 @@ cases:
         properties:
           count:
             type: number
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="set_limit">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'set_limit', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'set_limit', arguments: ''}
         sglang_python:
         - {index: 0, name: 'set_limit'}
-    - delta_text: '
-<｜DSML｜parameter name="count" string="false">'
+    - delta_text: ' <｜DSML｜parameter name="count" string="false">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '9007199254740993</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: '9007199254740993</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"count":9007199254740993}'}
         vllm_rust:
         - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_python:
         - {index: 0, arguments: '{"count":"9007199254740993"}'}
         sglang_python:
         - {index: 0, arguments: '{"count": 9007199254740993}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,93 +29,81 @@ cases:
             type: integer
           first_class:
             type: boolean
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="book_flight">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: book_flight
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="destination" string="true">'
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
+    - delta_text: '
+<｜DSML｜parameter name="destination" string="true">'
       expected:
-        vllm_python: []
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"destination":"'}
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: Paris</｜DSML｜parameter> <｜DSML｜parameter
+    - delta_text: 'Paris</｜DSML｜parameter>
+<｜DSML｜parameter'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-        dynamo_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'Paris"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
     - delta_text: ' name="passengers"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' string="false">2</｜DSML｜parameter>'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '"destination": "Paris"'
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' <｜DSML｜parameter name="first_class" string="false">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: true</｜DSML｜parameter>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2'
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: '{"destination": "Paris", "passengers": "2", "first_class": "true"}'
+        - {index: 0, arguments: ',"passengers":"2"'}
         sglang_python:
-        - index: 0
-          arguments: ', "first_class": true}'
-        vllm_rust:
-        - arguments: '{"destination":"Paris","first_class":true,"passengers":2}'
-          index: 0
-          name: book_flight
-        dynamo_rust:
-        - index: 0
-          arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-    - delta_text: ''
-      finish_reason: tool_calls
+        - {index: 0, arguments: '"destination": "Paris"'}
+    - delta_text: '
+<｜DSML｜parameter name="first_class" string="false">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: 'true</｜DSML｜parameter>'
+      expected:
         vllm_rust: []
-        dynamo_rust: []
+        vllm_python:
+        - {index: 0, arguments: ',"first_class":"true"'}
+        sglang_python:
+        - {index: 0, arguments: ', "passengers": 2'}
+    - delta_text: '
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: ', "first_class": true}'}
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in parameter
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in parameter'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -115,71 +111,60 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: Tōkyō central</｜DSML｜parameter>
-      expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' </｜DSML｜invoke>'
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Tōkyō central"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '"location": "Tōkyō central"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'Tōkyō central</｜DSML｜parameter>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'Tōkyō central"'}
+        sglang_python:
+        - {index: 0, arguments: '{'}
+    - delta_text: '
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"Tōkyō central"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"Tōkyō central"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '"location": "Tōkyō central"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -187,57 +172,46 @@ cases:
         properties:
           count:
             type: number
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="set_limit">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: set_limit
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="count" string="false">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: 9007199254740993</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-          arguments: '{"count": "9007199254740993"}'
+        - {index: 0, id: true, name: 'set_limit', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
+        - {index: 0, name: 'set_limit'}
+    - delta_text: '
+<｜DSML｜parameter name="count" string="false">'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: '9007199254740993</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
         vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
-          name: set_limit
-        dynamo_rust:
-        - index: 0
-          arguments: '{"count":9007199254740993}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count":"9007199254740993"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,59 +26,65 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -87,6 +94,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -100,46 +108,48 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: '<｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
         sglang_python:
         - {index: 0, arguments: '{"location": "NYC"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' Let me'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -147,6 +157,7 @@ cases:
         vllm_python: ' Let me'
     - delta_text: ' know if you'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -154,6 +165,7 @@ cases:
         vllm_python: ' know if you'
     - delta_text: ' need'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -161,6 +173,7 @@ cases:
         vllm_python: ' need'
     - delta_text: ' more.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -169,6 +182,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -182,59 +196,65 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -243,6 +263,7 @@ cases:
         - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -250,6 +271,7 @@ cases:
         vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -257,6 +279,7 @@ cases:
         vllm_python: ' me know'
     - delta_text: ' if'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -264,6 +287,7 @@ cases:
         vllm_python: ' if'
     - delta_text: ' you need'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -271,6 +295,7 @@ cases:
         vllm_python: ' you need'
     - delta_text: ' more.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -279,6 +304,7 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -292,59 +318,65 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
-    - delta_text: '
-<｜DSML｜invoke name="get_weather">'
+    - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter'
+    - delta_text: ' <｜DSML｜parameter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'NYC</｜DSML｜parameter>
-</｜DSML｜invoke>
-</｜DSML｜tool_calls>'
+    - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -353,6 +385,7 @@ cases:
         - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Then'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -360,6 +393,7 @@ cases:
         vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -367,14 +401,15 @@ cases:
         vllm_python: ' check LA'
     - delta_text: ' weather.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_python: ' weather.'
-    - delta_text: ' <｜DSML｜tool_calls>
-<｜DSML｜invoke'
+    - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -382,35 +417,39 @@ cases:
         vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<｜DSML｜parameter name="location" string="true">'
+    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{"location":"'}
         sglang_python: []
-    - delta_text: 'LA</｜DSML｜parameter>
-</｜DSML｜invoke>'
+    - delta_text: 'LA</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
+        dynamo_rust:
+        - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: 'LA"}'}
         sglang_python:
         - {index: 1, arguments: '{"location": "LA"}'}
-    - delta_text: '
-</｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜tool_calls>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,89 +25,74 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
-        dynamo_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
-        dynamo_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-        dynamo_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ''
-      finish_reason: tool_calls
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -107,87 +100,81 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <｜DSML｜tool_calls> <｜DSML｜invoke
+    - delta_text: '<｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' Let me'
     - delta_text: ' know if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' know if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' more.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -195,119 +182,109 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
-        dynamo_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
-        dynamo_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-        dynamo_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' more.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -315,144 +292,125 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
-        dynamo_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
-        dynamo_rust: ' check'
     - delta_text: ' the weather. <｜DSML｜tool_calls>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-        dynamo_rust: ' the weather. '
-    - delta_text: ' <｜DSML｜invoke name="get_weather">'
+        vllm_python: ' the weather. '
+    - delta_text: '
+<｜DSML｜invoke name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 0
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ' name="location" string="true">'
       expected:
-        vllm_python: []
-        sglang_python: []
         vllm_rust: []
-        dynamo_rust: []
-    - delta_text: NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>
-      expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'NYC</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜tool_calls>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-        dynamo_rust:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Then'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
+      normal_text:
+        vllm_python: ' weather.'
+    - delta_text: ' <｜DSML｜tool_calls>
+<｜DSML｜invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
+      normal_text:
+        vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:
-        vllm_python: []
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          name: get_weather
-          arguments: ''
-    - delta_text: ' <｜DSML｜parameter name="location" string="true">'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
-    - delta_text: LA</｜DSML｜parameter> </｜DSML｜invoke>
-      expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        vllm_rust: []
-        dynamo_rust:
-        - index: 1
-          arguments: '{"location":"LA"}'
-    - delta_text: ' </｜DSML｜tool_calls>'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<｜DSML｜parameter name="location" string="true">'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location":"'}
+        sglang_python: []
+    - delta_text: 'LA</｜DSML｜parameter>
+</｜DSML｜invoke>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: 'LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+    - delta_text: '
+</｜DSML｜tool_calls>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.9.yaml
@@ -11,6 +11,7 @@ family: deepseek_v4
 model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,17 +26,17 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -49,21 +50,22 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: '   '
         vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.9.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: deepseek_v4
-model_label: DeepSeek V4
+model_label: 'DeepSeek V4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
-  dynamo_rust: Dynamo parser v2
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +25,23 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -41,22 +49,21 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
-        dynamo_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-        dynamo_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,42 +26,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,54 +26,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        - index: 0
-          name: get_weather
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: LA<|"|>}<tool_call|>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'LA<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13.a:
-    description: Unknown-only call under default behavior
-    ref: derived from TOOLCALLING.batch.13.a
+    description: 'Unknown-only call under default behavior'
+    ref: 'derived from TOOLCALLING.batch.13.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:unknown_tool{location:<|"|>
+    - delta_text: '<|tool_call>call:unknown_tool{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-          arguments: ''
+        - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python:
-        - index: 0
-          name: unknown_tool
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'unknown_tool'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: unknown_tool
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.13.c:
-    description: Mixed known and unknown calls in one response
-    ref: derived from TOOLCALLING.batch.13.c
+    description: 'Mixed known and unknown calls in one response'
+    ref: 'derived from TOOLCALLING.batch.13.c'
     tools:
     - name: get_weather
       parameters:
@@ -67,54 +66,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>call:unknown_tool{location:<|"|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        - index: 1
-          name: unknown_tool
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: LA<|"|>}<tool_call|>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        - {index: 1, name: 'unknown_tool'}
+    - delta_text: 'LA<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: unknown_tool
+        - {index: 1, name: 'unknown_tool', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (back-to-back sentinels)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (back-to-back sentinels)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,60 +32,46 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>call:get_time{timezone:<|"|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        - index: 1
-          name: get_time
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: EST<|"|>}<tool_call|>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        - {index: 1, name: 'get_time'}
+    - delta_text: 'EST<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -91,79 +86,63 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: 'Both: '
         vllm_rust: 'Both: '
-    - delta_text: call:get_weather{location:<|"|>
+        sglang_python: 'Both: '
+    - delta_text: 'call:get_weather{location:<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: NYC<|"|>}<tool_call|><|tool_call>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>}<tool_call|><|tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: call:get_time{timezone:<|"|>EST<|"|>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'call:get_time{timezone:<|"|>EST<|"|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Done.'
         vllm_python: ' Done.'
         sglang_python: ' Done.'
-        vllm_rust: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -174,54 +153,40 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 1, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "NYC"}'
-        - index: 1
-          name: get_weather
-        vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: LA<|"|>}<tool_call|>
+        - {index: 1, arguments: '{"location": "NYC"}'}
+        - {index: 1, name: 'get_weather'}
+    - delta_text: 'LA<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.30.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.30.a:
-    description: Call/body delimiters `,`, `:`, and `{}` inside one argument string
-      value
-    ref: derived from TOOLCALLING.batch.30.a
+    description: 'Call/body delimiters `,`, `:`, and `{}` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.a'
     tools:
     - name: run_query
       parameters:
@@ -18,48 +26,38 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:run_query{sql:<|"|>
+    - delta_text: '<|tool_call>call:run_query{sql:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-          arguments: ''
+        - {index: 0, id: true, name: 'run_query', arguments: ''}
         sglang_python:
-        - index: 0
-          name: run_query
-        vllm_rust: []
-    - delta_text: SELECT
+        - {index: 0, name: 'run_query'}
+    - delta_text: 'SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
     - delta_text: ' a,b:and{brace}<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' a,b:and{brace}"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT a,b:and{brace}"}'
         vllm_rust:
-        - arguments: '{"sql":"SELECT a,b:and{brace}"}'
-          index: 0
-          name: run_query
+        - {index: 0, name: 'run_query', arguments: '{"sql":"SELECT a,b:and{brace}"}'}
+        vllm_python:
+        - {index: 0, arguments: ' a,b:and{brace}"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT a,b:and{brace}"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.30.b:
-    description: Structural delimiters `}` and `]` inside one argument string value
-    ref: derived from TOOLCALLING.batch.30.b
+    description: 'Structural delimiters `}` and `]` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.b'
     tools:
     - name: run_query
       parameters:
@@ -68,76 +66,62 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:run_query{sql:<|"|>
+    - delta_text: '<|tool_call>call:run_query{sql:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-          arguments: ''
+        - {index: 0, id: true, name: 'run_query', arguments: ''}
         sglang_python:
-        - index: 0
-          name: run_query
-        vllm_rust: []
-    - delta_text: SELECT
+        - {index: 0, name: 'run_query'}
+    - delta_text: 'SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
     - delta_text: ' value WHERE note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE note'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE note'}
+        sglang_python: []
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python: []
     - delta_text: ' }'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' '
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' '}
+        sglang_python: []
     - delta_text: ' and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '} and bracket'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '} and bracket'}
+        sglang_python: []
     - delta_text: ' ]<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT value WHERE note has brace } and bracket ]"}'
         vllm_rust:
-        - arguments: '{"sql":"SELECT value WHERE note has brace } and bracket ]"}'
-          index: 0
-          name: run_query
+        - {index: 0, name: 'run_query', arguments: '{"sql":"SELECT value WHERE note has brace } and bracket ]"}'}
+        vllm_python:
+        - {index: 0, arguments: ' ]"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT value WHERE note has brace } and bracket ]"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.30.c:
-    description: Tool-call marker `<|tool_call>` text inside one argument string value
-    ref: derived from TOOLCALLING.batch.30.c
+    description: 'Tool-call marker `<|tool_call>` text inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.c'
     tools:
     - name: run_query
       parameters:
@@ -146,56 +130,44 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:run_query{sql:<|"|>
+    - delta_text: '<|tool_call>call:run_query{sql:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-          arguments: ''
+        - {index: 0, id: true, name: 'run_query', arguments: ''}
         sglang_python:
-        - index: 0
-          name: run_query
-        vllm_rust: []
-    - delta_text: literal
+        - {index: 0, name: 'run_query'}
+    - delta_text: 'literal'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "literal'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "literal'}
+        sglang_python: []
     - delta_text: ' <|tool_call marker> call:get_time{}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' <|tool_call marker> call:get_time{'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' <|tool_call marker> call:get_time{'}
+        sglang_python: []
     - delta_text: ' stays text<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '} stays text'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '} stays text'}
+        sglang_python: []
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "literal <|tool_call marker> call:get_time{} stays text"}'
         vllm_rust:
-        - arguments: '{"sql":"literal <|tool_call marker> call:get_time{} stays text"}'
-          index: 0
-          name: run_query
+        - {index: 0, name: 'run_query', arguments: '{"sql":"literal <|tool_call marker> call:get_time{} stays text"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "literal <|tool_call marker> call:get_time{} stays text"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.31.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.31.a:
-    description: Multi-call response with Gemma delimiters `,`, `:`, and `{}` inside
-      the first argument string
-    ref: derived from TOOLCALLING.batch.31.a
+    description: 'Multi-call response with Gemma delimiters `,`, `:`, and `{}` inside the first argument string'
+    ref: 'derived from TOOLCALLING.batch.31.a'
     tools:
     - name: run_query
       parameters:
@@ -24,70 +32,52 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:run_query{sql:<|"|>
+    - delta_text: '<|tool_call>call:run_query{sql:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-          arguments: ''
+        - {index: 0, id: true, name: 'run_query', arguments: ''}
         sglang_python:
-        - index: 0
-          name: run_query
-        vllm_rust: []
-    - delta_text: SELECT
+        - {index: 0, name: 'run_query'}
+    - delta_text: 'SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
     - delta_text: ' a,b:and{brace}<|"|>}<tool_call|><|tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'run_query', arguments: '{"sql":"SELECT a,b:and{brace}"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT a,b:and{brace}"}'
-        vllm_rust:
-        - arguments: '{"sql":"SELECT a,b:and{brace}"}'
-          index: 0
-          name: run_query
-    - delta_text: call:get_time{timezone:<|"|>EST<|"|>
+        - {index: 0, arguments: '{"sql": "SELECT a,b:and{brace}"}'}
+    - delta_text: 'call:get_time{timezone:<|"|>EST<|"|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.31.b:
-    description: Multi-call response with structural delimiters inside one argument
-      string value
-    ref: derived from TOOLCALLING.batch.31.b
+    description: 'Multi-call response with structural delimiters inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.31.b'
     tools:
     - name: run_query
       parameters:
@@ -102,98 +92,76 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:run_query{sql:<|"|>
+    - delta_text: '<|tool_call>call:run_query{sql:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-          arguments: ''
+        - {index: 0, id: true, name: 'run_query', arguments: ''}
         sglang_python:
-        - index: 0
-          name: run_query
-        vllm_rust: []
-    - delta_text: SELECT
+        - {index: 0, name: 'run_query'}
+    - delta_text: 'SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
     - delta_text: ' value WHERE note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE note'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE note'}
+        sglang_python: []
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python: []
     - delta_text: ' }'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' '
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' '}
+        sglang_python: []
     - delta_text: ' and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '} and bracket'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '} and bracket'}
+        sglang_python: []
     - delta_text: ' ]<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT value WHERE note has brace } and bracket ]"}'
         vllm_rust:
-        - arguments: '{"sql":"SELECT value WHERE note has brace } and bracket ]"}'
-          index: 0
-          name: run_query
-    - delta_text: <|tool_call>
+        - {index: 0, name: 'run_query', arguments: '{"sql":"SELECT value WHERE note has brace } and bracket ]"}'}
+        vllm_python:
+        - {index: 0, arguments: ' ]"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT value WHERE note has brace } and bracket ]"}'}
+    - delta_text: '<|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: call:get_time{timezone:<|"|>EST<|"|>
+    - delta_text: 'call:get_time{timezone:<|"|>EST<|"|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Sentinel pair with garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Sentinel pair with garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,12 +26,10 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_call>nonsense<tool_call|>
+    - delta_text: '<|tool_call>nonsense<tool_call|>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -32,8 +39,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace in body
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace in body'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,28 +49,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
+        - {index: 0, arguments: '{"location": "NYC'}
         sglang_python: []
-    - delta_text: <tool_call|>
+    - delta_text: '<tool_call|>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -73,8 +73,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: No call:name prefix
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'No call:name prefix'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -83,16 +83,14 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_call>{location:<|"|>
+    - delta_text: '<|tool_call>{location:<|"|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: NYC<|"|>
+    - delta_text: 'NYC<|"|>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -106,8 +104,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Mismatched sentinels
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Mismatched sentinels'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -116,33 +114,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
+        - {index: 0, arguments: '{"location": "NYC'}
         sglang_python: []
     - delta_text: '}</tool_call>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: stop
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing <tool_call|> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing <tool_call|> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,41 +26,33 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
+        - {index: 0, arguments: '{"location": "NYC'}
         sglang_python: []
     - delta_text: '}'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing <tool_call|> without matching <|tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing <tool_call|> without matching <|tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -60,36 +61,35 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: call:get_weather{location:<|"|>NYC<|"|>
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: call:get_weather{location:<|"|>NYC<|"|>
-        sglang_python: call:get_weather{location:<|"|>NYC<|"|>
-        vllm_rust: call:get_weather{location:<|"|>NYC<|"|>
+        vllm_rust: 'call:get_weather{location:<|"|>NYC<|"|>'
+        vllm_python: 'call:get_weather{location:<|"|>NYC<|"|>'
+        sglang_python: 'call:get_weather{location:<|"|>NYC<|"|>'
     - delta_text: '}<tool_call|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '}<tool_call|>'
         vllm_python: '}<tool_call|>'
         sglang_python: '}<tool_call|>'
-        vllm_rust: '}<tool_call|>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-argument value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-argument value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -98,26 +98,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: N
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'N'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "N'
+        - {index: 0, arguments: '{"location": "N'}
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
@@ -125,8 +118,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -135,18 +128,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -199,53 +190,41 @@ cases:
     - delta_text: ' time!<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
       normal_text:
         sglang_python: ' time!'
-    - delta_text: Boston<|"|>
+    - delta_text: 'Boston<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "Boston'
+        - {index: 0, arguments: '{"location": "Boston'}
         sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: call:get_weather{location:<|"|>
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: 'call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: New York<|"|>}
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'New York<|"|>}'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": "New York'
+        - {index: 1, arguments: '{"location": "New York'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "New York"}'
+        - {index: 0, arguments: '{"location": "New York"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -254,18 +233,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -318,42 +295,31 @@ cases:
     - delta_text: ' time!<|tool_call>call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
       normal_text:
         sglang_python: ' time!'
-    - delta_text: Boston<|"|>
+    - delta_text: 'Boston<|"|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "Boston'
+        - {index: 0, arguments: '{"location": "Boston'}
         sglang_python: []
     - delta_text: '}<tool_call|><|tool_call>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-    - delta_text: call:get_weather{location:<|"|>
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: 'call:get_weather{location:<|"|>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: New York
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'New York'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": "New York'
+        - {index: 1, arguments: '{"location": "New York'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
@@ -361,8 +327,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid call before a complete wrapped call
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid call before a complete wrapped call'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -371,56 +337,50 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: call:get_weather{location:<|"|>NYC<|"|>
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: call:get_weather{location:<|"|>NYC<|"|>
-        sglang_python: call:get_weather{location:<|"|>NYC<|"|>
-        vllm_rust: call:get_weather{location:<|"|>NYC<|"|>
+        vllm_rust: 'call:get_weather{location:<|"|>NYC<|"|>'
+        vllm_python: 'call:get_weather{location:<|"|>NYC<|"|>'
+        sglang_python: 'call:get_weather{location:<|"|>NYC<|"|>'
     - delta_text: '}<tool_call|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '}<tool_call|>'
         vllm_python: '}<tool_call|>'
         sglang_python: '}<tool_call|>'
-        vllm_rust: '}<tool_call|>'
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>Boston<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>Boston<|"|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: <|tool_call>call:get_weather{location:<|"|>Boston<|"|>
+        vllm_python: '<|tool_call>call:get_weather{location:<|"|>Boston<|"|>'
     - delta_text: '}<tool_call|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-        vllm_rust:
-        - arguments: '{"location":"Boston"}'
-          index: 0
-          name: get_weather
+        - {index: 0, arguments: '{"location": "Boston"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing <tool_call|> without matching <|tool_call> open after prefix
-      prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing <tool_call|> without matching <|tool_call> open after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -429,48 +389,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' that. call:get_weather{location:<|"|>NYC<|"|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' that. call:get_weather{location:<|"|>NYC<|"|>'
         vllm_python: ' that. call:get_weather{location:<|"|>NYC<|"|>'
         sglang_python: ' that. call:get_weather{location:<|"|>NYC<|"|>'
-        vllm_rust: ' that. call:get_weather{location:<|"|>NYC<|"|>'
     - delta_text: '}<tool_call|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '}<tool_call|>'
         vllm_python: '}<tool_call|>'
         sglang_python: '}<tool_call|>'
-        vllm_rust: '}<tool_call|>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,79 +26,68 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|
+    - delta_text: '<|'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: too
+    - delta_text: 'too'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: l_cal
+    - delta_text: 'l_cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: l>call:get_
+    - delta_text: 'l>call:get_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: weather{location:<|
+    - delta_text: 'weather{location:<|'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
     - delta_text: '"|'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '>NY'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NY'
-        sglang_python: []
         vllm_rust: []
-    - delta_text: C<|"|
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NY'}
+        sglang_python: []
+    - delta_text: 'C<|"|'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: C
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: 'C'}
+        sglang_python: []
     - delta_text: '>}<tool_cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
-    - delta_text: l|>
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: 'l|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.6.yaml
@@ -1,90 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Canonical empty {} body
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Canonical empty {} body'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_time{}<tool_call|>
+    - delta_text: '<|tool_call>call:get_time{}<tool_call|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-        - index: 0
-          arguments: '{}'
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside empty {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside empty {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_time{
+    - delta_text: '<|tool_call>call:get_time{'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: ''
+        - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
     - delta_text: ' }<tool_call|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
-        - index: 0
-          arguments: '{}'
+        - {index: 0, arguments: '{}'}
         sglang_python:
-        - index: 0
-          arguments: '{}'
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.6.c:
-    description: No body (just call:name)
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No body (just call:name)'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Gemma4 tool call'
     chunks:
-    - delta_text: <|tool_call>call:get_time<tool_call|>
+    - delta_text: '<|tool_call>call:get_time<tool_call|>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,48 +30,38 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:book_flight{destination:<|"|>
+    - delta_text: '<|tool_call>call:book_flight{destination:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: ''
+        - {index: 0, id: true, name: 'book_flight', arguments: ''}
         sglang_python:
-        - index: 0
-          name: book_flight
-        vllm_rust: []
-    - delta_text: Paris<|"|>
+        - {index: 0, name: 'book_flight'}
+    - delta_text: 'Paris<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"destination": "Paris'}
+        sglang_python: []
     - delta_text: ',passengers:2,first_class:true}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '", "passengers": 2, "first_class": true}'
-        sglang_python:
-        - index: 0
-          arguments: '{"destination": "Paris", "passengers": 2, "first_class": true}'
         vllm_rust:
-        - arguments: '{"destination":"Paris","first_class":true,"passengers":2}'
-          index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_python:
+        - {index: 0, arguments: '", "passengers": 2, "first_class": true}'}
+        sglang_python:
+        - {index: 0, arguments: '{"destination": "Paris", "passengers": 2, "first_class": true}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in value
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in value'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -71,48 +70,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: Tōkyō
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'Tōkyō'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        sglang_python: []
     - delta_text: ' central<|"|>}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' central"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō central"}'
         vllm_rust:
-        - arguments: '{"location":"Tōkyō central"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
+        vllm_python:
+        - {index: 0, arguments: ' central"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Tōkyō central"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -121,48 +110,38 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:set_temperature{celsius:<|"|>
+    - delta_text: '<|tool_call>call:set_temperature{celsius:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-          arguments: ''
+        - {index: 0, id: true, name: 'set_temperature', arguments: ''}
         sglang_python:
-        - index: 0
-          name: set_temperature
-        vllm_rust: []
-    - delta_text: 20<|"|>
+        - {index: 0, name: 'set_temperature'}
+    - delta_text: '20<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"celsius": "20'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"celsius": "20'}
+        sglang_python: []
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
         vllm_rust:
-        - arguments: '{"celsius":"20"}'
-          index: 0
-          name: set_temperature
+        - {index: 0, name: 'set_temperature', arguments: '{"celsius":"20"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array (existing)
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array (existing)'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -173,41 +152,32 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:process_data{items:[1,2,3]
+    - delta_text: '<|tool_call>call:process_data{items:[1,2,3]'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ',config:{nested:true}}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'
-        sglang_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'
         vllm_rust:
-        - arguments: '{"config":{"nested":true},"items":[1,2,3]}'
-          index: 0
-          name: process_data
+        - {index: 0, name: 'process_data', arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
+        vllm_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'}
+        sglang_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3], "config": {"nested": true}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -216,57 +186,50 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Gemma4 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:process_data{payload:{regions:[{name:<|"|>
+    - delta_text: '<|tool_call>call:process_data{payload:{regions:[{name:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-          arguments: ''
+        - {index: 0, id: true, name: 'process_data', arguments: ''}
         sglang_python:
-        - index: 0
-          name: process_data
-    - delta_text: west<|"|>
+        - {index: 0, name: 'process_data'}
+    - delta_text: 'west<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{"payload": {"regions": [{"name": "west'
+        - {index: 0, arguments: '{"payload": {"regions": [{"name": "west'}
         sglang_python: []
     - delta_text: ',scores:[1,2,3]},{name:<|"|>east<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '", "scores": [1, 2, 3]}, {"name": "east'
+        - {index: 0, arguments: '", "scores": [1, 2, 3]}, {"name": "east'}
         sglang_python: []
     - delta_text: ',scores:[4,5,6]}]'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '", "scores": [4, 5, 6'
+        - {index: 0, arguments: '", "scores": [4, 5, 6'}
         sglang_python: []
     - delta_text: ',flags:{enabled:true,retry:null},empty:{}}}<tool_call|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'process_data', arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}'}
         vllm_python:
-        - index: 0
-          arguments: ']}], "flags": {"enabled": true, "retry": null}, "empty": {}}}'
+        - {index: 0, arguments: ']}], "flags": {"enabled": true, "retry": null}, "empty": {}}}'}
         sglang_python:
-        - index: 0
-          arguments: '{"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]},
-            {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry":
-            "null"}, "empty": {}}}'
+        - {index: 0, arguments: '{"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": "null"}, "empty": {}}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -275,24 +238,19 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:set_limit{count:9007199254740993}<tool_call|>
+    - delta_text: '<|tool_call>call:set_limit{count:9007199254740993}<tool_call|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: set_limit
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit'}
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,67 +26,58 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: call:get_weather{location:<|"|>NYC<|"|>
+        sglang_python: ' the weather. '
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -86,78 +86,68 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call>call:get_weather{location:<|"|>
+    - delta_text: '<|tool_call>call:get_weather{location:<|"|>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: NYC<|"|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC'}
+        sglang_python: []
     - delta_text: '}<tool_call|> Let me'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        sglang_python: ' Let me'
         vllm_rust: ' Let me'
+        sglang_python: ' Let me'
     - delta_text: ' know if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' know if'
         vllm_python: ' know if'
         sglang_python: ' know if'
-        vllm_rust: ' know if'
     - delta_text: ' you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' you'
         vllm_python: ' you'
         sglang_python: ' you'
-        vllm_rust: ' you'
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' need more.'
         vllm_python: ' need more.'
         sglang_python: ' need more.'
-        vllm_rust: ' need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -166,103 +156,94 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: call:get_weather{location:<|"|>NYC<|"|>
+        sglang_python: ' the weather. '
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Let me'
         vllm_python: ' Let me'
         sglang_python: ' Let me'
-        vllm_rust: ' Let me'
     - delta_text: ' know if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' know if you'
         vllm_python: ' know if you'
         sglang_python: ' know if you'
-        vllm_rust: ' know if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' need'
         vllm_python: ' need'
         sglang_python: ' need'
-        vllm_rust: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' more.'
         vllm_python: ' more.'
         sglang_python: ' more.'
-        vllm_rust: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -271,101 +252,84 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: call:get_weather{location:<|"|>NYC<|"|>
+        sglang_python: ' the weather. '
+    - delta_text: 'call:get_weather{location:<|"|>NYC<|"|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '}<tool_call|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Then check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Then check'
         vllm_python: ' Then check'
         sglang_python: ' Then check'
-        vllm_rust: ' Then check'
     - delta_text: ' LA weather. <|tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' LA weather. '
         vllm_rust: ' LA weather. '
-    - delta_text: call:get_weather{location:<|"|>
+        sglang_python: ' LA weather. '
+    - delta_text: 'call:get_weather{location:<|"|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
-    - delta_text: LA<|"|>}<tool_call|>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "LA"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'LA<|"|>}<tool_call|>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: gemma4
-model_label: Gemma 4
+model_label: 'Gemma 4'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,46 +26,34 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,87 +26,63 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: <tool_call>get_weather<arg_key>
-      expected:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 1
-          name: get_weather
-        - index: 1
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: location</arg_key>
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{'}
+    - delta_text: 'location</arg_key>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>LA</arg_value>
+        - {index: 1, arguments: '"location": '}
+    - delta_text: '<arg_value>LA</arg_value>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        sglang_python:
-        - index: 1
-          arguments: '"LA"'
         vllm_rust: []
-    - delta_text: </tool_call>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"location": "LA"'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '"LA"'}
+    - delta_text: '</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,46 +26,34 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>unknown_tool<arg_key>
+    - delta_text: '<tool_call>unknown_tool<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: unknown_tool
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'unknown_tool'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: unknown_tool
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (different names)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (different names)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,93 +32,69 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: <tool_call>get_time<arg_key>
-      expected:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 1
-          name: get_time
-        - index: 1
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: timezone</arg_key>
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '<tool_call>get_time<arg_key>'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{'}
+    - delta_text: 'timezone</arg_key>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '"timezone": '
-        vllm_rust: []
-    - delta_text: <arg_value>EST</arg_value>
+        - {index: 1, arguments: '"timezone": '}
+    - delta_text: '<arg_value>EST</arg_value>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"'
-        sglang_python:
-        - index: 1
-          arguments: '"EST"'
         vllm_rust: []
-    - delta_text: </tool_call>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"timezone": "EST"'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '"EST"'}
+    - delta_text: '</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel calls with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel calls with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -124,101 +109,77 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Checking: <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: 'Checking: '
         vllm_python: 'Checking: '
         sglang_python: 'Checking: '
-        vllm_rust: 'Checking: '
-    - delta_text: get_weather<arg_key>
+    - delta_text: 'get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key><arg_value>NYC</arg_value>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          arguments: '"location": "NYC"'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key><arg_value>NYC</arg_value>'
+      expected:
         vllm_rust: []
-    - delta_text: </tool_call><tool_call>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '{"location": "NYC"'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '"location": "NYC"'}
+    - delta_text: '</tool_call><tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: get_time<arg_key>
-      expected:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: ''
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 1
-          name: get_time
-        - index: 1
-          arguments: '{'
+        - {index: 0, arguments: '}'}
+    - delta_text: 'get_time<arg_key>'
+      expected:
         vllm_rust: []
-    - delta_text: timezone</arg_key><arg_value>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"timezone": '
+        - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
-        - index: 1
-          arguments: '"timezone": '
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{'}
+    - delta_text: 'timezone</arg_key><arg_value>'
+      expected:
         vllm_rust: []
-    - delta_text: EST</arg_value></tool_call> Done.
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '"EST"}'
+        - {index: 1, arguments: '{"timezone": '}
         sglang_python:
-        - index: 1
-          arguments: '"EST"'
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '"timezone": '}
+    - delta_text: 'EST</arg_value></tool_call> Done.'
+      expected:
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-          name: get_time
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '"EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '"EST"'}
+        - {index: 1, arguments: '}'}
       normal_text:
         vllm_python: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' Done.'
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice (id distinctness)
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice (id distinctness)'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -229,87 +190,63 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
-    - delta_text: <tool_call>get_weather<arg_key>
-      expected:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 1
-          name: get_weather
-        - index: 1
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: location</arg_key>
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{'}
+    - delta_text: 'location</arg_key>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>LA</arg_value>
+        - {index: 1, arguments: '"location": '}
+    - delta_text: '<arg_value>LA</arg_value>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        sglang_python:
-        - index: 1
-          arguments: '"LA"'
         vllm_rust: []
-    - delta_text: </tool_call>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"location": "LA"'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '"LA"'}
+    - delta_text: '</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with no function name
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with no function name'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,30 +26,29 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <tool_call><arg_key>
+    - delta_text: '<tool_call><arg_key>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: location</arg_key>
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </arg_value> end tag
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </arg_value> end tag'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -49,38 +57,28 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
-    - delta_text: location</arg_key>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-    - delta_text: <arg_value>NYC</tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '"NYC'
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '"NYC'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,45 +26,35 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete GLM MoE tool call'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
-    - delta_text: location</arg_key>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-    - delta_text: <arg_value>NYC</arg_value>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
+        - {index: 0, arguments: '{"location": "NYC"'}
         sglang_python:
-        - index: 0
-          arguments: '"NYC"'
+        - {index: 0, arguments: '"NYC"'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </tool_call> without matching <tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </tool_call> without matching <tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -64,45 +63,44 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: get_weather<arg_key>location</arg_key>
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: get_weather<arg_key>location</arg_key>
-        sglang_python: get_weather<arg_key>location</arg_key>
-        vllm_rust: get_weather<arg_key>location</arg_key>
-    - delta_text: <arg_value>
+        vllm_rust: 'get_weather<arg_key>location</arg_key>'
+        vllm_python: 'get_weather<arg_key>location</arg_key>'
+        sglang_python: 'get_weather<arg_key>location</arg_key>'
+    - delta_text: '<arg_value>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <arg_value>
-        sglang_python: <arg_value>
-        vllm_rust: <arg_value>
-    - delta_text: NYC</arg_value></tool_call>
+        vllm_rust: '<arg_value>'
+        vllm_python: '<arg_value>'
+        sglang_python: '<arg_value>'
+    - delta_text: 'NYC</arg_value></tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: NYC</arg_value></tool_call>
-        sglang_python: NYC</arg_value>
-        vllm_rust: NYC</arg_value></tool_call>
+        vllm_rust: 'NYC</arg_value></tool_call>'
+        vllm_python: 'NYC</arg_value></tool_call>'
+        sglang_python: 'NYC</arg_value>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arg_value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arg_value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -111,46 +109,35 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete GLM MoE tool call'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
-    - delta_text: location</arg_key>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-    - delta_text: <arg_value>N
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>N'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": N'
+        - {index: 0, arguments: '{"location": N'}
         sglang_python:
-        - index: 0
-          arguments: '"N'
+        - {index: 0, arguments: '"N'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only </tool_call> end marker (body
-      complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only </tool_call> end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -159,18 +146,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete GLM MoE tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -223,76 +208,57 @@ cases:
     - delta_text: ' time!<tool_call>get_weather<arg_key>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
       normal_text:
         vllm_python: ' time!'
         sglang_python: ' time!'
-    - delta_text: location</arg_key>
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-    - delta_text: <arg_value>Boston</arg_value>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>Boston</arg_value>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "Boston"'
+        - {index: 0, arguments: '{"location": "Boston"'}
         sglang_python:
-        - index: 0
-          arguments: '"Boston"'
-    - delta_text: </tool_call>
+        - {index: 0, arguments: '"Boston"'}
+    - delta_text: '</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
-    - delta_text: <tool_call>get_weather<arg_key>location</arg_key>
+        - {index: 0, arguments: '}'}
+    - delta_text: '<tool_call>get_weather<arg_key>location</arg_key>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-        - index: 1
-          arguments: '{"location": '
-    - delta_text: <arg_value>New
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": '}
+    - delta_text: '<arg_value>New'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": New'
+        - {index: 1, arguments: '{"location": New'}
         sglang_python:
-        - index: 1
-          arguments: '"New'
+        - {index: 1, arguments: '"New'}
     - delta_text: ' York</arg_value>'
       expected:
         vllm_python:
-        - index: 1
-          arguments: w York"
+        - {index: 1, arguments: 'w York"'}
         sglang_python:
-        - index: 1
-          arguments: ' York"'
+        - {index: 1, arguments: ' York"'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -301,18 +267,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        GLM MoE tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete GLM MoE tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -365,76 +329,57 @@ cases:
     - delta_text: ' time!<tool_call>get_weather<arg_key>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
       normal_text:
         vllm_python: ' time!'
         sglang_python: ' time!'
-    - delta_text: location</arg_key>
+    - delta_text: 'location</arg_key>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-    - delta_text: <arg_value>Boston</arg_value>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>Boston</arg_value>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "Boston"'
+        - {index: 0, arguments: '{"location": "Boston"'}
         sglang_python:
-        - index: 0
-          arguments: '"Boston"'
-    - delta_text: </tool_call>
+        - {index: 0, arguments: '"Boston"'}
+    - delta_text: '</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
-    - delta_text: <tool_call>get_weather<arg_key>location</arg_key>
+        - {index: 0, arguments: '}'}
+    - delta_text: '<tool_call>get_weather<arg_key>location</arg_key>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 1
-          name: get_weather
-        - index: 1
-          arguments: '{"location": '
-    - delta_text: <arg_value>New
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": '}
+    - delta_text: '<arg_value>New'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location": New'
+        - {index: 1, arguments: '{"location": New'}
         sglang_python:
-        - index: 1
-          arguments: '"New'
+        - {index: 1, arguments: '"New'}
     - delta_text: ' York'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' York'
+        - {index: 1, arguments: ' York'}
         sglang_python:
-        - index: 1
-          arguments: ' York'
+        - {index: 1, arguments: ' York'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid call before a complete wrapped call
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid call before a complete wrapped call'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -443,80 +388,67 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: get_weather<arg_key>location</arg_key>
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: get_weather<arg_key>location</arg_key>
-        sglang_python: get_weather<arg_key>location</arg_key>
-        vllm_rust: get_weather<arg_key>location</arg_key>
-    - delta_text: <arg_value>
+        vllm_rust: 'get_weather<arg_key>location</arg_key>'
+        vllm_python: 'get_weather<arg_key>location</arg_key>'
+        sglang_python: 'get_weather<arg_key>location</arg_key>'
+    - delta_text: '<arg_value>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <arg_value>
-        sglang_python: <arg_value>
-        vllm_rust: <arg_value>
-    - delta_text: NYC</arg_value></tool_call><tool_call>
+        vllm_rust: '<arg_value>'
+        vllm_python: '<arg_value>'
+        sglang_python: '<arg_value>'
+    - delta_text: 'NYC</arg_value></tool_call><tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: NYC</arg_value></tool_call>
-        sglang_python: NYC</arg_value></tool_call>
-        vllm_rust: NYC</arg_value></tool_call>
-    - delta_text: get_weather<arg_key>location</arg_key>
+        vllm_rust: 'NYC</arg_value></tool_call>'
+        vllm_python: 'NYC</arg_value></tool_call>'
+        sglang_python: 'NYC</arg_value></tool_call>'
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": '}
+    - delta_text: '<arg_value>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{"location": '
+        - {index: 0, arguments: '{"location": '}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: Boston</arg_value></tool_call>
+    - delta_text: 'Boston</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"Boston"}'
-        sglang_python:
-        - index: 0
-          arguments: '"Boston"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"Boston"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
+        vllm_python:
+        - {index: 0, arguments: '"Boston"}'}
+        sglang_python:
+        - {index: 0, arguments: '"Boston"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing </tool_call> without matching <tool_call> open after prefix
-      prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing </tool_call> without matching <tool_call> open after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -525,56 +457,55 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' that. get_weather<arg_key>location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' that. get_weather<arg_key>location</arg_key>'
         vllm_python: ' that. get_weather<arg_key>location</arg_key>'
         sglang_python: ' that. get_weather<arg_key>location</arg_key>'
-        vllm_rust: ' that. get_weather<arg_key>location</arg_key>'
-    - delta_text: <arg_value>NYC</arg_value>
+    - delta_text: '<arg_value>NYC</arg_value>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <arg_value>NYC</arg_value>
-        sglang_python: <arg_value>NYC</arg_value>
-        vllm_rust: <arg_value>NYC</arg_value>
-    - delta_text: </tool_call>
+        vllm_rust: '<arg_value>NYC</arg_value>'
+        vllm_python: '<arg_value>NYC</arg_value>'
+        sglang_python: '<arg_value>NYC</arg_value>'
+    - delta_text: '</tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: </tool_call>
-        vllm_rust: </tool_call>
+        vllm_rust: '</tool_call>'
+        vllm_python: '</tool_call>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,102 +26,87 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <t
+    - delta_text: '<t'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ool
+    - delta_text: 'ool'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: _call
+    - delta_text: '_call'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '>get_weathe'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: r<arg_key>location<
+    - delta_text: 'r<arg_key>location<'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
-        vllm_rust: []
-    - delta_text: /a
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: '/a'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: rg_
+    - delta_text: 'rg_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: key><
+    - delta_text: 'key><'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: arg_value>N
+        - {index: 0, arguments: '"location": '}
+    - delta_text: 'arg_value>N'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{"location": N'
+        - {index: 0, arguments: '{"location": N'}
         sglang_python:
-        - index: 0
-          arguments: '"N'
-        vllm_rust: []
-    - delta_text: YC</arg_value></too
+        - {index: 0, arguments: '"N'}
+    - delta_text: 'YC</arg_value></too'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: NYC"
+        - {index: 0, arguments: 'NYC"'}
         sglang_python:
-        - index: 0
-          arguments: YC"
-        vllm_rust: []
-    - delta_text: l_
+        - {index: 0, arguments: 'YC"'}
+    - delta_text: 'l_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: cal
+    - delta_text: 'cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: l>
+    - delta_text: 'l>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '}'
-        sglang_python:
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.6.yaml
@@ -1,73 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Function-only call (no arg keys)
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Function-only call (no arg keys)'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_time</tool_call>
+    - delta_text: '<tool_call>get_time</tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-        - index: 0
-          arguments: '{}'
-        vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Function-only with whitespace
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Function-only with whitespace'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_time
+    - delta_text: '<tool_call>get_time'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' </tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-        - index: 0
-          arguments: '{}'
-        vllm_rust:
-        - arguments: '{}'
-          index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters (existing multi-arg shape)
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters (existing multi-arg shape)'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,86 +30,67 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>book_flight<arg_key>
+    - delta_text: '<tool_call>book_flight<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: book_flight
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: destination</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'destination</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"destination": '
-        vllm_rust: []
-    - delta_text: <arg_value>Paris</arg_value><arg_key>
+        - {index: 0, arguments: '"destination": '}
+    - delta_text: '<arg_value>Paris</arg_value><arg_key>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris"'
+        - {index: 0, arguments: '{"destination": "Paris"'}
         sglang_python:
-        - index: 0
-          arguments: '"Paris", '
-        vllm_rust: []
-    - delta_text: passengers</arg_key><arg_value>
+        - {index: 0, arguments: '"Paris", '}
+    - delta_text: 'passengers</arg_key><arg_value>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: ', "passengers": '
+        - {index: 0, arguments: ', "passengers": '}
         sglang_python:
-        - index: 0
-          arguments: '"passengers": '
-        vllm_rust: []
-    - delta_text: 2</arg_value>
+        - {index: 0, arguments: '"passengers": '}
+    - delta_text: '2</arg_value>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          arguments: '2'
+        - {index: 0, arguments: '2'}
         sglang_python:
-        - index: 0
-          arguments: '2'
-        vllm_rust: []
-    - delta_text: <arg_key>first_class</arg_key>
+        - {index: 0, arguments: '2'}
+    - delta_text: '<arg_key>first_class</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: ', "first_class": '
-        vllm_rust: []
-    - delta_text: <arg_value>true</arg_value></tool_call>
+        - {index: 0, arguments: ', "first_class": '}
+    - delta_text: '<arg_value>true</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "first_class": true}'
-        sglang_python:
-        - index: 0
-          arguments: 'true'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"destination":"Paris","first_class":true,"passengers":2}'
-          index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_python:
+        - {index: 0, arguments: ', "first_class": true}'}
+        sglang_python:
+        - {index: 0, arguments: 'true'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in arg value
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in arg value'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -109,59 +99,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>Tōkyō central</arg_value>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>Tōkyō central</arg_value>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō central"'
-        sglang_python:
-        - index: 0
-          arguments: '"Tōkyō central"'
         vllm_rust: []
-    - delta_text: </tool_call>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '{"location": "Tōkyō central"'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '"Tōkyō central"'}
+    - delta_text: '</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"Tōkyō central"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
+        vllm_python:
+        - {index: 0, arguments: '}'}
+        sglang_python:
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -170,46 +147,34 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>set_limit<arg_key>
+    - delta_text: '<tool_call>set_limit<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: set_limit
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: count</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'count</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"count": '
-        vllm_rust: []
-    - delta_text: <arg_value>9007199254740993</arg_value></tool_call>
+        - {index: 0, arguments: '"count": '}
+    - delta_text: '<arg_value>9007199254740993</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        sglang_python:
-        - index: 0
-          arguments: '9007199254740993'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        sglang_python:
+        - {index: 0, arguments: '9007199254740993'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,79 +26,67 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
-    - delta_text: get_weather<arg_key>location</arg_key>
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{"location": '
         vllm_rust: []
-    - delta_text: <arg_value>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": '
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": '}
+    - delta_text: '<arg_value>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": '}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</arg_value></tool_call>
+    - delta_text: 'NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -98,84 +95,72 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <tool_call>get_weather<arg_key>
+    - delta_text: '<tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{'
         vllm_rust: []
-    - delta_text: location</arg_key>
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{'}
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>NYC</arg_value></tool_call>
+        - {index: 0, arguments: '"location": '}
+    - delta_text: '<arg_value>NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Let me'
         sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' know'
         sglang_python: ' know'
     - delta_text: ' if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' if you'
         sglang_python: ' if you'
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' need more.'
         sglang_python: ' need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -184,111 +169,99 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
-    - delta_text: get_weather<arg_key>location</arg_key>
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{"location": '
         vllm_rust: []
-    - delta_text: <arg_value>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": '
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": '}
+    - delta_text: '<arg_value>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": '}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</arg_value></tool_call>
+    - delta_text: 'NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' Let me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Let me know'
         sglang_python: ' Let me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' if'
         sglang_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' you need'
         sglang_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' more.'
         sglang_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -297,133 +270,109 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
-    - delta_text: get_weather<arg_key>location</arg_key>
+    - delta_text: 'get_weather<arg_key>location</arg_key>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 0
-          name: get_weather
-        - index: 0
-          arguments: '{"location": '
         vllm_rust: []
-    - delta_text: <arg_value>
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": '
+        - {index: 0, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": '}
+    - delta_text: '<arg_value>'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": '}
         sglang_python: []
-        vllm_rust: []
-    - delta_text: NYC</arg_value></tool_call>
+    - delta_text: 'NYC</arg_value></tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '"NYC"'
-        - index: 0
-          arguments: '}'
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '"NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '"NYC"'}
+        - {index: 0, arguments: '}'}
     - delta_text: ' Then check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' Then check LA'
         sglang_python: ' Then check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: ' weather.'
         sglang_python: ' weather.'
     - delta_text: ' <tool_call>get_weather<arg_key>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: ''
-        sglang_python:
-        - index: 1
-          name: get_weather
-        - index: 1
-          arguments: '{'
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather', arguments: ''}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{'}
       normal_text:
         vllm_python: ' '
         sglang_python: ' '
-    - delta_text: location</arg_key>
+    - delta_text: 'location</arg_key>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '"location": '
-        vllm_rust: []
-    - delta_text: <arg_value>LA</arg_value>
+        - {index: 1, arguments: '"location": '}
+    - delta_text: '<arg_value>LA</arg_value>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        sglang_python:
-        - index: 1
-          arguments: '"LA"'
         vllm_rust: []
-    - delta_text: </tool_call>
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"location": "LA"'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '"LA"'}
+    - delta_text: '</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '}'}
+        sglang_python:
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: glm47
-model_label: GLM 5.1
+model_label: 'GLM 5.1'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.1.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.10.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.13.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.2.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.3.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.4.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.5.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.50.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.6.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.7.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.8.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.9.yaml
@@ -11,7 +11,7 @@ family: harmony
 model_label: 'gpt-oss (harmony, token-id)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.1.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.10.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.13.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.2.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.3.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.4.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.5.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.50.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.6.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.7.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.8.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.9.yaml
@@ -15,7 +15,7 @@ family: harmony_text
 model_label: 'gpt-oss (harmony, text)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
   dynamo_rust: 'Dynamo parser v2'
 cases:

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,40 +26,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,79 +26,62 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location":'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":'}
+        sglang_python: []
     - delta_text: ' "LA"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
+        - {index: 1, arguments: ' "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13.a:
-    description: Unknown-only call under default behavior
-    ref: derived from TOOLCALLING.batch.13.a
+    description: 'Unknown-only call under default behavior'
+    ref: 'derived from TOOLCALLING.batch.13.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,44 +26,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool'}
+        sglang_python: []
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: unknown_tool
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'unknown_tool'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location": "NYC"}}'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.13.c:
-    description: Mixed known and unknown calls in one response
-    ref: derived from TOOLCALLING.batch.13.c
+    description: 'Mixed known and unknown calls in one response'
+    ref: 'derived from TOOLCALLING.batch.13.c'
     tools:
     - name: get_weather
       parameters:
@@ -63,79 +66,64 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'unknown_tool'}
+        sglang_python: []
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust:
-        - index: 1
-          name: unknown_tool
-        - arguments: '{"location":'
-          index: 1
+        - {index: 1, name: 'unknown_tool'}
+        - {index: 1, arguments: '{"location":'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":'}
+        sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location":'
     - delta_text: ' "LA"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
+        - {index: 1, arguments: ' "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "LA"}'}
+        sglang_python: []
       normal_text:
         sglang_python: ' "LA"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (back-to-back tool_call wrappers)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (back-to-back tool_call wrappers)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,85 +32,68 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' "arguments": {"timezone":'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone":'
-        sglang_python: []
         vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone":'
-          index: 1
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone":'}
+        sglang_python: []
     - delta_text: ' "EST"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - arguments: ' "EST"}'
-          index: 1
+        - {index: 1, arguments: ' "EST"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -116,93 +108,76 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: 'Both: '
         vllm_python: 'Both: '
         sglang_python: 'Both: '
-        vllm_rust: 'Both: '
     - delta_text: '{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "NYC"}}</tool_call><tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: ' "NYC"}'
-          index: 0
+        - {index: 0, arguments: ' "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "get_time", "arguments":'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
     - delta_text: ' {"timezone": "EST"}}</tool_call> Done.'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
         vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone": "EST"}'
-          index: 1
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
         vllm_rust: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' Done.'
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -213,79 +188,62 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location":'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":'}
+        sglang_python: []
     - delta_text: ' "LA"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
+        - {index: 1, arguments: ' "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with non-JSON garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with non-JSON garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,12 +26,10 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call>not
+    - delta_text: '<tool_call>not'
       expected:
         vllm_python: []
         sglang_python: []
@@ -40,8 +47,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace in JSON body
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace in JSON body'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -50,10 +57,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -62,26 +67,22 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
+        - {index: 0, arguments: '{"location": "NYC"'}
         sglang_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing name key
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing name key'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -90,9 +91,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: expected `name`'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes
+expected `name`'
     chunks:
     - delta_text: '<tool_call>{"arguments":'
       expected:
@@ -112,8 +113,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </tool_call> close
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </tool_call> close'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -122,10 +123,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -134,20 +133,15 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,10 +26,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -29,28 +36,23 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </tool_call> without matching <tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </tool_call> without matching <tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -59,45 +61,44 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '{"name": "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '{"name": "get_weather",'
         vllm_python: '{"name": "get_weather",'
         sglang_python: '{"name": "get_weather",'
-        vllm_rust: '{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' "arguments":'
         vllm_python: ' "arguments":'
         sglang_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}</tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' {"location": "NYC"}}</tool_call>'
         vllm_python: ' {"location": "NYC"}}</tool_call>'
         sglang_python: ' {"location": "NYC"}}'
-        vllm_rust: ' {"location": "NYC"}}</tool_call>'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arguments JSON'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -106,10 +107,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -118,17 +117,13 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"loc'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
@@ -136,8 +131,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -146,18 +141,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -217,65 +210,52 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":'
+        - {index: 0, arguments: '{"location":'}
         sglang_python: []
     - delta_text: ' "Boston"}}</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
+        - {index: 0, arguments: ' "Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location": "Boston"}'}
     - delta_text: '<tool_call>{"name": "get_weather",'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
+        - {index: 1, arguments: '{"location":'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' "New'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' "New'
+        - {index: 1, arguments: ' "New'}
         sglang_python: []
     - delta_text: ' York"}}'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' York"}'
+        - {index: 1, arguments: ' York"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New York"}'
+        - {index: 1, arguments: '{"location": "New York"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -284,18 +264,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -355,59 +333,46 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":'
+        - {index: 0, arguments: '{"location":'}
         sglang_python: []
     - delta_text: ' "Boston"}}</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
+        - {index: 0, arguments: ' "Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
+        - {index: 0, arguments: '{"location": "Boston"}'}
     - delta_text: '<tool_call>{"name": "get_weather",'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
-        sglang_python: </tool_call>
+        sglang_python: '</tool_call>'
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
+        - {index: 1, arguments: '{"location":'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' "New'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' "New'
+        - {index: 1, arguments: ' "New'}
         sglang_python: []
     - delta_text: ' York'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' York'
+        - {index: 1, arguments: ' York'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New'
+        - {index: 1, arguments: '{"location": "New'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,83 +26,71 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <t
+    - delta_text: '<t'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ool
+    - delta_text: 'ool'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: _call
+    - delta_text: '_call'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '>{"name": "'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: get_weather", "argu
+    - delta_text: 'get_weather", "argu'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
-    - delta_text: me
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: nts
+    - delta_text: 'nts'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '": {"'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm_python:
+        - {index: 0, arguments: '{"'}
+        sglang_python: []
     - delta_text: 'location": '
       expected:
-        vllm_python:
-        - index: 0
-          arguments: 'location":'
-        sglang_python: []
         vllm_rust:
-        - arguments: 'location": '
-          index: 0
+        - {index: 0, arguments: 'location": '}
+        vllm_python:
+        - {index: 0, arguments: 'location":'}
+        sglang_python: []
     - delta_text: '"NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - arguments: '"NYC"}'
-          index: 0
+        - {index: 0, arguments: '"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.6.yaml
@@ -1,116 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
-    ref: derived from TOOLCALLING.batch.6.a
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: ' "arguments": {}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{}'
-        sglang_python:
-        - index: 0
-          arguments: '{}'
         vllm_rust:
-        - index: 0
-          name: get_time
-        - arguments: '{}'
-          index: 0
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside arguments {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside arguments {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: ' "arguments": { }}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{ }'
-        sglang_python:
-        - index: 0
-          arguments: '{}'
         vllm_rust:
-        - index: 0
-          name: get_time
-        - arguments: '{ }'
-          index: 0
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{ }'}
+        vllm_python:
+        - {index: 0, arguments: '{ }'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.c:
-    description: No arguments key
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No arguments key'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -119,12 +110,9 @@ cases:
     - delta_text: ' "get_time"}</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
+        - {index: 0, id: true, name: 'get_time'}
         sglang_python:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,75 +30,60 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "book_flight",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
     - delta_text: ' "arguments": {"destination": "Paris",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris",'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: book_flight
-        - arguments: '{"destination": "Paris",'
-          index: 0
+        - {index: 0, name: 'book_flight'}
+        - {index: 0, arguments: '{"destination": "Paris",'}
+        vllm_python:
+        - {index: 0, arguments: '{"destination": "Paris",'}
+        sglang_python: []
     - delta_text: ' "passengers": 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "passengers": 2,'
-        sglang_python:
-        - index: 0
-          arguments: '{"destination": "Paris"'
         vllm_rust:
-        - arguments: ' "passengers": 2,'
-          index: 0
+        - {index: 0, arguments: ' "passengers": 2,'}
+        vllm_python:
+        - {index: 0, arguments: ' "passengers": 2,'}
+        sglang_python:
+        - {index: 0, arguments: '{"destination": "Paris"'}
     - delta_text: ' "first_class":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "first_class":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "first_class":'
-          index: 0
+        - {index: 0, arguments: ' "first_class":'}
+        vllm_python:
+        - {index: 0, arguments: ' "first_class":'}
+        sglang_python: []
     - delta_text: ' true}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' true}'
-        sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2, "first_class": true}'
         vllm_rust:
-        - arguments: ' true}'
-          index: 0
+        - {index: 0, arguments: ' true}'}
+        vllm_python:
+        - {index: 0, arguments: ' true}'}
+        sglang_python:
+        - {index: 0, arguments: ', "passengers": 2, "first_class": true}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -98,55 +92,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "Tōkyō'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "Tōkyō'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        sglang_python: []
     - delta_text: ' \"central\""}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' \"central\""}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō \"central\""}'
         vllm_rust:
-        - arguments: ' \"central\""}'
-          index: 0
+        - {index: 0, arguments: ' \"central\""}'}
+        vllm_python:
+        - {index: 0, arguments: ' \"central\""}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -155,46 +139,38 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "set_temperature",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python:
-        - index: 0
-          name: set_temperature
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python:
+        - {index: 0, name: 'set_temperature'}
     - delta_text: ' "arguments": {"celsius": "20"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
         vllm_rust:
-        - index: 0
-          name: set_temperature
-        - arguments: '{"celsius": "20"}'
-          index: 0
+        - {index: 0, name: 'set_temperature'}
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -205,75 +181,60 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ' "arguments": {"items": [1,2,3]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items": [1,2,3]'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
-        - arguments: '{"items": [1,2,3]'
-          index: 0
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"items": [1,2,3]'}
+        vllm_python:
+        - {index: 0, arguments: '{"items": [1,2,3]'}
+        sglang_python: []
     - delta_text: ', "config":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "config":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ', "config":'
-          index: 0
+        - {index: 0, arguments: ', "config":'}
+        vllm_python:
+        - {index: 0, arguments: ', "config":'}
+        sglang_python: []
     - delta_text: ' {"nested":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' {"nested":'
-        sglang_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3]'
         vllm_rust:
-        - arguments: ' {"nested":'
-          index: 0
+        - {index: 0, arguments: ' {"nested":'}
+        vllm_python:
+        - {index: 0, arguments: ' {"nested":'}
+        sglang_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3]'}
     - delta_text: ' true}}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' true}}'
-        sglang_python:
-        - index: 0
-          arguments: ', "config": {"nested": true}}'
         vllm_rust:
-        - arguments: ' true}}'
-          index: 0
+        - {index: 0, arguments: ' true}}'}
+        vllm_python:
+        - {index: 0, arguments: ' true}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "config": {"nested": true}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -282,181 +243,138 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ' "arguments": {"payload": {"regions":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload": {"regions":'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
-        - arguments: '{"payload": {"regions":'
-          index: 0
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"payload": {"regions":'}
+        vllm_python:
+        - {index: 0, arguments: '{"payload": {"regions":'}
+        sglang_python: []
     - delta_text: ' [{"name": "west",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [{"name": "west",'
-        sglang_python:
-        - index: 0
-          arguments: '{"payload": {'
         vllm_rust:
-        - arguments: ' [{"name": "west",'
-          index: 0
+        - {index: 0, arguments: ' [{"name": "west",'}
+        vllm_python:
+        - {index: 0, arguments: ' [{"name": "west",'}
+        sglang_python:
+        - {index: 0, arguments: '{"payload": {'}
     - delta_text: ' "scores":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "scores":'
-          index: 0
+        - {index: 0, arguments: ' "scores":'}
+        vllm_python:
+        - {index: 0, arguments: ' "scores":'}
+        sglang_python: []
     - delta_text: ' [1, 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [1, 2,'
-        sglang_python:
-        - index: 0
-          arguments: '"regions": [{"name": "west"'
         vllm_rust:
-        - arguments: ' [1, 2,'
-          index: 0
+        - {index: 0, arguments: ' [1, 2,'}
+        vllm_python:
+        - {index: 0, arguments: ' [1, 2,'}
+        sglang_python:
+        - {index: 0, arguments: '"regions": [{"name": "west"'}
     - delta_text: ' 3]}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 3]}, {"name":'
-        sglang_python:
-        - index: 0
-          arguments: ', "scores": [1, 2'
         vllm_rust:
-        - arguments: ' 3]}, {"name":'
-          index: 0
+        - {index: 0, arguments: ' 3]}, {"name":'}
+        vllm_python:
+        - {index: 0, arguments: ' 3]}, {"name":'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [1, 2'}
     - delta_text: ' "east",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "east",'
-        sglang_python:
-        - index: 0
-          arguments: ', 3]}, {'
         vllm_rust:
-        - arguments: ' "east",'
-          index: 0
+        - {index: 0, arguments: ' "east",'}
+        vllm_python:
+        - {index: 0, arguments: ' "east",'}
+        sglang_python:
+        - {index: 0, arguments: ', 3]}, {'}
     - delta_text: ' "scores": [4,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores": [4,'
-        sglang_python:
-        - index: 0
-          arguments: '"name": "east"'
         vllm_rust:
-        - arguments: ' "scores": [4,'
-          index: 0
+        - {index: 0, arguments: ' "scores": [4,'}
+        vllm_python:
+        - {index: 0, arguments: ' "scores": [4,'}
+        sglang_python:
+        - {index: 0, arguments: '"name": "east"'}
     - delta_text: ' 5,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 5,'
-        sglang_python:
-        - index: 0
-          arguments: ', "scores": [4'
         vllm_rust:
-        - arguments: ' 5,'
-          index: 0
+        - {index: 0, arguments: ' 5,'}
+        vllm_python:
+        - {index: 0, arguments: ' 5,'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [4'}
     - delta_text: ' 6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 6]}]'
-        sglang_python:
-        - index: 0
-          arguments: ', 5'
         vllm_rust:
-        - arguments: ' 6]}]'
-          index: 0
+        - {index: 0, arguments: ' 6]}]'}
+        vllm_python:
+        - {index: 0, arguments: ' 6]}]'}
+        sglang_python:
+        - {index: 0, arguments: ', 5'}
     - delta_text: ','
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ','
-        sglang_python: []
         vllm_rust:
-        - arguments: ','
-          index: 0
+        - {index: 0, arguments: ','}
+        vllm_python:
+        - {index: 0, arguments: ','}
+        sglang_python: []
     - delta_text: ' "flags": {"enabled": true,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "flags": {"enabled": true,'
-        sglang_python:
-        - index: 0
-          arguments: ', 6]}]'
         vllm_rust:
-        - arguments: ' "flags": {"enabled": true,'
-          index: 0
+        - {index: 0, arguments: ' "flags": {"enabled": true,'}
+        vllm_python:
+        - {index: 0, arguments: ' "flags": {"enabled": true,'}
+        sglang_python:
+        - {index: 0, arguments: ', 6]}]'}
     - delta_text: ' "retry": null},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "retry": null},'
-        sglang_python:
-        - index: 0
-          arguments: ', "flags": {"enabled": true'
         vllm_rust:
-        - arguments: ' "retry": null},'
-          index: 0
+        - {index: 0, arguments: ' "retry": null},'}
+        vllm_python:
+        - {index: 0, arguments: ' "retry": null},'}
+        sglang_python:
+        - {index: 0, arguments: ', "flags": {"enabled": true'}
     - delta_text: ' "empty":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "empty":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "empty":'
-          index: 0
+        - {index: 0, arguments: ' "empty":'}
+        vllm_python:
+        - {index: 0, arguments: ' "empty":'}
+        sglang_python: []
     - delta_text: ' {}}}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' {}}}'
-        sglang_python:
-        - index: 0
-          arguments: ', "retry": null}, "empty": {}}}'
         vllm_rust:
-        - arguments: ' {}}}'
-          index: 0
+        - {index: 0, arguments: ' {}}}'}
+        vllm_python:
+        - {index: 0, arguments: ' {}}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "retry": null}, "empty": {}}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -465,40 +383,32 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "set_limit",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
     - delta_text: ' "arguments": {"count": 9007199254740993}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        sglang_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
         vllm_rust:
-        - index: 0
-          name: set_limit
-        - arguments: '{"count": 9007199254740993}'
-          index: 0
+        - {index: 0, name: 'set_limit'}
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        sglang_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,73 +26,65 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -92,78 +93,70 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' Let me'
         vllm_rust: ' Let me'
+        sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' know'
         vllm_rust: ' know'
+        sglang_python: ' know'
     - delta_text: ' if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' if you'
         vllm_rust: ' if you'
+        sglang_python: ' if you'
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' need more.'
         vllm_rust: ' need more.'
+        sglang_python: ' need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -172,105 +165,97 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Let me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' Let me know'
         vllm_rust: ' Let me know'
+        sglang_python: ' Let me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' if'
         vllm_rust: ' if'
+        sglang_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' you need'
         vllm_rust: ' you need'
+        sglang_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' more.'
         vllm_rust: ' more.'
+        sglang_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -279,123 +264,106 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ' {"location": "NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
     - delta_text: ' Then check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' Then check LA'
         vllm_rust: ' Then check LA'
+        sglang_python: ' Then check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' weather.'
         vllm_rust: ' weather.'
+        sglang_python: ' weather.'
     - delta_text: ' <tool_call>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' '
         vllm_rust: ' '
+        sglang_python: ' '
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location":'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":'}
+        sglang_python: []
     - delta_text: ' "LA"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
+        - {index: 1, arguments: ' "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: hermes
-model_label: Hermes-3 / Llama variants
+model_label: 'Hermes-3 / Llama variants'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.1.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.1:
     description: 'Single tool call (happy path)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -42,7 +43,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.10.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.10:
     description: 'Duplicate calls (same name twice)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -52,7 +53,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.13.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.13.a:
     description: 'Unknown-only call under default behavior'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -42,7 +43,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -57,8 +58,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -85,7 +87,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.2.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.2.a:
     description: 'Parallel calls in JSON array'
@@ -30,8 +30,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -58,7 +59,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}
@@ -79,8 +80,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'Both: <tool_calls>'
       expected:
@@ -107,7 +109,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}
@@ -124,8 +126,9 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -152,7 +155,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.3.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.3:
     description: 'No tool call (plain text)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'Hello, how'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.30.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.30.a:
     description: 'JSON-array call separator `,` inside one argument string value'
@@ -24,8 +24,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -50,7 +51,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -65,8 +66,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -103,7 +105,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -118,8 +120,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -148,7 +151,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ' stays text'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.31.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.31.a:
     description: 'Multi-call JSON array with call separator `,` inside the first argument string'
@@ -30,8 +30,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -64,7 +65,7 @@ cases:
         vllm_python:
         - {index: 1, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}
@@ -85,8 +86,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -136,7 +138,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.4.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.4.a:
     description: 'Tool_calls wrapper with garbage'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>not'
       expected:
@@ -51,8 +52,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -81,8 +83,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"arguments":'
       expected:
@@ -108,8 +111,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -122,7 +126,7 @@ cases:
         vllm_python:
         - {index: 0, id: true, name: 'get_weather'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.5.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.5.a:
     description: 'Missing </tool_calls> end marker'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -38,7 +39,7 @@ cases:
         vllm_python:
         - {index: 0, id: true, name: 'get_weather'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -53,8 +54,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '[{"name": "get_weather",'
       expected:
@@ -86,8 +88,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -114,8 +117,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:
@@ -182,7 +186,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}
@@ -197,8 +201,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:
@@ -266,7 +271,7 @@ cases:
         vllm_python:
         - {index: 1, arguments: '{"location": "New York'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 1, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.50.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.50:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<t'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.6.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
@@ -22,8 +22,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -36,7 +37,7 @@ cases:
         vllm_python:
         - {index: 0, id: true, name: 'get_time'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.6.b:
@@ -48,8 +49,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -65,7 +67,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.6.c:
@@ -77,8 +79,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.7.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.7.a:
     description: 'Standard scalar types'
@@ -28,8 +28,9 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -54,7 +55,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ', "first_class": true'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -69,8 +70,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -86,7 +88,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -101,8 +103,9 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -119,7 +122,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -136,8 +139,9 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -162,7 +166,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: '"nested": true'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -177,8 +181,9 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -243,7 +248,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: '}, "empty": {'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -258,8 +263,9 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -276,7 +282,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.8.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.8.a:
     description: 'Narration before tool call only'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -54,7 +55,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -69,8 +70,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '<tool_calls>[{"name":'
       expected:
@@ -99,7 +101,7 @@ cases:
         vllm_python:
         - {index: 0, arguments: ''}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -114,8 +116,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -156,7 +159,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}
@@ -171,8 +174,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -219,7 +223,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python:
         - {index: 0, arguments: ''}

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.9.yaml
@@ -11,7 +11,7 @@ family: jamba
 model_label: 'AI21 Jamba'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.9.a:
     description: 'Empty model text'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: ''
       expected:
@@ -45,8 +46,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''jamba''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''jamba''.'
+      sglang_python: 'No SGLang Python parser for family ''jamba''.'
     chunks:
     - delta_text: '   '
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,40 +26,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,56 +26,42 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_weather
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":"LA"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
+        - {index: 1, arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":"LA"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,40 +26,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.unknown_tool:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.unknown_tool:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: unknown_tool
+        - {index: 0, name: 'unknown_tool'}
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 0
-          name: unknown_tool
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang_python:
+        - {index: 0, name: 'unknown_tool'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls in single section
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls in single section'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,62 +32,48 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_time
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_time'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
         vllm_rust:
-        - arguments: '{"timezone":"EST"}'
-          index: 1
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
+        - {index: 1, name: 'get_time'}
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back sections (each with one call)
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back sections (each with one call)'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -93,70 +88,57 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|><|tool_calls_section_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>
-      expected:
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
+        - {index: 0, arguments: '{"location":"NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>'
+      expected:
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: '{"timezone":"EST"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust: []
-    - delta_text: <|tool_calls_section_end|>
+        vllm_python:
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone":"EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel calls with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel calls with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -171,90 +153,75 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' both. <|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' both. '
         vllm_rust: ' both. '
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>
+        vllm_python: ' both. '
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":"NYC"}'
-          index: 0
-    - delta_text: <|tool_call_begin|>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
-    - delta_text: functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|>
+        - {index: 0, arguments: '{"location":"NYC"}'}
+    - delta_text: 'functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        sglang_python:
-        - index: 1
-          name: get_time
         vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone":"EST"}'
-          index: 1
-    - delta_text: <|tool_calls_section_end|> Done.
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone":"EST"}'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: '<|tool_calls_section_end|> Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone":"EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone":"EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice (id distinctness)
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice (id distinctness)'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -265,56 +232,42 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
-        - index: 1
-          name: get_weather
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: '{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":"LA"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
         vllm_rust:
-        - arguments: '{"location":"LA"}'
-          index: 1
+        - {index: 1, arguments: '{"location":"LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location":"LA"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Garbage between section fences (no call_begin)
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Garbage between section fences (no call_begin)'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,11 +26,10 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_calls_section_begin|>nonsense<|tool_calls_section_end|>
+    - delta_text: '<|tool_calls_section_begin|>nonsense<|tool_calls_section_end|>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -31,8 +39,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Invalid JSON args (missing close brace)
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Invalid JSON args (missing close brace)'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -41,40 +49,33 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Kimi K2 tool call'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: '{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"'
+        - {index: 0, arguments: '{"location":"NYC"'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"'
+        - {index: 0, arguments: '{"location":"NYC"'}
   TOOLCALLING.streamv2.4.c:
-    description: Missing function name (call_begin without functions.X:N)
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing function name (call_begin without functions.X:N)'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -83,15 +84,14 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <|tool_call_argument_begin|>
+    - delta_text: '<|tool_call_argument_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -105,8 +105,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Mismatched fences (call_end before call_begin closes)
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Mismatched fences (call_end before call_begin closes)'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -115,33 +115,27 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_calls_section_end|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}<|tool_calls_section_end|>'
+        - {index: 0, arguments: '{"location":"NYC"}<|tool_calls_section_end|>'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}<|tool_calls_section_end|>'
+        - {index: 0, arguments: '{"location":"NYC"}<|tool_calls_section_end|>'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
     description: 'Missing section_end (max_tokens truncation, PR #8208)'
-    ref: derived from TOOLCALLING.batch.5.a
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,46 +26,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"NYC"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"NYC"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}
   TOOLCALLING.streamv2.5.b:
-    description: Closing section_end without matching section_begin
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing section_end without matching section_begin'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -65,46 +66,43 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
-        vllm_rust: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
+        vllm_rust: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
+        vllm_python: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
     - delta_text: '{"location":"NYC"}<|tool_call_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"location":"NYC"}<|tool_call_end|>'
         vllm_rust: '{"location":"NYC"}<|tool_call_end|>'
-    - delta_text: <|tool_calls_section_end|>
+        vllm_python: '{"location":"NYC"}<|tool_call_end|>'
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}
       normal_text:
-        vllm_python: <|tool_calls_section_end|>
-        vllm_rust: <|tool_calls_section_end|>
+        vllm_rust: '<|tool_calls_section_end|>'
+        vllm_python: '<|tool_calls_section_end|>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments (incomplete JSON body)
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arguments (incomplete JSON body)'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -113,40 +111,33 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Kimi K2 tool call'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: '{"loc'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -155,18 +146,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Kimi K2 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -222,48 +211,38 @@ cases:
         sglang_python: []
       normal_text:
         vllm_python: ' time!'
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: '{"location":"Boston"}<|tool_call_end|><|tool_call_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: functions.get_weather:1<|tool_call_argument_begin|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'functions.get_weather:1<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
     - delta_text: '{"location":"New York"}'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":"New York"}'
+        - {index: 1, arguments: '{"location":"New York"}'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"New York"}'
+        - {index: 1, arguments: '{"location":"New York"}'}
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -272,18 +251,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Kimi K2 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -339,48 +316,38 @@ cases:
         sglang_python: []
       normal_text:
         vllm_python: ' time!'
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: '{"location":"Boston"}<|tool_call_end|><|tool_call_begin|>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: functions.get_weather:1<|tool_call_argument_begin|>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'functions.get_weather:1<|tool_call_argument_begin|>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        - {index: 1, id: true, name: 'get_weather'}
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Boston"}'
+        - {index: 0, arguments: '{"location":"Boston"}'}
     - delta_text: '{"location":"New York'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":"New York'
+        - {index: 1, arguments: '{"location":"New York'}
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"New York'
+        - {index: 1, arguments: '{"location":"New York'}
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid call before a complete wrapped section
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid call before a complete wrapped section'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -389,69 +356,59 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
-        vllm_rust: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>
+        vllm_rust: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
+        vllm_python: '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
     - delta_text: '{"location":"NYC"}<|tool_call_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"location":"NYC"}<|tool_call_end|>'
         vllm_rust: '{"location":"NYC"}<|tool_call_end|>'
-    - delta_text: <|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>
+        vllm_python: '{"location":"NYC"}<|tool_call_end|>'
+    - delta_text: '<|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}
       normal_text:
-        vllm_python: <|tool_calls_section_end|>
-        vllm_rust: <|tool_calls_section_end|>
-    - delta_text: functions.get_weather:1<|tool_call_argument_begin|>{"location":"Boston"}<|tool_call_end|>
+        vllm_rust: '<|tool_calls_section_end|>'
+        vllm_python: '<|tool_calls_section_end|>'
+    - delta_text: 'functions.get_weather:1<|tool_call_argument_begin|>{"location":"Boston"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":"Boston"}'
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":"Boston"}'
-          index: 1
-    - delta_text: <|tool_calls_section_end|>
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location":"Boston"}'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"Boston"}'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"Boston"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"location":"Boston"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing section_end without matching section_begin after prefix prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing section_end without matching section_begin after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -460,50 +417,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
         vllm_rust: ' that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
+        vllm_python: ' that. <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
     - delta_text: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
         vllm_rust: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
+        vllm_python: '{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,165 +26,157 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|
+    - delta_text: '<|'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: <|
-    - delta_text: too
+        sglang_python: '<|'
+    - delta_text: 'too'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: too
-    - delta_text: l_cal
+        sglang_python: 'too'
+    - delta_text: 'l_cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: l_cal
-    - delta_text: ls_section_
+        sglang_python: 'l_cal'
+    - delta_text: 'ls_section_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ls_section_
-    - delta_text: begin|><|tool_call_
+        sglang_python: 'ls_section_'
+    - delta_text: 'begin|><|tool_call_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: begin|><|tool_call_
-    - delta_text: be
+        sglang_python: 'begin|><|tool_call_'
+    - delta_text: 'be'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: be
-    - delta_text: gin
+        sglang_python: 'be'
+    - delta_text: 'gin'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: gin
+        sglang_python: 'gin'
     - delta_text: '|>fun'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: '|>fun'
-    - delta_text: ctions.get_
+    - delta_text: 'ctions.get_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ctions.get_
-    - delta_text: weather:0<|tool_cal
+        sglang_python: 'ctions.get_'
+    - delta_text: 'weather:0<|tool_cal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: weather:0<|tool_cal
-    - delta_text: l_
+        sglang_python: 'weather:0<|tool_cal'
+    - delta_text: 'l_'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: l_
-    - delta_text: arg
+        sglang_python: 'l_'
+    - delta_text: 'arg'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: arg
-    - delta_text: ument
+        sglang_python: 'arg'
+    - delta_text: 'ument'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ument
-    - delta_text: _begin|>{"l
+        sglang_python: 'ument'
+    - delta_text: '_begin|>{"l'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"l'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"l'
-          index: 0
-      normal_text:
-        sglang_python: _begin|>{"l
-    - delta_text: ocation":"NYC"}<|to
-      expected:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"l'}
         vllm_python:
-        - index: 0
-          arguments: ocation":"NYC"}
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"l'}
         sglang_python: []
+      normal_text:
+        sglang_python: '_begin|>{"l'
+    - delta_text: 'ocation":"NYC"}<|to'
+      expected:
         vllm_rust:
-        - arguments: ocation":"NYC"}
-          index: 0
+        - {index: 0, arguments: 'ocation":"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: 'ocation":"NYC"}'}
+        sglang_python: []
       normal_text:
-        sglang_python: ocation":"NYC"}<|to
-    - delta_text: ol
+        sglang_python: 'ocation":"NYC"}<|to'
+    - delta_text: 'ol'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ol
-    - delta_text: _ca
+        sglang_python: 'ol'
+    - delta_text: '_ca'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: _ca
-    - delta_text: ll_en
+        sglang_python: '_ca'
+    - delta_text: 'll_en'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ll_en
-    - delta_text: d|><|tool_c
+        sglang_python: 'll_en'
+    - delta_text: 'd|><|tool_c'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: d|><|tool_c
-    - delta_text: alls_section_end|>
+        sglang_python: 'd|><|tool_c'
+    - delta_text: 'alls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: alls_section_end|>
+        sglang_python: 'alls_section_end|>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.6.yaml
@@ -1,126 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Canonical empty {} arguments
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Canonical empty {} arguments'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_time:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_time:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python: []
     - delta_text: '{}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{}'
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust:
-        - arguments: '{}'
-          index: 0
+        - {index: 0, arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        vllm_rust: []
+        - {index: 0, arguments: '{}'}
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside empty {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside empty {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_time:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_time:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python: []
     - delta_text: '{ }<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{ }'
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust:
-        - arguments: '{ }'
-          index: 0
+        - {index: 0, arguments: '{ }'}
+        vllm_python:
+        - {index: 0, arguments: '{ }'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{ }'
-        vllm_rust: []
+        - {index: 0, arguments: '{ }'}
   TOOLCALLING.streamv2.6.c:
-    description: No argument body (skip argument_begin → end)
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No argument body (skip argument_begin → end)'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Kimi K2 tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Kimi K2 tool call'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: functions.get_time:0<|tool_call_end|>
+    - delta_text: 'functions.get_time:0<|tool_call_end|>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: <|tool_calls_section_end|>
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types (string + int + bool)
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types (string + int + bool)'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,46 +30,38 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.book_flight:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.book_flight:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: book_flight
+        - {index: 0, name: 'book_flight'}
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python: []
     - delta_text: '{"destination":"Paris","passengers":2,"first_class":true}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust:
-        - arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-          index: 0
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_python:
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"destination":"Paris","passengers":2,"first_class":true}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars in string value
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars in string value'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -69,46 +70,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"Tōkyō \"central\""}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"Tōkyō \"central\""}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"Tōkyō \"central\""}'
-          index: 0
+        - {index: 0, arguments: '{"location":"Tōkyō \"central\""}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"Tōkyō \"central\""}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Tōkyō \"central\""}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"Tōkyō \"central\""}'}
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -117,46 +110,38 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.set_temperature:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.set_temperature:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: set_temperature
+        - {index: 0, name: 'set_temperature'}
+        vllm_python:
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python: []
     - delta_text: '{"celsius":"20"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"celsius":"20"}'
-        sglang_python:
-        - index: 0
-          name: set_temperature
         vllm_rust:
-        - arguments: '{"celsius":"20"}'
-          index: 0
+        - {index: 0, arguments: '{"celsius":"20"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"celsius":"20"}'}
+        sglang_python:
+        - {index: 0, name: 'set_temperature'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"celsius":"20"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"celsius":"20"}'}
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array (existing shape)
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array (existing shape)'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -167,46 +152,38 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.process_data:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.process_data:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
+        - {index: 0, name: 'process_data'}
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python: []
     - delta_text: '{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items":[1,2,3],"config":{"nested":true}}'
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust:
-        - arguments: '{"items":[1,2,3],"config":{"nested":true}}'
-          index: 0
+        - {index: 0, arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
+        vllm_python:
+        - {index: 0, arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"items":[1,2,3],"config":{"nested":true}}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"items":[1,2,3],"config":{"nested":true}}'}
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -215,55 +192,45 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.process_data:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.process_data:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
+        - {index: 0, name: 'process_data'}
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python: []
     - delta_text: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust:
-        - arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'
-          index: 0
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'}
+        vllm_python:
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}]'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ',"flags":{"enabled":true,"retry":null},"empty":{}}}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'
-        sglang_python:
-        - index: 0
-          arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}'
         vllm_rust:
-        - arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'
-          index: 0
+        - {index: 0, arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'}
+        vllm_python:
+        - {index: 0, arguments: ',"flags":{"enabled":true,"retry":null},"empty":{}}}'}
+        sglang_python:
+        - {index: 0, arguments: '{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -272,40 +239,32 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.set_limit:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.set_limit:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: set_limit
+        - {index: 0, name: 'set_limit'}
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python: []
     - delta_text: '{"count":9007199254740993}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"count":9007199254740993}'
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust:
-        - arguments: '{"count":9007199254740993}'
-          index: 0
+        - {index: 0, arguments: '{"count":9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count":9007199254740993}'}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"count":9007199254740993}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"count":9007199254740993}'}

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,67 +26,59 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll check
+    - delta_text: 'I''ll check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll check
-        sglang_python: I'll check
-        vllm_rust: I'll check
+        vllm_rust: 'I''ll check'
+        vllm_python: 'I''ll check'
+        sglang_python: 'I''ll check'
     - delta_text: ' the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the'
         vllm_python: ' the'
         sglang_python: ' the'
-        vllm_rust: ' the'
     - delta_text: ' weather. <|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' weather. '
         vllm_rust: ' weather. '
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|>
+        vllm_python: ' weather. '
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":"Dallas"}'
-          index: 0
-    - delta_text: <|tool_calls_section_end|>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"Dallas"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -86,73 +87,64 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>
+    - delta_text: '<|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-    - delta_text: '{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
-        Let'
+    - delta_text: '{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"Dallas"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"Dallas"}'}
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -161,95 +153,87 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll check
+    - delta_text: 'I''ll check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll check
-        sglang_python: I'll check
-        vllm_rust: I'll check
+        vllm_rust: 'I''ll check'
+        vllm_python: 'I''ll check'
+        sglang_python: 'I''ll check'
     - delta_text: ' the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the'
         vllm_python: ' the'
         sglang_python: ' the'
-        vllm_rust: ' the'
     - delta_text: ' weather. <|tool_calls_section_begin|><|tool_call_begin|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' weather. '
         vllm_rust: ' weather. '
-    - delta_text: functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|>
+        vllm_python: ' weather. '
+    - delta_text: 'functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":"Dallas"}'
-          index: 0
-    - delta_text: <|tool_calls_section_end|>
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"Dallas"}'}
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' Let me'
     - delta_text: ' know if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' know if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -258,92 +242,79 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: First check
+    - delta_text: 'First check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: First check
-        sglang_python: First check
-        vllm_rust: First check
+        vllm_rust: 'First check'
+        vllm_python: 'First check'
+        sglang_python: 'First check'
     - delta_text: ' Dallas.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Dallas.'
         vllm_python: ' Dallas.'
         sglang_python: ' Dallas.'
-        vllm_rust: ' Dallas.'
     - delta_text: ' <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
-        vllm_python: ' '
         vllm_rust: ' '
+        vllm_python: ' '
     - delta_text: '{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust:
-        - arguments: '{"location":"Dallas"}'
-          index: 0
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location":"Dallas"}'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' Then'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location":"Dallas"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location":"Dallas"}'}
     - delta_text: ' check NYC.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: ' check NYC.'
     - delta_text: ' <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
     - delta_text: '{"location":"NYC"}<|tool_call_end|>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":"NYC"}'
-        sglang_python:
-        - index: 1
-          name: get_weather
         vllm_rust: []
-    - delta_text: <|tool_calls_section_end|>
+        vllm_python:
+        - {index: 1, arguments: '{"location":"NYC"}'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '<|tool_calls_section_end|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location":"NYC"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"location":"NYC"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/kimi_k2/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: kimi_k2
-model_label: Kimi K2.6
+model_label: 'Kimi K2.6'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,44 +26,37 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice, semicolon-separated)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice, semicolon-separated)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,67 +26,59 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}};{"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}};{"name":'
     - delta_text: ' "get_weather", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather", "arguments":'
     - delta_text: ' {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {"location":'
     - delta_text: ' "LA"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"location": "LA"}'}
       normal_text:
         vllm_rust: ' "LA"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13.a:
-    description: Unknown-only call under default behavior
-    ref: derived from TOOLCALLING.batch.13.a
+    description: 'Unknown-only call under default behavior'
+    ref: 'derived from TOOLCALLING.batch.13.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,47 +26,42 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "unknown_tool",'
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
         vllm_rust: ' "arguments": {"location": "NYC"}}'
+        sglang_python: ' "arguments": {"location": "NYC"}}'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.13.c:
-    description: Mixed known and unknown calls in one response
-    ref: derived from TOOLCALLING.batch.13.c
+    description: 'Mixed known and unknown calls in one response'
+    ref: 'derived from TOOLCALLING.batch.13.c'
     tools:
     - name: get_weather
       parameters:
@@ -66,65 +70,59 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}};{"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}};{"name":'
     - delta_text: ' "unknown_tool", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "unknown_tool", "arguments":'
     - delta_text: ' {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' {"location":'
         vllm_rust: ' {"location":'
+        sglang_python: ' {"location":'
     - delta_text: ' "LA"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' "LA"}}'
         vllm_rust: ' "LA"}}'
+        sglang_python: ' "LA"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (semicolon-separated)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (semicolon-separated)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,73 +32,65 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}};{"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}};{"name":'
     - delta_text: ' "get_time", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
+        - {index: 1, name: 'get_time'}
       normal_text:
         vllm_rust: ' "get_time", "arguments":'
     - delta_text: ' {"timezone":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {"timezone":'
     - delta_text: ' "EST"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
         vllm_rust: ' "EST"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -104,83 +105,78 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <|python_tag|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: 'Both: <|python_tag|>'
         vllm_rust: 'Both: <|python_tag|>'
+        vllm_python: 'Both: <|python_tag|>'
     - delta_text: '{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '{"name":'
         vllm_rust: '{"name":'
+        vllm_python: '{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather", "arguments": {"location":'
         vllm_rust: ' "get_weather", "arguments": {"location":'
+        vllm_python: ' "get_weather", "arguments": {"location":'
     - delta_text: ' "NYC"}};{"name": "get_time",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_python: ' "NYC"}};{"name": "get_time",'
         vllm_rust: ' "NYC"}};{"name": "get_time",'
+        vllm_python: ' "NYC"}};{"name": "get_time",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
+        - {index: 1, name: 'get_time'}
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"timezone": "EST"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
-        vllm_python: ' {"timezone": "EST"}}'
         vllm_rust: ' {"timezone": "EST"}}'
+        vllm_python: ' {"timezone": "EST"}}'
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Done.'
         vllm_python: ' Done.'
         sglang_python: ' Done.'
-        vllm_rust: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice (semicolon-separated)
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice (semicolon-separated)'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -191,67 +187,59 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}};{"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}};{"name":'
     - delta_text: ' "get_weather", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather", "arguments":'
     - delta_text: ' {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {"location":'
     - delta_text: ' "LA"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"location": "LA"}'}
       normal_text:
         vllm_rust: ' "LA"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.30.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.30.a:
-    description: Llama JSON call separator `;` inside one argument string value
-    ref: derived from TOOLCALLING.batch.30.a
+    description: 'Llama JSON call separator `;` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.a'
     tools:
     - name: run_query
       parameters:
@@ -17,69 +26,59 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python:
-        - index: 0
-          name: run_query
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python:
+        - {index: 0, name: 'run_query'}
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' a; SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
       normal_text:
         vllm_rust: ' a; SELECT'
     - delta_text: ' b"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' a; SELECT b"}'
-        sglang_python:
-        - index: 0
-          arguments: ' a; SELECT b"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' a; SELECT b"}'}
+        sglang_python:
+        - {index: 0, arguments: ' a; SELECT b"}'}
       normal_text:
         vllm_rust: ' b"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.30.b:
-    description: JSON structural delimiters `}` and `]` inside one argument string
-      value
-    ref: derived from TOOLCALLING.batch.30.b
+    description: 'JSON structural delimiters `}` and `]` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.b'
     tools:
     - name: run_query
       parameters:
@@ -88,112 +87,95 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python:
-        - index: 0
-          name: run_query
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python:
+        - {index: 0, name: 'run_query'}
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' value WHERE'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
       normal_text:
         vllm_rust: ' value WHERE'
     - delta_text: ' note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE'
-        sglang_python:
-        - index: 0
-          arguments: ' value WHERE'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE'}
+        sglang_python:
+        - {index: 0, arguments: ' value WHERE'}
       normal_text:
         vllm_rust: ' note'
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' note'
-        sglang_python:
-        - index: 0
-          arguments: ' note'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' note'}
+        sglang_python:
+        - {index: 0, arguments: ' note'}
       normal_text:
         vllm_rust: ' has brace'
     - delta_text: ' } and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python:
-        - index: 0
-          arguments: ' has brace'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python:
+        - {index: 0, arguments: ' has brace'}
       normal_text:
         vllm_rust: ' } and bracket'
     - delta_text: ' ]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' } and bracket'
-        sglang_python:
-        - index: 0
-          arguments: ' } and bracket'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' } and bracket'}
+        sglang_python:
+        - {index: 0, arguments: ' } and bracket'}
       normal_text:
         vllm_rust: ' ]'
     - delta_text: '"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]"}'
-        sglang_python:
-        - index: 0
-          arguments: ' ]"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' ]"}'}
+        sglang_python:
+        - {index: 0, arguments: ' ]"}'}
       normal_text:
         vllm_rust: '"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.30.c:
-    description: Start marker `<|python_tag|>` text inside one argument string value
-    ref: derived from TOOLCALLING.batch.30.c
+    description: 'Start marker `<|python_tag|>` text inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.c'
     tools:
     - name: run_query
       parameters:
@@ -202,73 +184,62 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python:
-        - index: 0
-          name: run_query
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python:
+        - {index: 0, name: 'run_query'}
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "literal'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "literal'
     - delta_text: ' <|python_tag marker|>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "literal'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "literal'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "literal'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "literal'}
       normal_text:
         vllm_rust: ' <|python_tag marker|>'
     - delta_text: '{name:x}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' <|python_tag marker|>'
-        sglang_python:
-        - index: 0
-          arguments: ' <|python_tag marker|>'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' <|python_tag marker|>'}
+        sglang_python:
+        - {index: 0, arguments: ' <|python_tag marker|>'}
       normal_text:
         vllm_rust: '{name:x}'
     - delta_text: ' stays text"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{name:x} stays text"}'
-        sglang_python:
-        - index: 0
-          arguments: '{name:x} stays text"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{name:x} stays text"}'}
+        sglang_python:
+        - {index: 0, arguments: '{name:x} stays text"}'}
       normal_text:
         vllm_rust: ' stays text"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.31.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.31.a:
-    description: Multi-call Llama JSON response with call separator `;` inside the
-      first argument string
-    ref: derived from TOOLCALLING.batch.31.a
+    description: 'Multi-call Llama JSON response with call separator `;` inside the first argument string'
+    ref: 'derived from TOOLCALLING.batch.31.a'
     tools:
     - name: run_query
       parameters:
@@ -24,85 +32,74 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python:
-        - index: 0
-          name: run_query
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python:
+        - {index: 0, name: 'run_query'}
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' a; SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
       normal_text:
         vllm_rust: ' a; SELECT'
     - delta_text: ' b"}};{"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' a; SELECT b"}'
-        sglang_python:
-        - index: 0
-          arguments: ' a; SELECT b"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' a; SELECT b"}'}
+        sglang_python:
+        - {index: 0, arguments: ' a; SELECT b"}'}
       normal_text:
         vllm_rust: ' b"}};{"name":'
     - delta_text: ' "get_time", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
+        - {index: 1, name: 'get_time'}
       normal_text:
         vllm_rust: ' "get_time", "arguments":'
     - delta_text: ' {"timezone": "EST"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
         vllm_rust: ' {"timezone": "EST"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.31.b:
-    description: Multi-call response with structural delimiters inside one argument
-      string value
-    ref: derived from TOOLCALLING.batch.31.b
+    description: 'Multi-call response with structural delimiters inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.31.b'
     tools:
     - name: run_query
       parameters:
@@ -117,122 +114,104 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python:
-        - index: 0
-          name: run_query
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python:
+        - {index: 0, name: 'run_query'}
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' value WHERE'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
       normal_text:
         vllm_rust: ' value WHERE'
     - delta_text: ' note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE'
-        sglang_python:
-        - index: 0
-          arguments: ' value WHERE'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE'}
+        sglang_python:
+        - {index: 0, arguments: ' value WHERE'}
       normal_text:
         vllm_rust: ' note'
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' note'
-        sglang_python:
-        - index: 0
-          arguments: ' note'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' note'}
+        sglang_python:
+        - {index: 0, arguments: ' note'}
       normal_text:
         vllm_rust: ' has brace'
     - delta_text: ' } and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python:
-        - index: 0
-          arguments: ' has brace'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python:
+        - {index: 0, arguments: ' has brace'}
       normal_text:
         vllm_rust: ' } and bracket'
     - delta_text: ' ]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' } and bracket'
-        sglang_python:
-        - index: 0
-          arguments: ' } and bracket'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' } and bracket'}
+        sglang_python:
+        - {index: 0, arguments: ' } and bracket'}
       normal_text:
         vllm_rust: ' ]'
     - delta_text: '"}};{"name": "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]"}'
-        sglang_python:
-        - index: 0
-          arguments: ' ]"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' ]"}'}
+        sglang_python:
+        - {index: 0, arguments: ' ]"}'}
       normal_text:
         vllm_rust: '"}};{"name": "get_time",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-        vllm_rust: []
+        - {index: 1, name: 'get_time'}
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"timezone": "EST"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"timezone": "EST"}'}
       normal_text:
         vllm_rust: ' {"timezone": "EST"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Python_tag prefix with non-JSON garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Python_tag prefix with non-JSON garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,39 +26,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|python_tag|>not
+    - delta_text: '<|python_tag|>not'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: <|python_tag|>not
+        vllm_rust: '<|python_tag|>not'
     - delta_text: ' even'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' even'
     - delta_text: ' json'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' json'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -58,44 +66,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing name key
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing name key'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -104,61 +108,57 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"arguments":'
     - delta_text: ' {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {"location":'
     - delta_text: ' "NYC"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "NYC"}}'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.e:
-    description: Malformed JSON prefix followed by a valid complete call
-    ref: derived from TOOLCALLING.batch.4.e
+    description: 'Malformed JSON prefix followed by a valid complete call'
+    ref: 'derived from TOOLCALLING.batch.4.e'
     tools:
     - name: get_weather
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: expected `parameters`'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Llama JSON
+expected `parameters`'
     chunks:
     - delta_text: '{"name": "get_weather",'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
     - delta_text: ' {{"name": "get_weather", "arguments":'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: No explicit end (truncation)
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'No explicit end (truncation)'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,45 +26,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation deeper inside arguments JSON (vs .a which truncates at
-      the closing brace)
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation deeper inside arguments JSON (vs .a which truncates at the closing brace)'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -64,44 +68,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"loc'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"loc'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -110,144 +110,140 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        vllm_rust: I'll start
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
-        vllm_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        vllm_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
-        vllm_rust: ' for both'
     - delta_text: ' Boston'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        vllm_rust: ' Boston'
     - delta_text: ' and New'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
-        vllm_rust: ' and New'
     - delta_text: ' York at the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        vllm_rust: ' York at the'
     - delta_text: ' same'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-        vllm_rust: ' same'
     - delta_text: ' time!<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' time!<|python_tag|>{"name":'
         vllm_rust: ' time!<|python_tag|>{"name":'
+        vllm_python: ' time!<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments": {"location":'
         vllm_rust: ' "arguments": {"location":'
+        vllm_python: ' "arguments": {"location":'
     - delta_text: ' "Boston"}};{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "Boston"}'}
       normal_text:
-        vllm_python: ' "Boston"}};{"name":'
         vllm_rust: ' "Boston"}};{"name":'
+        vllm_python: ' "Boston"}};{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather", "arguments": {"location":'
         vllm_rust: ' "get_weather", "arguments": {"location":'
+        vllm_python: ' "get_weather", "arguments": {"location":'
     - delta_text: ' "New York"}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "New York"}'
         vllm_rust: ' "New York"}'
+        vllm_python: ' "New York"}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -256,138 +252,134 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        vllm_rust: I'll start
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
-        vllm_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        vllm_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
-        vllm_rust: ' for both'
     - delta_text: ' Boston'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        vllm_rust: ' Boston'
     - delta_text: ' and New'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
-        vllm_rust: ' and New'
     - delta_text: ' York at the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        vllm_rust: ' York at the'
     - delta_text: ' same'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-        vllm_rust: ' same'
     - delta_text: ' time!<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' time!<|python_tag|>{"name":'
         vllm_rust: ' time!<|python_tag|>{"name":'
+        vllm_python: ' time!<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments": {"location":'
         vllm_rust: ' "arguments": {"location":'
+        vllm_python: ' "arguments": {"location":'
     - delta_text: ' "Boston"}};{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "Boston"}'}
       normal_text:
-        vllm_python: ' "Boston"}};{"name":'
         vllm_rust: ' "Boston"}};{"name":'
+        vllm_python: ' "Boston"}};{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather", "arguments": {"location":'
         vllm_rust: ' "get_weather", "arguments": {"location":'
+        vllm_python: ' "get_weather", "arguments": {"location":'
     - delta_text: ' "New York'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "New York'
         vllm_rust: ' "New York'
+        vllm_python: ' "New York'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,96 +26,89 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <|
+    - delta_text: '<|'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <|
-        vllm_rust: <|
-    - delta_text: pyt
+        vllm_rust: '<|'
+        vllm_python: '<|'
+    - delta_text: 'pyt'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: pyt
-        vllm_rust: pyt
-    - delta_text: hon_t
+        vllm_rust: 'pyt'
+        vllm_python: 'pyt'
+    - delta_text: 'hon_t'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: hon_t
-        vllm_rust: hon_t
-    - delta_text: ag|>{"name"
+        vllm_rust: 'hon_t'
+        vllm_python: 'hon_t'
+    - delta_text: 'ag|>{"name"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: ag|>{"name"
+        vllm_rust: 'ag|>{"name"'
     - delta_text: ': "get_weather", "a'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ': "get_weather", "a'
-    - delta_text: rg
+    - delta_text: 'rg'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: rg
-    - delta_text: ume
+        vllm_rust: 'rg'
+    - delta_text: 'ume'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: ume
+        vllm_rust: 'ume'
     - delta_text: 'nts":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: 'nts":'
     - delta_text: ' {"location'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {"location'
     - delta_text: '": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: '": "NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.6.yaml
@@ -1,137 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
-    ref: derived from TOOLCALLING.batch.6.a
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": {}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        vllm_rust: []
+        - {index: 0, arguments: '{}'}
       normal_text:
         vllm_rust: ' "arguments": {}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside arguments {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside arguments {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": { }}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{}'
-        vllm_rust: []
+        - {index: 0, arguments: '{}'}
       normal_text:
         vllm_rust: ' "arguments": { }}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.c:
-    description: No arguments key
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No arguments key'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_time"}'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python:
-        - index: 0
-          name: get_time
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
       normal_text:
         vllm_rust: ' "get_time"}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,75 +30,66 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "book_flight",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python:
-        - index: 0
-          name: book_flight
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
       normal_text:
         vllm_rust: ' "book_flight",'
     - delta_text: ' "arguments": {"destination": "Paris",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"destination": "Paris",'
     - delta_text: ' "passengers": 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris"'
-        sglang_python:
-        - index: 0
-          arguments: '{"destination": "Paris"'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"destination": "Paris"'}
+        sglang_python:
+        - {index: 0, arguments: '{"destination": "Paris"'}
       normal_text:
         vllm_rust: ' "passengers": 2,'
     - delta_text: ' "first_class":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "first_class":'
     - delta_text: ' true}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "passengers": 2, "first_class": true}'
-        sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2, "first_class": true}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "passengers": 2, "first_class": true}'}
+        sglang_python:
+        - {index: 0, arguments: ', "passengers": 2, "first_class": true}'}
       normal_text:
         vllm_rust: ' true}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -98,57 +98,50 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "Tōkyō'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "Tōkyō'
     - delta_text: ' \"central\""}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō \"central\""}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō \"central\""}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
       normal_text:
         vllm_rust: ' \"central\""}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -157,50 +150,43 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "set_temperature",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python:
-        - index: 0
-          name: set_temperature
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python:
+        - {index: 0, name: 'set_temperature'}
       normal_text:
         vllm_rust: ' "set_temperature",'
     - delta_text: ' "arguments": {"celsius": "20"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
       normal_text:
         vllm_rust: ' "arguments": {"celsius": "20"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -211,75 +197,66 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
       normal_text:
         vllm_rust: ' "process_data",'
     - delta_text: ' "arguments": {"items": [1,2,3]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"items": [1,2,3]'
     - delta_text: ', "config":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ', "config":'
     - delta_text: ' {"nested":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3]'
-        sglang_python:
-        - index: 0
-          arguments: '{"items": [1, 2, 3]'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3]'}
+        sglang_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3]'}
       normal_text:
         vllm_rust: ' {"nested":'
     - delta_text: ' true}}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "config": {"nested": true}}'
-        sglang_python:
-        - index: 0
-          arguments: ', "config": {"nested": true}}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "config": {"nested": true}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "config": {"nested": true}}'}
       normal_text:
         vllm_rust: ' true}}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -288,177 +265,152 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python:
-        - index: 0
-          name: process_data
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
       normal_text:
         vllm_rust: ' "process_data",'
     - delta_text: ' "arguments": {"payload": {"regions":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"payload": {"regions":'
     - delta_text: ' [{"name": "west",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload": {'
-        sglang_python:
-        - index: 0
-          arguments: '{"payload": {'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"payload": {'}
+        sglang_python:
+        - {index: 0, arguments: '{"payload": {'}
       normal_text:
         vllm_rust: ' [{"name": "west",'
     - delta_text: ' "scores":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "scores":'
     - delta_text: ' [1, 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"regions": [{"name": "west"'
-        sglang_python:
-        - index: 0
-          arguments: '"regions": [{"name": "west"'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"regions": [{"name": "west"'}
+        sglang_python:
+        - {index: 0, arguments: '"regions": [{"name": "west"'}
       normal_text:
         vllm_rust: ' [1, 2,'
     - delta_text: ' 3]}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "scores": [1, 2'
-        sglang_python:
-        - index: 0
-          arguments: ', "scores": [1, 2'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "scores": [1, 2'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [1, 2'}
       normal_text:
         vllm_rust: ' 3]}, {"name":'
     - delta_text: ' "east",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', 3]}, {'
-        sglang_python:
-        - index: 0
-          arguments: ', 3]}, {'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', 3]}, {'}
+        sglang_python:
+        - {index: 0, arguments: ', 3]}, {'}
       normal_text:
         vllm_rust: ' "east",'
     - delta_text: ' "scores": [4,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"name": "east"'
-        sglang_python:
-        - index: 0
-          arguments: '"name": "east"'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"name": "east"'}
+        sglang_python:
+        - {index: 0, arguments: '"name": "east"'}
       normal_text:
         vllm_rust: ' "scores": [4,'
     - delta_text: ' 5,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "scores": [4'
-        sglang_python:
-        - index: 0
-          arguments: ', "scores": [4'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "scores": [4'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [4'}
       normal_text:
         vllm_rust: ' 5,'
     - delta_text: ' 6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', 5'
-        sglang_python:
-        - index: 0
-          arguments: ', 5'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', 5'}
+        sglang_python:
+        - {index: 0, arguments: ', 5'}
       normal_text:
         vllm_rust: ' 6]}]'
     - delta_text: ','
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ','
     - delta_text: ' "flags": {"enabled": true,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', 6]}]'
-        sglang_python:
-        - index: 0
-          arguments: ', 6]}]'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', 6]}]'}
+        sglang_python:
+        - {index: 0, arguments: ', 6]}]'}
       normal_text:
         vllm_rust: ' "flags": {"enabled": true,'
     - delta_text: ' "retry": null},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "flags": {"enabled": true'
-        sglang_python:
-        - index: 0
-          arguments: ', "flags": {"enabled": true'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "flags": {"enabled": true'}
+        sglang_python:
+        - {index: 0, arguments: ', "flags": {"enabled": true'}
       normal_text:
         vllm_rust: ' "retry": null},'
     - delta_text: ' "empty":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "empty":'
     - delta_text: ' {}}}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "retry": null}, "empty": {}}}'
-        sglang_python:
-        - index: 0
-          arguments: ', "retry": null}, "empty": {}}}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "retry": null}, "empty": {}}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "retry": null}, "empty": {}}}'}
       normal_text:
         vllm_rust: ' {}}}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -467,44 +419,37 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "set_limit",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python:
-        - index: 0
-          name: set_limit
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
       normal_text:
         vllm_rust: ' "set_limit",'
     - delta_text: ' "arguments": {"count": 9007199254740993}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        sglang_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        sglang_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
       normal_text:
         vllm_rust: ' "arguments": {"count": 9007199254740993}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ''
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ''}
+        sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,72 +26,69 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|python_tag|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. <|python_tag|>'
         vllm_rust: ' the weather. <|python_tag|>'
+        vllm_python: ' the weather. <|python_tag|>'
     - delta_text: '{"name": "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"name": "get_weather",'
         vllm_rust: '{"name": "get_weather",'
+        vllm_python: '{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_python: ' {"location": "NYC"}}'
         vllm_rust: ' {"location": "NYC"}}'
+        vllm_python: ' {"location": "NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -91,80 +97,74 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '<|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python:
-        - index: 0
-          name: get_weather
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}'
     - delta_text: ' Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' Let me'
         vllm_rust: ' Let me'
+        sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' know'
         vllm_rust: ' know'
+        sglang_python: ' know'
     - delta_text: ' if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' if you'
         vllm_rust: ' if you'
+        sglang_python: ' if you'
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' need more.'
         vllm_rust: ' need more.'
+        sglang_python: ' need more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -173,108 +173,105 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|python_tag|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. <|python_tag|>'
         vllm_rust: ' the weather. <|python_tag|>'
+        vllm_python: ' the weather. <|python_tag|>'
     - delta_text: '{"name": "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"name": "get_weather",'
         vllm_rust: '{"name": "get_weather",'
+        vllm_python: '{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_python: ' {"location": "NYC"}}'
         vllm_rust: ' {"location": "NYC"}}'
+        vllm_python: ' {"location": "NYC"}}'
     - delta_text: ' Let me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Let me know'
         vllm_python: ' Let me know'
         sglang_python: ' Let me know'
-        vllm_rust: ' Let me know'
     - delta_text: ' if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' if'
         vllm_python: ' if'
         sglang_python: ' if'
-        vllm_rust: ' if'
     - delta_text: ' you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' you need'
         vllm_python: ' you need'
         sglang_python: ' you need'
-        vllm_rust: ' you need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' more.'
         vllm_python: ' more.'
         sglang_python: ' more.'
-        vllm_rust: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -283,120 +280,115 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <|python_tag|>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. <|python_tag|>'
         vllm_rust: ' the weather. <|python_tag|>'
+        vllm_python: ' the weather. <|python_tag|>'
     - delta_text: '{"name": "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-        vllm_rust: []
+        - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_python: '{"name": "get_weather",'
         vllm_rust: '{"name": "get_weather",'
+        vllm_python: '{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        vllm_rust: []
+        - {index: 0, arguments: '{"location": "NYC"}'}
       normal_text:
-        vllm_python: ' {"location": "NYC"}}'
         vllm_rust: ' {"location": "NYC"}}'
+        vllm_python: ' {"location": "NYC"}}'
     - delta_text: ' Then check LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Then check LA'
         vllm_python: ' Then check LA'
         sglang_python: ' Then check LA'
-        vllm_rust: ' Then check LA'
     - delta_text: ' weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' weather.'
         vllm_python: ' weather.'
         sglang_python: ' weather.'
-        vllm_rust: ' weather.'
     - delta_text: ' <|python_tag|>{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' <|python_tag|>{"name":'
         vllm_rust: ' <|python_tag|>{"name":'
+        vllm_python: ' <|python_tag|>{"name":'
     - delta_text: ' "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-        vllm_rust: []
+        - {index: 1, name: 'get_weather'}
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "arguments": {"location":'
         vllm_rust: ' "arguments": {"location":'
+        vllm_python: ' "arguments": {"location":'
     - delta_text: ' "LA"}}'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        vllm_rust: []
+        - {index: 1, arguments: '{"location": "LA"}'}
       normal_text:
-        vllm_python: ' "LA"}}'
         vllm_rust: ' "LA"}}'
+        vllm_python: ' "LA"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: llama3_json
-model_label: Llama 3 (JSON fmt)
+model_label: 'Llama 3 (JSON fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,38 +26,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,60 +26,63 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> <invoke'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+<invoke'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: ' <parameter name="location">'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: LA</parameter> </invoke> </minimax:tool_call>
+    - delta_text: 'LA</parameter>
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: '{"location": "LA"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"location": "LA"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,19 +26,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <minimax:tool_call> <minimax:tool_name>
+    - delta_text: '<minimax:tool_call>
+<minimax:tool_name>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: unknown_tool</minimax:tool_name>
+    - delta_text: 'unknown_tool</minimax:tool_name>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' <minimax:tool_args>{"location":"NYC"}</minimax:tool_args> </minimax:tool_call>'
+    - delta_text: '
+<minimax:tool_args>{"location":"NYC"}</minimax:tool_args>
+</minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Two invokes inside one tool_call wrapper
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Two invokes inside one tool_call wrapper'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,66 +32,69 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> <invoke'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+<invoke'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' name="get_time">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-    - delta_text: ' <parameter name="timezone">'
+        - {index: 1, name: 'get_time'}
+    - delta_text: '
+<parameter name="timezone">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: EST</parameter> </invoke> </minimax:tool_call>
+    - delta_text: 'EST</parameter>
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "EST"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"'
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"timezone": "EST"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back tool_call wrappers
-    ref: derived from TOOLCALLING.batch.2.b
+    description: 'Two back-to-back tool_call wrappers'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -97,80 +109,84 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
-    - delta_text: ' <minimax:tool_call>'
+        - {index: 0, arguments: '}'}
+    - delta_text: '
+<minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python: []
       normal_text:
-        vllm_python: ' '
-    - delta_text: ' <invoke name="get_time">'
+        vllm_python: '
+'
+    - delta_text: '
+<invoke name="get_time">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-    - delta_text: ' <parameter name="timezone">EST</parameter>'
+        - {index: 1, name: 'get_time'}
+    - delta_text: '
+<parameter name="timezone">EST</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"'
-    - delta_text: ' </invoke>'
+        - {index: 1, arguments: '{"timezone": "EST"'}
+    - delta_text: '
+</invoke>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "EST"}'}
         sglang_python:
-        - index: 1
-          arguments: '}'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 1, arguments: '}'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
-    description: Parallel with surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'Parallel with surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -185,77 +201,83 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: 'Both: '
         vllm_python: 'Both: '
         sglang_python: 'Both: '
-    - delta_text: ' <invoke'
+    - delta_text: '
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <parameter name="location">'
+    - delta_text: ' name="get_weather">
+<parameter name="location">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: NYC</parameter> </invoke>
+        - {index: 0, name: 'get_weather'}
+    - delta_text: 'NYC</parameter>
+</invoke>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-        - index: 0
-          arguments: '}'
-    - delta_text: ' <invoke'
+        - {index: 0, arguments: '{"location": "NYC"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_time"> <parameter'
+    - delta_text: ' name="get_time">
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_time
-    - delta_text: ' name="timezone">EST</parameter> </invoke>'
+        - {index: 1, name: 'get_time'}
+    - delta_text: ' name="timezone">EST</parameter>
+</invoke>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-          arguments: '{"timezone": "EST"}'
+        - {index: 1, id: true, name: 'get_time', arguments: '{"timezone": "EST"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"timezone": "EST"'
-        - index: 1
-          arguments: '}'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 1, arguments: '{"timezone": "EST"'}
+        - {index: 1, arguments: '}'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -266,60 +288,63 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> <invoke'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+<invoke'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: ' <parameter name="location">'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: LA</parameter> </invoke> </minimax:tool_call>
+    - delta_text: 'LA</parameter>
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: '{"location": "LA"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '{"location": "LA"'}
+        - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with garbage body
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with garbage body'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,11 +26,11 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <minimax:tool_call> not
+    - delta_text: '<minimax:tool_call>
+not'
       expected:
         vllm_python: []
         sglang_python: []
@@ -29,7 +38,8 @@ cases:
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' valid invoke </minimax:tool_call>'
+    - delta_text: ' valid invoke
+</minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -39,8 +49,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Invoke without name attribute
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Invoke without name attribute'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -49,23 +59,26 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: <minimax:tool_call> <invoke>
+    - delta_text: '<minimax:tool_call>
+<invoke>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' <parameter'
+    - delta_text: '
+<parameter'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="location">NYC</parameter> </invoke>'
+    - delta_text: ' name="location">NYC</parameter>
+</invoke>'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </minimax:tool_call>'
+    - delta_text: '
+</minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []
@@ -75,8 +88,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing closing </invoke>
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing closing </invoke>'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -85,11 +98,11 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete MiniMax M2 tool call'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
         vllm_python: []
         sglang_python: []
@@ -97,15 +110,15 @@ cases:
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </minimax:tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </minimax:tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,11 +26,11 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete MiniMax M2 tool call'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
         vllm_python: []
         sglang_python: []
@@ -29,32 +38,28 @@ cases:
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </minimax:tool_call> without matching open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </minimax:tool_call> without matching open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -63,54 +68,65 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <invoke name="get_weather">
+    - delta_text: '<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: <invoke name="get_weather">
-        sglang_python: <invoke name="get_weather">
-        vllm_rust: <invoke name="get_weather">
-    - delta_text: ' <parameter'
+        vllm_rust: '<invoke name="get_weather">'
+        vllm_python: '<invoke name="get_weather">'
+        sglang_python: '<invoke name="get_weather">'
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' <parameter'
-        sglang_python: ' <parameter'
-        vllm_rust: ' <parameter'
-    - delta_text: ' name="location">NYC</parameter> </invoke>'
+        vllm_rust: '
+<parameter'
+        vllm_python: '
+<parameter'
+        sglang_python: '
+<parameter'
+    - delta_text: ' name="location">NYC</parameter>
+</invoke>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' name="location">NYC</parameter> </invoke>'
-        sglang_python: ' name="location">NYC</parameter> </invoke>'
-        vllm_rust: ' name="location">NYC</parameter> </invoke>'
-    - delta_text: ' </minimax:tool_call>'
+        vllm_rust: ' name="location">NYC</parameter>
+</invoke>'
+        vllm_python: ' name="location">NYC</parameter>
+</invoke>'
+        sglang_python: ' name="location">NYC</parameter>
+</invoke>'
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' </minimax:tool_call>'
-        sglang_python: ' </minimax:tool_call>'
-        vllm_rust: ' </minimax:tool_call>'
+        vllm_rust: '
+</minimax:tool_call>'
+        vllm_python: '
+</minimax:tool_call>'
+        sglang_python: '
+</minimax:tool_call>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-parameter value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-parameter value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -119,11 +135,11 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete MiniMax M2 tool call'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
         vllm_python: []
         sglang_python: []
@@ -131,9 +147,9 @@ cases:
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NY'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NY'
       expected:
         vllm_python: []
         sglang_python: []
@@ -143,8 +159,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -153,17 +169,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete MiniMax M2 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -213,73 +228,70 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <minimax:tool_call>'
+    - delta_text: ' time!
+<minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-        sglang_python: ' time! '
-    - delta_text: ' <invoke'
+        vllm_python: ' time!
+'
+        sglang_python: ' time!
+'
+    - delta_text: '
+<invoke'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <parameter'
+    - delta_text: ' name="get_weather">
+<parameter'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location">'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: Boston</parameter> </invoke> <invoke
+    - delta_text: 'Boston</parameter>
+</invoke>
+<invoke'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"'
-        - index: 0
-          arguments: '}'
-    - delta_text: ' name="get_weather"> <parameter'
+        - {index: 0, arguments: '{"location": "Boston"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: ' name="get_weather">
+<parameter'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location">'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: New York</parameter>
+    - delta_text: 'New York</parameter>'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          arguments: '{"location": "New York"'
-    - delta_text: ' </invoke>'
+        - {index: 1, arguments: '{"location": "New York"'}
+    - delta_text: '
+</invoke>'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "New York"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: '{"location": "New York"}'}
         sglang_python:
-        - index: 1
-          arguments: '}'
+        - {index: 1, arguments: '}'}
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -288,17 +300,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete MiniMax M2 tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -348,61 +359,62 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <minimax:tool_call>'
+    - delta_text: ' time!
+<minimax:tool_call>'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time! '
-        sglang_python: ' time! '
-    - delta_text: ' <invoke'
+        vllm_python: ' time!
+'
+        sglang_python: ' time!
+'
+    - delta_text: '
+<invoke'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <parameter'
+    - delta_text: ' name="get_weather">
+<parameter'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' name="location">'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: Boston</parameter> </invoke> <invoke
+    - delta_text: 'Boston</parameter>
+</invoke>
+<invoke'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"'
-        - index: 0
-          arguments: '}'
-    - delta_text: ' name="get_weather"> <parameter'
+        - {index: 0, arguments: '{"location": "Boston"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: ' name="get_weather">
+<parameter'
       expected:
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
+        - {index: 1, name: 'get_weather'}
     - delta_text: ' name="location">'
       expected:
         vllm_python: []
         sglang_python: []
-    - delta_text: New York
+    - delta_text: 'New York'
       expected:
         vllm_python: []
         sglang_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
-    description: Bare valid invoke before a complete wrapped call
-    ref: derived from TOOLCALLING.batch.5.f
+    description: 'Bare valid invoke before a complete wrapped call'
+    ref: 'derived from TOOLCALLING.batch.5.f'
     tools:
     - name: get_weather
       parameters:
@@ -411,76 +423,99 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <invoke name="get_weather">
+    - delta_text: '<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: <invoke name="get_weather">
-        sglang_python: <invoke name="get_weather">
-    - delta_text: ' <parameter'
+        vllm_rust: '<invoke name="get_weather">'
+        vllm_python: '<invoke name="get_weather">'
+        sglang_python: '<invoke name="get_weather">'
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' <parameter'
-        sglang_python: ' <parameter'
-    - delta_text: ' name="location">NYC</parameter> </invoke>'
+        vllm_rust: '
+<parameter'
+        vllm_python: '
+<parameter'
+        sglang_python: '
+<parameter'
+    - delta_text: ' name="location">NYC</parameter>
+</invoke>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' name="location">NYC</parameter> </invoke>'
-        sglang_python: ' name="location">NYC</parameter> </invoke>'
-    - delta_text: ' </minimax:tool_call> <minimax:tool_call>'
+        vllm_rust: ' name="location">NYC</parameter>
+</invoke>'
+        vllm_python: ' name="location">NYC</parameter>
+</invoke>'
+        sglang_python: ' name="location">NYC</parameter>
+</invoke>'
+    - delta_text: '
+</minimax:tool_call>
+<minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python: []
       normal_text:
-        vllm_python: ' </minimax:tool_call> '
-        sglang_python: ' </minimax:tool_call> '
-    - delta_text: ' <invoke'
+        vllm_rust: '
+</minimax:tool_call>
+'
+        vllm_python: '
+</minimax:tool_call>
+'
+        sglang_python: '
+</minimax:tool_call>
+'
+    - delta_text: '
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="get_weather"> <parameter'
+    - delta_text: ' name="get_weather">
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' name="location">Boston</parameter> </invoke>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' name="location">Boston</parameter>
+</invoke>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "Boston"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: '{"location": "Boston"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Boston"'
-        - index: 0
-          arguments: '}'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "Boston"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.g:
-    description: Closing </minimax:tool_call> without matching open after prefix prose
-    ref: derived from TOOLCALLING.batch.5.g
+    description: 'Closing </minimax:tool_call> without matching open after prefix prose'
+    ref: 'derived from TOOLCALLING.batch.5.g'
     tools:
     - name: get_weather
       parameters:
@@ -489,66 +524,77 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' that. <invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' that. <invoke name="get_weather">'
         vllm_python: ' that. <invoke name="get_weather">'
         sglang_python: ' that. <invoke name="get_weather">'
-        vllm_rust: ' that. <invoke name="get_weather">'
-    - delta_text: ' <parameter name="location">'
+    - delta_text: '
+<parameter name="location">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' <parameter name="location">'
-        sglang_python: ' <parameter name="location">'
-        vllm_rust: ' <parameter name="location">'
-    - delta_text: NYC</parameter>
+        vllm_rust: '
+<parameter name="location">'
+        vllm_python: '
+<parameter name="location">'
+        sglang_python: '
+<parameter name="location">'
+    - delta_text: 'NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: NYC</parameter>
-        sglang_python: NYC</parameter>
-        vllm_rust: NYC</parameter>
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        vllm_rust: 'NYC</parameter>'
+        vllm_python: 'NYC</parameter>'
+        sglang_python: 'NYC</parameter>'
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' </invoke> </minimax:tool_call>'
-        sglang_python: ' </invoke> </minimax:tool_call>'
-        vllm_rust: ' </invoke> </minimax:tool_call>'
+        vllm_rust: '
+</invoke>
+</minimax:tool_call>'
+        vllm_python: '
+</invoke>
+</minimax:tool_call>'
+        sglang_python: '
+</invoke>
+</minimax:tool_call>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,117 +26,132 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <m
+    - delta_text: '<m'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: <m
-        sglang_python: <m
-    - delta_text: ini
+        vllm_python: '<m'
+        sglang_python: '<m'
+    - delta_text: 'ini'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ini
-        sglang_python: ini
-    - delta_text: max:t
+        vllm_python: 'ini'
+        sglang_python: 'ini'
+    - delta_text: 'max:t'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: max:t
-        sglang_python: max:t
-    - delta_text: ool_call> <
+        vllm_python: 'max:t'
+        sglang_python: 'max:t'
+    - delta_text: 'ool_call> <'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ool_call> <
-        sglang_python: ool_call> <
-    - delta_text: invoke name="get_we
+        vllm_python: 'ool_call> <'
+        sglang_python: 'ool_call> <'
+    - delta_text: 'invoke name="get_we'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: invoke name="get_we
-        sglang_python: invoke name="get_we
-    - delta_text: at
+        vllm_python: 'invoke name="get_we'
+        sglang_python: 'invoke name="get_we'
+    - delta_text: 'at'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: at
-        sglang_python: at
-    - delta_text: her
+        vllm_python: 'at'
+        sglang_python: 'at'
+    - delta_text: 'her'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: her
-        sglang_python: her
+        vllm_python: 'her'
+        sglang_python: 'her'
     - delta_text: '"> <p'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_python: '"> <p'
         sglang_python: '"> <p'
-    - delta_text: arameter na
+    - delta_text: 'arameter na'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: arameter na
-        sglang_python: arameter na
-    - delta_text: me="location">NYC</
+        vllm_python: 'arameter na'
+        sglang_python: 'arameter na'
+    - delta_text: 'me="location">NYC</'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: me="location">NYC</
-        sglang_python: me="location">NYC</
-    - delta_text: pa
+        vllm_python: 'me="location">NYC</'
+        sglang_python: 'me="location">NYC</'
+    - delta_text: 'pa'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: pa
-        sglang_python: pa
-    - delta_text: ram
+        vllm_python: 'pa'
+        sglang_python: 'pa'
+    - delta_text: 'ram'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ram
-        sglang_python: ram
-    - delta_text: eter>
+        vllm_python: 'ram'
+        sglang_python: 'ram'
+    - delta_text: 'eter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: eter>
-        sglang_python: eter>
+        vllm_python: 'eter>'
+        sglang_python: 'eter>'
     - delta_text: ' </invoke> '
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_python: ' </invoke> '
         sglang_python: ' </invoke> '
-    - delta_text: </minimax:tool_call
+    - delta_text: '</minimax:tool_call'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: </minimax:tool_call
-        sglang_python: </minimax:tool_call
+        vllm_python: '</minimax:tool_call'
+        sglang_python: '</minimax:tool_call'
     - delta_text: '>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
@@ -137,5 +160,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.6.yaml
@@ -1,82 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Invoke with no <parameter>
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Invoke with no <parameter>'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, name: 'get_time'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
+        - {index: 0, id: true, name: 'get_time', arguments: '{}'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.6.b:
-    description: Invoke with extra newline
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Invoke with extra newline'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_time
+        - {index: 0, name: 'get_time'}
     - delta_text: '
 
-        </invoke> </minimax:tool_call>'
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-          arguments: '{}'
+        - {index: 0, id: true, name: 'get_time', arguments: '{}'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,60 +30,65 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="book_flight">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: book_flight
-    - delta_text: ' <parameter name="destination">Paris</parameter>'
+        - {index: 0, name: 'book_flight'}
+    - delta_text: '
+<parameter name="destination">Paris</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"destination": "Paris"'
-    - delta_text: ' <parameter name="passengers">'
+        - {index: 0, arguments: '{"destination": "Paris"'}
+    - delta_text: '
+<parameter name="passengers">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: 2</parameter>
+    - delta_text: '2</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: ', "passengers": 2'
-    - delta_text: ' <parameter name="first_class">'
+        - {index: 0, arguments: ', "passengers": 2'}
+    - delta_text: '
+<parameter name="first_class">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: true</parameter> </invoke> </minimax:tool_call>
+    - delta_text: 'true</parameter>
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-          arguments: '{"destination": "Paris", "passengers": "2", "first_class": "true"}'
+        - {index: 0, id: true, name: 'book_flight', arguments: '{"destination": "Paris", "passengers": "2", "first_class": "true"}'}
         sglang_python:
-        - index: 0
-          arguments: ', "first_class": true'
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: ', "first_class": true'}
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in parameter
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in parameter'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -83,48 +97,51 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">Tōkyō'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">Tōkyō'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' central</parameter> </invoke>'
+    - delta_text: ' central</parameter>
+</invoke>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "Tōkyō central"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "Tōkyō central"}'}
         sglang_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō central"'
-        - index: 0
-          arguments: '}'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "Tōkyō central"'}
+        - {index: 0, arguments: '}'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -133,38 +150,40 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="set_limit">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: set_limit
-    - delta_text: ' <parameter name="count">9007199254740993</parameter>'
+        - {index: 0, name: 'set_limit'}
+    - delta_text: '
+<parameter name="count">9007199254740993</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"count": 9007199254740992'
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, arguments: '{"count": 9007199254740992'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-          arguments: '{"count": "9007199254740993"}'
+        - {index: 0, id: true, name: 'set_limit', arguments: '{"count": "9007199254740993"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,65 +26,73 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <invoke name="get_weather">'
+    - delta_text: '
+<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -84,60 +101,66 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <minimax:tool_call> <invoke
+    - delta_text: '<minimax:tool_call>
+<invoke'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter name="location">NYC</parameter>'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call>'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' me know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' if you need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -146,81 +169,93 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <invoke name="get_weather">'
+    - delta_text: '
+<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call> Let'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call> Let'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' know if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -229,103 +264,113 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <invoke name="get_weather">'
+    - delta_text: '
+<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          name: get_weather
-    - delta_text: ' <parameter'
+        - {index: 0, name: 'get_weather'}
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' name="location">NYC</parameter>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
-    - delta_text: ' </invoke> </minimax:tool_call> Then'
+        - {index: 0, arguments: '{"location": "NYC"'}
+    - delta_text: '
+</invoke>
+</minimax:tool_call> Then'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python:
-        - index: 0
-          arguments: '}'
+        - {index: 0, arguments: '}'}
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' LA weather.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' <minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location": "NYC"}'}
         sglang_python: []
       normal_text:
         vllm_python: ' '
-    - delta_text: ' <invoke name="get_weather">'
+    - delta_text: '
+<invoke name="get_weather">'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python:
-        - index: 1
-          name: get_weather
-    - delta_text: ' <parameter'
+        - {index: 1, name: 'get_weather'}
+    - delta_text: '
+<parameter'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' name="location">LA</parameter> </invoke>'
+    - delta_text: ' name="location">LA</parameter>
+</invoke>'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-          arguments: '{"location": "LA"}'
+        - {index: 1, id: true, name: 'get_weather', arguments: '{"location": "LA"}'}
         sglang_python:
-        - index: 1
-          arguments: '{"location": "LA"'
-        - index: 1
-          arguments: '}'
-    - delta_text: ' </minimax:tool_call>'
+        - {index: 1, arguments: '{"location": "LA"'}
+        - {index: 1, arguments: '}'}
+    - delta_text: '
+</minimax:tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: minimax_m2
-model_label: MiniMax 2.7
+model_label: 'MiniMax 2.7'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,46 +26,42 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,72 +26,65 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "LA"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "LA"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13.a:
-    description: Unknown-only call under default behavior
-    ref: derived from TOOLCALLING.batch.13.a
+    description: 'Unknown-only call under default behavior'
+    ref: 'derived from TOOLCALLING.batch.13.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,52 +26,48 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'unknown_tool'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "unknown_tool",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.13.c:
-    description: Mixed known and unknown calls in one response
-    ref: derived from TOOLCALLING.batch.13.c
+    description: 'Mixed known and unknown calls in one response'
+    ref: 'derived from TOOLCALLING.batch.13.c'
     tools:
     - name: get_weather
       parameters:
@@ -71,72 +76,65 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'unknown_tool'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "unknown_tool",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "LA"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "LA"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls in JSON array
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls in JSON array'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,78 +32,71 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_time",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_time",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"timezone": "EST"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"timezone": "EST"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -109,79 +111,72 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: [TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: 'Both: '
         vllm_python: 'Both: '
         sglang_python: 'Both: '
-        vllm_rust: 'Both: '
     - delta_text: '[{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather', arguments: '{"location":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather", "arguments": {"location":'
     - delta_text: ' "NYC"}}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "NYC"}}, {"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": {"timezone":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"timezone":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"timezone":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"timezone":'
     - delta_text: ' "EST"}}][/TOOL_CALLS] Done.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "EST"}}][/TOOL_CALLS] Done.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -192,72 +187,65 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "LA"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "LA"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "LA"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.30.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.30.a:
-    description: JSON-array call separator `,` inside one argument string value
-    ref: derived from TOOLCALLING.batch.30.a
+    description: 'JSON-array call separator `,` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.a'
     tools:
     - name: run_query
       parameters:
@@ -17,71 +26,64 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' a, SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' a, SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' a, SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' a, SELECT'
     - delta_text: ' b"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' b"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' b"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' b"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.30.b:
-    description: JSON structural delimiters `}` and `]` inside one argument string
-      value
-    ref: derived from TOOLCALLING.batch.30.b
+    description: 'JSON structural delimiters `}` and `]` inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.b'
     tools:
     - name: run_query
       parameters:
@@ -90,97 +92,87 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' value WHERE'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' value WHERE'
     - delta_text: ' note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' note'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' note'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' note'
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' has brace'
     - delta_text: ' } and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' } and bracket'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' } and bracket'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' } and bracket'
     - delta_text: ' ]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' ]'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' ]'
     - delta_text: '"}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '"}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.30.c:
-    description: Mistral wrapper marker `[TOOL_CALLS]...[/TOOL_CALLS]` text inside
-      one argument string value
-    ref: derived from TOOLCALLING.batch.30.c
+    description: 'Mistral wrapper marker `[TOOL_CALLS]...[/TOOL_CALLS]` text inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.30.c'
     tools:
     - name: run_query
       parameters:
@@ -189,72 +181,65 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "literal'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "literal'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "literal'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "literal'
     - delta_text: ' [TOOL_CALLS marker]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [TOOL_CALLS marker]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' [TOOL_CALLS marker]'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' [TOOL_CALLS marker]'
     - delta_text: '[]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '[]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '[]'}
+        sglang_python: []
       normal_text:
         vllm_rust: '[]'
     - delta_text: '[/TOOL_CALLS marker]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '[/TOOL_CALLS marker]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '[/TOOL_CALLS marker]'}
+        sglang_python: []
       normal_text:
         vllm_rust: '[/TOOL_CALLS marker]'
     - delta_text: ' stays text"}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' stays text"}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.31.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.31.a:
-    description: Multi-call JSON array with call separator `,` inside the first argument
-      string
-    ref: derived from TOOLCALLING.batch.31.a
+    description: 'Multi-call JSON array with call separator `,` inside the first argument string'
+    ref: 'derived from TOOLCALLING.batch.31.a'
     tools:
     - name: run_query
       parameters:
@@ -24,90 +32,80 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' a, SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' a, SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' a, SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' a, SELECT'
     - delta_text: ' b"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' b"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' b"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' b"}},'
     - delta_text: ' {"name": "get_time",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_time",'
     - delta_text: ' "arguments": {"timezone": "EST"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"timezone": "EST"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.31.b:
-    description: Multi-call response with structural delimiters inside one argument
-      string value
-    ref: derived from TOOLCALLING.batch.31.b
+    description: 'Multi-call response with structural delimiters inside one argument string value'
+    ref: 'derived from TOOLCALLING.batch.31.b'
     tools:
     - name: run_query
       parameters:
@@ -122,127 +120,114 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "run_query",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: run_query
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'run_query'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "run_query",'
     - delta_text: ' "arguments": {"sql": "SELECT'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"sql": "SELECT'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"sql": "SELECT'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"sql": "SELECT'
     - delta_text: ' value WHERE'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' value WHERE'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' value WHERE'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' value WHERE'
     - delta_text: ' note'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' note'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' note'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' note'
     - delta_text: ' has brace'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' has brace'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' has brace'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' has brace'
     - delta_text: ' } and bracket'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' } and bracket'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' } and bracket'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' } and bracket'
     - delta_text: ' ]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' ]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' ]'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' ]'
     - delta_text: '"}}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: '"}}, {"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": {"timezone":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"timezone":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"timezone":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"timezone":'
     - delta_text: ' "EST"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "EST"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "EST"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "EST"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: TOOL_CALLS wrapper with garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'TOOL_CALLS wrapper with garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,39 +26,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS]not'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS]not'
     - delta_text: ' a'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' a'
     - delta_text: ' json array[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' json array[/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace in JSON
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace in JSON'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -58,49 +66,46 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing name key
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing name key'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -109,42 +114,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"arguments":'
     - delta_text: ' {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, arguments: '{"location":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location":'
     - delta_text: ' "NYC"}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "NYC"}}][/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing [/TOOL_CALLS] close
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing [/TOOL_CALLS] close'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -153,38 +155,34 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing [/TOOL_CALLS] end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing [/TOOL_CALLS] end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,44 +26,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -63,45 +68,44 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[{"name": "get_weather",'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '[{"name": "get_weather",'
         vllm_python: '[{"name": "get_weather",'
         sglang_python: '[{"name": "get_weather",'
-        vllm_rust: '[{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' "arguments":'
         vllm_python: ' "arguments":'
         sglang_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' {"location": "NYC"}}][/TOOL_CALLS]'
         vllm_python: ' {"location": "NYC"}}][/TOOL_CALLS]'
         sglang_python: ' {"location": "NYC"}}[/TOOL_CALLS'
-        vllm_rust: ' {"location": "NYC"}}][/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-arguments JSON'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -110,44 +114,40 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"loc'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"loc'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"loc'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"loc'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -156,155 +156,146 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        vllm_rust: I'll start
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
-        vllm_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        vllm_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
-        vllm_rust: ' for both'
     - delta_text: ' Boston'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        vllm_rust: ' Boston'
     - delta_text: ' and New'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
-        vllm_rust: ' and New'
     - delta_text: ' York at the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        vllm_rust: ' York at the'
     - delta_text: ' same'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-        vllm_rust: ' same'
     - delta_text: ' time![TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' time![TOOL_CALLS][{"name":'
         vllm_python: ' time!'
         sglang_python: ' time!'
-        vllm_rust: ' time![TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location":'
     - delta_text: ' "Boston"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "Boston"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "Boston"}},'
     - delta_text: ' {"name": "get_weather", "arguments":'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_weather", "arguments":'
     - delta_text: ' {"location": "New'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "New'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location": "New'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "New'
     - delta_text: ' York"}}]'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' York"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: ' York"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' York"}}]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -313,149 +304,140 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
-        vllm_rust: I'll start
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
-        vllm_rust: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
-        vllm_rust: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
-        vllm_rust: ' for both'
     - delta_text: ' Boston'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
-        vllm_rust: ' Boston'
     - delta_text: ' and New'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
-        vllm_rust: ' and New'
     - delta_text: ' York at the'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
-        vllm_rust: ' York at the'
     - delta_text: ' same'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-        vllm_rust: ' same'
     - delta_text: ' time![TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' time![TOOL_CALLS][{"name":'
         vllm_python: ' time!'
         sglang_python: ' time!'
-        vllm_rust: ' time![TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location":'
     - delta_text: ' "Boston"}},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "Boston"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "Boston"}},'
     - delta_text: ' {"name": "get_weather", "arguments":'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"name": "get_weather", "arguments":'
     - delta_text: ' {"location": "New'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location": "New'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: '{"location": "New'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "New'
     - delta_text: ' York'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' York'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 1, arguments: ' York'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' York'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,96 +26,95 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[T'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_python: '[T'
-    - delta_text: OOL
+    - delta_text: 'OOL'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: OOL
-    - delta_text: _CALL
+        vllm_python: 'OOL'
+    - delta_text: '_CALL'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: _CALL
+        vllm_python: '_CALL'
     - delta_text: 'S][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather", "ar'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "get_weather", "ar'
-    - delta_text: gu
+    - delta_text: 'gu'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: gu
-    - delta_text: men
+        vllm_rust: 'gu'
+    - delta_text: 'men'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: men
+        vllm_rust: 'men'
     - delta_text: 'ts": '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: 'ts": '
     - delta_text: '{"location"'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '{"location"'
     - delta_text: ': "NYC"}}][/TOOL_CA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ': "NYC"}}][/TOOL_CA'
-    - delta_text: LL
+    - delta_text: 'LL'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: LL
-    - delta_text: S]
+        vllm_rust: 'LL'
+    - delta_text: 'S]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_rust: S]
+        vllm_rust: 'S]'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.6.yaml
@@ -1,145 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
-    ref: derived from TOOLCALLING.batch.6.a
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": {}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments": {}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside arguments {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside arguments {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_time",'
     - delta_text: ' "arguments": { }}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{ }'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{ }'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": { }}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.c:
-    description: No arguments key
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No arguments key'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_time"}]'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_time"}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,69 +30,63 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "book_flight",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "book_flight",'
     - delta_text: ' "arguments": {"destination": "Paris",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris",'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"destination": "Paris",'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"destination": "Paris",'
     - delta_text: ' "passengers": 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "passengers": 2,'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "passengers": 2,'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "passengers": 2,'
     - delta_text: ' "first_class":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "first_class":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "first_class":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "first_class":'
     - delta_text: ' true}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' true}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -92,51 +95,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "Tōkyō'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "Tōkyō'
     - delta_text: ' \"central\""}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' \"central\""}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -145,52 +144,48 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "set_temperature",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "set_temperature",'
     - delta_text: ' "arguments": {"celsius": "20"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"celsius": "20"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -201,69 +196,63 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "process_data",'
     - delta_text: ' "arguments": {"items": [1,2,3]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items": [1,2,3]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"items": [1,2,3]'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"items": [1,2,3]'
     - delta_text: ', "config":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "config":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ', "config":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ', "config":'
     - delta_text: ' {"nested":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' {"nested":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' {"nested":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"nested":'
     - delta_text: ' true}}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' true}}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -272,159 +261,143 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "process_data",'
     - delta_text: ' "arguments": {"payload": {"regions":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload": {"regions":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"payload": {"regions":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"payload": {"regions":'
     - delta_text: ' [{"name": "west",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [{"name": "west",'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' [{"name": "west",'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' [{"name": "west",'
     - delta_text: ' "scores":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "scores":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "scores":'
     - delta_text: ' [1, 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [1, 2,'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' [1, 2,'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' [1, 2,'
     - delta_text: ' 3]}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 3]}, {"name":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' 3]}, {"name":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' 3]}, {"name":'
     - delta_text: ' "east",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "east",'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "east",'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "east",'
     - delta_text: ' "scores": [4,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores": [4,'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "scores": [4,'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "scores": [4,'
     - delta_text: ' 5,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 5,'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' 5,'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' 5,'
     - delta_text: ' 6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 6]}]'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' 6]}]'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' 6]}]'
     - delta_text: ','
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ','
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ','}
+        sglang_python: []
       normal_text:
         vllm_rust: ','
     - delta_text: ' "flags": {"enabled": true,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "flags": {"enabled": true,'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "flags": {"enabled": true,'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "flags": {"enabled": true,'
     - delta_text: ' "retry": null},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "retry": null},'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "retry": null},'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "retry": null},'
     - delta_text: ' "empty":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "empty":'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: ' "empty":'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "empty":'
     - delta_text: ' {}}}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' {}}}}][/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -433,46 +406,42 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "set_limit",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "set_limit",'
     - delta_text: ' "arguments": {"count": 9007199254740993}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"count": 9007199254740993}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,79 +26,75 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. [TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '[{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS]'
         vllm_rust: '[/TOOL_CALLS]'
+        vllm_python: '[/TOOL_CALLS]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -98,76 +103,72 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '[TOOL_CALLS][{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS] Let'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS] Let'
         vllm_rust: '[/TOOL_CALLS] Let'
+        vllm_python: '[/TOOL_CALLS] Let'
     - delta_text: ' me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' me'
         vllm_rust: ' me'
+        vllm_python: ' me'
     - delta_text: ' know if'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' know if'
         vllm_rust: ' know if'
+        vllm_python: ' know if'
     - delta_text: ' you need more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' you need more.'
         vllm_rust: ' you need more.'
+        vllm_python: ' you need more.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -176,111 +177,107 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. [TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '[{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS] Let me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS] Let me'
         vllm_rust: '[/TOOL_CALLS] Let me'
+        vllm_python: '[/TOOL_CALLS] Let me'
     - delta_text: ' know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' know'
         vllm_rust: ' know'
+        vllm_python: ' know'
     - delta_text: ' if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' if you'
         vllm_rust: ' if you'
+        vllm_python: ' if you'
     - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' need'
         vllm_rust: ' need'
+        vllm_python: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' more.'
         vllm_rust: ' more.'
+        vllm_python: ' more.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -289,121 +286,117 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. [TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-        vllm_rust: ' the weather. '
     - delta_text: '[{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python: []
       normal_text:
         vllm_rust: '[TOOL_CALLS][{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         vllm_rust: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust: []
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         vllm_rust: ' {"location": "NYC"}}]'
     - delta_text: '[/TOOL_CALLS] Then check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[/TOOL_CALLS] Then check'
         vllm_rust: '[/TOOL_CALLS] Then check'
+        vllm_python: '[/TOOL_CALLS] Then check'
     - delta_text: ' LA'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' LA'
         vllm_rust: ' LA'
+        vllm_python: ' LA'
     - delta_text: ' weather. [TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' weather. '
         vllm_rust: ' weather. '
+        vllm_python: ' weather. '
     - delta_text: '[{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: '[{"name":'
         vllm_rust: '[TOOL_CALLS][{"name":'
+        vllm_python: '[{"name":'
     - delta_text: ' "get_weather", "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "get_weather", "arguments":'
         vllm_rust: ' "get_weather", "arguments":'
+        vllm_python: ' "get_weather", "arguments":'
     - delta_text: ' {"location":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' {"location":'
         vllm_rust: ' {"location":'
+        vllm_python: ' {"location":'
     - delta_text: ' "LA"}}][/TOOL_CALLS]'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' "LA"}}][/TOOL_CALLS]'
         vllm_rust: ' "LA"}}][/TOOL_CALLS]'
+        vllm_python: ' "LA"}}][/TOOL_CALLS]'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/mistral/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: mistral
-model_label: Mistral series
+model_label: 'Mistral series'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.1.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -16,40 +25,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}]'
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' "arguments": {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.10.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -16,61 +25,60 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}},'
         vllm_rust: ' "arguments": {"location": "NYC"}},'
+        vllm_python: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"name": "get_weather",'
         vllm_rust: ' {"name": "get_weather",'
+        vllm_python: ' {"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "LA"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location": "LA"}}]'
         vllm_rust: ' {"location": "LA"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' {"location": "LA"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.13.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -16,40 +25,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "unknown_tool",'
         vllm_rust: ' "unknown_tool",'
+        vllm_python: ' "unknown_tool",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}]'
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' "arguments": {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.2.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls in JSON array
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls in JSON array'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -22,142 +31,66 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}},'
         vllm_rust: ' "arguments": {"location": "NYC"}},'
+        vllm_python: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_time",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"name": "get_time",'
         vllm_rust: ' {"name": "get_time",'
+        vllm_python: ' {"name": "get_time",'
     - delta_text: ' "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"timezone": "EST"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"timezone": "EST"}}]'
         vllm_rust: ' {"timezone": "EST"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' {"timezone": "EST"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.2.b:
-    description: Two back-to-back TOOLCALL wrappers
-    ref: derived from TOOLCALLING.batch.2.b
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
-        vllm_rust: '<TOOLCALL>[{"name":'
-    - delta_text: ' "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_weather",'
-        vllm_rust: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}]'
-        vllm_rust: ' "arguments": {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL><TOOLCALL>
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL><TOOLCALL>
-        vllm_rust: </TOOLCALL><TOOLCALL>
-    - delta_text: '[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '[{"name":'
-        vllm_rust: '[{"name":'
-    - delta_text: ' "get_time", "arguments":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_time", "arguments":'
-        vllm_rust: ' "get_time", "arguments":'
-    - delta_text: ' {"timezone": "EST"}}]</TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' {"timezone": "EST"}}]</TOOLCALL>'
-        vllm_rust: ' {"timezone": "EST"}}]</TOOLCALL>'
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
-  TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+        vllm_python: []
+  TOOLCALLING.streamv2.2.b:
+    description: 'Two back-to-back TOOLCALL wrappers'
+    ref: 'derived from TOOLCALLING.batch.2.b'
     tools:
     - name: get_weather
       parameters:
@@ -172,67 +105,140 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
+    - delta_text: ' "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
+    - delta_text: ' "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments": {"location": "NYC"}}]'
+        vllm_python: ' "arguments": {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL><TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL><TOOLCALL>'
+        vllm_python: '</TOOLCALL><TOOLCALL>'
+    - delta_text: '[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '[{"name":'
+        vllm_python: '[{"name":'
+    - delta_text: ' "get_time", "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_time", "arguments":'
+        vllm_python: ' "get_time", "arguments":'
+    - delta_text: ' {"timezone": "EST"}}]</TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' {"timezone": "EST"}}]</TOOLCALL>'
+        vllm_python: ' {"timezone": "EST"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.2.c:
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: 'Both: <TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: 'Both: <TOOLCALL>'
         vllm_rust: 'Both: <TOOLCALL>'
+        vllm_python: 'Both: <TOOLCALL>'
     - delta_text: '[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '[{"name":'
         vllm_rust: '[{"name":'
+        vllm_python: '[{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather", "arguments": {"location":'
         vllm_rust: ' "get_weather", "arguments": {"location":'
+        vllm_python: ' "get_weather", "arguments": {"location":'
     - delta_text: ' "NYC"}}, {"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "NYC"}}, {"name":'
         vllm_rust: ' "NYC"}}, {"name":'
+        vllm_python: ' "NYC"}}, {"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_time",'
         vllm_rust: ' "get_time",'
+        vllm_python: ' "get_time",'
     - delta_text: ' "arguments": {"timezone":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"timezone":'
         vllm_rust: ' "arguments": {"timezone":'
+        vllm_python: ' "arguments": {"timezone":'
     - delta_text: ' "EST"}}]</TOOLCALL> Done.'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "EST"}}]</TOOLCALL> Done.'
         vllm_rust: ' "EST"}}]</TOOLCALL> Done.'
+        vllm_python: ' "EST"}}]</TOOLCALL> Done.'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -243,61 +249,60 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}},'
         vllm_rust: ' "arguments": {"location": "NYC"}},'
+        vllm_python: ' "arguments": {"location": "NYC"}},'
     - delta_text: ' {"name": "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"name": "get_weather",'
         vllm_rust: ' {"name": "get_weather",'
+        vllm_python: ' {"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "LA"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location": "LA"}}]'
         vllm_rust: ' {"location": "LA"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' {"location": "LA"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.3.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -16,40 +25,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
     - delta_text: ' can'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' can'
         vllm_rust: ' can'
+        vllm_python: ' can'
     - delta_text: ' I help you'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' I help you'
         vllm_rust: ' I help you'
+        vllm_python: ' I help you'
     - delta_text: ' today?'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' today?'
         vllm_rust: ' today?'
+        vllm_python: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.4.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: TOOLCALL wrapper with garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'TOOLCALL wrapper with garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,39 +25,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: <TOOLCALL>not
+    - delta_text: '<TOOLCALL>not'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: <TOOLCALL>not
-        vllm_rust: <TOOLCALL>not
+        vllm_rust: '<TOOLCALL>not'
+        vllm_python: '<TOOLCALL>not'
     - delta_text: ' a'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' a'
         vllm_rust: ' a'
+        vllm_python: ' a'
     - delta_text: ' json array</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' json array</TOOLCALL>'
         vllm_rust: ' json array</TOOLCALL>'
+        vllm_python: ' json array</TOOLCALL>'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Unterminated JSON string in args
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Unterminated JSON string in args'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -57,39 +65,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC</TOOLCALL>'
         vllm_rust: ' "arguments": {"location": "NYC</TOOLCALL>'
+        vllm_python: ' "arguments": {"location": "NYC</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing name key in JSON
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing name key in JSON'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -98,39 +105,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"arguments":'
         vllm_rust: '<TOOLCALL>[{"arguments":'
+        vllm_python: '<TOOLCALL>[{"arguments":'
     - delta_text: ' {"location":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location":'
         vllm_rust: ' {"location":'
+        vllm_python: ' {"location":'
     - delta_text: ' "NYC"}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "NYC"}}]</TOOLCALL>'
         vllm_rust: ' "NYC"}}]</TOOLCALL>'
+        vllm_python: ' "NYC"}}]</TOOLCALL>'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Mismatched JSON brackets
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Mismatched JSON brackets'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -139,33 +145,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}</TOOLCALL>'
         vllm_rust: ' "arguments": {"location": "NYC"}}</TOOLCALL>'
+        vllm_python: ' "arguments": {"location": "NYC"}}</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.5.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </TOOLCALL> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </TOOLCALL> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,121 +25,38 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}]'
         vllm_rust: ' "arguments": {"location": "NYC"}}]'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.5.b:
-    description: Closing </TOOLCALL> without matching <TOOLCALL> open
-    ref: derived from TOOLCALLING.batch.5.b
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '[{"name": "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '[{"name": "get_weather",'
-        vllm_rust: '[{"name": "get_weather",'
-    - delta_text: ' "arguments":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}]</TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' {"location": "NYC"}}]</TOOLCALL>'
-        vllm_rust: ' {"location": "NYC"}}]</TOOLCALL>'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON
-    ref: derived from TOOLCALLING.batch.5.c
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
-        vllm_rust: '<TOOLCALL>[{"name":'
-    - delta_text: ' "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_weather",'
-        vllm_rust: ' "get_weather",'
-    - delta_text: ' "arguments": {"loc'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments": {"loc'
-        vllm_rust: ' "arguments": {"loc'
+        vllm_python: ' "arguments": {"location": "NYC"}}]'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
-  TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+        vllm_python: []
+  TOOLCALLING.streamv2.5.b:
+    description: 'Closing </TOOLCALL> without matching <TOOLCALL> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -139,123 +65,202 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: '[{"name": "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: I'll start
-        vllm_rust: I'll start
-    - delta_text: ' by'
+        vllm_rust: '[{"name": "get_weather",'
+        vllm_python: '[{"name": "get_weather",'
+    - delta_text: ' "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' by'
-        vllm_rust: ' by'
-    - delta_text: ' fetching the weather'
+        vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
+    - delta_text: ' {"location": "NYC"}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' fetching the weather'
-        vllm_rust: ' fetching the weather'
-    - delta_text: ' for both'
+        vllm_rust: ' {"location": "NYC"}}]</TOOLCALL>'
+        vllm_python: ' {"location": "NYC"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
-      normal_text:
-        vllm_python: ' for both'
-        vllm_rust: ' for both'
-    - delta_text: ' Boston'
+        vllm_python: []
+  TOOLCALLING.streamv2.5.c:
+    description: 'Truncation mid-arguments JSON'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
-      normal_text:
-        vllm_python: ' Boston'
-        vllm_rust: ' Boston'
-    - delta_text: ' and New'
-      expected:
         vllm_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' and New'
-        vllm_rust: ' and New'
-    - delta_text: ' York at the'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' York at the'
-        vllm_rust: ' York at the'
-    - delta_text: ' same'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' same'
-        vllm_rust: ' same'
-    - delta_text: ' time!<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' time!<TOOLCALL>[{"name":'
-        vllm_rust: ' time!<TOOLCALL>[{"name":'
+        vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
+    - delta_text: ' "arguments": {"loc'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments": {"loc'
+        vllm_python: ' "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.5.d:
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: 'I''ll start'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
+    - delta_text: ' by'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' by'
+        vllm_python: ' by'
+    - delta_text: ' fetching the weather'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' fetching the weather'
+        vllm_python: ' fetching the weather'
+    - delta_text: ' for both'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' for both'
+        vllm_python: ' for both'
+    - delta_text: ' Boston'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' Boston'
+        vllm_python: ' Boston'
+    - delta_text: ' and New'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' and New'
+        vllm_python: ' and New'
+    - delta_text: ' York at the'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' York at the'
+        vllm_python: ' York at the'
+    - delta_text: ' same'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' same'
+        vllm_python: ' same'
+    - delta_text: ' time!<TOOLCALL>[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' time!<TOOLCALL>[{"name":'
+        vllm_python: ' time!<TOOLCALL>[{"name":'
+    - delta_text: ' "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location":'
         vllm_rust: ' "arguments": {"location":'
+        vllm_python: ' "arguments": {"location":'
     - delta_text: ' "Boston"}},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "Boston"}},'
         vllm_rust: ' "Boston"}},'
+        vllm_python: ' "Boston"}},'
     - delta_text: ' {"name": "get_weather", "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"name": "get_weather", "arguments":'
         vllm_rust: ' {"name": "get_weather", "arguments":'
+        vllm_python: ' {"name": "get_weather", "arguments":'
     - delta_text: ' {"location": "New'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location": "New'
         vllm_rust: ' {"location": "New'
+        vllm_python: ' {"location": "New'
     - delta_text: ' York"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' York"}}]'
         vllm_rust: ' York"}}]'
+        vllm_python: ' York"}}]'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -264,117 +269,116 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: I'll start
-        vllm_rust: I'll start
+        vllm_rust: 'I''ll start'
+        vllm_python: 'I''ll start'
     - delta_text: ' by'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' by'
         vllm_rust: ' by'
+        vllm_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' fetching the weather'
         vllm_rust: ' fetching the weather'
+        vllm_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' for both'
         vllm_rust: ' for both'
+        vllm_python: ' for both'
     - delta_text: ' Boston'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' Boston'
         vllm_rust: ' Boston'
+        vllm_python: ' Boston'
     - delta_text: ' and New'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' and New'
         vllm_rust: ' and New'
+        vllm_python: ' and New'
     - delta_text: ' York at the'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' York at the'
         vllm_rust: ' York at the'
+        vllm_python: ' York at the'
     - delta_text: ' same'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' same'
         vllm_rust: ' same'
+        vllm_python: ' same'
     - delta_text: ' time!<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' time!<TOOLCALL>[{"name":'
         vllm_rust: ' time!<TOOLCALL>[{"name":'
+        vllm_python: ' time!<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location":'
         vllm_rust: ' "arguments": {"location":'
+        vllm_python: ' "arguments": {"location":'
     - delta_text: ' "Boston"}},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "Boston"}},'
         vllm_rust: ' "Boston"}},'
+        vllm_python: ' "Boston"}},'
     - delta_text: ' {"name": "get_weather", "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"name": "get_weather", "arguments":'
         vllm_rust: ' {"name": "get_weather", "arguments":'
+        vllm_python: ' {"name": "get_weather", "arguments":'
     - delta_text: ' {"location": "New'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location": "New'
         vllm_rust: ' {"location": "New'
+        vllm_python: ' {"location": "New'
     - delta_text: ' York'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' York'
         vllm_rust: ' York'
+        vllm_python: ' York'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.50.yaml
@@ -1,14 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,82 +25,81 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: <T
+    - delta_text: '<T'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: <T
-        vllm_rust: <T
-    - delta_text: OOL
+        vllm_rust: '<T'
+        vllm_python: '<T'
+    - delta_text: 'OOL'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: OOL
-        vllm_rust: OOL
-    - delta_text: CALL>
+        vllm_rust: 'OOL'
+        vllm_python: 'OOL'
+    - delta_text: 'CALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: CALL>
-        vllm_rust: CALL>
+        vllm_rust: 'CALL>'
+        vllm_python: 'CALL>'
     - delta_text: '[{"name": "'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '[{"name": "'
         vllm_rust: '[{"name": "'
-    - delta_text: get_weather", "argu
+        vllm_python: '[{"name": "'
+    - delta_text: 'get_weather", "argu'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: get_weather", "argu
-        vllm_rust: get_weather", "argu
-    - delta_text: me
+        vllm_rust: 'get_weather", "argu'
+        vllm_python: 'get_weather", "argu'
+    - delta_text: 'me'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: me
-        vllm_rust: me
-    - delta_text: nts
+        vllm_rust: 'me'
+        vllm_python: 'me'
+    - delta_text: 'nts'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: nts
-        vllm_rust: nts
+        vllm_rust: 'nts'
+        vllm_python: 'nts'
     - delta_text: '": {"'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '": {"'
         vllm_rust: '": {"'
+        vllm_python: '": {"'
     - delta_text: 'location": '
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: 'location": '
         vllm_rust: 'location": '
+        vllm_python: 'location": '
     - delta_text: '"NYC"}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '"NYC"}}]</TOOLCALL>'
         vllm_rust: '"NYC"}}]</TOOLCALL>'
+        vllm_python: '"NYC"}}]</TOOLCALL>'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.6.yaml
@@ -1,131 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
-    ref: derived from TOOLCALLING.batch.6.a
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_time",'
         vllm_rust: ' "get_time",'
+        vllm_python: ' "get_time",'
     - delta_text: ' "arguments": {}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {}}]</TOOLCALL>'
         vllm_rust: ' "arguments": {}}]</TOOLCALL>'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside arguments {}
-    ref: derived from TOOLCALLING.batch.6.b
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
-        vllm_rust: '<TOOLCALL>[{"name":'
-    - delta_text: ' "get_time",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_time",'
-        vllm_rust: ' "get_time",'
-    - delta_text: ' "arguments": { }}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments": { }}]'
-        vllm_rust: ' "arguments": { }}]'
-    - delta_text: </TOOLCALL>
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.6.c:
-    description: No arguments key
-    ref: derived from TOOLCALLING.batch.6.c
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
-        vllm_rust: '<TOOLCALL>[{"name":'
-    - delta_text: ' "get_time"}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_time"}]'
-        vllm_rust: ' "get_time"}]'
-    - delta_text: </TOOLCALL>
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_python: ' "arguments": {}}]</TOOLCALL>'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.6.b:
+    description: 'Whitespace inside arguments {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
+    - delta_text: ' "get_time",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_time",'
+        vllm_python: ' "get_time",'
+    - delta_text: ' "arguments": { }}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments": { }}]'
+        vllm_python: ' "arguments": { }}]'
+    - delta_text: '</TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.6.c:
+    description: 'No arguments key'
+    ref: 'derived from TOOLCALLING.batch.6.c'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
+    - delta_text: ' "get_time"}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_time"}]'
+        vllm_python: ' "get_time"}]'
+    - delta_text: '</TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.7.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -20,60 +29,59 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "book_flight",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "book_flight",'
         vllm_rust: ' "book_flight",'
+        vllm_python: ' "book_flight",'
     - delta_text: ' "arguments": {"destination": "Paris",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"destination": "Paris",'
         vllm_rust: ' "arguments": {"destination": "Paris",'
+        vllm_python: ' "arguments": {"destination": "Paris",'
     - delta_text: ' "passengers": 2,'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "passengers": 2,'
         vllm_rust: ' "passengers": 2,'
+        vllm_python: ' "passengers": 2,'
     - delta_text: ' "first_class":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "first_class":'
         vllm_rust: ' "first_class":'
+        vllm_python: ' "first_class":'
     - delta_text: ' true}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' true}}]</TOOLCALL>'
         vllm_rust: ' true}}]</TOOLCALL>'
+        vllm_python: ' true}}]</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -82,46 +90,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "get_weather",'
         vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "Tōkyō'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"location": "Tōkyō'
         vllm_rust: ' "arguments": {"location": "Tōkyō'
+        vllm_python: ' "arguments": {"location": "Tōkyō'
     - delta_text: ' \"central\""}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' \"central\""}}]</TOOLCALL>'
         vllm_rust: ' \"central\""}}]</TOOLCALL>'
+        vllm_python: ' \"central\""}}]</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -130,46 +137,45 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "set_temperature",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "set_temperature",'
         vllm_rust: ' "set_temperature",'
+        vllm_python: ' "set_temperature",'
     - delta_text: ' "arguments": {"celsius": "20"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"celsius": "20"}}]'
         vllm_rust: ' "arguments": {"celsius": "20"}}]'
-    - delta_text: </TOOLCALL>
+        vllm_python: ' "arguments": {"celsius": "20"}}]'
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array (existing)
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array (existing)'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -180,60 +186,59 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "process_data",'
         vllm_rust: ' "process_data",'
+        vllm_python: ' "process_data",'
     - delta_text: ' "arguments": {"items": [1,2,3]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"items": [1,2,3]'
         vllm_rust: ' "arguments": {"items": [1,2,3]'
+        vllm_python: ' "arguments": {"items": [1,2,3]'
     - delta_text: ', "config":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ', "config":'
         vllm_rust: ', "config":'
+        vllm_python: ', "config":'
     - delta_text: ' {"nested":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"nested":'
         vllm_rust: ' {"nested":'
+        vllm_python: ' {"nested":'
     - delta_text: ' true}}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' true}}}]</TOOLCALL>'
         vllm_rust: ' true}}}]</TOOLCALL>'
+        vllm_python: ' true}}}]</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -242,124 +247,123 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '<TOOLCALL>[{"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
         vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "process_data",'
         vllm_rust: ' "process_data",'
+        vllm_python: ' "process_data",'
     - delta_text: ' "arguments": {"payload": {"regions":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments": {"payload": {"regions":'
         vllm_rust: ' "arguments": {"payload": {"regions":'
+        vllm_python: ' "arguments": {"payload": {"regions":'
     - delta_text: ' [{"name": "west",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' [{"name": "west",'
         vllm_rust: ' [{"name": "west",'
+        vllm_python: ' [{"name": "west",'
     - delta_text: ' "scores":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "scores":'
         vllm_rust: ' "scores":'
+        vllm_python: ' "scores":'
     - delta_text: ' [1, 2,'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' [1, 2,'
         vllm_rust: ' [1, 2,'
+        vllm_python: ' [1, 2,'
     - delta_text: ' 3]}, {"name":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' 3]}, {"name":'
         vllm_rust: ' 3]}, {"name":'
+        vllm_python: ' 3]}, {"name":'
     - delta_text: ' "east",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "east",'
         vllm_rust: ' "east",'
+        vllm_python: ' "east",'
     - delta_text: ' "scores": [4,'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "scores": [4,'
         vllm_rust: ' "scores": [4,'
+        vllm_python: ' "scores": [4,'
     - delta_text: ' 5,'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' 5,'
         vllm_rust: ' 5,'
+        vllm_python: ' 5,'
     - delta_text: ' 6]}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' 6]}]'
         vllm_rust: ' 6]}]'
+        vllm_python: ' 6]}]'
     - delta_text: ','
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ','
         vllm_rust: ','
+        vllm_python: ','
     - delta_text: ' "flags": {"enabled": true,'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "flags": {"enabled": true,'
         vllm_rust: ' "flags": {"enabled": true,'
+        vllm_python: ' "flags": {"enabled": true,'
     - delta_text: ' "retry": null},'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "retry": null},'
         vllm_rust: ' "retry": null},'
+        vllm_python: ' "retry": null},'
     - delta_text: ' "empty":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "empty":'
         vllm_rust: ' "empty":'
+        vllm_python: ' "empty":'
     - delta_text: ' {}}}}]</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {}}}}]</TOOLCALL>'
         vllm_rust: ' {}}}}]</TOOLCALL>'
+        vllm_python: ' {}}}}]</TOOLCALL>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.8.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,338 +25,334 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
     - delta_text: ' check'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' check'
         vllm_rust: ' check'
+        vllm_python: ' check'
     - delta_text: ' the weather. <TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' the weather. <TOOLCALL>'
         vllm_rust: ' the weather. <TOOLCALL>'
+        vllm_python: ' the weather. <TOOLCALL>'
     - delta_text: '[{"name": "get_weather",'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '[{"name": "get_weather",'
         vllm_rust: '[{"name": "get_weather",'
+        vllm_python: '[{"name": "get_weather",'
     - delta_text: ' "arguments":'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' "arguments":'
         vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
     - delta_text: ' {"location": "NYC"}}]'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' {"location": "NYC"}}]'
         vllm_rust: ' {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL>
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL>
-        vllm_rust: </TOOLCALL>
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: '<TOOLCALL>[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '<TOOLCALL>[{"name":'
-        vllm_rust: '<TOOLCALL>[{"name":'
-    - delta_text: ' "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_weather",'
-        vllm_rust: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments": {"location": "NYC"}}]'
-        vllm_rust: ' "arguments": {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL> Let
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL> Let
-        vllm_rust: </TOOLCALL> Let
-    - delta_text: ' me'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' me'
-        vllm_rust: ' me'
-    - delta_text: ' know if'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' know if'
-        vllm_rust: ' know if'
-    - delta_text: ' you need more.'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' you need more.'
-        vllm_rust: ' you need more.'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: I will
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: I will
-        vllm_rust: I will
-    - delta_text: ' check'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' check'
-        vllm_rust: ' check'
-    - delta_text: ' the weather. <TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' the weather. <TOOLCALL>'
-        vllm_rust: ' the weather. <TOOLCALL>'
-    - delta_text: '[{"name": "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '[{"name": "get_weather",'
-        vllm_rust: '[{"name": "get_weather",'
-    - delta_text: ' "arguments":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
         vllm_python: ' {"location": "NYC"}}]'
-        vllm_rust: ' {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL> Let me
+    - delta_text: '</TOOLCALL>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: </TOOLCALL> Let me
-        vllm_rust: </TOOLCALL> Let me
-    - delta_text: ' know'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' know'
-        vllm_rust: ' know'
-    - delta_text: ' if you'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' if you'
-        vllm_rust: ' if you'
-    - delta_text: ' need'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' need'
-        vllm_rust: ' need'
-    - delta_text: ' more.'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' more.'
-        vllm_rust: ' more.'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
-    chunks:
-    - delta_text: I will
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: I will
-        vllm_rust: I will
-    - delta_text: ' check'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' check'
-        vllm_rust: ' check'
-    - delta_text: ' the weather. <TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' the weather. <TOOLCALL>'
-        vllm_rust: ' the weather. <TOOLCALL>'
-    - delta_text: '[{"name": "get_weather",'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '[{"name": "get_weather",'
-        vllm_rust: '[{"name": "get_weather",'
-    - delta_text: ' "arguments":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}]'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' {"location": "NYC"}}]'
-        vllm_rust: ' {"location": "NYC"}}]'
-    - delta_text: </TOOLCALL> Then check
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: </TOOLCALL> Then check
-        vllm_rust: </TOOLCALL> Then check
-    - delta_text: ' LA'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' LA'
-        vllm_rust: ' LA'
-    - delta_text: ' weather. <TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' weather. <TOOLCALL>'
-        vllm_rust: ' weather. <TOOLCALL>'
-    - delta_text: '[{"name":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '[{"name":'
-        vllm_rust: '[{"name":'
-    - delta_text: ' "get_weather", "arguments":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "get_weather", "arguments":'
-        vllm_rust: ' "get_weather", "arguments":'
-    - delta_text: ' {"location":'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' {"location":'
-        vllm_rust: ' {"location":'
-    - delta_text: ' "LA"}}]</TOOLCALL>'
-      expected:
-        vllm_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "LA"}}]</TOOLCALL>'
-        vllm_rust: ' "LA"}}]</TOOLCALL>'
+        vllm_rust: '</TOOLCALL>'
+        vllm_python: '</TOOLCALL>'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.8.b:
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '<TOOLCALL>[{"name":'
+        vllm_python: '<TOOLCALL>[{"name":'
+    - delta_text: ' "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_weather",'
+        vllm_python: ' "get_weather",'
+    - delta_text: ' "arguments": {"location": "NYC"}}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments": {"location": "NYC"}}]'
+        vllm_python: ' "arguments": {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL> Let'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL> Let'
+        vllm_python: '</TOOLCALL> Let'
+    - delta_text: ' me'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' me'
+        vllm_python: ' me'
+    - delta_text: ' know if'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' know if'
+        vllm_python: ' know if'
+    - delta_text: ' you need more.'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' you need more.'
+        vllm_python: ' you need more.'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.8.c:
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: 'I will'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+    - delta_text: ' check'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' check'
+        vllm_python: ' check'
+    - delta_text: ' the weather. <TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' the weather. <TOOLCALL>'
+        vllm_python: ' the weather. <TOOLCALL>'
+    - delta_text: '[{"name": "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '[{"name": "get_weather",'
+        vllm_python: '[{"name": "get_weather",'
+    - delta_text: ' "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
+    - delta_text: ' {"location": "NYC"}}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' {"location": "NYC"}}]'
+        vllm_python: ' {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL> Let me'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL> Let me'
+        vllm_python: '</TOOLCALL> Let me'
+    - delta_text: ' know'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' know'
+        vllm_python: ' know'
+    - delta_text: ' if you'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' if you'
+        vllm_python: ' if you'
+    - delta_text: ' need'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' need'
+        vllm_python: ' need'
+    - delta_text: ' more.'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' more.'
+        vllm_python: ' more.'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+  TOOLCALLING.streamv2.8.d:
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
+    chunks:
+    - delta_text: 'I will'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+    - delta_text: ' check'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' check'
+        vllm_python: ' check'
+    - delta_text: ' the weather. <TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' the weather. <TOOLCALL>'
+        vllm_python: ' the weather. <TOOLCALL>'
+    - delta_text: '[{"name": "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '[{"name": "get_weather",'
+        vllm_python: '[{"name": "get_weather",'
+    - delta_text: ' "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
+    - delta_text: ' {"location": "NYC"}}]'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' {"location": "NYC"}}]'
+        vllm_python: ' {"location": "NYC"}}]'
+    - delta_text: '</TOOLCALL> Then check'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '</TOOLCALL> Then check'
+        vllm_python: '</TOOLCALL> Then check'
+    - delta_text: ' LA'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' LA'
+        vllm_python: ' LA'
+    - delta_text: ' weather. <TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' weather. <TOOLCALL>'
+        vllm_python: ' weather. <TOOLCALL>'
+    - delta_text: '[{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: '[{"name":'
+        vllm_python: '[{"name":'
+    - delta_text: ' "get_weather", "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "get_weather", "arguments":'
+        vllm_python: ' "get_weather", "arguments":'
+    - delta_text: ' {"location":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' {"location":'
+        vllm_python: ' {"location":'
+    - delta_text: ' "LA"}}]</TOOLCALL>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+      normal_text:
+        vllm_rust: ' "LA"}}]</TOOLCALL>'
+        vllm_python: ' "LA"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.9.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_deci
-model_label: Nemotron (DeciLM) v1/v2
+model_label: 'Nemotron (DeciLM) v1/v2'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,22 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: ''
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -40,19 +48,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_deci'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_deci''.'
     chunks:
     - delta_text: '   '
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '   '
         vllm_rust: '   '
+        vllm_python: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.1.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -16,25 +25,29 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.10.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -16,34 +25,45 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_weather>'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.13.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -16,22 +25,24 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=unknown_tool>
+    - delta_text: '<tool_call>
+<function=unknown_tool>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: NYC</parameter> </function> </tool_call>
+    - delta_text: 'NYC</parameter>
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.2.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (back-to-back tool_call wrappers)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (back-to-back tool_call wrappers)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -22,40 +31,51 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_time>'
+    - delta_text: '
+<function=get_time>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=timezone> EST'
+    - delta_text: '
+<parameter=timezone>
+EST'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -70,48 +90,59 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
     - delta_text: 'Both: <tool_call>'
       expected:
         vllm_python: []
       normal_text:
         vllm_python: 'Both: '
-    - delta_text: ' <function=get_weather>'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> NYC </parameter>'
+    - delta_text: '
+<parameter=location>
+NYC
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <tool_call>'
+    - delta_text: '
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_time> <parameter=timezone>'
+    - delta_text: '
+<function=get_time>
+<parameter=timezone>'
       expected:
         vllm_python: []
-    - delta_text: ' EST </parameter> </function>'
+    - delta_text: '
+EST
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ' Done.'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -122,34 +153,45 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_weather>'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.3.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -16,40 +25,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
     - delta_text: ' can'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' can'
         vllm_rust: ' can'
+        vllm_python: ' can'
     - delta_text: ' I help you'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' I help you'
         vllm_rust: ' I help you'
+        vllm_python: ' I help you'
     - delta_text: ' today?'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' today?'
         vllm_rust: ' today?'
+        vllm_python: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.4.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with no <function> body
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with no <function> body'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,19 +25,19 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> random
+    - delta_text: '<tool_call>
+random'
       expected:
         vllm_python: []
     - delta_text: ' text'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
@@ -36,8 +45,8 @@ cases:
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </parameter> closing tag
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </parameter> closing tag'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -46,22 +55,25 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </function> </tool_call>'
+    - delta_text: '
+NYC
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.5.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,28 +25,31 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.5.b:
-    description: Closing </tool_call> without matching <tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
+    description: 'Closing </tool_call> without matching <tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -46,39 +58,53 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
     chunks:
-    - delta_text: <function=get_weather> <parameter=location>
+    - delta_text: '<function=get_weather>
+<parameter=location>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: <function=get_weather> <parameter=location>
-        vllm_rust: <function=get_weather> <parameter=location>
-    - delta_text: ' NYC'
+        vllm_rust: '<function=get_weather>
+<parameter=location>'
+        vllm_python: '<function=get_weather>
+<parameter=location>'
+    - delta_text: '
+NYC'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' NYC'
-        vllm_rust: ' NYC'
-    - delta_text: ' </parameter> </function> </tool_call>'
+        vllm_rust: '
+NYC'
+        vllm_python: '
+NYC'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: ' </parameter> </function> </tool_call>'
-        vllm_rust: ' </parameter> </function> </tool_call>'
+        vllm_rust: '
+</parameter>
+</function>
+</tool_call>'
+        vllm_python: '
+</parameter>
+</function>
+</tool_call>'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-parameter value
-    ref: derived from TOOLCALLING.batch.5.c
+    description: 'Truncation mid-parameter value'
+    ref: 'derived from TOOLCALLING.batch.5.c'
     tools:
     - name: get_weather
       parameters:
@@ -87,28 +113,29 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NY'
+    - delta_text: '
+NY'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -117,17 +144,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: I'll start
+        vllm_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -163,42 +188,56 @@ cases:
         vllm_python: []
       normal_text:
         vllm_python: ' same'
-    - delta_text: ' time! <tool_call>'
+    - delta_text: ' time!
+<tool_call>'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: ' <function=get_weather>'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> Boston'
+    - delta_text: '
+<parameter=location>
+Boston'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call> <tool_call>'
+    - delta_text: '
+</function>
+</tool_call>
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' New'
+    - delta_text: '
+New'
       expected:
         vllm_python: []
-    - delta_text: ' York </parameter>'
+    - delta_text: ' York
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function>'
+    - delta_text: '
+</function>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -207,17 +246,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: I'll start
+        vllm_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -253,33 +290,45 @@ cases:
         vllm_python: []
       normal_text:
         vllm_python: ' same'
-    - delta_text: ' time! <tool_call>'
+    - delta_text: ' time!
+<tool_call>'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: ' time! '
-    - delta_text: ' <function=get_weather>'
+        vllm_python: ' time!
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> Boston'
+    - delta_text: '
+<parameter=location>
+Boston'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call> <tool_call>'
+    - delta_text: '
+</function>
+</tool_call>
+<tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' New'
+    - delta_text: '
+New'
       expected:
         vllm_python: []
     - delta_text: ' York'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.50.yaml
@@ -1,14 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,52 +25,50 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <t
+    - delta_text: '<t'
       expected:
         vllm_python: []
-    - delta_text: ool
+    - delta_text: 'ool'
       expected:
         vllm_python: []
-    - delta_text: _call
+    - delta_text: '_call'
       expected:
         vllm_python: []
     - delta_text: '> <function'
       expected:
         vllm_python: []
-    - delta_text: =get_weather> <para
+    - delta_text: '=get_weather> <para'
       expected:
         vllm_python: []
-    - delta_text: me
+    - delta_text: 'me'
       expected:
         vllm_python: []
-    - delta_text: ter
+    - delta_text: 'ter'
       expected:
         vllm_python: []
-    - delta_text: =loca
+    - delta_text: '=loca'
       expected:
         vllm_python: []
-    - delta_text: tion> NYC <
+    - delta_text: 'tion> NYC <'
       expected:
         vllm_python: []
-    - delta_text: /parameter> </funct
+    - delta_text: '/parameter> </funct'
       expected:
         vllm_python: []
-    - delta_text: io
+    - delta_text: 'io'
       expected:
         vllm_python: []
     - delta_text: 'n> '
       expected:
         vllm_python: []
-    - delta_text: </too
+    - delta_text: '</too'
       expected:
         vllm_python: []
-    - delta_text: l_call>
+    - delta_text: 'l_call>'
       expected:
         vllm_python: []
     - delta_text: ''

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.6.yaml
@@ -1,65 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.6.a:
-    description: Function block with no <parameter>
-    ref: derived from TOOLCALLING.batch.6.a
+    description: 'Function block with no <parameter>'
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_time>
+    - delta_text: '<tool_call>
+<function=get_time>'
       expected:
         vllm_python: []
-    - delta_text: ' </function>'
+    - delta_text: '
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.6.b:
-    description: Function block with extra whitespace inside
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Function block with extra whitespace inside'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_time>
+    - delta_text: '<tool_call>
+<function=get_time>'
       expected:
         vllm_python: []
     - delta_text: '
 
-        </function>'
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.7.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Multiple parameters
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Multiple parameters'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -20,40 +29,50 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=book_flight>
+    - delta_text: '<tool_call>
+<function=book_flight>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=destination>'
+    - delta_text: '
+<parameter=destination>'
       expected:
         vllm_python: []
-    - delta_text: ' Paris </parameter> <parameter=passengers>'
+    - delta_text: '
+Paris
+</parameter>
+<parameter=passengers>'
       expected:
         vllm_python: []
-    - delta_text: ' 2 </parameter>'
+    - delta_text: '
+2
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=first_class>'
+    - delta_text: '
+<parameter=first_class>'
       expected:
         vllm_python: []
-    - delta_text: ' true </parameter>'
+    - delta_text: '
+true
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode in parameter
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode in parameter'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -62,31 +81,35 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' Tōkyō central </parameter>'
+    - delta_text: '
+Tōkyō central
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -95,25 +118,29 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=set_limit>
+    - delta_text: '<tool_call>
+<function=set_limit>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=count>'
+    - delta_text: '
+<parameter=count>'
       expected:
         vllm_python: []
-    - delta_text: ' 9007199254740993 </parameter> </function>'
+    - delta_text: '
+9007199254740993
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.8.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,17 +25,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: I will
+        vllm_python: 'I will'
     - delta_text: ' check'
       expected:
         vllm_python: []
@@ -37,25 +44,31 @@ cases:
         vllm_python: []
       normal_text:
         vllm_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -64,22 +77,26 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call> <function=get_weather>
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> Let'
+    - delta_text: '
+</tool_call> Let'
       expected:
         vllm_python: []
     - delta_text: ' me'
@@ -92,12 +109,12 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
       parameters:
@@ -106,17 +123,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: I will
+        vllm_python: 'I will'
     - delta_text: ' check'
       expected:
         vllm_python: []
@@ -127,16 +142,22 @@ cases:
         vllm_python: []
       normal_text:
         vllm_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> Let me'
+    - delta_text: '
+</tool_call> Let me'
       expected:
         vllm_python: []
     - delta_text: ' know'
@@ -152,12 +173,12 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -166,17 +187,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
         vllm_python: []
       normal_text:
-        vllm_python: I will
+        vllm_python: 'I will'
     - delta_text: ' check'
       expected:
         vllm_python: []
@@ -187,16 +206,22 @@ cases:
         vllm_python: []
       normal_text:
         vllm_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
         vllm_python: []
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
         vllm_python: []
-    - delta_text: ' </tool_call> Then check'
+    - delta_text: '
+</tool_call> Then check'
       expected:
         vllm_python: []
     - delta_text: ' LA'
@@ -205,19 +230,25 @@ cases:
     - delta_text: ' weather. <tool_call>'
       expected:
         vllm_python: []
-    - delta_text: ' <function=get_weather>'
+    - delta_text: '
+<function=get_weather>'
       expected:
         vllm_python: []
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
         vllm_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
         vllm_python: []
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_nano/TOOLCALLING.streamv2.9.yaml
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: nemotron_nano
-model_label: Nemotron Nano v3
+model_label: 'Nemotron Nano v3'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -16,22 +25,21 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: ''
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -40,19 +48,18 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      sglang_python: No SGLang parser for family 'nemotron_nano'.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      sglang_python: 'No SGLang Python parser for family ''nemotron_nano''.'
     chunks:
     - delta_text: '   '
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []
       normal_text:
-        vllm_python: '   '
         vllm_rust: '   '
+        vllm_python: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
-        vllm_python: []
         vllm_rust: []
+        vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.1.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.1:
     description: 'Single tool call (happy path)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -37,6 +38,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.10.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.10:
     description: 'Duplicate calls (same name twice)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -46,6 +47,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.13.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.13.a:
     description: 'Unknown-only call under default behavior'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "unknown_tool",'
       expected:
@@ -37,7 +38,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.13.c:
@@ -51,8 +52,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -73,6 +75,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.2.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.2.a:
     description: 'Parallel calls in JSON array'
@@ -30,8 +30,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -52,7 +53,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.2.c:
@@ -72,8 +73,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'Both: functools[{"name":'
       expected:
@@ -97,7 +99,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.2.d:
@@ -113,8 +115,9 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -135,6 +138,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.3.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.3:
     description: 'No tool call (plain text)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'Hello, how'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.30.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.30.a:
     description: 'JSON-array call separator `,` inside one argument string value'
@@ -24,8 +24,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "run_query",'
       expected:
@@ -40,7 +41,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.30.b:
@@ -54,8 +55,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "run_query",'
       expected:
@@ -82,7 +84,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.30.c:
@@ -96,8 +98,9 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "run_query",'
       expected:
@@ -115,6 +118,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.31.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.31.a:
     description: 'Multi-call JSON array with call separator `,` inside the first argument string'
@@ -30,8 +30,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "run_query",'
       expected:
@@ -55,7 +56,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.31.b:
@@ -75,8 +76,9 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "run_query",'
       expected:
@@ -112,6 +114,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.4.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.4.a:
     description: 'functools[ wrapper with garbage'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[not a'
       expected:
@@ -51,8 +52,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -78,8 +80,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"arguments": {"location":'
       expected:
@@ -102,8 +105,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.5.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.5.a:
     description: 'No explicit end (truncation)'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -51,8 +52,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools{"name": "get_weather",'
       expected:
@@ -64,7 +66,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.5.c:
@@ -78,8 +80,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -105,8 +108,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:
@@ -165,8 +169,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.50.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.50:
     description: 'Complete single tool call with a grammar token split across chunk boundaries'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'fu'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.6.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
@@ -22,8 +22,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_time",'
       expected:
@@ -35,7 +36,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.6.b:
@@ -47,8 +48,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_time",'
       expected:
@@ -60,7 +62,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.6.c:
@@ -72,8 +74,9 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_time"}]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.7.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.7.a:
     description: 'Standard scalar types'
@@ -28,8 +28,9 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "book_flight",'
       expected:
@@ -47,7 +48,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.b:
@@ -61,8 +62,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -74,7 +76,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.c:
@@ -88,8 +90,9 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "set_temperature",'
       expected:
@@ -101,7 +104,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.d:
@@ -117,8 +120,9 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "process_data",'
       expected:
@@ -136,7 +140,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.7.e:
@@ -150,8 +154,9 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "process_data",'
       expected:
@@ -199,6 +204,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.8.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.8.a:
     description: 'Narration before tool call only'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -46,7 +47,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.b:
@@ -60,8 +61,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'functools[{"name": "get_weather",'
       expected:
@@ -85,7 +87,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.c:
@@ -99,8 +101,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -130,7 +133,7 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
   TOOLCALLING.streamv2.8.d:
@@ -144,8 +147,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -181,6 +185,6 @@ cases:
       expected:
         vllm_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.9.yaml
@@ -11,7 +11,7 @@ family: phi4
 model_label: 'Phi-4'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
 cases:
   TOOLCALLING.streamv2.9.a:
     description: 'Empty model text'
@@ -24,8 +24,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: ''
       expected:
@@ -45,8 +46,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
-      sglang_python: 'No SGLang parser for family ''phi4''.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''phi4''.'
+      sglang_python: 'No SGLang Python parser for family ''phi4''.'
     chunks:
     - delta_text: '   '
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.1.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC")]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.10.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.13.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13.a:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[unknown_tool(location="NYC")]'
       expected:
@@ -33,7 +34,7 @@ cases:
         - {index: 0, id: true, name: 'unknown_tool', arguments: '{"location": "NYC"}'}
         sglang_python: []
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
@@ -48,7 +49,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"), unknown_tool(location="LA")]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.2.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
@@ -31,7 +31,8 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"), get_time(timezone="EST")]'
       expected:
@@ -63,7 +64,8 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'Both: [get_weather(location="NYC"),'
       expected:
@@ -105,7 +107,8 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.3.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'Hello, how'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.30.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.30.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.30.a:
@@ -25,7 +25,8 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[run_query(sql="SELECT a,'
       expected:
@@ -59,7 +60,8 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[run_query(sql="SELECT value'
       expected:
@@ -108,7 +110,8 @@ cases:
           sql:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[run_query(sql="literal [get_time'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.31.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.31.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.31.a:
@@ -31,7 +31,8 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[run_query(sql="SELECT a,'
       expected:
@@ -73,7 +74,8 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[run_query(sql="SELECT value'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.4.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[not a'
       expected:
@@ -57,7 +58,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"'
       expected:
@@ -79,7 +81,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC"]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.5.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC")'
       expected:
@@ -48,7 +49,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'get_weather(location="NYC")]'
       expected:
@@ -73,7 +75,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="N'
       expected:
@@ -96,7 +99,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:
@@ -183,7 +187,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'I''ll start'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.50.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[g'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.6.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
@@ -23,7 +23,8 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_time()]'
       expected:
@@ -45,7 +46,8 @@ cases:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_time( )]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.7.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
@@ -29,7 +29,8 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[book_flight(destination="Paris", passengers=2,'
       expected:
@@ -57,7 +58,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="Tōkyō \"central\"")]'
       expected:
@@ -81,7 +83,8 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[set_temperature(celsius="20")]'
       expected:
@@ -107,7 +110,8 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[process_data(items=[1, 2,'
       expected:
@@ -139,7 +143,8 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[process_data(payload={"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.8.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -65,7 +66,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '[get_weather(location="NYC")] Let'
       expected:
@@ -106,7 +108,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -174,7 +177,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: 'I will'
       expected:
@@ -221,7 +225,7 @@ cases:
         vllm_python: ' weather. [get_weather(location="LA")]'
         sglang_python: ' weather. '
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.9.yaml
@@ -11,7 +11,7 @@ family: pythonic
 model_label: 'Llama 4 (pythonic fmt)'
 mode: streamv2
 captured_with:
-  vllm_python: '0.22.0'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
@@ -25,7 +25,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: ''
       expected:
@@ -47,7 +48,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang per-chunk output is the target to match.'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'No vLLM Rust parser for family ''pythonic''.'
     chunks:
     - delta_text: '   '
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.1.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
-    description: Single tool call (happy path)
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -17,42 +26,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments": {"location": "NYC"}}'
+      expected:
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.10.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
-    description: Duplicate calls (same name twice)
-    ref: derived from TOOLCALLING.batch.10
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
     tools:
     - name: get_weather
       parameters:
@@ -17,83 +26,62 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: '<tool_call>{"name":'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call><tool_call>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: '
+{"name":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
-    - delta_text: ' "get_weather",'
-      expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        vllm_python: []
         sglang_python: []
+    - delta_text: ' "get_weather", "arguments":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location":'
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
-        vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "LA"}}</tool_call>'
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: ' {"location": "LA"}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
-      normal_text:
-        sglang_python: ' "LA"}}'
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.13.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
-    description: Unknown tool name absent from supplied tools
-    ref: derived from TOOLCALLING.batch.13
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
     tools:
     - name: get_weather
       parameters:
@@ -17,42 +26,39 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "unknown_tool",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: unknown_tool
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "unknown_tool",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, id: true, name: 'unknown_tool'}
         sglang_python: []
+    - delta_text: ' "arguments": {"location": "NYC"}}'
+      expected:
         vllm_rust:
-        - index: 0
-          name: unknown_tool
-        - arguments: '{"location": "NYC"}'
-          index: 0
+        - {index: 0, name: 'unknown_tool'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: ''
-      finish_reason: tool_calls
+    - delta_text: '
+</tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: ''
+      finish_reason: stop
+      expected:
         vllm_rust: []
+        vllm_python: []
+        sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.2.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
-    description: Parallel calls (back-to-back tool_call wrappers)
-    ref: derived from TOOLCALLING.batch.2.a
+    description: 'Parallel calls (back-to-back tool_call wrappers)'
+    ref: 'derived from TOOLCALLING.batch.2.a'
     tools:
     - name: get_weather
       parameters:
@@ -23,89 +32,68 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: '<tool_call>{"name":'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call><tool_call>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: '
+{"name":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
-    - delta_text: ' "get_time",'
-      expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
+        vllm_python: []
         sglang_python: []
+    - delta_text: ' "get_time", "arguments":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_time",'
-    - delta_text: ' "arguments": {"timezone":'
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"timezone":'
-        sglang_python: []
-        vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone":'
-          index: 1
-      normal_text:
-        sglang_python: ' "arguments": {"timezone":'
-    - delta_text: ' "EST"}}</tool_call>'
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: ' {"timezone": "EST"}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "EST"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "EST"}'
-          index: 1
-      normal_text:
-        sglang_python: ' "EST"}}'
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.c:
-    description: With surrounding narration
-    ref: derived from TOOLCALLING.batch.2.c
+    description: 'With surrounding narration'
+    ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather
       parameters:
@@ -120,89 +108,85 @@ cases:
           timezone:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both: <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: 'Both: '
         vllm_rust: 'Both: '
-    - delta_text: '{"name":'
+        vllm_python: 'Both: '
+    - delta_text: '
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: 'Both: <tool_call>{"name":'
     - delta_text: ' "get_weather", "arguments": {"location":'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        - index: 0
-          arguments: '{"location":'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location":'
-          index: 0
-      normal_text:
-        sglang_python: ' "get_weather", "arguments": {"location":'
-    - delta_text: ' "NYC"}}</tool_call><tool_call>'
-      expected:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
         vllm_python:
-        - index: 0
-          arguments: ' "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - arguments: ' "NYC"}'
-          index: 0
-    - delta_text: '{"name":'
+        - {index: 0, id: true, name: 'get_weather'}
+        - {index: 0, arguments: '{"location":'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "NYC"}}
+</tool_call>'
       expected:
+        vllm_rust:
+        - {index: 0, arguments: ' "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '<tool_call>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' "NYC"}}<tool_call>{"name":'
-    - delta_text: ' "get_time", "arguments":'
+    - delta_text: '
+{"name": "get_time",'
       expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_time", "arguments":'
-    - delta_text: ' {"timezone": "EST"}}</tool_call> Done.'
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"timezone": "EST"}'
-        sglang_python: []
+        - {index: 1, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 1, name: 'get_time'}
+    - delta_text: ' "arguments": {"timezone": "EST"}}'
+      expected:
         vllm_rust:
-        - index: 1
-          name: get_time
-        - arguments: '{"timezone": "EST"}'
-          index: 1
+        - {index: 1, name: 'get_time'}
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"timezone": "EST"}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: ' Done.'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
       normal_text:
-        sglang_python: ' {"timezone": "EST"}} Done.'
         vllm_rust: ' Done.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.2.d:
-    description: Same-name twice
-    ref: derived from TOOLCALLING.batch.2.d
+    description: 'Same-name twice'
+    ref: 'derived from TOOLCALLING.batch.2.d'
     tools:
     - &id001
       name: get_weather
@@ -213,83 +197,62 @@ cases:
             type: string
     - *id001
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: '<tool_call>{"name":'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call><tool_call>'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
+    - delta_text: '
+{"name":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
-    - delta_text: ' "get_weather",'
-      expected:
-        vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
+        vllm_python: []
         sglang_python: []
+    - delta_text: ' "get_weather", "arguments":'
+      expected:
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location":'
-      expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
-        sglang_python: []
-        vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "LA"}}</tool_call>'
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: ' {"location": "LA"}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
-      normal_text:
-        sglang_python: ' "LA"}}'
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location": "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.3.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
-    description: No tool call (plain text)
-    ref: derived from TOOLCALLING.batch.3
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
     tools:
     - name: get_weather
       parameters:
@@ -17,48 +26,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: Hello, how
+    - delta_text: 'Hello, how'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: Hello, how
-        sglang_python: Hello, how
-        vllm_rust: Hello, how
+        vllm_rust: 'Hello, how'
+        vllm_python: 'Hello, how'
+        sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
-        vllm_rust: ' can'
     - delta_text: ' I help you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
-        vllm_rust: ' I help you'
     - delta_text: ' today?'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
-        vllm_rust: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.4.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
-    description: Tool_call wrapper with non-JSON garbage
-    ref: derived from TOOLCALLING.batch.4.a
+    description: 'Tool_call wrapper with non-JSON garbage'
+    ref: 'derived from TOOLCALLING.batch.4.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,17 +26,15 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
-    - delta_text: <tool_call>not
+    - delta_text: '<tool_call>not'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        sglang_python: <tool_call>not
+        sglang_python: '<tool_call>not'
     - delta_text: ' even'
       expected:
         vllm_python: []
@@ -46,8 +53,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.b:
-    description: Missing close brace in JSON body
-    ref: derived from TOOLCALLING.batch.4.b
+    description: 'Missing close brace in JSON body'
+    ref: 'derived from TOOLCALLING.batch.4.b'
     tools:
     - name: get_weather
       parameters:
@@ -56,10 +63,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -70,28 +75,25 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
         sglang_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"'
+        - {index: 0, arguments: '{"location": "NYC"'}
         sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location": "NYC"'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.c:
-    description: Missing name key
-    ref: derived from TOOLCALLING.batch.4.c
+    description: 'Missing name key'
+    ref: 'derived from TOOLCALLING.batch.4.c'
     tools:
     - name: get_weather
       parameters:
@@ -100,9 +102,9 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: expected `name`'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes
+expected `name`'
     chunks:
     - delta_text: '<tool_call>{"arguments":'
       expected:
@@ -128,8 +130,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
-    description: Missing </tool_call> close
-    ref: derived from TOOLCALLING.batch.4.d
+    description: 'Missing </tool_call> close'
+    ref: 'derived from TOOLCALLING.batch.4.d'
     tools:
     - name: get_weather
       parameters:
@@ -138,10 +140,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -152,22 +152,19 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
         sglang_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location": "NYC"}}'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.5.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
-    description: Missing </tool_call> end marker
-    ref: derived from TOOLCALLING.batch.5.a
+    description: 'Missing </tool_call> end marker'
+    ref: 'derived from TOOLCALLING.batch.5.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,10 +26,8 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -31,75 +38,25 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
         sglang_python: ' "get_weather",'
     - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
+        - {index: 0, arguments: '{"location": "NYC"}'}
         sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        sglang_python: []
-  TOOLCALLING.streamv2.5.b:
-    description: Closing </tool_call> without matching <tool_call> open
-    ref: derived from TOOLCALLING.batch.5.b
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-    chunks:
-    - delta_text: '{"name": "get_weather",'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: '{"name": "get_weather",'
-        sglang_python: '{"name": "get_weather",'
-        vllm_rust: '{"name": "get_weather",'
-    - delta_text: ' "arguments":'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' "arguments":'
-        sglang_python: ' "arguments":'
-        vllm_rust: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}</tool_call>'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' {"location": "NYC"}}</tool_call>'
-        sglang_python: ' {"location": "NYC"}}'
-        vllm_rust: ' {"location": "NYC"}}</tool_call>'
     - delta_text: ''
       finish_reason: stop
       expected:
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.5.c:
-    description: Truncation mid-arguments JSON
-    ref: derived from TOOLCALLING.batch.5.c
+  TOOLCALLING.streamv2.5.b:
+    description: 'Closing </tool_call> without matching <tool_call> open'
+    ref: 'derived from TOOLCALLING.batch.5.b'
     tools:
     - name: get_weather
       parameters:
@@ -108,10 +65,54 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+    chunks:
+    - delta_text: '{"name": "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: '{"name": "get_weather",'
+        vllm_python: '{"name": "get_weather",'
+        sglang_python: '{"name": "get_weather",'
+    - delta_text: ' "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' "arguments":'
+        vllm_python: ' "arguments":'
+        sglang_python: ' "arguments":'
+    - delta_text: ' {"location": "NYC"}}</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' {"location": "NYC"}}</tool_call>'
+        vllm_python: ' {"location": "NYC"}}</tool_call>'
+        sglang_python: ' {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+  TOOLCALLING.streamv2.5.c:
+    description: 'Truncation mid-arguments JSON'
+    ref: 'derived from TOOLCALLING.batch.5.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -122,17 +123,14 @@ cases:
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
       normal_text:
         sglang_python: ' "get_weather",'
     - delta_text: ' "arguments": {"loc'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"loc'
+        - {index: 0, arguments: '{"loc'}
         sglang_python: []
       normal_text:
         sglang_python: ' "arguments": {"loc'
@@ -142,8 +140,8 @@ cases:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
-    description: Multi-call, last call missing only end marker (body complete)
-    ref: derived from TOOLCALLING.batch.5.d
+    description: 'Multi-call, last call missing only end marker (body complete)'
+    ref: 'derived from TOOLCALLING.batch.5.d'
     tools:
     - name: get_weather
       parameters:
@@ -152,18 +150,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -213,79 +209,61 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!<tool_call>{"name":'
+    - delta_text: ' time!<tool_call>
+{"name":'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_python: ' time!'
-        sglang_python: ' time!<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
-      normal_text:
-        sglang_python: ' "get_weather",'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":'
+        - {index: 0, arguments: '{"location":'}
         sglang_python: []
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "Boston"}}</tool_call>'
+    - delta_text: ' "Boston"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
+        - {index: 0, arguments: ' "Boston"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+</tool_call><tool_call>
+{"name":'
+      expected:
+        vllm_python: []
         sglang_python: []
-      normal_text:
-        sglang_python: ' "Boston"}}'
-    - delta_text: '<tool_call>{"name": "get_weather",'
+    - delta_text: ' "get_weather", "arguments":'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
-      normal_text:
-        sglang_python: '<tool_call>{"name": "get_weather",'
-    - delta_text: ' "arguments": {"location":'
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: ' {"location":'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
+        - {index: 1, arguments: '{"location":'}
         sglang_python: []
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "New'
+    - delta_text: ' "New York"}}'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' "New'
-        sglang_python: []
-      normal_text:
-        sglang_python: ' "New'
-    - delta_text: ' York"}}'
-      expected:
-        vllm_python:
-        - index: 1
-          arguments: ' York"}'
-        sglang_python: []
-      normal_text:
-        sglang_python: ' York"}}'
+        - {index: 1, arguments: ' "New York"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "New York"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
-    description: Multi-call, last call truncated mid-arg-value
-    ref: derived from TOOLCALLING.batch.5.e
+    description: 'Multi-call, last call truncated mid-arg-value'
+    ref: 'derived from TOOLCALLING.batch.5.e'
     tools:
     - name: get_weather
       parameters:
@@ -294,18 +272,16 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete
-        Hermes tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Hermes tool call'
     chunks:
-    - delta_text: I'll start
+    - delta_text: 'I''ll start'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: I'll start
-        sglang_python: I'll start
+        vllm_python: 'I''ll start'
+        sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
         vllm_python: []
@@ -355,71 +331,52 @@ cases:
       normal_text:
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!<tool_call>{"name":'
+    - delta_text: ' time!<tool_call>
+{"name":'
       expected:
         vllm_python: []
         sglang_python: []
       normal_text:
         vllm_python: ' time!'
-        sglang_python: ' time!<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
-      normal_text:
-        sglang_python: ' "get_weather",'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location":'
       expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location":'
+        - {index: 0, arguments: '{"location":'}
         sglang_python: []
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "Boston"}}</tool_call>'
+    - delta_text: ' "Boston"}}'
       expected:
         vllm_python:
-        - index: 0
-          arguments: ' "Boston"}'
+        - {index: 0, arguments: ' "Boston"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Boston"}'}
+    - delta_text: '
+</tool_call><tool_call>
+{"name":'
+      expected:
+        vllm_python: []
         sglang_python: []
-      normal_text:
-        sglang_python: ' "Boston"}}'
-    - delta_text: '<tool_call>{"name": "get_weather",'
+    - delta_text: ' "get_weather", "arguments":'
       expected:
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
-      normal_text:
-        sglang_python: '<tool_call>{"name": "get_weather",'
-    - delta_text: ' "arguments": {"location":'
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: ' {"location":'
       expected:
         vllm_python:
-        - index: 1
-          arguments: '{"location":'
+        - {index: 1, arguments: '{"location":'}
         sglang_python: []
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "New'
+    - delta_text: ' "New York'
       expected:
         vllm_python:
-        - index: 1
-          arguments: ' "New'
+        - {index: 1, arguments: ' "New York'}
         sglang_python: []
-      normal_text:
-        sglang_python: ' "New'
-    - delta_text: ' York'
-      expected:
-        vllm_python:
-        - index: 1
-          arguments: ' York'
-        sglang_python: []
-      normal_text:
-        sglang_python: ' York'
     - delta_text: ''
       finish_reason: tool_calls
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.50.yaml
@@ -1,15 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
-    description: Complete single tool call with a grammar token split across chunk
-      boundaries
-    ref: derived from TOOLCALLING.batch.1
+    description: 'Complete single tool call with a grammar token split across chunk boundaries'
+    ref: 'derived from TOOLCALLING.batch.1'
     tools:
     - name: get_weather
       parameters:
@@ -18,93 +26,83 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: <t
+    - delta_text: '<t'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: ool
+    - delta_text: 'ool'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-    - delta_text: _call
+    - delta_text: '_call'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: '>{"name": "'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
         sglang_python: '<tool_call>{"name": "'
-    - delta_text: get_weather", "argu
+    - delta_text: 'get_weather", "argu'
       expected:
+        vllm_rust: []
         vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
+        - {index: 0, id: true, name: 'get_weather'}
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: get_weather", "argu
-    - delta_text: me
+        sglang_python: 'get_weather", "argu'
+    - delta_text: 'me'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: me
-    - delta_text: nts
+        sglang_python: 'me'
+    - delta_text: 'nts'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: nts
+        sglang_python: 'nts'
     - delta_text: '": {"'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"'
-          index: 0
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"'}
+        vllm_python:
+        - {index: 0, arguments: '{"'}
+        sglang_python: []
       normal_text:
         sglang_python: '": {"'
     - delta_text: 'location": '
       expected:
-        vllm_python:
-        - index: 0
-          arguments: 'location":'
-        sglang_python: []
         vllm_rust:
-        - arguments: 'location": '
-          index: 0
+        - {index: 0, arguments: 'location": '}
+        vllm_python:
+        - {index: 0, arguments: 'location":'}
+        sglang_python: []
       normal_text:
         sglang_python: 'location": '
     - delta_text: '"NYC"}}</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "NYC"}'
-        sglang_python: []
         vllm_rust:
-        - arguments: '"NYC"}'
-          index: 0
+        - {index: 0, arguments: '"NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: ' "NYC"}'}
+        sglang_python: []
       normal_text:
         sglang_python: '"NYC"}}'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.6.yaml
@@ -1,120 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
     description: 'Canonical "arguments": {}'
-    ref: derived from TOOLCALLING.batch.6.a
+    ref: 'derived from TOOLCALLING.batch.6.a'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_time",'
-    - delta_text: ' "arguments": {}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{}'
-        sglang_python: []
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
+    - delta_text: ' "arguments": {}}
+</tool_call>'
+      expected:
         vllm_rust:
-        - index: 0
-          name: get_time
-        - arguments: '{}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {}}'
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{}'}
+        vllm_python:
+        - {index: 0, arguments: '{}'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.b:
-    description: Whitespace inside arguments {}
-    ref: derived from TOOLCALLING.batch.6.b
+    description: 'Whitespace inside arguments {}'
+    ref: 'derived from TOOLCALLING.batch.6.b'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_time",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_time
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_time",'
-    - delta_text: ' "arguments": { }}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{ }'
-        sglang_python: []
+        - {index: 0, id: true, name: 'get_time'}
+        sglang_python:
+        - {index: 0, name: 'get_time'}
+    - delta_text: ' "arguments": { }}'
+      expected:
         vllm_rust:
-        - index: 0
-          name: get_time
-        - arguments: '{ }'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": { }}'
+        - {index: 0, name: 'get_time'}
+        - {index: 0, arguments: '{ }'}
+        vllm_python:
+        - {index: 0, arguments: '{ }'}
+        sglang_python:
+        - {index: 0, arguments: '{}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.6.c:
-    description: No arguments key
-    ref: derived from TOOLCALLING.batch.6.c
+    description: 'No arguments key'
+    ref: 'derived from TOOLCALLING.batch.6.c'
     tools:
     - name: get_time
       parameters:
         type: object
         properties: {}
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: invalid
-        Hermes'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: invalid Hermes'
     chunks:
     - delta_text: '<tool_call>{"name":'
       expected:
@@ -125,9 +121,7 @@ cases:
     - delta_text: ' "get_time"}</tool_call>'
       expected:
         vllm_python:
-        - index: 0
-          id: true
-          name: get_time
+        - {index: 0, id: true, name: 'get_time'}
         sglang_python: []
       normal_text:
         sglang_python: ' "get_time"}'

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.7.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
-    description: Standard scalar types
-    ref: derived from TOOLCALLING.batch.7.a
+    description: 'Standard scalar types'
+    ref: 'derived from TOOLCALLING.batch.7.a'
     tools:
     - name: book_flight
       parameters:
@@ -21,81 +30,62 @@ cases:
           first_class:
             type: boolean
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "book_flight",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: book_flight
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "book_flight",'
+        vllm_python:
+        - {index: 0, id: true, name: 'book_flight'}
+        sglang_python:
+        - {index: 0, name: 'book_flight'}
     - delta_text: ' "arguments": {"destination": "Paris",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"destination": "Paris",'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: book_flight
-        - arguments: '{"destination": "Paris",'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"destination": "Paris",'
+        - {index: 0, name: 'book_flight'}
+        - {index: 0, arguments: '{"destination": "Paris",'}
+        vllm_python:
+        - {index: 0, arguments: '{"destination": "Paris",'}
+        sglang_python: []
     - delta_text: ' "passengers": 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "passengers": 2,'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "passengers": 2,'
-          index: 0
-      normal_text:
-        sglang_python: ' "passengers": 2,'
+        - {index: 0, arguments: ' "passengers": 2,'}
+        vllm_python:
+        - {index: 0, arguments: ' "passengers": 2,'}
+        sglang_python:
+        - {index: 0, arguments: '{"destination": "Paris"'}
     - delta_text: ' "first_class":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "first_class":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "first_class":'
-          index: 0
-      normal_text:
-        sglang_python: ' "first_class":'
-    - delta_text: ' true}}</tool_call>'
+        - {index: 0, arguments: ' "first_class":'}
+        vllm_python:
+        - {index: 0, arguments: ' "first_class":'}
+        sglang_python: []
+    - delta_text: ' true}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' true}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' true}'
-          index: 0
-      normal_text:
-        sglang_python: ' true}}'
+        - {index: 0, arguments: ' true}'}
+        vllm_python:
+        - {index: 0, arguments: ' true}'}
+        sglang_python:
+        - {index: 0, arguments: ', "passengers": 2, "first_class": true}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.b:
-    description: Unicode + escaped chars
-    ref: derived from TOOLCALLING.batch.7.b
+    description: 'Unicode + escaped chars'
+    ref: 'derived from TOOLCALLING.batch.7.b'
     tools:
     - name: get_weather
       parameters:
@@ -104,59 +94,47 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments": {"location": "Tōkyō'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "Tōkyō'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "Tōkyō'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "Tōkyō'
-    - delta_text: ' \"central\""}}</tool_call>'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "Tōkyō'}
+        sglang_python: []
+    - delta_text: ' \"central\""}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' \"central\""}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' \"central\""}'
-          index: 0
-      normal_text:
-        sglang_python: ' \"central\""}}'
+        - {index: 0, arguments: ' \"central\""}'}
+        vllm_python:
+        - {index: 0, arguments: ' \"central\""}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "Tōkyō \"central\""}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.c:
-    description: Schema mismatch — string value where schema declares integer
-    ref: derived from TOOLCALLING.batch.7.c
+    description: 'Schema mismatch - string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
     tools:
     - name: set_temperature
       parameters:
@@ -165,48 +143,45 @@ cases:
           celsius:
             type: integer
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "set_temperature",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_temperature
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "set_temperature",'
-    - delta_text: ' "arguments": {"celsius": "20"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"celsius": "20"}'
-        sglang_python: []
+        - {index: 0, id: true, name: 'set_temperature'}
+        sglang_python:
+        - {index: 0, name: 'set_temperature'}
+    - delta_text: ' "arguments": {"celsius": "20"}}'
+      expected:
         vllm_rust:
-        - index: 0
-          name: set_temperature
-        - arguments: '{"celsius": "20"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"celsius": "20"}}'
+        - {index: 0, name: 'set_temperature'}
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"celsius": "20"}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.d:
-    description: Nested object + array
-    ref: derived from TOOLCALLING.batch.7.d
+    description: 'Nested object + array'
+    ref: 'derived from TOOLCALLING.batch.7.d'
     tools:
     - name: process_data
       parameters:
@@ -217,81 +192,62 @@ cases:
           config:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "process_data",'
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ' "arguments": {"items": [1,2,3]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"items": [1,2,3]'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
-        - arguments: '{"items": [1,2,3]'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"items": [1,2,3]'
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"items": [1,2,3]'}
+        vllm_python:
+        - {index: 0, arguments: '{"items": [1,2,3]'}
+        sglang_python: []
     - delta_text: ', "config":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ', "config":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ', "config":'
-          index: 0
-      normal_text:
-        sglang_python: ', "config":'
+        - {index: 0, arguments: ', "config":'}
+        vllm_python:
+        - {index: 0, arguments: ', "config":'}
+        sglang_python: []
     - delta_text: ' {"nested":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' {"nested":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' {"nested":'
-          index: 0
-      normal_text:
-        sglang_python: ' {"nested":'
-    - delta_text: ' true}}}</tool_call>'
+        - {index: 0, arguments: ' {"nested":'}
+        vllm_python:
+        - {index: 0, arguments: ' {"nested":'}
+        sglang_python:
+        - {index: 0, arguments: '{"items": [1, 2, 3]'}
+    - delta_text: ' true}}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' true}}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' true}}'
-          index: 0
-      normal_text:
-        sglang_python: ' true}}}'
+        - {index: 0, arguments: ' true}}'}
+        vllm_python:
+        - {index: 0, arguments: ' true}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "config": {"nested": true}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.e:
-    description: Large / deep JSON-edge argument payload
-    ref: derived from TOOLCALLING.batch.7.e
+    description: 'Large / deep JSON-edge argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
     tools:
     - name: process_data
       parameters:
@@ -300,191 +256,140 @@ cases:
           payload:
             type: object
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "process_data",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: process_data
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "process_data",'
+        vllm_python:
+        - {index: 0, id: true, name: 'process_data'}
+        sglang_python:
+        - {index: 0, name: 'process_data'}
     - delta_text: ' "arguments": {"payload": {"regions":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"payload": {"regions":'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: process_data
-        - arguments: '{"payload": {"regions":'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"payload": {"regions":'
+        - {index: 0, name: 'process_data'}
+        - {index: 0, arguments: '{"payload": {"regions":'}
+        vllm_python:
+        - {index: 0, arguments: '{"payload": {"regions":'}
+        sglang_python: []
     - delta_text: ' [{"name": "west",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [{"name": "west",'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' [{"name": "west",'
-          index: 0
-      normal_text:
-        sglang_python: ' [{"name": "west",'
+        - {index: 0, arguments: ' [{"name": "west",'}
+        vllm_python:
+        - {index: 0, arguments: ' [{"name": "west",'}
+        sglang_python:
+        - {index: 0, arguments: '{"payload": {'}
     - delta_text: ' "scores":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "scores":'
-          index: 0
-      normal_text:
-        sglang_python: ' "scores":'
+        - {index: 0, arguments: ' "scores":'}
+        vllm_python:
+        - {index: 0, arguments: ' "scores":'}
+        sglang_python: []
     - delta_text: ' [1, 2,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' [1, 2,'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' [1, 2,'
-          index: 0
-      normal_text:
-        sglang_python: ' [1, 2,'
+        - {index: 0, arguments: ' [1, 2,'}
+        vllm_python:
+        - {index: 0, arguments: ' [1, 2,'}
+        sglang_python:
+        - {index: 0, arguments: '"regions": [{"name": "west"'}
     - delta_text: ' 3]}, {"name":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 3]}, {"name":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' 3]}, {"name":'
-          index: 0
-      normal_text:
-        sglang_python: ' 3]}, {"name":'
+        - {index: 0, arguments: ' 3]}, {"name":'}
+        vllm_python:
+        - {index: 0, arguments: ' 3]}, {"name":'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [1, 2'}
     - delta_text: ' "east",'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "east",'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "east",'
-          index: 0
-      normal_text:
-        sglang_python: ' "east",'
+        - {index: 0, arguments: ' "east",'}
+        vllm_python:
+        - {index: 0, arguments: ' "east",'}
+        sglang_python:
+        - {index: 0, arguments: ', 3]}, {'}
     - delta_text: ' "scores": [4,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "scores": [4,'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "scores": [4,'
-          index: 0
-      normal_text:
-        sglang_python: ' "scores": [4,'
+        - {index: 0, arguments: ' "scores": [4,'}
+        vllm_python:
+        - {index: 0, arguments: ' "scores": [4,'}
+        sglang_python:
+        - {index: 0, arguments: '"name": "east"'}
     - delta_text: ' 5,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 5,'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' 5,'
-          index: 0
-      normal_text:
-        sglang_python: ' 5,'
+        - {index: 0, arguments: ' 5,'}
+        vllm_python:
+        - {index: 0, arguments: ' 5,'}
+        sglang_python:
+        - {index: 0, arguments: ', "scores": [4'}
     - delta_text: ' 6]}]'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' 6]}]'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' 6]}]'
-          index: 0
-      normal_text:
-        sglang_python: ' 6]}]'
+        - {index: 0, arguments: ' 6]}]'}
+        vllm_python:
+        - {index: 0, arguments: ' 6]}]'}
+        sglang_python:
+        - {index: 0, arguments: ', 5'}
     - delta_text: ','
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ','
-        sglang_python: []
         vllm_rust:
-        - arguments: ','
-          index: 0
-      normal_text:
-        sglang_python: ','
+        - {index: 0, arguments: ','}
+        vllm_python:
+        - {index: 0, arguments: ','}
+        sglang_python: []
     - delta_text: ' "flags": {"enabled": true,'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "flags": {"enabled": true,'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "flags": {"enabled": true,'
-          index: 0
-      normal_text:
-        sglang_python: ' "flags": {"enabled": true,'
+        - {index: 0, arguments: ' "flags": {"enabled": true,'}
+        vllm_python:
+        - {index: 0, arguments: ' "flags": {"enabled": true,'}
+        sglang_python:
+        - {index: 0, arguments: ', 6]}]'}
     - delta_text: ' "retry": null},'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "retry": null},'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "retry": null},'
-          index: 0
-      normal_text:
-        sglang_python: ' "retry": null},'
+        - {index: 0, arguments: ' "retry": null},'}
+        vllm_python:
+        - {index: 0, arguments: ' "retry": null},'}
+        sglang_python:
+        - {index: 0, arguments: ', "flags": {"enabled": true'}
     - delta_text: ' "empty":'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' "empty":'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' "empty":'
-          index: 0
-      normal_text:
-        sglang_python: ' "empty":'
-    - delta_text: ' {}}}}</tool_call>'
+        - {index: 0, arguments: ' "empty":'}
+        vllm_python:
+        - {index: 0, arguments: ' "empty":'}
+        sglang_python: []
+    - delta_text: ' {}}}}
+</tool_call>'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: ' {}}}'
-        sglang_python: []
         vllm_rust:
-        - arguments: ' {}}}'
-          index: 0
-      normal_text:
-        sglang_python: ' {}}}}'
+        - {index: 0, arguments: ' {}}}'}
+        vllm_python:
+        - {index: 0, arguments: ' {}}}'}
+        sglang_python:
+        - {index: 0, arguments: ', "retry": null}, "empty": {}}}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.7.f:
-    description: Numeric precision edge preserves integer-like number literal
-    ref: derived from TOOLCALLING.batch.7.f
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
     tools:
     - name: set_limit
       parameters:
@@ -493,42 +398,39 @@ cases:
           count:
             type: number
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "set_limit",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: set_limit
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "set_limit",'
-    - delta_text: ' "arguments": {"count": 9007199254740993}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"count": 9007199254740993}'
-        sglang_python: []
+        - {index: 0, id: true, name: 'set_limit'}
+        sglang_python:
+        - {index: 0, name: 'set_limit'}
+    - delta_text: ' "arguments": {"count": 9007199254740993}}'
+      expected:
         vllm_rust:
-        - index: 0
-          name: set_limit
-        - arguments: '{"count": 9007199254740993}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"count": 9007199254740993}}'
+        - {index: 0, name: 'set_limit'}
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        vllm_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+        sglang_python:
+        - {index: 0, arguments: '{"count": 9007199254740993}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.8.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
-    description: Narration before tool call only
-    ref: derived from TOOLCALLING.batch.8.a
+    description: 'Narration before tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,74 +26,71 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: '{"name": "get_weather",'
+        vllm_python: ' the weather. '
+    - delta_text: '
+{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' the weather. <tool_call>{"name": "get_weather",'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}</tool_call>'
+    - delta_text: ' {"location": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' {"location": "NYC"}}'
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.b:
-    description: Narration after tool call only
-    ref: derived from TOOLCALLING.batch.8.b
+    description: 'Narration after tool call only'
+    ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
       parameters:
@@ -93,188 +99,171 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>{"name":'
+    - delta_text: '<tool_call>
+{"name":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: '<tool_call>{"name":'
     - delta_text: ' "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location": "NYC"}}</tool_call>'
-      expected:
         vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' "arguments": {"location": "NYC"}}'
-    - delta_text: ' Let me'
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments": {"location": "NYC"}}'
       expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call> Let'
+      expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' Let me'
+        vllm_rust: ' Let'
+    - delta_text: ' me'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' me'
+    - delta_text: ' know if'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' know if'
+    - delta_text: ' you need more.'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' you need more.'
+    - delta_text: ''
+      finish_reason: tool_calls
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+  TOOLCALLING.streamv2.8.c:
+    description: 'Narration both before and after (sandwich)'
+    ref: 'derived from TOOLCALLING.batch.8.c'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+    chunks:
+    - delta_text: 'I will'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
+    - delta_text: ' check'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' check'
+        vllm_python: ' check'
+        sglang_python: ' check'
+    - delta_text: ' the weather. <tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' the weather. '
+        vllm_python: ' the weather. '
+    - delta_text: '
+{"name": "get_weather",'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
+    - delta_text: ' "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: ' {"location": "NYC"}}'
+      expected:
+        vllm_rust:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        vllm_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call> Let me'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
         vllm_rust: ' Let me'
     - delta_text: ' know'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' know'
         vllm_rust: ' know'
     - delta_text: ' if you'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' if you'
         vllm_rust: ' if you'
-    - delta_text: ' need more.'
+    - delta_text: ' need'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' need more.'
-        vllm_rust: ' need more.'
-    - delta_text: ''
-      finish_reason: tool_calls
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-  TOOLCALLING.streamv2.8.c:
-    description: Narration both before and after (sandwich)
-    ref: derived from TOOLCALLING.batch.8.c
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-    unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
-    chunks:
-    - delta_text: I will
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
-    - delta_text: ' check'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' check'
-        sglang_python: ' check'
-        vllm_rust: ' check'
-    - delta_text: ' the weather. <tool_call>'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        vllm_python: ' the weather. '
-        vllm_rust: ' the weather. '
-    - delta_text: '{"name": "get_weather",'
-      expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' the weather. <tool_call>{"name": "get_weather",'
-    - delta_text: ' "arguments":'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}</tool_call>'
-      expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
-        vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' {"location": "NYC"}}'
-    - delta_text: ' Let me know'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' Let me know'
-        vllm_rust: ' Let me know'
-    - delta_text: ' if'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' if'
-        vllm_rust: ' if'
-    - delta_text: ' you need'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' you need'
-        vllm_rust: ' you need'
+        vllm_rust: ' need'
     - delta_text: ' more.'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        sglang_python: ' more.'
         vllm_rust: ' more.'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.8.d:
-    description: Narration between multiple tool calls
-    ref: derived from TOOLCALLING.batch.8.d
+    description: 'Narration between multiple tool calls'
+    ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather
       parameters:
@@ -283,126 +272,111 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: I will
+    - delta_text: 'I will'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: I will
-        sglang_python: I will
-        vllm_rust: I will
+        vllm_rust: 'I will'
+        vllm_python: 'I will'
+        sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-        vllm_rust: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
-        vllm_python: ' the weather. '
         vllm_rust: ' the weather. '
-    - delta_text: '{"name": "get_weather",'
+        vllm_python: ' the weather. '
+    - delta_text: '
+{"name": "get_weather",'
       expected:
-        vllm_python:
-        - index: 0
-          id: true
-          name: get_weather
-        sglang_python: []
         vllm_rust: []
-      normal_text:
-        sglang_python: ' the weather. <tool_call>{"name": "get_weather",'
+        vllm_python:
+        - {index: 0, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 0, name: 'get_weather'}
     - delta_text: ' "arguments":'
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' "arguments":'
-    - delta_text: ' {"location": "NYC"}}</tool_call>'
+    - delta_text: ' {"location": "NYC"}}'
       expected:
-        vllm_python:
-        - index: 0
-          arguments: '{"location": "NYC"}'
-        sglang_python: []
         vllm_rust:
-        - index: 0
-          name: get_weather
-        - arguments: '{"location": "NYC"}'
-          index: 0
-      normal_text:
-        sglang_python: ' {"location": "NYC"}}'
-    - delta_text: ' Then check LA'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' Then check LA'
-        vllm_rust: ' Then check LA'
-    - delta_text: ' weather.'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' weather.'
-        vllm_rust: ' weather.'
-    - delta_text: ' <tool_call>{"name":'
-      expected:
-        vllm_python: []
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' <tool_call>{"name":'
-        vllm_rust: ' '
-    - delta_text: ' "get_weather",'
-      expected:
+        - {index: 0, name: 'get_weather'}
+        - {index: 0, arguments: '{"location": "NYC"}'}
         vllm_python:
-        - index: 1
-          id: true
-          name: get_weather
-        sglang_python: []
-        vllm_rust: []
-      normal_text:
-        sglang_python: ' "get_weather",'
-    - delta_text: ' "arguments": {"location":'
+        - {index: 0, arguments: '{"location": "NYC"}'}
+        sglang_python:
+        - {index: 0, arguments: '{"location": "NYC"}'}
+    - delta_text: '
+</tool_call> Then check'
       expected:
-        vllm_python:
-        - index: 1
-          arguments: '{"location":'
+        vllm_rust: []
+        vllm_python: []
         sglang_python: []
+      normal_text:
+        vllm_rust: ' Then check'
+    - delta_text: ' LA'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' LA'
+    - delta_text: ' weather. <tool_call>'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+      normal_text:
+        vllm_rust: ' weather. '
+    - delta_text: '
+{"name":'
+      expected:
+        vllm_rust: []
+        vllm_python: []
+        sglang_python: []
+    - delta_text: ' "get_weather", "arguments":'
+      expected:
+        vllm_rust: []
+        vllm_python:
+        - {index: 1, id: true, name: 'get_weather'}
+        sglang_python:
+        - {index: 1, name: 'get_weather'}
+    - delta_text: ' {"location":'
+      expected:
         vllm_rust:
-        - index: 1
-          name: get_weather
-        - arguments: '{"location":'
-          index: 1
-      normal_text:
-        sglang_python: ' "arguments": {"location":'
-    - delta_text: ' "LA"}}</tool_call>'
-      expected:
+        - {index: 1, name: 'get_weather'}
+        - {index: 1, arguments: '{"location":'}
         vllm_python:
-        - index: 1
-          arguments: ' "LA"}'
+        - {index: 1, arguments: '{"location":'}
         sglang_python: []
+    - delta_text: ' "LA"}}
+</tool_call>'
+      expected:
         vllm_rust:
-        - arguments: ' "LA"}'
-          index: 1
-      normal_text:
-        sglang_python: ' "LA"}}'
+        - {index: 1, arguments: ' "LA"}'}
+        vllm_python:
+        - {index: 1, arguments: ' "LA"}'}
+        sglang_python:
+        - {index: 1, arguments: '{"location": "LA"}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.9.yaml
@@ -1,14 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). Each chunk: input (delta_text +
+# optional delta_token_ids) and `expected.<impl>` = tool-call deltas emitted at
+# that chunk. `normal_text.<impl>` (when non-empty) = non-tool text (leaks show
+# here). Assembled result is derived by concatenating per index. A delta:
+# {index, id?, name?, arguments?}; id:true = an id was emitted.
+
 family: qwen25
-model_label: Qwen 2.5
+model_label: 'Qwen 2.5'
 mode: streamv2
 captured_with:
-  vllm_python: 0.22.0
-  sglang_python: 0.5.12.post1
-  vllm_rust: v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
-    description: Empty model text
-    ref: derived from TOOLCALLING.batch.9.a
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
     tools:
     - name: get_weather
       parameters:
@@ -17,23 +26,22 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
   TOOLCALLING.streamv2.9.b:
-    description: Blank / whitespace-only model text
-    ref: derived from TOOLCALLING.batch.9.b
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
     tools:
     - name: get_weather
       parameters:
@@ -42,21 +50,20 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: Dynamo parser v2 TC streaming not yet implemented for this family; vLLM/SGLang
-        per-chunk output is the target to match.
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []
       normal_text:
+        vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
-        vllm_rust: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        vllm_rust: []
         vllm_python: []
         sglang_python: []
-        vllm_rust: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.1:
@@ -26,25 +25,28 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -52,18 +54,17 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.1.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,46 +26,44 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.10:
@@ -26,25 +25,28 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -52,37 +54,42 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
       normal_text:
-        vllm_rust: ' '
-        sglang_python: ' '
-    - delta_text: ' <function=get_weather>'
+        vllm_rust: '
+'
+        sglang_python: '
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -92,7 +99,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.10.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,80 +26,73 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>
-<tool_call>'
+    - delta_text: ' </tool_call> <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
       normal_text:
-        vllm_rust: '
-'
-        sglang_python: '
-'
-    - delta_text: '
-<function=get_weather>'
+        vllm_rust: ' '
+        sglang_python: ' '
+    - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>
-LA'
+    - delta_text: ' <parameter=location> LA'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>
-</tool_call>'
+    - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"location": "LA"'}
+        - {index: 1, arguments: '"location": " LA "'}
         - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,27 +26,25 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=unknown_tool>'
+    - delta_text: '<tool_call> <function=unknown_tool>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'unknown_tool'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python: []
-    - delta_text: 'NYC</parameter>
-</function>
-</tool_call>'
+    - delta_text: 'NYC</parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -57,6 +56,7 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.13.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.13:
@@ -26,25 +25,27 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=unknown_tool>'
+    - delta_text: '<tool_call>
+<function=unknown_tool>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'unknown_tool'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
         sglang_python: []
-    - delta_text: 'NYC</parameter> </function> </tool_call>'
+    - delta_text: 'NYC</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}
         vllm_python:
@@ -56,7 +57,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -31,80 +32,73 @@ cases:
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>
-<tool_call>'
+    - delta_text: ' </tool_call> <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
       normal_text:
-        vllm_rust: '
-'
-        sglang_python: '
-'
-    - delta_text: '
-<function=get_time>'
+        vllm_rust: ' '
+        sglang_python: ' '
+    - delta_text: ' <function=get_time>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_time'}
-    - delta_text: '
-<parameter=timezone>
-EST'
+    - delta_text: ' <parameter=timezone> EST'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>
-</tool_call>'
+    - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        vllm_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"timezone": "EST"'}
+        - {index: 1, arguments: '"timezone": " EST "'}
         - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -124,93 +118,89 @@ EST'
         properties:
           timezone:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both queries:'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'Both queries:'
         vllm_rust: 'Both queries:'
         vllm_python: 'Both queries:'
         sglang_python: 'Both queries:'
     - delta_text: ' <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' '
         vllm_rust: ' '
         vllm_python: ' '
         sglang_python: ' '
-    - delta_text: '
-<function=get_weather>
-<parameter=location>
-NYC'
+    - delta_text: ' <function=get_weather> <parameter=location> NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-</parameter>
-</function>'
+    - delta_text: ' </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
-    - delta_text: '
-<tool_call>
-<function=get_time>'
+    - delta_text: ' <tool_call> <function=get_time>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_time'}
       normal_text:
-        vllm_rust: '
-'
-        sglang_python: '
-'
-    - delta_text: '
-<parameter=timezone>
-EST
-</parameter>'
+        vllm_rust: ' '
+        sglang_python: ' '
+    - delta_text: ' <parameter=timezone> EST </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"timezone": "EST"'}
-    - delta_text: '
-</function>'
+        - {index: 1, arguments: '"timezone": " EST "'}
+    - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 1, arguments: '}'}
-    - delta_text: '
-</tool_call> Results'
+    - delta_text: ' </tool_call> Results'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
+        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
@@ -219,9 +209,10 @@ EST
         sglang_python: ' Results'
     - delta_text: ' above.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
-        - {index: 1, arguments: '"timezone": "EST"'}
+        - {index: 1, arguments: '"timezone": " EST "'}
         sglang_python: []
       normal_text:
         vllm_rust: ' above.'
@@ -229,6 +220,7 @@ EST
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -244,80 +236,73 @@ EST
           location:
             type: string
     - *id001
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>
-<tool_call>'
+    - delta_text: ' </tool_call> <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
       normal_text:
-        vllm_rust: '
-'
-        sglang_python: '
-'
-    - delta_text: '
-<function=get_weather>'
+        vllm_rust: ' '
+        sglang_python: ' '
+    - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>
-LA'
+    - delta_text: ' <parameter=location> LA'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>
-</tool_call>'
+    - delta_text: ' </parameter> </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"location": "LA"'}
+        - {index: 1, arguments: '"location": " LA "'}
         - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.2.a:
@@ -32,25 +31,28 @@ cases:
         properties:
           timezone:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -58,37 +60,42 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
       normal_text:
-        vllm_rust: ' '
-        sglang_python: ' '
-    - delta_text: ' <function=get_time>'
+        vllm_rust: '
+'
+        sglang_python: '
+'
+    - delta_text: '
+<function=get_time>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_time'}
-    - delta_text: ' <parameter=timezone> EST'
+    - delta_text: '
+<parameter=timezone>
+EST'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_rust:
-        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
@@ -98,7 +105,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -118,41 +124,41 @@ cases:
         properties:
           timezone:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Both queries:'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'Both queries:'
         vllm_rust: 'Both queries:'
         vllm_python: 'Both queries:'
         sglang_python: 'Both queries:'
     - delta_text: ' <tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' '
         vllm_rust: ' '
         vllm_python: ' '
         sglang_python: ' '
-    - delta_text: ' <function=get_weather> <parameter=location> NYC'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -160,47 +166,51 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
-    - delta_text: ' <tool_call> <function=get_time>'
+    - delta_text: '
+<tool_call>
+<function=get_time>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_time'}
       normal_text:
-        vllm_rust: ' '
-        sglang_python: ' '
-    - delta_text: ' <parameter=timezone> EST </parameter>'
+        vllm_rust: '
+'
+        sglang_python: '
+'
+    - delta_text: '
+<parameter=timezone>
+EST
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, arguments: '{'}
         - {index: 1, arguments: '"timezone": "EST"'}
-    - delta_text: ' </function>'
+    - delta_text: '
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 1, arguments: '}'}
-    - delta_text: ' </tool_call> Results'
+    - delta_text: '
+</tool_call> Results'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 1, name: 'get_time', arguments: '{"timezone":" EST "}'}
+        - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
@@ -209,7 +219,6 @@ cases:
         sglang_python: ' Results'
     - delta_text: ' above.'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '"timezone": "EST"'}
@@ -220,7 +229,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -236,25 +244,28 @@ cases:
           location:
             type: string
     - *id001
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -262,37 +273,42 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> <tool_call>'
+    - delta_text: '
+</tool_call>
+<tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
       normal_text:
-        vllm_rust: ' '
-        sglang_python: ' '
-    - delta_text: ' <function=get_weather>'
+        vllm_rust: '
+'
+        sglang_python: '
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </parameter> </function> </tool_call>'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -302,7 +318,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,48 +26,55 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Hello, how'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'Hello, how'
         vllm_rust: 'Hello, how'
         vllm_python: 'Hello, how'
         sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' can'
         vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
     - delta_text: ' I help you'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' I help you'
         vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
     - delta_text: ' today?'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' today?'
         vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.3.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.3:
@@ -26,55 +25,48 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'Hello, how'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'Hello, how'
         vllm_rust: 'Hello, how'
         vllm_python: 'Hello, how'
         sglang_python: 'Hello, how'
     - delta_text: ' can'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' can'
         vllm_rust: ' can'
         vllm_python: ' can'
         sglang_python: ' can'
     - delta_text: ' I help you'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' I help you'
         vllm_rust: ' I help you'
         vllm_python: ' I help you'
         sglang_python: ' I help you'
     - delta_text: ' today?'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' today?'
         vllm_rust: ' today?'
         vllm_python: ' today?'
         sglang_python: ' today?'
     - delta_text: ''
       finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -26,30 +27,32 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call>
-random'
+    - delta_text: '<tool_call> random'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' text'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' without function tag'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
@@ -63,35 +66,34 @@ random'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</function>
-</tool_call>'
+    - delta_text: ' NYC </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.f:
@@ -105,23 +107,21 @@ NYC
           command:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call>
-<terminal>'
+    - delta_text: '<tool_call> <terminal>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-echo'
+    - delta_text: ' echo'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' hello
-</function>
-</tool_call>'
+    - delta_text: ' hello </function> </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
@@ -129,5 +129,6 @@ echo'
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.4.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.4.a:
@@ -27,32 +26,30 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call> random'
+    - delta_text: '<tool_call>
+random'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' text'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ' without function tag'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.d:
@@ -66,24 +63,26 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </function> </tool_call>'
+    - delta_text: '
+NYC
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
@@ -93,7 +92,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.4.f:
@@ -107,21 +105,23 @@ cases:
           command:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: '
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: '
     chunks:
-    - delta_text: '<tool_call> <terminal>'
+    - delta_text: '<tool_call>
+<terminal>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' echo'
+    - delta_text: '
+echo'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' hello </function> </tool_call>'
+    - delta_text: ' hello
+</function>
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
@@ -129,6 +129,5 @@ cases:
     - delta_text: ''
       finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.5.a:
@@ -27,24 +26,26 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
@@ -54,7 +55,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
@@ -67,31 +67,39 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<function=get_weather> <parameter=location>'
+    - delta_text: '<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_rust: '<function=get_weather> <parameter=location>'
-        vllm_python: '<function=get_weather> <parameter=location>'
-        sglang_python: ' '
-    - delta_text: ' NYC'
+        vllm_rust: '<function=get_weather>
+<parameter=location>'
+        vllm_python: '<function=get_weather>
+<parameter=location>'
+        sglang_python: '
+'
+    - delta_text: '
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: ' NYC'
-        vllm_python: ' NYC'
-    - delta_text: ' </parameter> </function> </tool_call>'
+        vllm_rust: '
+NYC'
+        vllm_python: '
+NYC'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -99,13 +107,20 @@ cases:
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: ' </parameter> </function> </tool_call>'
-        vllm_python: ' </parameter> </function> </tool_call>'
-        sglang_python: "\n"
+        vllm_rust: '
+</parameter>
+</function>
+</tool_call>'
+        vllm_python: '
+</parameter>
+</function>
+</tool_call>'
+        sglang_python: '
+
+'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -120,30 +135,30 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NY'
+    - delta_text: '
+NY'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
@@ -157,144 +172,133 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <tool_call>'
+    - delta_text: ' time!
+<tool_call>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' time! '
-        vllm_python: ' time! '
-        sglang_python: ' time! '
-    - delta_text: ' <function=get_weather>'
+        vllm_python: ' time!
+'
+        sglang_python: ' time!
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location> Boston'
+    - delta_text: '
+<parameter=location>
+Boston'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '"location": "Boston"'}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "Boston"'}
-    - delta_text: ' </function> </tool_call> <tool_call>'
+    - delta_text: '
+</function>
+</tool_call>
+<tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        sglang_python: ' '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+        sglang_python: '
+'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: ' New'
+    - delta_text: '
+New'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' York </parameter>'
+    - delta_text: ' York
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python:
         - {index: 1, arguments: '{'}
         - {index: 1, arguments: '"location": "New York"'}
-    - delta_text: ' </function>'
+    - delta_text: '
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":"New York"}'}
         vllm_python:
         - {index: 1, arguments: '"location": "New York"'}
         sglang_python:
@@ -302,7 +306,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
@@ -316,142 +319,130 @@ cases:
           location:
             type: string
     unavailable:
-      vllm_rust: 'vLLM Rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time! <tool_call>'
+    - delta_text: ' time!
+<tool_call>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' time! '
-        vllm_python: ' time! '
-        sglang_python: ' time! '
-    - delta_text: ' <function=get_weather>'
+        vllm_python: ' time!
+'
+        sglang_python: ' time!
+'
+    - delta_text: '
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location> Boston'
+    - delta_text: '
+<parameter=location>
+Boston'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '"location": "Boston"'}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "Boston"'}
-    - delta_text: ' </function> </tool_call> <tool_call>'
+    - delta_text: '
+</function>
+</tool_call>
+<tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        sglang_python: ' '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+        sglang_python: '
+'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: ' New'
+    - delta_text: '
+New'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' York'
       expected:
-        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
@@ -464,31 +455,39 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<function=get_weather> <parameter=location>'
+    - delta_text: '<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_rust: '<function=get_weather> <parameter=location>'
-        vllm_python: '<function=get_weather> <parameter=location>'
-        sglang_python: ' '
-    - delta_text: ' NYC'
+        vllm_rust: '<function=get_weather>
+<parameter=location>'
+        vllm_python: '<function=get_weather>
+<parameter=location>'
+        sglang_python: '
+'
+    - delta_text: '
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: ' NYC'
-        vllm_python: ' NYC'
-    - delta_text: ' </parameter> </function> </tool_call>'
+        vllm_rust: '
+NYC'
+        vllm_python: '
+NYC'
+    - delta_text: '
+</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -496,42 +495,55 @@ cases:
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: ' </parameter> </function> </tool_call>'
-        vllm_python: ' </parameter> </function> </tool_call>'
-        sglang_python: "\n"
-    - delta_text: ' <tool_call> <function=get_weather>'
+        vllm_rust: '
+</parameter>
+</function>
+</tool_call>'
+        vllm_python: '
+</parameter>
+</function>
+</tool_call>'
+        sglang_python: '
+
+'
+    - delta_text: '
+<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
       normal_text:
-        vllm_rust: ' '
-        vllm_python: ' '
-        sglang_python: ' '
-    - delta_text: ' <parameter=location>'
+        vllm_rust: '
+'
+        vllm_python: '
+'
+        sglang_python: '
+'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' Boston </parameter>'
+    - delta_text: '
+Boston
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 1, arguments: '{'}
         - {index: 1, arguments: '"location": "Boston"'}
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" Boston "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "Boston"'}
         sglang_python:
@@ -539,7 +551,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -553,78 +564,87 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-    - delta_text: ' that. <function=get_weather> <parameter=location>'
+    - delta_text: ' that. <function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        dynamo_rust: ' that. '
-        vllm_rust: ' that. <function=get_weather> <parameter=location>'
-        vllm_python: ' that. <function=get_weather> <parameter=location>'
-        sglang_python: ' that. '
-    - delta_text: ' NYC </parameter>'
+        vllm_rust: ' that. <function=get_weather>
+<parameter=location>'
+        vllm_python: ' that. <function=get_weather>
+<parameter=location>'
+        sglang_python: ' that. 
+'
+    - delta_text: '
+NYC
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
       normal_text:
-        vllm_rust: ' NYC </parameter>'
-        vllm_python: ' NYC </parameter>'
-    - delta_text: ' </function>'
+        vllm_rust: '
+NYC
+</parameter>'
+        vllm_python: '
+NYC
+</parameter>'
+    - delta_text: '
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: ' </function>'
-        vllm_python: ' </function>'
-        sglang_python: ' '
-    - delta_text: ' </tool_call>'
+        vllm_rust: '
+</function>'
+        vllm_python: '
+</function>'
+        sglang_python: '
+'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: ' </tool_call>'
-        vllm_python: ' </tool_call>'
-        sglang_python: ' '
+        vllm_rust: '
+</tool_call>'
+        vllm_python: '
+</tool_call>'
+        sglang_python: '
+'
     - delta_text: ''
-      finish_reason: tool_calls
+      finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.5.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -26,35 +27,34 @@ cases:
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.b:
@@ -67,60 +67,45 @@ NYC
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<function=get_weather>
-<parameter=location>'
+    - delta_text: '<function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_rust: '<function=get_weather>
-<parameter=location>'
-        vllm_python: '<function=get_weather>
-<parameter=location>'
-        sglang_python: '
-'
-    - delta_text: '
-NYC'
+        vllm_rust: '<function=get_weather> <parameter=location>'
+        vllm_python: '<function=get_weather> <parameter=location>'
+        sglang_python: ' '
+    - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-NYC'
-        vllm_python: '
-NYC'
-    - delta_text: '
-</parameter>
-</function>
-</tool_call>'
+        vllm_rust: ' NYC'
+        vllm_python: ' NYC'
+    - delta_text: ' </parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: '
-</parameter>
-</function>
-</tool_call>'
-        vllm_python: '
-</parameter>
-</function>
-</tool_call>'
-        sglang_python: '
-
-'
+        vllm_rust: ' </parameter> </function> </tool_call>'
+        vllm_python: ' </parameter> </function> </tool_call>'
+        sglang_python: '  '
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -135,30 +120,30 @@ NYC'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NY'
+    - delta_text: ' NY'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.d:
@@ -172,140 +157,152 @@ NY'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!
-<tool_call>'
+    - delta_text: ' time! <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time!
-'
-        sglang_python: ' time!
-'
-    - delta_text: '
-<function=get_weather>'
+        dynamo_rust: ' time! '
+        vllm_python: ' time! '
+        sglang_python: ' time! '
+    - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>
-Boston'
+    - delta_text: ' <parameter=location> Boston'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>'
+    - delta_text: ' </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - {index: 0, arguments: '"location": "Boston"'}
+        - {index: 0, arguments: '"location": " Boston "'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "Boston"'}
-    - delta_text: '
-</function>
-</tool_call>
-<tool_call>'
+        - {index: 0, arguments: '"location": " Boston "'}
+    - delta_text: ' </function> </tool_call> <tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        sglang_python: '
-'
-    - delta_text: '
-<function=get_weather>
-<parameter=location>'
+        sglang_python: ' '
+    - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-New'
+    - delta_text: ' New'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' York
-</parameter>'
+    - delta_text: ' York </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"location": "New York"'}
-    - delta_text: '
-</function>'
+        - {index: 1, arguments: '"location": " New York "'}
+    - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"New York"}'}
         vllm_python:
-        - {index: 1, arguments: '"location": "New York"'}
+        - {index: 1, arguments: '"location": " New York "'}
         sglang_python:
         - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.e:
@@ -319,130 +316,142 @@ New'
           location:
             type: string
     unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
       vllm_rust: 'vllm_rust parser not captured: tool parser parsing failed: incomplete Qwen Coder tool call'
     chunks:
     - delta_text: 'I''ll start'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I''ll start'
         vllm_python: 'I''ll start'
         sglang_python: 'I''ll start'
     - delta_text: ' by'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' by'
         vllm_python: ' by'
         sglang_python: ' by'
     - delta_text: ' fetching the weather'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' fetching the weather'
         vllm_python: ' fetching the weather'
         sglang_python: ' fetching the weather'
     - delta_text: ' for both'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' for both'
         vllm_python: ' for both'
         sglang_python: ' for both'
     - delta_text: ' Boston'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Boston'
         vllm_python: ' Boston'
         sglang_python: ' Boston'
     - delta_text: ' and New'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' and New'
         vllm_python: ' and New'
         sglang_python: ' and New'
     - delta_text: ' York at the'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' York at the'
         vllm_python: ' York at the'
         sglang_python: ' York at the'
     - delta_text: ' same'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' same'
         vllm_python: ' same'
         sglang_python: ' same'
-    - delta_text: ' time!
-<tool_call>'
+    - delta_text: ' time! <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_python: ' time!
-'
-        sglang_python: ' time!
-'
-    - delta_text: '
-<function=get_weather>'
+        dynamo_rust: ' time! '
+        vllm_python: ' time! '
+        sglang_python: ' time! '
+    - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>
-Boston'
+    - delta_text: ' <parameter=location> Boston'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>'
+    - delta_text: ' </parameter>'
       expected:
+        dynamo_rust: []
         vllm_python:
-        - {index: 0, arguments: '"location": "Boston"'}
+        - {index: 0, arguments: '"location": " Boston "'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "Boston"'}
-    - delta_text: '
-</function>
-</tool_call>
-<tool_call>'
+        - {index: 0, arguments: '"location": " Boston "'}
+    - delta_text: ' </function> </tool_call> <tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        sglang_python: '
-'
-    - delta_text: '
-<function=get_weather>
-<parameter=location>'
+        sglang_python: ' '
+    - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-New'
+    - delta_text: ' New'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
     - delta_text: ' York'
       expected:
+        dynamo_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_python: []
         sglang_python: []
   TOOLCALLING.streamv2.5.f:
@@ -455,102 +464,82 @@ New'
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<function=get_weather>
-<parameter=location>'
+    - delta_text: '<function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_rust: '<function=get_weather>
-<parameter=location>'
-        vllm_python: '<function=get_weather>
-<parameter=location>'
-        sglang_python: '
-'
-    - delta_text: '
-NYC'
+        vllm_rust: '<function=get_weather> <parameter=location>'
+        vllm_python: '<function=get_weather> <parameter=location>'
+        sglang_python: ' '
+    - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-NYC'
-        vllm_python: '
-NYC'
-    - delta_text: '
-</parameter>
-</function>
-</tool_call>'
+        vllm_rust: ' NYC'
+        vllm_python: ' NYC'
+    - delta_text: ' </parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: '
-</parameter>
-</function>
-</tool_call>'
-        vllm_python: '
-</parameter>
-</function>
-</tool_call>'
-        sglang_python: '
-
-'
-    - delta_text: '
-<tool_call>
-<function=get_weather>'
+        vllm_rust: ' </parameter> </function> </tool_call>'
+        vllm_python: ' </parameter> </function> </tool_call>'
+        sglang_python: '  '
+    - delta_text: ' <tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 1, name: 'get_weather'}
       normal_text:
-        vllm_rust: '
-'
-        vllm_python: '
-'
-        sglang_python: '
-'
-    - delta_text: '
-<parameter=location>'
+        vllm_rust: ' '
+        vllm_python: ' '
+        sglang_python: ' '
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-Boston
-</parameter>'
+    - delta_text: ' Boston </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"location": "Boston"'}
-    - delta_text: '
-</function>
-</tool_call>'
+        - {index: 1, arguments: '"location": " Boston "'}
+    - delta_text: ' </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":"Boston"}'}
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" Boston "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "Boston"'}
+        - {index: 0, arguments: '"location": " Boston "'}
         sglang_python:
         - {index: 1, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -564,87 +553,78 @@ Boston
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
-    - delta_text: ' that. <function=get_weather>
-<parameter=location>'
+    - delta_text: ' that. <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
       normal_text:
-        vllm_rust: ' that. <function=get_weather>
-<parameter=location>'
-        vllm_python: ' that. <function=get_weather>
-<parameter=location>'
-        sglang_python: ' that. 
-'
-    - delta_text: '
-NYC
-</parameter>'
+        dynamo_rust: ' that. '
+        vllm_rust: ' that. <function=get_weather> <parameter=location>'
+        vllm_python: ' that. <function=get_weather> <parameter=location>'
+        sglang_python: ' that.  '
+    - delta_text: ' NYC </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
       normal_text:
-        vllm_rust: '
-NYC
-</parameter>'
-        vllm_python: '
-NYC
-</parameter>'
-    - delta_text: '
-</function>'
+        vllm_rust: ' NYC </parameter>'
+        vllm_python: ' NYC </parameter>'
+    - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '}'}
       normal_text:
-        vllm_rust: '
-</function>'
-        vllm_python: '
-</function>'
-        sglang_python: '
-'
-    - delta_text: '
-</tool_call>'
+        vllm_rust: ' </function>'
+        vllm_python: ' </function>'
+        sglang_python: ' '
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        vllm_rust: '
-</tool_call>'
-        vllm_python: '
-</tool_call>'
-        sglang_python: '
-'
+        vllm_rust: ' </tool_call>'
+        vllm_python: ' </tool_call>'
+        sglang_python: ' '
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,11 +26,10 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -37,6 +37,7 @@ cases:
         vllm_python: '<t'
     - delta_text: 'ool'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -44,6 +45,7 @@ cases:
         vllm_python: 'ool'
     - delta_text: '_call'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -51,6 +53,7 @@ cases:
         vllm_python: '_call'
     - delta_text: '> <function'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -58,6 +61,7 @@ cases:
         vllm_python: '> <function'
     - delta_text: '=get_weather> <para'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -66,6 +70,7 @@ cases:
         vllm_python: '=get_weather> <para'
     - delta_text: 'me'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -73,6 +78,7 @@ cases:
         vllm_python: 'me'
     - delta_text: 'ter'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -80,6 +86,7 @@ cases:
         vllm_python: 'ter'
     - delta_text: '=loca'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -87,6 +94,7 @@ cases:
         vllm_python: '=loca'
     - delta_text: 'tion> NYC <'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -94,6 +102,7 @@ cases:
         vllm_python: 'tion> NYC <'
     - delta_text: '/parameter> </funct'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -103,6 +112,7 @@ cases:
         vllm_python: '/parameter> </funct'
     - delta_text: 'io'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -110,6 +120,8 @@ cases:
         vllm_python: 'io'
     - delta_text: 'n> '
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -118,6 +130,7 @@ cases:
         vllm_python: 'n> '
     - delta_text: '</too'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -125,6 +138,7 @@ cases:
         vllm_python: '</too'
     - delta_text: 'l_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python: []
@@ -134,6 +148,7 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.50.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.50:
@@ -26,10 +25,11 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '<t'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -37,7 +37,6 @@ cases:
         vllm_python: '<t'
     - delta_text: 'ool'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -45,7 +44,6 @@ cases:
         vllm_python: 'ool'
     - delta_text: '_call'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -53,7 +51,6 @@ cases:
         vllm_python: '_call'
     - delta_text: '> <function'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -61,7 +58,6 @@ cases:
         vllm_python: '> <function'
     - delta_text: '=get_weather> <para'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -70,7 +66,6 @@ cases:
         vllm_python: '=get_weather> <para'
     - delta_text: 'me'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -78,7 +73,6 @@ cases:
         vllm_python: 'me'
     - delta_text: 'ter'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -86,7 +80,6 @@ cases:
         vllm_python: 'ter'
     - delta_text: '=loca'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -94,7 +87,6 @@ cases:
         vllm_python: '=loca'
     - delta_text: 'tion> NYC <'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -102,17 +94,15 @@ cases:
         vllm_python: 'tion> NYC <'
     - delta_text: '/parameter> </funct'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
       normal_text:
         vllm_python: '/parameter> </funct'
     - delta_text: 'io'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -120,8 +110,6 @@ cases:
         vllm_python: 'io'
     - delta_text: 'n> '
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -130,7 +118,6 @@ cases:
         vllm_python: 'n> '
     - delta_text: '</too'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -138,7 +125,6 @@ cases:
         vllm_python: '</too'
     - delta_text: 'l_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python: []
@@ -148,7 +134,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.6.a:
@@ -24,27 +23,28 @@ cases:
       parameters:
         type: object
         properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_time>'
+    - delta_text: '<tool_call>
+<function=get_time>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_time'}
-    - delta_text: ' </function>'
+    - delta_text: '
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -53,7 +53,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -65,28 +64,29 @@ cases:
       parameters:
         type: object
         properties: {}
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_time>'
+    - delta_text: '<tool_call>
+<function=get_time>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_time'}
     - delta_text: '
+
 </function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -95,7 +95,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.6.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -23,28 +24,27 @@ cases:
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_time>'
+    - delta_text: '<tool_call> <function=get_time>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_time'}
-    - delta_text: '
-</function>'
+    - delta_text: ' </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -53,6 +53,7 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -64,29 +65,28 @@ cases:
       parameters:
         type: object
         properties: {}
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_time>'
+    - delta_text: '<tool_call> <function=get_time>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_time'}
     - delta_text: '
-
 </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
         vllm_python:
@@ -95,6 +95,7 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -29,64 +30,58 @@ cases:
             type: integer
           first_class:
             type: boolean
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=book_flight>'
+    - delta_text: '<tool_call> <function=book_flight>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'book_flight'}
-    - delta_text: '
-<parameter=destination>'
+    - delta_text: ' <parameter=destination>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'book_flight', arguments: ''}
         sglang_python: []
-    - delta_text: '
-Paris
-</parameter>
-<parameter=passengers>'
+    - delta_text: ' Paris </parameter> <parameter=passengers>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"destination": "Paris"'}
-    - delta_text: '
-2
-</parameter>'
+        - {index: 0, arguments: '"destination": " Paris "'}
+    - delta_text: ' 2 </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
-        - {index: 0, arguments: '"destination": "Paris", "passengers": "2"'}
+        - {index: 0, arguments: '"destination": " Paris ", "passengers": " 2 "'}
         sglang_python:
         - {index: 0, arguments: ', "passengers": 2'}
-    - delta_text: '
-<parameter=first_class>'
+    - delta_text: ' <parameter=first_class>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: '
-true
-</parameter>'
+    - delta_text: ' true </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
-        - {index: 0, arguments: ', "first_class": "true"'}
+        - {index: 0, arguments: ', "first_class": " true "'}
         sglang_python:
-        - {index: 0, arguments: ', "first_class": true'}
-    - delta_text: '
-</function>
-</tool_call>'
+        - {index: 0, arguments: ', "first_class": false'}
+    - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
+        vllm_rust:
+        - {index: 0, name: 'book_flight', arguments: '{"destination":" Paris ","passengers":" 2 ","first_class":true}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
@@ -94,6 +89,7 @@ true
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -107,46 +103,44 @@ true
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-Tōkyō central
-</parameter>'
+    - delta_text: ' Tōkyō central </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "Tōkyō central"'}
-    - delta_text: '
-</function>
-</tool_call>'
+        - {index: 0, arguments: '"location": " Tōkyō central "'}
+    - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
+        vllm_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":" Tōkyō central "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "Tōkyō central"'}
+        - {index: 0, arguments: '"location": " Tōkyō central "'}
         sglang_python:
         - {index: 0, arguments: '}'}
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -160,27 +154,25 @@ Tōkyō central
         properties:
           count:
             type: number
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=set_limit>'
+    - delta_text: '<tool_call> <function=set_limit>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'set_limit'}
-    - delta_text: '
-<parameter=count>'
+    - delta_text: ' <parameter=count>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'set_limit', arguments: ''}
         sglang_python: []
-    - delta_text: '9007199254740993</parameter>
-</function>
-</tool_call>'
+    - delta_text: '9007199254740993</parameter> </function> </tool_call>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_rust:
         - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_python:
@@ -192,6 +184,7 @@ Tōkyō central
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.7.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.7.a:
@@ -30,58 +29,64 @@ cases:
             type: integer
           first_class:
             type: boolean
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=book_flight>'
+    - delta_text: '<tool_call>
+<function=book_flight>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'book_flight'}
-    - delta_text: ' <parameter=destination>'
+    - delta_text: '
+<parameter=destination>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'book_flight', arguments: ''}
         sglang_python: []
-    - delta_text: ' Paris </parameter> <parameter=passengers>'
+    - delta_text: '
+Paris
+</parameter>
+<parameter=passengers>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"destination": "Paris"'}
-    - delta_text: ' 2 </parameter>'
+    - delta_text: '
+2
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '"destination": "Paris", "passengers": "2"'}
         sglang_python:
         - {index: 0, arguments: ', "passengers": 2'}
-    - delta_text: ' <parameter=first_class>'
+    - delta_text: '
+<parameter=first_class>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
-    - delta_text: ' true </parameter>'
+    - delta_text: '
+true
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: ', "first_class": "true"'}
         sglang_python:
         - {index: 0, arguments: ', "first_class": true'}
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_rust:
-        - {index: 0, name: 'book_flight', arguments: '{"destination":" Paris ","first_class":true,"passengers":" 2 "}'}
+        - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python:
@@ -89,7 +94,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -103,36 +107,39 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' Tōkyō central </parameter>'
+    - delta_text: '
+Tōkyō central
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "Tōkyō central"'}
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" Tōkyō central "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "Tōkyō central"'}
         sglang_python:
@@ -140,7 +147,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -154,25 +160,27 @@ cases:
         properties:
           count:
             type: number
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=set_limit>'
+    - delta_text: '<tool_call>
+<function=set_limit>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'set_limit'}
-    - delta_text: ' <parameter=count>'
+    - delta_text: '
+<parameter=count>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'set_limit', arguments: ''}
         sglang_python: []
-    - delta_text: '9007199254740993</parameter> </function> </tool_call>'
+    - delta_text: '9007199254740993</parameter>
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_rust:
         - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}
         vllm_python:
@@ -184,7 +192,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.8.a:
@@ -26,59 +25,56 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
@@ -86,18 +82,17 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call>'
+    - delta_text: '
+</tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -111,25 +106,28 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call> <function=get_weather>'
+    - delta_text: '<tool_call>
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' <parameter=location>'
+    - delta_text: '
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: ' NYC </parameter> </function>'
+    - delta_text: '
+NYC
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
@@ -137,11 +135,11 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> Let'
+    - delta_text: '
+</tool_call> Let'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
         sglang_python: []
@@ -150,7 +148,6 @@ cases:
         sglang_python: ' Let'
     - delta_text: ' me'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
@@ -160,7 +157,6 @@ cases:
         sglang_python: ' me'
     - delta_text: ' know if'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -169,7 +165,6 @@ cases:
         sglang_python: ' know if'
     - delta_text: ' you need more.'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -180,7 +175,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -194,59 +188,56 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
@@ -254,11 +245,11 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> Let me'
+    - delta_text: '
+</tool_call> Let me'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
@@ -267,7 +258,6 @@ cases:
         sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -276,7 +266,6 @@ cases:
         sglang_python: ' know'
     - delta_text: ' if you'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -286,7 +275,6 @@ cases:
         sglang_python: ' if you'
     - delta_text: ' need'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -296,7 +284,6 @@ cases:
         sglang_python: ' need'
     - delta_text: ' more.'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -307,7 +294,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -321,59 +307,56 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: ' <function=get_weather> <parameter=location>'
+    - delta_text: '
+<function=get_weather>
+<parameter=location>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: ' NYC'
+    - delta_text: '
+NYC'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter> </function>'
+    - delta_text: '
+</parameter>
+</function>'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '"location": "NYC"'}
@@ -381,11 +364,11 @@ cases:
         - {index: 0, arguments: '{'}
         - {index: 0, arguments: '"location": "NYC"'}
         - {index: 0, arguments: '}'}
-    - delta_text: ' </tool_call> Then check'
+    - delta_text: '
+</tool_call> Then check'
       expected:
-        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
@@ -394,7 +377,6 @@ cases:
         sglang_python: ' Then check'
     - delta_text: ' LA'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -403,7 +385,6 @@ cases:
         sglang_python: ' LA'
     - delta_text: ' weather. <tool_call>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -411,36 +392,37 @@ cases:
         vllm_rust: ' weather. '
         vllm_python: ' weather. '
         sglang_python: ' weather. '
-    - delta_text: ' <function=get_weather>'
+    - delta_text: '
+<function=get_weather>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: ' <parameter=location> LA'
+    - delta_text: '
+<parameter=location>
+LA'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
-    - delta_text: ' </parameter>'
+    - delta_text: '
+</parameter>'
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '"location": "LA"'}
         sglang_python:
         - {index: 1, arguments: '{'}
         - {index: 1, arguments: '"location": "LA"'}
-    - delta_text: ' </function> </tool_call>'
+    - delta_text: '
+</function>
+</tool_call>'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_rust:
-        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
+        - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
         vllm_python:
         - {index: 1, arguments: '}'}
         sglang_python:
@@ -448,7 +430,6 @@ cases:
     - delta_text: ''
       finish_reason: tool_calls
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,74 +26,78 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: '
-<function=get_weather>
-<parameter=location>'
+    - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-NYC'
+    - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>'
+    - delta_text: ' </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call>'
+    - delta_text: ' </tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -106,48 +111,46 @@ NYC'
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
-    - delta_text: '<tool_call>
-<function=get_weather>'
+    - delta_text: '<tool_call> <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>'
+    - delta_text: ' <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python: []
-    - delta_text: '
-NYC
-</parameter>
-</function>'
+    - delta_text: ' NYC </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call> Let'
+    - delta_text: ' </tool_call> Let'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python: []
       normal_text:
         vllm_rust: ' Let'
         sglang_python: ' Let'
     - delta_text: ' me'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '}'}
@@ -157,6 +160,7 @@ NYC
         sglang_python: ' me'
     - delta_text: ' know if'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -165,6 +169,7 @@ NYC
         sglang_python: ' know if'
     - delta_text: ' you need more.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -175,6 +180,7 @@ NYC
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -188,68 +194,71 @@ NYC
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: '
-<function=get_weather>
-<parameter=location>'
+    - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-NYC'
+    - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>'
+    - delta_text: ' </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call> Let me'
+    - delta_text: ' </tool_call> Let me'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
@@ -258,6 +267,7 @@ NYC'
         sglang_python: ' Let me'
     - delta_text: ' know'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -266,6 +276,7 @@ NYC'
         sglang_python: ' know'
     - delta_text: ' if you'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -275,6 +286,7 @@ NYC'
         sglang_python: ' if you'
     - delta_text: ' need'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -284,6 +296,7 @@ NYC'
         sglang_python: ' need'
     - delta_text: ' more.'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -294,6 +307,7 @@ NYC'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -307,68 +321,71 @@ NYC'
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: 'I will'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: 'I will'
         vllm_rust: 'I will'
         vllm_python: 'I will'
         sglang_python: 'I will'
     - delta_text: ' check'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check'
         vllm_rust: ' check'
         vllm_python: ' check'
         sglang_python: ' check'
     - delta_text: ' the weather. <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' the weather. '
         vllm_rust: ' the weather. '
         vllm_python: ' the weather. '
         sglang_python: ' the weather. '
-    - delta_text: '
-<function=get_weather>
-<parameter=location>'
+    - delta_text: ' <function=get_weather> <parameter=location>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_weather'}
-    - delta_text: '
-NYC'
+    - delta_text: ' NYC'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>
-</function>'
+    - delta_text: ' </parameter> </function>'
       expected:
+        dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python:
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         sglang_python:
         - {index: 0, arguments: '{'}
-        - {index: 0, arguments: '"location": "NYC"'}
+        - {index: 0, arguments: '"location": " NYC "'}
         - {index: 0, arguments: '}'}
-    - delta_text: '
-</tool_call> Then check'
+    - delta_text: ' </tool_call> Then check'
       expected:
+        dynamo_rust: []
         vllm_rust:
-        - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
+        - {index: 0, name: 'get_weather', arguments: '{"location":" NYC "}'}
         vllm_python:
         - {index: 0, arguments: '}'}
         sglang_python: []
@@ -377,6 +394,7 @@ NYC'
         sglang_python: ' Then check'
     - delta_text: ' LA'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -385,6 +403,7 @@ NYC'
         sglang_python: ' LA'
     - delta_text: ' weather. <tool_call>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -392,37 +411,36 @@ NYC'
         vllm_rust: ' weather. '
         vllm_python: ' weather. '
         sglang_python: ' weather. '
-    - delta_text: '
-<function=get_weather>'
+    - delta_text: ' <function=get_weather>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
         - {index: 1, name: 'get_weather'}
-    - delta_text: '
-<parameter=location>
-LA'
+    - delta_text: ' <parameter=location> LA'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, arguments: '{'}
         sglang_python: []
-    - delta_text: '
-</parameter>'
+    - delta_text: ' </parameter>'
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
-        - {index: 1, arguments: '"location": "LA"'}
+        - {index: 1, arguments: '"location": " LA "'}
         sglang_python:
         - {index: 1, arguments: '{'}
-        - {index: 1, arguments: '"location": "LA"'}
-    - delta_text: '
-</function>
-</tool_call>'
+        - {index: 1, arguments: '"location": " LA "'}
+    - delta_text: ' </function> </tool_call>'
       expected:
-        vllm_rust:
+        dynamo_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}
+        vllm_rust:
+        - {index: 1, name: 'get_weather', arguments: '{"location":" LA "}'}
         vllm_python:
         - {index: 1, arguments: '}'}
         sglang_python:
@@ -430,6 +448,7 @@ LA'
     - delta_text: ''
       finish_reason: tool_calls
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
@@ -11,9 +11,8 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
-  dynamo_rust: 'Dynamo parser v2'
-  vllm_rust: 'v0.22.0 0b3ba88f165976e77ca5e6a7a3f5bba4562b80af'
-  vllm_python: '0.22.0'
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
 cases:
   TOOLCALLING.streamv2.9.a:
@@ -26,17 +25,17 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -50,22 +49,21 @@ cases:
         properties:
           location:
             type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: '   '
         vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
-        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.9.yaml
@@ -11,6 +11,7 @@ family: qwen3_coder
 model_label: 'Qwen 3 Coder'
 mode: streamv2
 captured_with:
+  dynamo_rust: 'Dynamo parser v2'
   vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
   vllm_python: '0.23.0'
   sglang_python: '0.5.12.post1'
@@ -25,17 +26,17 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: ''
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
@@ -49,21 +50,22 @@ cases:
         properties:
           location:
             type: string
-    unavailable:
-      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
     chunks:
     - delta_text: '   '
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: '   '
         vllm_rust: '   '
         vllm_python: '   '
         sglang_python: '   '
     - delta_text: ''
       finish_reason: stop
       expected:
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python: []

--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -103,13 +103,13 @@ conformance/utils/capture.sh dynamo-stream \
 conformance/utils/capture.sh stream \
   --vllm-container vllm-localdev \
   --sglang-container sglang-localdev \
-  --vllm-rust-source ~/dynamo/vllm-0.22.0
+  --vllm-rust-source ~/dynamo/vllm-0.23.0
 
 # Example: capture all Dynamo v2 Rust, vLLM Python, vLLM Rust, and SGLang Python batch-on-stream behavior, then refresh `fixtures-batch-on-stream-v2/`.
 conformance/utils/capture.sh batch-on-stream \
   --vllm-container vllm-localdev \
   --sglang-container sglang-localdev \
-  --vllm-rust-source ~/dynamo/vllm-0.22.0 \
+  --vllm-rust-source ~/dynamo/vllm-0.23.0 \
   --capture-dynamo-rust-json /tmp/dynamo_batch_on_stream.json
 
 # Example: capture one Dynamo v2 Rust batch-on-stream JSON file without refreshing fixture YAML.
@@ -128,16 +128,16 @@ Use this before capture commands that refresh `expected.vllm_rust`.
 
 ```bash
 # Downloads the vLLM source tree used for current Rust captures.
-git clone https://github.com/vllm-project/vllm.git ~/dynamo/vllm-0.22.0
+git clone https://github.com/vllm-project/vllm.git ~/dynamo/vllm-0.23.0
 
 # Checks out the pinned vLLM version.
-git -C ~/dynamo/vllm-0.22.0 checkout v0.22.0
+git -C ~/dynamo/vllm-0.23.0 checkout v0.23.0
 
 # Confirms the Rust tool-parser crate exists.
-test -f ~/dynamo/vllm-0.22.0/rust/src/tool-parser/Cargo.toml
+test -f ~/dynamo/vllm-0.23.0/rust/src/tool-parser/Cargo.toml
 
 # Makes capture scripts pick up this checkout.
-export VLLM_RUST_SOURCE=~/dynamo/vllm-0.22.0
+export VLLM_RUST_SOURCE=~/dynamo/vllm-0.23.0
 
 # Shows the source version that will be stamped into YAML.
 git -C "$VLLM_RUST_SOURCE" describe --tags --exact-match
@@ -172,7 +172,7 @@ The matrix has four parser identities:
 | Selector | Marker form |
 |---|---|
 | Dynamo Rust | `D_rs` (Dynamo Rust stream parser), `D_rb` (Dynamo Rust batch parser). |
-| vLLM Rust | `V_rs` (vLLM Rust stream parser). There is no `V_rb`; vLLM Rust batch-style complete parsing delegates through streaming `push(full_output)` and `finish()` in vLLM Rust 0.22.0. |
+| vLLM Rust | `V_rs` (vLLM Rust stream parser). There is no `V_rb`; vLLM Rust batch-style complete parsing delegates through streaming `parse_into(full_output, ...)` and `finish()` in vLLM Rust 0.23.0. |
 | vLLM Python | `V_ps` (vLLM Python stream parser), `V_pb` (vLLM Python batch parser). |
 | SGLang | `S_rs` (SGLang stream parser), `S_rb` (SGLang batch parser). |
 
@@ -202,6 +202,6 @@ The implementation lives under `src/` — don't run these directly unless you're
 
 ## Notes
 
-Peer parser versions for vLLM Python and SGLang are pinned in `src/pyproject.stub.toml`; the table currently reports vLLM Python `0.22.0` and SGLang `0.5.12.post1`. vLLM Rust is captured from a local source checkout and recorded in YAML under `captured_with.vllm_rust`.
+Peer parser versions for vLLM Python and SGLang are pinned in `src/pyproject.stub.toml` — currently vLLM Python `0.23.0` and SGLang `0.5.12.post1`. This stub is the single source of truth for both the v2 `captured_with` stamps and the v1 batch fixtures (`expected.vllm` / `expected.sglang`), which carry no per-file version stamp; `check.sh vllm|sglang --container` validates the live engine against the committed v1 fixtures and reports it as `pinned (fixtures captured against)`. As of the 0.23.0 bump the live vLLM `0.23.0` and SGLang `0.5.12.post1` batch parsers match all committed v1 cases (519 vLLM, 448 SGLang). vLLM Rust is captured from a local source checkout and recorded in YAML under `captured_with.vllm_rust`.
 
 The scripts build an ephemeral `.stage/` tree because the vendored Dynamo Python table code assumes Dynamo's repo layout. `.stage*/` is gitignored.

--- a/conformance/utils/src/build_stream_fixtures.py
+++ b/conformance/utils/src/build_stream_fixtures.py
@@ -192,6 +192,16 @@ def main():
                                             allow_unicode=True, sort_keys=False).rstrip(), 4))
         # unavailable block
         case_unavail = dict(unavail)
+        # Per-case capture errors: the probe emits {"error": ...} for a case the
+        # parser rejected (e.g. garbage/incomplete tool call). That's expected
+        # behavior for some edge cases, not a chunk list — record it as a
+        # case-level unavailable so the per-chunk loop below skips the impl.
+        for impl in IMPL_KEYS:
+            if impl in case_unavail or impl in na_impls:
+                continue
+            cap = caps.get(impl, {}).get(cid)
+            if isinstance(cap, dict):
+                case_unavail[impl] = f"{impl} parser not captured: {cap.get('error', 'capture failed')}"
         if case_unavail:
             L.append("    unavailable:")
             for impl, reason in case_unavail.items():

--- a/conformance/utils/src/capture_vllm_rust.py
+++ b/conformance/utils/src/capture_vllm_rust.py
@@ -38,7 +38,7 @@ use vllm_tool_parser::{
     DeepSeekV31ToolParser, DeepSeekV32ToolParser, DeepSeekV3ToolParser, DeepSeekV4ToolParser,
     Gemma4ToolParser, Glm47MoeToolParser, HermesToolParser, KimiK2ToolParser,
     Llama3JsonToolParser, MinimaxM2ToolParser, MistralToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, Tool, ToolCallDelta, ToolParseResult, ToolParser,
+    Qwen3XmlToolParser, Tool, ToolCallDelta, ToolParser, ToolParserOutput,
 };
 
 #[derive(Debug, Deserialize)]
@@ -135,19 +135,19 @@ fn output_delta(delta: ToolCallDelta) -> OutputDelta {
     }
 }
 
-fn output_chunk(result: ToolParseResult) -> OutputChunk {
+fn output_chunk(result: ToolParserOutput) -> OutputChunk {
     OutputChunk {
         deltas: result.calls.into_iter().map(output_delta).collect(),
         normal_text: result.normal_text,
     }
 }
 
-fn append_result(out: &mut ToolParseResult, mut next: ToolParseResult) {
+fn append_result(out: &mut ToolParserOutput, mut next: ToolParserOutput) {
     out.normal_text.push_str(&next.normal_text);
     out.calls.append(&mut next.calls);
 }
 
-fn assembled_call_map(result: ToolParseResult) -> Vec<Value> {
+fn assembled_call_map(result: ToolParserOutput) -> Vec<Value> {
     let mut order = Vec::<usize>::new();
     let mut names = BTreeMap::<usize, String>::new();
     let mut args = BTreeMap::<usize, String>::new();
@@ -185,7 +185,8 @@ fn run_stream(input: Input) -> anyhow::Result<Value> {
             let mut parser = create_parser(&input.parser, &tools)?;
             let mut chunks = Vec::new();
             for chunk in case.chunks {
-                let mut result = parser.push(&chunk.delta_text)?;
+                let mut result = ToolParserOutput::default();
+                parser.parse_into(&chunk.delta_text, &mut result)?;
                 if chunk.finish_reason.is_some() {
                     append_result(&mut result, parser.finish()?);
                 }
@@ -211,9 +212,9 @@ fn run_batch_on_stream(input: Input) -> anyhow::Result<Value> {
         let result = (|| -> anyhow::Result<Option<Value>> {
             let tools = make_tools(case.tools);
             let mut parser = create_parser(&input.parser, &tools)?;
-            let mut result = ToolParseResult::default();
+            let mut result = ToolParserOutput::default();
             if let Some(model_text) = case.model_text {
-                append_result(&mut result, parser.push(&model_text)?);
+                parser.parse_into(&model_text, &mut result)?;
                 append_result(&mut result, parser.finish()?);
                 let normal_text = std::mem::take(&mut result.normal_text);
                 let calls = assembled_call_map(result);

--- a/conformance/utils/src/fill_streamv2.py
+++ b/conformance/utils/src/fill_streamv2.py
@@ -189,7 +189,7 @@ def main():
                 cmd += ["--unavailable", f"vllm_rust={cd._vllm_rust_unavailable(vllm_rust_source_version)}"]
             cmd += cd._impl_args("vllm_python", family, cd.VLLM.get(family),
                                  vllm_caps.get(fp, {}), vllm_ver, work, f"{family}_{num}", fp)
-            cmd += cd._impl_args("sglang", family, cd.SGLANG.get(family),
+            cmd += cd._impl_args("sglang_python", family, cd.SGLANG.get(family),
                                  sglang_caps.get(fp, {}), sglang_ver, work, f"{family}_{num}", fp)
             subprocess.run(cmd, check=True)
             # build_stream_fixtures.py hardcodes `mode: stream`; this is the v2 tab.

--- a/conformance/utils/src/markers.py
+++ b/conformance/utils/src/markers.py
@@ -420,7 +420,7 @@ def _stream_parity_explainer_html(marker_context: str | None) -> str:
     return (
         "Red means that engine's stream parser diverges from its batch parser. "
         "There is no <code>V_rb</code>; vLLM Rust has stream parser capture only. "
-        "Harmony captured against vLLM 0.22.0 / SGLang 0.5.12.post1."
+        "Harmony captured against vLLM 0.23.0 / SGLang 0.5.12.post1."
     )
 
 

--- a/conformance/utils/src/pyproject.stub.toml
+++ b/conformance/utils/src/pyproject.stub.toml
@@ -3,5 +3,5 @@
 [tool.parity]
 peers = [
   "sglang[diffusion]==0.5.12.post1",
-  "vllm[flashinfer,runai,otel]==0.22.0",
+  "vllm[flashinfer,runai,otel]==0.23.0",
 ]

--- a/conformance/utils/src/validate.py
+++ b/conformance/utils/src/validate.py
@@ -42,7 +42,7 @@ import yaml
 from tests.parity.common import ParseResult, canonical
 
 PH = Path(__file__).resolve().parent
-PKG = PH / "tests" / "parity"
+PKG = PH.parent / "tests" / "parity"
 STUB = PH / "pyproject.stub.toml"
 from impls import FIXTURE_IMPL_ALIASES  # noqa: E402  (identity table; see impls.py)
 
@@ -144,7 +144,7 @@ def run_container(impl: str, container: str, cases: list[dict]) -> dict[str, dic
     """Ship the adapter + a worker into ``container`` and run all cases there."""
     dest = "/tmp/parity_validate"
     bundle = {
-        "tests/__init__.py": PH / "tests" / "__init__.py",
+        "tests/__init__.py": PKG.parent / "__init__.py",
         "tests/parity/__init__.py": PKG / "__init__.py",
         "tests/parity/common.py": PKG / "common.py",
         "tests/parity/toolcalling/__init__.py": PKG / "toolcalling" / "__init__.py",


### PR DESCRIPTION
#### Overview:

This PR repegs the parser conformance fixtures to vLLM 0.23.0 / SGLang 0.5.12.post1 (matching dynamo `main`) and fixes the capture-harness bugs that blocked the recapture.

#### Details:

- Regenerated all v2 fixtures (streamv2 + batch-on-stream) against vLLM 0.23.0 / SGLang 0.5.12.post1; vllm_rust recaptured at v0.23.0.
- Ported the vLLM Rust probe to the 0.23.0 `ToolParser` API (`ToolParseResult` -> `ToolParserOutput`, `push` -> `parse_into`), added per-case capture-error handling in `build_stream_fixtures`, and fixed a `fill_streamv2` `sglang_python` KeyError.
- Preserved the v2 stream `dynamo_rust` for families that have a v2 parser — qwen3_coder (#53), deepseek_v4 (#66) — by recapturing via `record_dynamo_stream` (a bare `fill_streamv2` regen TODOs it). Values match `main` exactly (0 / 466 chunk mismatches); `parity_toolcalling_stream` validates both families again.
- Fixed `validate.py`'s helper-bundle path (`src/tests` -> `conformance/utils/tests`) so `check.sh vllm|sglang --container` runs again; v1 batch fixtures verified consistent with live vLLM 0.23.0 / SGLang 0.5.12.post1 (519 vLLM / 448 SGLang cases) and documented in `utils/README` (v1 carries no per-file version stamp).
- Harmony token-id output verified byte-identical at 0.23.0 (stamp-only bump); updated the `pyproject` stub + `markers` label.

#### Verification:

`validate_fixtures` clean; `parity_toolcalling_stream` + `parity_toolcalling_batch_via_stream` pass; v1 `check.sh vllm|sglang --container` passes 519 vLLM / 448 SGLang cases at 0.23.0.

#### Related issue:

[DIS-2266](https://linear.app/nvidia/issue/DIS-2266)

#### Where should the reviewer start?

`conformance/utils/src/capture_vllm_rust.py`, then `conformance/utils/src/build_stream_fixtures.py`

/coderabbit profile chill
