### PR TITLE
fix(parsers-v2): drop DSv4 tool calls truncated mid-call to match v1 batch

### DIFF
--- a/conformance/tests/parity_toolcalling_batch_via_stream.rs
+++ b/conformance/tests/parity_toolcalling_batch_via_stream.rs
@@ -67,23 +67,14 @@ fn toolcalling_batch_via_stream_parity() {
     // strict batch parser. Removing an entry asserts that stream and batch now
     // agree on that sample.
     //
-    // The DSv4 stream parser emits the function `name` eagerly the moment the
-    // `<｜DSML｜invoke name="...">` header closes (SGLang-style streaming latency).
-    // When the invoke then truncates before `</｜DSML｜invoke>`, that name has
-    // already escaped with empty arguments, while the strict batch parser drops
-    // the incomplete call entirely — so stream and batch diverge by design:
-    //   5.c: invoke header closed, truncated mid-parameter -> stream emits
-    //        ("get_weather", "") ; batch emits nothing.
-    //   5.e: first call complete, second call's header closed then truncated
-    //        mid-arg -> stream emits the extra ("get_weather", "") ; batch drops it.
-    //   5.g: bare invoke after prose, recovered eagerly (pre-existing).
-    let known_divergences: std::collections::BTreeSet<&str> = [
-        "deepseek_v4:TOOLCALLING.batch.5.c",
-        "deepseek_v4:TOOLCALLING.batch.5.e",
-        "deepseek_v4:TOOLCALLING.batch.5.g",
-    ]
-    .into_iter()
-    .collect();
+    // The DSv4 stream parser now buffers each invoke until `</｜DSML｜invoke>` and
+    // drops a call truncated before its close (v1 parity), so the former 5.c /
+    // 5.e truncation divergences are gone. The remaining entry:
+    //   5.g: bare invoke after prose — the stream parser recovers it while the
+    //        strict batch parser drops it (pre-existing recovery divergence,
+    //        unrelated to truncation).
+    let known_divergences: std::collections::BTreeSet<&str> =
+        ["deepseek_v4:TOOLCALLING.batch.5.g"].into_iter().collect();
 
     let mut total = 0usize;
     let mut consistent = 0usize;

--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -57,9 +57,7 @@ cases:
           location: NYC
   TOOLCALLING.batch.5.c:
     dynamo_rust:
-      calls:
-      - name: get_weather
-        arguments: ''
+      calls: []
       normal_text: ''
     vllm_rust:
       error: 'tool parser parsing failed: incomplete DeepSeek DSML tool call'
@@ -112,8 +110,6 @@ cases:
       - name: get_weather
         arguments:
           location: Boston
-      - name: get_weather
-        arguments: ''
       normal_text: 'I''ll start by fetching the weather for both Boston and New York
         at the same time!
 

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.1.yaml
@@ -35,8 +35,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -52,6 +51,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.10.yaml
@@ -35,8 +35,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -52,6 +51,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -67,8 +67,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
@@ -85,6 +84,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.13.yaml
@@ -35,8 +35,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="unknown_tool">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'unknown_tool', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'unknown_tool', arguments: ''}
@@ -52,6 +51,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'unknown_tool', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'unknown_tool', arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -41,8 +41,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -58,6 +57,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -73,8 +73,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_time"> <｜DSML｜parameter'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_time', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
@@ -91,6 +90,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust:
         - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
@@ -136,8 +136,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -153,6 +152,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -176,8 +176,7 @@ cases:
         vllm_python: ' '
     - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_time', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
@@ -193,6 +192,7 @@ cases:
     - delta_text: 'EST</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust: []
         vllm_python:
@@ -247,8 +247,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather"> <｜DSML｜parameter name="location"'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -265,6 +264,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -274,8 +274,7 @@ cases:
         - {index: 0, arguments: '"location": "NYC"}'}
     - delta_text: ' <｜DSML｜invoke name="get_time">'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_time', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_time', arguments: ''}
@@ -299,6 +298,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_time', arguments: ''}
         - {index: 1, arguments: '{"timezone":"EST"}'}
         vllm_rust:
         - {index: 1, name: 'get_time', arguments: '{"timezone":"EST"}'}
@@ -342,8 +342,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -359,6 +358,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -374,8 +374,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
@@ -392,6 +391,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust:
         - {index: 1, name: 'get_weather', arguments: '{"location":"LA"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
@@ -109,8 +109,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -124,6 +123,7 @@ cases:
     - delta_text: 'NYC </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{}'}
         vllm_python:
         - {index: 0, arguments: 'NYC </｜DSML｜invoke>'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.5.yaml
@@ -36,8 +36,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -51,6 +50,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC"}'}
@@ -75,8 +75,7 @@ cases:
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -106,6 +105,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
@@ -141,8 +141,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -266,8 +265,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -280,6 +278,7 @@ cases:
     - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '{"location":"Boston"}'}
