### PR TITLE
build: bump fastokens to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38849fadd9e96f872be6549556d26b3e9f5135b6ac8b616205de554fdd4318"
+checksum = "796a262ed47d1458a4b40d0ed831c927e6f54d5b9c1de2683bb4ac9b04f4c7cc"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dynamo-protocols = { path = "protocols", version = "2.0.0" }
 dynamo-renderer = { path = "renderer", version = "1.3.3" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.3.1" }
 either = { version = "1.13", features = ["serde"] }
-fastokens = "0.1.0"
+fastokens = "0.2.0"
 futures = "0.3"
 hf-hub = { version = "0.4", default-features = false }
 minijinja = { version = "2.21.0" }


### PR DESCRIPTION
## Summary
- Bump the workspace `fastokens` dependency from `0.1.0` to `0.2.0`.
- Refresh `Cargo.lock` so the resolved `fastokens` package is `0.2.0`.

## Validation
- `cargo test -p dynamo-tokenizers`