@@ -287,8 +286,7 @@ cases:
         - {index: 0, arguments: '{"location": "Boston"}'}
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -307,6 +305,7 @@ cases:
     - delta_text: 'New York</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         - {index: 1, arguments: '{"location":"New York"}'}
         vllm_python:
         - {index: 1, arguments: 'New York"}'}
@@ -418,8 +417,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather"> <｜DSML｜parameter'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -432,6 +430,7 @@ cases:
     - delta_text: ' string="true">Boston</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"Boston"}'}
         vllm_python:
         - {index: 0, arguments: '{"location":"Boston"}'}
@@ -439,8 +438,7 @@ cases:
         - {index: 0, arguments: '{"location": "Boston"}'}
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
         sglang_python:
@@ -482,8 +480,7 @@ cases:
     chunks:
     - delta_text: '<｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -513,6 +510,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []
@@ -532,8 +530,7 @@ cases:
         vllm_python: ' '
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -557,6 +554,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         - {index: 1, arguments: '{"location":"Boston"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"Boston"}'}
@@ -606,8 +604,7 @@ cases:
         sglang_python: ' check'
     - delta_text: ' that. <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python: []
         sglang_python:
@@ -637,6 +634,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust: []
         vllm_python: []

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.50.yaml
@@ -77,8 +77,7 @@ cases:
         sglang_python: []
     - delta_text: '"> <｜DSML｜p'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -146,6 +145,7 @@ cases:
     - delta_text: 'invoke> </｜'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.6.yaml
@@ -33,8 +33,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_time', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
@@ -43,6 +42,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: ''}
         - {index: 0, arguments: '{}'}
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}
@@ -74,17 +74,16 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_time">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_time', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_time', arguments: ''}
         sglang_python:
         - {index: 0, name: 'get_time'}
-    - delta_text: '
-</｜DSML｜invoke> </｜DSML｜tool_calls>'
+    - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_time', arguments: ''}
         - {index: 0, arguments: '{}'}
         vllm_rust:
         - {index: 0, name: 'get_time', arguments: '{}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.7.yaml
@@ -39,8 +39,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="book_flight">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'book_flight', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'book_flight', arguments: ''}
@@ -92,6 +91,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'book_flight', arguments: ''}
         - {index: 0, arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
         vllm_rust:
         - {index: 0, name: 'book_flight', arguments: '{"destination":"Paris","passengers":2,"first_class":true}'}
@@ -125,8 +125,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -150,6 +149,7 @@ cases:
     - delta_text: ' </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"Tōkyō central"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"Tōkyō central"}'}
@@ -189,8 +189,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="set_limit">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'set_limit', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'set_limit', arguments: ''}
@@ -205,6 +204,7 @@ cases:
     - delta_text: '9007199254740993</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'set_limit', arguments: ''}
         - {index: 0, arguments: '{"count":9007199254740993}'}
         vllm_rust:
         - {index: 0, name: 'set_limit', arguments: '{"count":9007199254740993}'}

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -61,8 +61,7 @@ cases:
         vllm_python: ' the weather. '
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -84,6 +83,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -117,8 +117,7 @@ cases:
         sglang_python: []
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -134,6 +133,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -231,8 +231,7 @@ cases:
         vllm_python: ' the weather. '
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -254,6 +253,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -353,8 +353,7 @@ cases:
         vllm_python: ' the weather. '
     - delta_text: ' <｜DSML｜invoke name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 0, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 0, id: true, name: 'get_weather', arguments: ''}
@@ -376,6 +375,7 @@ cases:
     - delta_text: 'NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>'
       expected:
         dynamo_rust:
+        - {index: 0, name: 'get_weather', arguments: ''}
         - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_rust:
         - {index: 0, name: 'get_weather', arguments: '{"location":"NYC"}'}
@@ -417,8 +417,7 @@ cases:
         vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:
-        dynamo_rust:
-        - {index: 1, name: 'get_weather', arguments: ''}
+        dynamo_rust: []
         vllm_rust: []
         vllm_python:
         - {index: 1, id: true, name: 'get_weather', arguments: ''}
@@ -434,6 +433,7 @@ cases:
     - delta_text: 'LA</｜DSML｜parameter> </｜DSML｜invoke>'
       expected:
         dynamo_rust:
+        - {index: 1, name: 'get_weather', arguments: ''}
         - {index: 1, arguments: '{"location":"LA"}'}
         vllm_rust: []
         vllm_python:

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -16,20 +16,22 @@ const PARAMETER_END: &str = "</｜DSML｜parameter>";
 
 /// Stream parser for DeepSeek V4 DSML tool calls.
 ///
-/// Emits eagerly to match SGLang's streaming latency: the function `name` is
-/// emitted as a delta the moment the `<｜DSML｜invoke name="...">` header closes,
-/// before any parameter body has streamed. The complete JSON `arguments` are
-/// emitted in a second delta once `</｜DSML｜invoke>` arrives. Consumers coalesce
-/// the two deltas by `tool_index` (name on the first, args on the second). This
-/// is the same wire shape Harmony uses (`name`-first, then arguments fragment).
+/// Conforms to the v1 batch baseline: a tool call is emitted only once its
+/// `</｜DSML｜invoke>` has streamed. A call truncated mid-call (header seen but no
+/// closing marker by end of stream) is DROPPED rather than emitted with empty
+/// arguments, matching the v1 DSML parser's "drop truncated-mid-value" rule. The
+/// `name` delta is emitted immediately before the `arguments` delta (both once
+/// the call closes), so consumers still coalesce the two by `tool_index` — the
+/// same wire shape Harmony uses (`name`-first, then arguments fragment).
 pub struct DeepSeekV4ToolStreamParser {
     buffer: String,
     in_block: bool,
     suppress_normal_text: bool,
     next_index: usize,
-    /// Set to `Some(tool_index)` after the invoke header (and its `name`) has
-    /// been emitted, while we wait for `</｜DSML｜invoke>` to emit the arguments.
-    open_invoke: Option<usize>,
+    /// Set to `Some((tool_index, name))` after the invoke header has streamed,
+    /// while we buffer the body and wait for `</｜DSML｜invoke>`. Nothing is
+    /// emitted until the close arrives; if it never does, the call is dropped.
+    open_invoke: Option<(usize, String)>,
 }
 
 impl DeepSeekV4ToolStreamParser {
@@ -47,17 +49,17 @@ impl DeepSeekV4ToolStreamParser {
         let mut out = ToolParseResult::default();
 
         loop {
-            // An invoke header (with its name) has already been emitted; we are
-            // now waiting for the closing marker to emit the complete arguments.
-            if let Some(tool_index) = self.open_invoke {
+            // The invoke header has streamed; buffer the body until the closing
+            // marker arrives, then emit `name` + `arguments` together. If the
+            // close never arrives (truncated mid-call), drop the call to match
+            // the v1 batch parser instead of emitting empty arguments.
+            if let Some((tool_index, name)) = self.open_invoke.clone() {
                 let Some(end) = self.buffer.find(INVOKE_END) else {
                     if flush {
-                        // Eager name already escaped; the truncated body cannot
-                        // produce arguments, so the call lands with empty args.
                         tracing::warn!(
                             why = "dsv4_incomplete_invoke",
                             tool_index,
-                            "DSML stream truncated after eager name emit; arguments dropped"
+                            "DSML stream truncated before </invoke>; dropping the call (v1 parity)"
                         );
                         self.buffer.clear();
                         self.in_block = false;
@@ -68,6 +70,14 @@ impl DeepSeekV4ToolStreamParser {
                 let body = self.buffer[..end].to_string();
                 self.buffer.drain(..end + INVOKE_END.len());
                 let arguments = serde_json::to_string(&parse_parameters(&body)?)?;
+                // Complete call: emit the name delta, then the arguments delta
+                // (coalesced by tool_index) — the call only appears once known
+                // complete.
+                out.calls.push(ToolCallDelta {
+                    tool_index,
+                    name: Some(name),
+                    arguments: String::new(),
+                });
                 out.calls.push(ToolCallDelta {
                     tool_index,
                     name: None,
@@ -107,7 +117,7 @@ impl DeepSeekV4ToolStreamParser {
                 if start > 0 {
                     self.buffer.drain(..start);
                 }
-                if self.open_invoke_header(&mut out)?.is_none() {
+                if self.open_invoke_header()?.is_none() {
                     // Header not fully streamed yet; wait for more input.
                     if flush {
                         tracing::warn!(
@@ -161,12 +171,12 @@ impl DeepSeekV4ToolStreamParser {
                     self.in_block = true;
                     self.suppress_normal_text = true;
                 }
-                Marker::BareInvoke => match self.open_invoke_header(&mut out)? {
+                Marker::BareInvoke => match self.open_invoke_header()? {
                     Some(tool_index) => {
                         tracing::warn!(
                             why = "dsv4_bare_invoke_recovery",
                             tool_index,
-                            "DSML stream recovering a bare invoke (eager name emit)"
+                            "DSML stream recovering a bare invoke (buffered until close)"
                         );
                     }
                     None => {
@@ -188,21 +198,18 @@ impl DeepSeekV4ToolStreamParser {
 
     /// Given `self.buffer` positioned at an `INVOKE_START_PREFIX`, parse the
     /// invoke header. If the header is complete (its closing `>` has streamed),
-    /// emit a name-only delta, consume the header bytes, mark `open_invoke`, and
-    /// return `Some(tool_index)`. If the header is still partial, leave the
+    /// consume the header bytes, buffer the `(tool_index, name)` in `open_invoke`
+    /// WITHOUT emitting yet, and return `Some(tool_index)`. The name + arguments
+    /// are emitted together once `</｜DSML｜invoke>` arrives, so a call that never
+    /// closes is dropped (v1 parity). If the header is still partial, leave the
     /// buffer intact and return `None` so the caller can wait for more input.
-    fn open_invoke_header(&mut self, out: &mut ToolParseResult) -> anyhow::Result<Option<usize>> {
+    fn open_invoke_header(&mut self) -> anyhow::Result<Option<usize>> {
         let Some((name, header_len)) = parse_invoke_header(&self.buffer) else {
             return Ok(None);
         };
         self.buffer.drain(..header_len);
         let tool_index = self.next_index;
-        out.calls.push(ToolCallDelta {
-            tool_index,
-            name: Some(name),
-            arguments: String::new(),
-        });
-        self.open_invoke = Some(tool_index);
+        self.open_invoke = Some((tool_index, name));
         self.suppress_normal_text = true;
         Ok(Some(tool_index))
     }
@@ -321,7 +328,9 @@ mod tests {
     }
 
     #[test]
-    fn emits_name_eagerly_then_args_on_close() {
+    fn emits_name_then_args_on_close() {
+        // Name and arguments are both emitted once `</invoke>` arrives, as two
+        // deltas (name-only, then arguments-only) coalesced by tool_index.
         let out = parse_chunks(&[
             "<｜DSML｜tool_calls> <｜DSML｜invoke",
             " name=\"get_weather\">",
@@ -386,17 +395,34 @@ mod tests {
     }
 
     #[test]
-    fn eager_name_escapes_when_invoke_truncates_at_eof() {
-        // The header closed, so the name was already emitted eagerly. The
-        // truncated parameter body never closes, so arguments stay empty.
+    fn drops_invoke_truncated_after_header() {
+        // The header closed (name seen) but the parameter body never closes
+        // before EOF. v1 parity: drop the call entirely rather than emit it
+        // with empty arguments.
         let out = parse_chunks(&[
             "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weather\">",
             " <｜DSML｜parameter name=\"location\" string=\"true\">NY",
         ]);
         assert_eq!(out.normal_text, "");
-        assert_eq!(out.calls.len(), 1);
-        assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
-        assert_eq!(out.calls[0].arguments, "");
+        assert!(
+            out.calls.is_empty(),
+            "truncated-mid-value call must be dropped"
+        );
+    }
+
+    #[test]
+    fn drops_last_call_when_truncated_keeps_earlier_complete_call() {
+        // Multi-call, last call truncated mid-arg-value (conformance 5.e): the
+        // first complete call survives, the truncated second is dropped.
+        let out = parse_chunks(&[
+            "I'll check both. <｜DSML｜tool_calls>",
+            " <｜DSML｜invoke name=\"get_weather\"> <｜DSML｜parameter name=\"location\" string=\"true\">Boston</｜DSML｜parameter> </｜DSML｜invoke>",
+            " <｜DSML｜invoke name=\"get_weather\"> <｜DSML｜parameter name=\"location\" string=\"true\">New York",
+        ]);
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1, "truncated 2nd call dropped");
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"Boston"}"#);
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:

This PR fixes the DSv4 streaming impl to conform to the correct batch behavior: tool calls truncated mid-call are dropped (matching the v1 batch parser) instead of emitted with empty arguments.

#### Details:

- `dsml.rs`: buffer each invoke until `</｜DSML｜invoke>` and emit `name` + `arguments` together; a call that truncates before its close is dropped (was: `name` emitted eagerly at the header, leaving `get_weather('')`).
- Regenerated deepseek_v4 streamv2 + batch-on-stream fixtures — 5.c -> `[]`, 5.e -> `[get_weather(Boston)]`, now matching `expected.dynamo`.
- Removed the now-stale `deepseek_v4:5.c`/`5.e` entries from the `parity_toolcalling_batch_via_stream` known-divergence allowlist (kept `5.g`, a separate bare-invoke recovery divergence).

#### Verification:

`validate_fixtures` clean; dsml unit tests + `parity_toolcalling_stream` + `parity_toolcalling_batch_via_stream` pass.

#### Related issue:

[DIS-2267](https://linear.app/nvidia/issue/DIS-2267)

#### Where should the reviewer start?

`parsers_v2/src/tool_calling/dsml.rs`, then `conformance/tests/parity_toolcalling_batch_via_stream.rs`

/coderabbit profile chill
