### PR TITLE
fix(parsers): preserve surrounding text where the spec is silent, drop where the reference decoder mandates a terminal block

### DIFF
--- a/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures-batch-on-stream-v2/deepseek_v4/TOOLCALLING.batch.4.yaml
@@ -30,7 +30,8 @@ cases:
     dynamo_rust:
       calls:
       - name: get_weather
-        arguments: {}
+        arguments:
+          location: NYC
       normal_text: ''
     vllm_rust:
       error: 'tool parser parsing failed: '

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.2.yaml
@@ -194,6 +194,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3/TOOLCALLING.streamv2.8.yaml
@@ -91,6 +91,7 @@ cases:
         - {index: 0, arguments: '{"location": "NYC"}'}
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -176,6 +177,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -289,6 +291,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.2.yaml
@@ -132,6 +132,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'Parallel with surrounding narration'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_1/TOOLCALLING.streamv2.8.yaml
@@ -81,6 +81,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -152,6 +153,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -243,6 +245,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.2.yaml
@@ -205,6 +205,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v3_2/TOOLCALLING.streamv2.8.yaml
@@ -92,6 +92,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -174,6 +175,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -284,6 +286,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -173,7 +173,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' '
+        dynamo_rust: ''
         vllm_python: ' '
     - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
       expected:
@@ -314,7 +314,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Done.'
+        dynamo_rust: ''
         vllm_python: ' Done.'
     - delta_text: ''
       finish_reason: stop

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.2.yaml
@@ -173,6 +173,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' '
         vllm_python: ' '
     - delta_text: ' name="get_time"> <｜DSML｜parameter name="timezone"'
       expected:
@@ -313,6 +314,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Done.'
         vllm_python: ' Done.'
     - delta_text: ''
       finish_reason: stop

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.4.yaml
@@ -124,7 +124,7 @@ cases:
       expected:
         dynamo_rust:
         - {index: 0, name: 'get_weather', arguments: ''}
-        - {index: 0, arguments: '{}'}
+        - {index: 0, arguments: '{"location":"NYC"}'}
         vllm_python:
         - {index: 0, arguments: 'NYC </｜DSML｜invoke>'}
         sglang_python:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -154,6 +154,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Let me'
         vllm_python: ' Let me'
     - delta_text: ' know if you'
       expected:
@@ -162,6 +163,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' know if you'
         vllm_python: ' know if you'
     - delta_text: ' need'
       expected:
@@ -170,6 +172,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' need'
         vllm_python: ' need'
     - delta_text: ' more.'
       expected:
@@ -178,6 +181,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' more.'
         vllm_python: ' more.'
     - delta_text: ''
       finish_reason: stop
@@ -268,6 +272,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Let'
         vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
@@ -276,6 +281,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' me know'
         vllm_python: ' me know'
     - delta_text: ' if'
       expected:
@@ -284,6 +290,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' if'
         vllm_python: ' if'
     - delta_text: ' you need'
       expected:
@@ -292,6 +299,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' you need'
         vllm_python: ' you need'
     - delta_text: ' more.'
       expected:
@@ -300,6 +308,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' more.'
         vllm_python: ' more.'
     - delta_text: ''
       finish_reason: stop
@@ -390,6 +399,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' Then'
         vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
@@ -398,6 +408,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' check LA'
         vllm_python: ' check LA'
     - delta_text: ' weather.'
       expected:
@@ -406,6 +417,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' weather.'
         vllm_python: ' weather.'
     - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
@@ -414,6 +426,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
+        dynamo_rust: ' '
         vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/deepseek_v4/TOOLCALLING.streamv2.8.yaml
@@ -154,7 +154,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Let me'
+        dynamo_rust: ''
         vllm_python: ' Let me'
     - delta_text: ' know if you'
       expected:
@@ -163,7 +163,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' know if you'
+        dynamo_rust: ''
         vllm_python: ' know if you'
     - delta_text: ' need'
       expected:
@@ -172,7 +172,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' need'
+        dynamo_rust: ''
         vllm_python: ' need'
     - delta_text: ' more.'
       expected:
@@ -181,7 +181,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' more.'
+        dynamo_rust: ''
         vllm_python: ' more.'
     - delta_text: ''
       finish_reason: stop
@@ -272,7 +272,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Let'
+        dynamo_rust: ''
         vllm_python: ' Let'
     - delta_text: ' me know'
       expected:
@@ -281,7 +281,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' me know'
+        dynamo_rust: ''
         vllm_python: ' me know'
     - delta_text: ' if'
       expected:
@@ -290,7 +290,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' if'
+        dynamo_rust: ''
         vllm_python: ' if'
     - delta_text: ' you need'
       expected:
@@ -299,7 +299,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' you need'
+        dynamo_rust: ''
         vllm_python: ' you need'
     - delta_text: ' more.'
       expected:
@@ -308,7 +308,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' more.'
+        dynamo_rust: ''
         vllm_python: ' more.'
     - delta_text: ''
       finish_reason: stop
@@ -399,7 +399,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' Then'
+        dynamo_rust: ''
         vllm_python: ' Then'
     - delta_text: ' check LA'
       expected:
@@ -408,7 +408,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' check LA'
+        dynamo_rust: ''
         vllm_python: ' check LA'
     - delta_text: ' weather.'
       expected:
@@ -417,7 +417,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' weather.'
+        dynamo_rust: ''
         vllm_python: ' weather.'
     - delta_text: ' <｜DSML｜tool_calls> <｜DSML｜invoke'
       expected:
@@ -426,7 +426,7 @@ cases:
         vllm_python: []
         sglang_python: []
       normal_text:
-        dynamo_rust: ' '
+        dynamo_rust: ''
         vllm_python: ' '
     - delta_text: ' name="get_weather">'
       expected:

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.2.yaml
@@ -71,6 +71,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/gemma4/TOOLCALLING.streamv2.8.yaml
@@ -77,6 +77,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -147,6 +148,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -243,6 +245,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.2.yaml
@@ -94,6 +94,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'Parallel calls with surrounding narration'
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/glm47/TOOLCALLING.streamv2.8.yaml
@@ -86,6 +86,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -160,6 +161,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -261,6 +263,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.2.yaml
@@ -186,6 +186,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony/TOOLCALLING.streamv2.8.yaml
@@ -168,6 +168,7 @@ cases:
         dynamo_rust: 'I will check the weather.'
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -326,6 +327,7 @@ cases:
         dynamo_rust: 'Let me know if you need more.'
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -511,6 +513,7 @@ cases:
         dynamo_rust: 'I will check the weather.  Let me know if you need more.'
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.2.yaml
@@ -190,6 +190,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'harmony_text is the Dynamo-internal text variant of the OpenAI Harmony format. Harmony terminates a commentary-channel tool call with the <|call|> stop token, so trailing narration cannot occur in a well-formed turn (this case is synthetic); text is routed by channel, not position, so Dynamo preserves any surrounding text it sees rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/harmony_text/TOOLCALLING.streamv2.8.yaml
@@ -172,6 +172,7 @@ cases:
         dynamo_rust: 'I will check the weather.'
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'harmony_text is the Dynamo-internal text variant of the OpenAI Harmony format. Harmony terminates a commentary-channel tool call with the <|call|> stop token, so trailing narration cannot occur in a well-formed turn (this case is synthetic); text is routed by channel, not position, so Dynamo preserves any surrounding text it sees rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -330,6 +331,7 @@ cases:
         dynamo_rust: 'Let me know if you need more.'
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'harmony_text is the Dynamo-internal text variant of the OpenAI Harmony format. Harmony terminates a commentary-channel tool call with the <|call|> stop token, so trailing narration cannot occur in a well-formed turn (this case is synthetic); text is routed by channel, not position, so Dynamo preserves any surrounding text it sees rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -515,6 +517,7 @@ cases:
         dynamo_rust: 'I will check the weather.  Let me know if you need more.'
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'harmony_text is the Dynamo-internal text variant of the OpenAI Harmony format. Harmony terminates a commentary-channel tool call with the <|call|> stop token, so trailing narration cannot occur in a well-formed turn (this case is synthetic); text is routed by channel, not position, so Dynamo preserves any surrounding text it sees rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.2.yaml
@@ -93,6 +93,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/hermes/TOOLCALLING.streamv2.8.yaml
@@ -84,6 +84,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -156,6 +157,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -255,6 +257,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.2.yaml
@@ -65,6 +65,7 @@ cases:
         - {index: 1, arguments: ''}
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/jamba/TOOLCALLING.streamv2.8.yaml
@@ -61,6 +61,7 @@ cases:
         - {index: 0, arguments: ''}
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -107,6 +108,7 @@ cases:
         - {index: 0, arguments: ''}
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -165,6 +167,7 @@ cases:
         - {index: 0, arguments: ''}
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.2.yaml
@@ -90,6 +90,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/llama3_json/TOOLCALLING.streamv2.8.yaml
@@ -88,6 +88,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -164,6 +165,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -271,6 +273,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.2.yaml
@@ -186,6 +186,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'Parallel with surrounding narration'
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m2/TOOLCALLING.streamv2.8.yaml
@@ -92,6 +92,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -160,6 +161,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -255,6 +257,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.2.yaml
@@ -164,6 +164,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/nemotron_deci/TOOLCALLING.streamv2.8.yaml
@@ -84,6 +84,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -152,6 +153,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -248,6 +250,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.2.yaml
@@ -58,6 +58,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/phi4/TOOLCALLING.streamv2.8.yaml
@@ -52,6 +52,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -92,6 +93,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -138,6 +140,7 @@ cases:
         vllm_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.2.yaml
@@ -49,6 +49,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/pythonic/TOOLCALLING.streamv2.8.yaml
@@ -57,6 +57,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -99,6 +100,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -168,6 +170,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.2.yaml
@@ -93,6 +93,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'With surrounding narration'
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen25/TOOLCALLING.streamv2.8.yaml
@@ -90,6 +90,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -160,6 +161,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -263,6 +265,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.2.yaml
@@ -104,6 +104,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.2.c:
     description: 'Parallel calls with surrounding narration'
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: 'derived from TOOLCALLING.batch.2.c'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/qwen3_coder/TOOLCALLING.streamv2.8.yaml
@@ -103,6 +103,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.b:
     description: 'Narration after tool call only'
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: 'derived from TOOLCALLING.batch.8.b'
     tools:
     - name: get_weather
@@ -186,6 +187,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.c:
     description: 'Narration both before and after (sandwich)'
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: 'derived from TOOLCALLING.batch.8.c'
     tools:
     - name: get_weather
@@ -313,6 +315,7 @@ cases:
         sglang_python: []
   TOOLCALLING.streamv2.8.d:
     description: 'Narration between multiple tool calls'
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: 'derived from TOOLCALLING.batch.8.d'
     tools:
     - name: get_weather

--- a/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml
@@ -83,7 +83,20 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls (only the DeepSeek V3 wrapper is
+          stripped); vLLM keeps the prefix (with its trailing space) and drops the
+          trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -92,9 +105,11 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      vllm: *id005
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3 tool-call blocks.
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls (only the DeepSeek V3 wrapper is
+          stripped); SGLang trims the boundary whitespace and drops the trailing
+          text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.2.yaml
@@ -70,6 +70,7 @@ cases:
       sglang: *id004
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather

--- a/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml
@@ -37,6 +37,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
@@ -64,6 +65,7 @@ cases:
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: |-
       I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
@@ -101,6 +103,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather

--- a/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.8.yaml
@@ -46,13 +46,21 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm: &id003
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM and SGLang drop everything after the parsed
+          DeepSeek V3 wrapper. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
@@ -65,15 +73,27 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      vllm:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the DeepSeek V3 wrapper is stripped); vLLM keeps
+          the prefix (with its trailing space) and drops the trailing text. Non-parity
+          by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *id004
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3 tool-call blocks.
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the DeepSeek V3 wrapper is stripped); SGLang
+          trims the boundary whitespace and drops the trailing text. Non-parity by
+          design.'
         calls:
         - name: get_weather
           arguments:
@@ -93,7 +113,20 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather.'
+      vllm:
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the two DeepSeek V3 wrappers; vLLM keeps
+          the leading prefix (with its trailing space) and drops the inter-call text.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -102,9 +135,10 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *id005
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3 tool-call blocks.
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the two DeepSeek V3 wrappers; SGLang trims
+          the boundary whitespace and drops the inter-call text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml
@@ -56,6 +56,7 @@ cases:
       sglang: *id004
   TOOLCALLING.batch.2.c:
     description: Parallel with surrounding narration
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: 'Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Results.'

--- a/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.2.yaml
@@ -63,7 +63,20 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Results.'
+      vllm:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Results.") around the parallel calls (only the DeepSeek V3.1 wrapper is
+          stripped); vLLM keeps the prefix (with its trailing space) and drops the
+          trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -72,9 +85,11 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      vllm: *id005
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3.1 tool-call blocks.
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Results.") around the parallel calls (only the DeepSeek V3.1 wrapper is
+          stripped); SGLang trims the boundary whitespace and drops the trailing
+          text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml
@@ -33,6 +33,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Let me know if you need more.
@@ -57,6 +58,7 @@ cases:
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Let me know if you need more.
@@ -91,6 +93,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Then check LA weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.8.yaml
@@ -39,13 +39,21 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm: &id003
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM and SGLang drop everything after the parsed
+          DeepSeek V3.1 wrapper. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
@@ -55,15 +63,27 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      vllm:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the DeepSeek V3.1 wrapper is stripped); vLLM
+          keeps the prefix (with its trailing space) and drops the trailing text.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *id004
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3.1 tool-call blocks.
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the DeepSeek V3.1 wrapper is stripped); SGLang
+          trims the boundary whitespace and drops the trailing text. Non-parity by
+          design.'
         calls:
         - name: get_weather
           arguments:
@@ -77,7 +97,20 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather.'
+      vllm:
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the two DeepSeek V3.1 wrappers; vLLM keeps
+          the leading prefix (with its trailing space) and drops the inter-call text.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -86,9 +119,11 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *id005
       sglang:
-        reason: SGLang trims trailing whitespace from normal_text that precedes DeepSeek V3.1 tool-call blocks.
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the two DeepSeek V3.1 wrappers; SGLang
+          trims the boundary whitespace and drops the inter-call text. Non-parity by
+          design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.2.yaml
@@ -92,6 +92,7 @@ cases:
         normal_text: ''
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       Both: <｜DSML｜function_calls>

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.2.yaml
@@ -114,7 +114,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
+        normal_text: 'Both:  Done.'
       vllm:
         calls:
         - arguments:
@@ -134,7 +134,7 @@ cases:
             timezone: EST
           name: get_time
         normal_text: 'Both:'
-        reason: trims trailing space from preceding normal_text
+        reason: drops trailing normal_text after tool-call wrapper end (keeps prefix, trimmed)
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L370

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.4.yaml
@@ -84,13 +84,7 @@ cases:
         - name: get_weather
           arguments: {}
         normal_text: ''
-        reason: |-
-          Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md
-          goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even
-          though its own </｜DSML｜parameter> close is missing. This is the
-          value-capture path, not allow_eof_recovery (the invoke is already
-          closed). vLLM/SGLang's DSML parser requires </｜DSML｜parameter>, so
-          they emit empty args.
+        reason: 'Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even though its own </｜DSML｜parameter> close is missing. This is the value-capture path, not allow_eof_recovery (the invoke is already closed). vLLM/SGLang''s DSML parser requires </｜DSML｜parameter>, so they emit empty args.'
       sglang: *d_4_d_peer
   TOOLCALLING.batch.4.b:
     description: Malformed variant 4.b — not yet authored for this family

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.4.yaml
@@ -73,13 +73,25 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &d_4_d_peer
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
-      vllm: *d_4_d
-      sglang: *d_4_d
+        reason: |-
+          Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md
+          goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even
+          though its own </｜DSML｜parameter> close is missing. This is the
+          value-capture path, not allow_eof_recovery (the invoke is already
+          closed). vLLM/SGLang's DSML parser requires </｜DSML｜parameter>, so
+          they emit empty args.
+      sglang: *d_4_d_peer
   TOOLCALLING.batch.4.b:
     description: Malformed variant 4.b — not yet authored for this family
     reason: |-

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.8.yaml
@@ -35,7 +35,7 @@ cases:
             location: NYC
           name: get_weather
         normal_text: I will check the weather.
-        reason: drops trailing normal_text after tool-call wrapper end
+        reason: trims the trailing space from the prefix normal_text (no text after the wrapper here)
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -53,13 +53,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
+        normal_text: ' Let me know if you need more.'
       vllm:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: ''
+        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls:
         - arguments:
@@ -84,20 +85,21 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: 'I will check the weather. '
+        reason: drops trailing normal_text after tool-call wrapper end (keeps prefix)
       sglang:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: I will check the weather.
-        reason: drops trailing normal_text after tool-call wrapper end
+        reason: drops trailing normal_text after tool-call wrapper end (keeps prefix, trimmed)
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -122,7 +124,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Then check LA weather. '
       vllm:
         calls:
         - arguments:
@@ -132,10 +134,11 @@ cases:
             location: LA
           name: get_weather
         normal_text: 'I will check the weather. '
+        reason: keeps only the prefix and drops the inter-call narration between the two wrappers
       sglang:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: I will check the weather.
-        reason: drops trailing normal_text after tool-call wrapper end
+        reason: parses only the first wrapper (drops the second call) and keeps only the trimmed prefix as normal_text

--- a/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.8.yaml
@@ -38,6 +38,7 @@ cases:
         reason: trims the trailing space from the prefix normal_text (no text after the wrapper here)
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       <｜DSML｜function_calls>
@@ -70,6 +71,7 @@ cases:
         reason: drops trailing normal_text after tool-call wrapper end
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       I will check the weather. <｜DSML｜function_calls>
@@ -102,6 +104,7 @@ cases:
         reason: drops trailing normal_text after tool-call wrapper end (keeps prefix, trimmed)
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'DeepSeek-V3/V3.1/V3.2 publishes only the tool-call encoding grammar (a chat-template renderer, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/README.md'
     ref: dynamo
     model_text: |-
       I will check the weather. <｜DSML｜function_calls>

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml
@@ -48,6 +48,7 @@ cases:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.2.b:
     description: Two back-to-back tool_calls wrappers
+    dynamo_note: 'DeepSeek-V4 publishes a reference decoder (encoding/encoding_dsv4.py::parse_message_from_completion_text) that establishes the tool-call block is terminal: content is only the text before the block, and it executes `assert not tool_ends_text, "Unexpected content after tool calls"`. Dynamo takes that normative "should not" at face value and drops text from the first tool-call marker onward. (Contrast V3/V3.1/V3.2, whose specs are silent and where Dynamo preserves trailing text.) Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/raw/main/encoding/encoding_dsv4.py'
     ref: dynamo
     model_text: |-
       <｜DSML｜tool_calls>
@@ -72,7 +73,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: "\n"
+        normal_text: ''
       vllm:
         calls:
         - name: get_weather
@@ -87,6 +88,7 @@ cases:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.2.c:
     description: Parallel with surrounding narration
+    dynamo_note: 'DeepSeek-V4 publishes a reference decoder (encoding/encoding_dsv4.py::parse_message_from_completion_text) that establishes the tool-call block is terminal: content is only the text before the block, and it executes `assert not tool_ends_text, "Unexpected content after tool calls"`. Dynamo takes that normative "should not" at face value and drops text from the first tool-call marker onward. (Contrast V3/V3.1/V3.2, whose specs are silent and where Dynamo preserves trailing text.) Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/raw/main/encoding/encoding_dsv4.py'
     ref: dynamo
     model_text: |-
       Both: <｜DSML｜tool_calls>
@@ -109,7 +111,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:  Done.'
+        normal_text: 'Both: '
       vllm:
         calls:
         - name: get_weather

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.2.yaml
@@ -72,7 +72,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: ''
+        normal_text: "\n"
       vllm:
         calls:
         - name: get_weather
@@ -109,7 +109,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
+        normal_text: 'Both:  Done.'
       vllm:
         calls:
         - name: get_weather
@@ -119,6 +119,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
+        reason: vLLM drops trailing normal_text after the tool-call wrapper end
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.2.d:

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml
@@ -82,13 +82,7 @@ cases:
         - name: get_weather
           arguments: {}
         normal_text: ''
-        reason: |-
-          Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md
-          goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even
-          though its own </｜DSML｜parameter> close is missing. This is the
-          value-capture path, not allow_eof_recovery (the invoke is already
-          closed). vLLM's DSML parser requires </｜DSML｜parameter>, so it emits
-          empty args.
+        reason: 'Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even though its own </｜DSML｜parameter> close is missing. This is the value-capture path, not allow_eof_recovery (the invoke is already closed). vLLM''s DSML parser requires </｜DSML｜parameter>, so it emits empty args.'
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.4.b:

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml
@@ -71,12 +71,24 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
-      vllm: *d_4_d
+        reason: |-
+          Dynamo recovers "NYC" per the recover/drop rule (parsers_v2/README.md
+          goal 5): the value is delimiter-terminated by </｜DSML｜invoke> even
+          though its own </｜DSML｜parameter> close is missing. This is the
+          value-capture path, not allow_eof_recovery (the invoke is already
+          closed). vLLM's DSML parser requires </｜DSML｜parameter>, so it emits
+          empty args.
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.4.b:

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml
@@ -33,6 +33,7 @@ cases:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'DeepSeek-V4 publishes a reference decoder (encoding/encoding_dsv4.py::parse_message_from_completion_text) that establishes the tool-call block is terminal: content is only the text before the block, and it executes `assert not tool_ends_text, "Unexpected content after tool calls"`. Dynamo takes that normative "should not" at face value and drops text from the first tool-call marker onward. (Contrast V3/V3.1/V3.2, whose specs are silent and where Dynamo preserves trailing text.) Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/raw/main/encoding/encoding_dsv4.py'
     ref: dynamo
     model_text: |-
       <｜DSML｜tool_calls>
@@ -48,7 +49,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ' Let me know if you need more.'
+        normal_text: ''
       vllm:
         calls:
         - name: get_weather
@@ -60,6 +61,7 @@ cases:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'DeepSeek-V4 publishes a reference decoder (encoding/encoding_dsv4.py::parse_message_from_completion_text) that establishes the tool-call block is terminal: content is only the text before the block, and it executes `assert not tool_ends_text, "Unexpected content after tool calls"`. Dynamo takes that normative "should not" at face value and drops text from the first tool-call marker onward. (Contrast V3/V3.1/V3.2, whose specs are silent and where Dynamo preserves trailing text.) Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/raw/main/encoding/encoding_dsv4.py'
     ref: dynamo
     model_text: |-
       I will check the weather. <｜DSML｜tool_calls>
@@ -75,7 +77,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather.  Let me know if you need more.'
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather
@@ -87,6 +89,7 @@ cases:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'DeepSeek-V4 publishes a reference decoder (encoding/encoding_dsv4.py::parse_message_from_completion_text) that establishes the tool-call block is terminal: content is only the text before the block, and it executes `assert not tool_ends_text, "Unexpected content after tool calls"`. Dynamo takes that normative "should not" at face value and drops text from the first tool-call marker onward. (Contrast V3/V3.1/V3.2, whose specs are silent and where Dynamo preserves trailing text.) Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/raw/main/encoding/encoding_dsv4.py'
     ref: dynamo
     model_text: |-
       I will check the weather. <｜DSML｜tool_calls>
@@ -109,7 +112,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather.  Then check LA weather. '
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather

--- a/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.8.yaml
@@ -48,13 +48,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
+        normal_text: ' Let me know if you need more.'
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
+        reason: vLLM drops trailing normal_text after the tool-call wrapper end
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.8.c:
@@ -74,13 +75,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
+        reason: vLLM drops trailing normal_text after the tool-call wrapper end
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.8.d:
@@ -107,7 +109,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Then check LA weather. '
       vllm:
         calls:
         - name: get_weather
@@ -117,5 +119,6 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
+        reason: vLLM keeps only the prefix and drops the inter-call narration between the two wrappers
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.2.yaml
@@ -37,6 +37,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: dynamo
     model_text: 'Both: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
       Done.'

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.2.yaml
@@ -44,7 +44,16 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -53,7 +62,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both:'
-      vllm: *id004
+        reason: keeps only the prefix before the first tool-call wrapper start and drops trailing normal_text; Dynamo preserves both
       sglang:
         calls:
         - name: get_weather
@@ -63,7 +72,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end
+        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end; Dynamo preserves both
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
@@ -36,12 +36,15 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
-        reason: vLLM leaks the tool call tag into normal_text on the recovery path
+        reason: Dynamo recovers the call -- the value NYC is <|"|>-delimited (complete) and the close sentinel follows, so Dynamo completes the truncated args object and emits the call (recover/drop rule, parsers_v2/README.md goal 5), matching SGLang; vLLM leaks the markup into normal_text instead.
       sglang:
         calls:
         - name: get_weather

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
@@ -75,16 +75,19 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}</tool_call>
-        reason: vLLM leaks the tool call tag into normal_text on the recovery path
+        reason: Dynamo accepts either close sentinel -- the canonical <tool_call|> or the mismatched </tool_call> -- and recovers the complete call body, stripping the stray close (recover/drop rule, parsers_v2/README.md goal 5); vLLM leaks the tool-call markup into normal_text instead.
       sglang:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}</tool_call>
-        reason: SGLang leaks the tool call tag into normal_text on the recovery path
+        reason: Dynamo accepts either close sentinel -- the canonical <tool_call|> or the mismatched </tool_call> -- and recovers the complete call body; SGLang leaks the tool-call markup into normal_text instead.
   TOOLCALLING.batch.4.e:
     description: Malformed-prefix recovery — n/a for this family's syntax
     reason: |-

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.8.yaml
@@ -38,14 +38,26 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
-      sglang: *id003
+        reason: drops trailing normal_text after tool-call wrapper end; Dynamo preserves it
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+        reason: drops trailing normal_text after tool-call wrapper end; Dynamo preserves it
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -54,20 +66,26 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.  Let me know if you need more.
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather.
-      vllm: *id004
+        reason: keeps only the prefix before the tool-call wrapper start and drops trailing normal_text; Dynamo preserves both
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end
+        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end; Dynamo preserves both
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -76,7 +94,16 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.  Then check LA weather.
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -85,7 +112,7 @@ cases:
           arguments:
             location: LA
         normal_text: I will check the weather.
-      vllm: *id005
+        reason: keeps only the prefix before the first tool-call wrapper start and drops inter-call normal_text; Dynamo preserves the text between calls
       sglang:
         calls:
         - name: get_weather
@@ -95,4 +122,4 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end
+        reason: preserves pre-tool-call whitespace and drops inter-call normal_text after the first tool-call wrapper end; Dynamo preserves the text between calls

--- a/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/gemma4/TOOLCALLING.batch.8.yaml
@@ -33,6 +33,7 @@ cases:
         reason: preserves whitespace before tool-call wrapper start
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: dynamo
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Let me know if you need more.
     tools:
@@ -60,6 +61,7 @@ cases:
         reason: drops trailing normal_text after tool-call wrapper end; Dynamo preserves it
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: dynamo
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Let me know if
       you need more.
@@ -88,6 +90,7 @@ cases:
         reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end; Dynamo preserves both
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Gemma publishes only a chat-template plus a non-normative regex recipe; two reference decoders (vLLM, SGLang) even disagree on trailing text but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4'
     ref: dynamo
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Then check LA weather.
       <|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml
@@ -44,7 +44,16 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Checking:  Done.'
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -53,7 +62,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Checking: '
-      vllm: *id004
+        reason: vLLM drops the trailing prose after the last </tool_call>; Dynamo and SGLang preserve it
       sglang:
         calls:
         - name: get_weather
@@ -63,7 +72,6 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Checking:  Done.'
-        reason: SGLang glm47 preserves trailing prose after the last </tool_call>; Dynamo and vLLM drop it
   TOOLCALLING.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.2.yaml
@@ -37,6 +37,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: Parallel calls with surrounding narration
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: dynamo
     model_text: 'Checking: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
       Done.'

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.4.yaml
@@ -36,12 +36,17 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id002
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
-      vllm: *id002
       sglang: *id002
   TOOLCALLING.batch.4.b:
     description: Malformed variant 4.b — not yet authored for this family

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -18,12 +18,19 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: &id001
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-        reason: vLLM and SGLang preserve the truncated <tool_call>... markup as content on missing-end-token recovery; Dynamo drops to keep wire tags out of message.content
+        reason: |-
+          allow_eof_recovery=true, so Dynamo recovers the call: NYC is
+          delimiter-terminated by </arg_value> and only the outer </tool_call> is
+          missing (recover/drop rule, parsers_v2/README.md goal 5). vLLM and
+          SGLang instead leak the truncated <tool_call>... markup as content.
       sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
@@ -71,6 +78,9 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls:
@@ -78,6 +88,10 @@ cases:
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: |-
+          allow_eof_recovery=true, so Dynamo also recovers the last call: "New York" is
+          delimiter-terminated by </arg_value> and only its </tool_call> is missing
+          (recover/drop rule). vLLM drops the trailing truncated call.
       sglang:
         calls:
         - name: get_weather
@@ -85,7 +99,7 @@ cases:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
           York</arg_value>
-        reason: SGLang preserves the trailing truncated <tool_call>... block as content; Dynamo and vLLM both drop it
+        reason: SGLang preserves the trailing truncated <tool_call>... block as content; Dynamo recovers it as a call (allow_eof_recovery=true) and vLLM drops it.
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -26,11 +26,7 @@ cases:
       vllm: &id001
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-        reason: |-
-          allow_eof_recovery=true, so Dynamo recovers the call: NYC is
-          delimiter-terminated by </arg_value> and only the outer </tool_call> is
-          missing (recover/drop rule, parsers_v2/README.md goal 5). vLLM and
-          SGLang instead leak the truncated <tool_call>... markup as content.
+        reason: 'allow_eof_recovery=true, so Dynamo recovers the call: NYC is delimiter-terminated by </arg_value> and only the outer </tool_call> is missing (recover/drop rule, parsers_v2/README.md goal 5). vLLM and SGLang instead leak the truncated <tool_call>... markup as content.'
       sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
@@ -88,10 +84,7 @@ cases:
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-        reason: |-
-          allow_eof_recovery=true, so Dynamo also recovers the last call: "New York" is
-          delimiter-terminated by </arg_value> and only its </tool_call> is missing
-          (recover/drop rule). vLLM drops the trailing truncated call.
+        reason: 'allow_eof_recovery=true, so Dynamo also recovers the last call: "New York" is delimiter-terminated by </arg_value> and only its </tool_call> is missing (recover/drop rule). vLLM drops the trailing truncated call.'
       sglang:
         calls:
         - name: get_weather

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml
@@ -33,6 +33,7 @@ cases:
         reason: SGLang glm47 trims trailing whitespace before the first <tool_call>; Dynamo and vLLM keep it verbatim
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call> Let me know if you
       need more.
@@ -60,6 +61,7 @@ cases:
         normal_text: Let me know if you need more.
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: dynamo
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       Let me know if you need more.
@@ -87,6 +89,7 @@ cases:
         normal_text: 'I will check the weather.  Let me know if you need more.'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'GLM-4.x publishes only a chat_template/tokenizer_config registering the <tool_call>/<arg_key>/<arg_value> tokens (an encoder, not a decoder) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/zai-org/GLM-4.5/raw/main/chat_template.jinja'
     ref: dynamo
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       Then check LA weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml
@@ -39,20 +39,25 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ' Let me know if you need more.'
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
+        reason: vLLM drops text after the tool call; Dynamo and SGLang preserve the trailing narration after </tool_call>
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: Let me know if you need more.
-        reason: SGLang glm47 preserves trailing normal_text after the last </tool_call>; Dynamo and vLLM drop it
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -61,20 +66,25 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *id004
+        reason: vLLM drops text after the tool call; Dynamo and SGLang preserve the surrounding narration (prefix + trailing prose)
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather.  Let me know if you need more.'
-        reason: SGLang glm47 concatenates the prefix and trailing prose; Dynamo and vLLM drop the post-wrapper text
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -83,7 +93,16 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather. '
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -92,7 +111,7 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *id005
+        reason: vLLM only emits the prefix before the first <tool_call>; Dynamo and SGLang preserve the inter-call narration too
       sglang:
         calls:
         - name: get_weather
@@ -102,4 +121,3 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather.  Then check LA weather.'
-        reason: SGLang glm47 concatenates inter-call narration and trailing prose; Dynamo and vLLM only emit the prefix before the first <tool_call>

--- a/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/glm47/TOOLCALLING.batch.yaml
@@ -119,15 +119,19 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
         normal_text: ''
+        reason: Dynamo forwards a tool call whose name is not in the request's tools list rather than dropping it; parsing is separate from validation (the serving layer rejects unknown tools), and the model may reference a tool the caller adds later or one baked into its chat template. Matches vLLM.
       vllm:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-        reason: vLLM forwards the unknown GLM tool name, while Dynamo validates against the supplied tools and drops the unparseable block.
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang drops a tool call whose name is not in the supplied tools list; Dynamo and vLLM forward it (validation is the serving layer's job, not the parser's).

--- a/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.2.yaml
@@ -54,6 +54,7 @@ cases:
         normal_text: ''
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: "OpenAI Harmony preambles should be commentary messages: https://developers.openai.com/cookbook/articles/openai-harmony#preambles"
     model_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
       to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.

--- a/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml
@@ -38,6 +38,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: dynamo
     model_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
@@ -64,6 +65,7 @@ cases:
         normal_text: Let me know if you need more.
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
@@ -91,6 +93,7 @@ cases:
         reason: "No spec-correct winner on whitespace: analysis is correctly hidden and the same call is extracted; surrounding prose is outside Harmony messages, so whitespace is recovery-only"
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'The OpenAI Harmony spec terminates a commentary-channel tool call with the <|call|> stop token, so in a well-formed turn no natural-language text follows the call within the same message — this trailing-narration case is synthetic. Harmony routes text by channel rather than by position, so when surrounding text does appear Dynamo preserves it as channel content rather than dropping it. Source: https://developers.openai.com/cookbook/articles/openai-harmony'
     ref: dynamo
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
@@ -38,6 +38,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: dynamo
     model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
       "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
@@ -45,7 +45,7 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id004
+      dynamo:
         calls:
         - name: get_weather
           arguments:
@@ -53,11 +53,12 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both:  Done.'
       vllm:
-        reason: 'vLLM preserves the trailing space before the first <tool_call> in
-          normal_text; Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by
-          design.'
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls; only the two <tool_call> blocks are
+          stripped. vLLM keeps the prefix (with its trailing space) and drops the
+          text after the calls. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -66,7 +67,19 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      sglang: *id004
+      sglang:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls; only the two <tool_call> blocks are
+          stripped. SGLang trims the boundary whitespace and drops the trailing text.
+          Non-parity by design.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
@@ -40,37 +40,54 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm: &id003
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM and SGLang drop everything after the parsed
+          <tool_call> block. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: dynamo
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L128
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
       Let me know if you need more.'
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
-        reason: 'vLLM preserves the trailing space before <tool_call> in normal_text;
-          Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by design.'
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the <tool_call> block is stripped); vLLM and
+          SGLang keep only the prefix and drop the trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      sglang: *id004
+      sglang:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the <tool_call> block is stripped); SGLang trims
+          the boundary whitespace and drops the trailing text. Non-parity by design.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -79,7 +96,7 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
         calls:
         - name: get_weather
           arguments:
@@ -87,10 +104,11 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Then check LA weather.'
       vllm:
-        reason: 'vLLM preserves the trailing space before <tool_call> in normal_text;
-          Dynamo and SGLang trim it. Cosmetic whitespace, non-parity by design.'
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text; only the two <tool_call> blocks are stripped. vLLM keeps
+          only the leading prefix and drops the inter-call text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -99,4 +117,15 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      sglang: *id005
+      sglang:
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text; only the two <tool_call> blocks are stripped. SGLang trims
+          the boundary whitespace and drops the inter-call text. Non-parity by design.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.

--- a/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
@@ -34,6 +34,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you need
       more.'
@@ -58,6 +59,7 @@ cases:
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L128
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
       Let me know if you need more.'
@@ -90,6 +92,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Hermes publishes only a chat_template; the model card delegates parsing to an external repo but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B'
     ref: dynamo
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
       Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
@@ -54,9 +54,12 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both:  Done.'
       vllm:
-        reason: "Cosmetic whitespace only: Dynamo trims the single space between the leading narration and the <tool_calls> fence; vLLM preserves it. Calls are identical."
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls; only the <tool_calls> block is
+          stripped. vLLM keeps the prefix (with its trailing space) and drops the
+          text after the calls. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.2.yaml
@@ -39,6 +39,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: dynamo
     model_text: 'Both: <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]</tool_calls> Done.'

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
@@ -40,13 +40,21 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM drops everything after the parsed <tool_calls>
+          block. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.8.c:
@@ -62,9 +70,12 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
-        reason: "Cosmetic whitespace only: Dynamo trims the trailing space between the narration and the <tool_calls> fence; vLLM preserves it. Calls are identical."
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the <tool_calls> block is stripped); vLLM keeps
+          the prefix (with its trailing space) and drops the trailing text. Non-parity
+          by design.'
         calls:
         - name: get_weather
           arguments:
@@ -82,9 +93,9 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Then check LA weather.'
       vllm:
-        reason: "Known Dynamo limitation: the jamba framed parser spans from the first <tool_calls> opener to the last </tool_calls> closer, so narration between two separate fences lands inside the captured region and breaks the JSON parse, dropping both calls and keeping only the leading narration. vLLM extracts the first call. Multiple-disjoint-fence support is a base JSON-parser change tracked as a follow-up, out of scope for the never-leak fix."
+        reason: "Two divergences. (1) Calls: the jamba framed parser spans from the first <tool_calls> opener to the last </tool_calls> closer, so two disjoint fences are captured as one region whose joined body is not valid JSON; both calls drop. vLLM extracts the first call. Multiple-disjoint-fence support is a base JSON-parser change tracked as a follow-up. (2) normal_text: Dynamo now preserves the inter-call narration (\"Then check LA weather.\") by stripping only the <tool_calls> spans; vLLM keeps just the leading prefix. Non-parity by design."
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/jamba/TOOLCALLING.batch.8.yaml
@@ -34,6 +34,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls> Let me know if you need
       more.'
@@ -59,6 +60,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: dynamo
     model_text: 'I will check the weather. <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>
       Let me know if you need more.'
@@ -85,6 +87,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'AI21 Jamba publishes only an encoder chat_template; the card describes encoding with no decode or ordering rule but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Mini'
     ref: dynamo
     model_text: 'I will check the weather. <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>
       Then check LA weather. <tool_calls>[{"name": "get_weather", "arguments": {"location": "LA"}}]</tool_calls>'

--- a/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml
@@ -63,10 +63,21 @@ cases:
     - *id002
     - *id003
     expected:
-      # Kimi tool-call turns are intermediate: keep prefix content before the
-      # tool section, but drop post-wrapper narration until tool results
-      # produce final user-facing content.
-      dynamo: &d_2_c
+      # normal_text is the model text minus the tool-call block: BOTH the prefix
+      # and the post-wrapper narration are preserved verbatim.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'I will check both.  Done.'
+      vllm: &v_2_c
+        # vLLM/SGLang keep the prefix but drop the post-wrapper narration;
+        # Dynamo preserves all surrounding natural text.
+        reason: vLLM and SGLang keep the prefix but drop the post-wrapper narration; Dynamo preserves all surrounding natural text, so normal_text keeps both the prefix and the post-wrapper text.
         calls:
         - name: get_weather
           arguments:
@@ -75,8 +86,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'I will check both. '
-      vllm: *d_2_c
-      sglang: *d_2_c
+      sglang: *v_2_c
   TOOLCALLING.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo

--- a/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.2.yaml
@@ -56,6 +56,7 @@ cases:
       sglang: *id004
   TOOLCALLING.batch.2.c:
     description: Parallel calls with surrounding narration
+    dynamo_note: 'Moonshot publishes a reference decoder (docs/tool_call_guidance.md, extract_tool_call_info) that slices out the <|tool_calls_section_begin|>…<|tool_calls_section_end|> section and defines content as the text before it, never collecting text after. Dynamo follows that decoder: text from the tool-call section onward is dropped. Source: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md'
     ref: dynamo
     model_text: I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
       Done.
@@ -73,7 +74,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'I will check both.  Done.'
+        normal_text: 'I will check both.'
       vllm: &v_2_c
         # vLLM/SGLang keep the prefix but drop the post-wrapper narration;
         # Dynamo preserves all surrounding natural text.

--- a/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml
@@ -27,6 +27,7 @@ cases:
       sglang: *d_8_a
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Moonshot publishes a reference decoder (docs/tool_call_guidance.md, extract_tool_call_info) that slices out the <|tool_calls_section_begin|>…<|tool_calls_section_end|> section and defines content as the text before it, never collecting text after. Dynamo follows that decoder: text from the tool-call section onward is dropped. Source: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L435
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
       Let me know if you need more.
@@ -40,7 +41,7 @@ cases:
         - name: get_weather
           arguments:
             location: Dallas
-        normal_text: ' Let me know if you need more.'
+        normal_text: ''
       vllm: &v_8_b
         # vLLM/SGLang drop post-wrapper narration on a Kimi tool-call turn;
         # Dynamo preserves it as normal_text.
@@ -53,6 +54,7 @@ cases:
       sglang: *v_8_b
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Moonshot publishes a reference decoder (docs/tool_call_guidance.md, extract_tool_call_info) that slices out the <|tool_calls_section_begin|>…<|tool_calls_section_end|> section and defines content as the text before it, never collecting text after. Dynamo follows that decoder: text from the tool-call section onward is dropped. Source: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md'
     ref: dynamo
     model_text: I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
       Let me know if you need more.
@@ -66,7 +68,7 @@ cases:
         - name: get_weather
           arguments:
             location: Dallas
-        normal_text: 'I''ll check the weather.  Let me know if you need more.'
+        normal_text: 'I''ll check the weather.'
       vllm: &v_8_c
         # vLLM/SGLang keep the prefix but drop the post-wrapper narration;
         # Dynamo preserves all surrounding natural text.
@@ -79,6 +81,7 @@ cases:
       sglang: *v_8_c
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Moonshot publishes a reference decoder (docs/tool_call_guidance.md, extract_tool_call_info) that slices out the <|tool_calls_section_begin|>…<|tool_calls_section_end|> section and defines content as the text before it, never collecting text after. Dynamo follows that decoder: text from the tool-call section onward is dropped. Source: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md'
     ref: dynamo
     model_text: First check Dallas. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
       Then check NYC. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
@@ -96,7 +99,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'First check Dallas.  Then check NYC. '
+        normal_text: 'First check Dallas.'
       vllm:
         # vLLM keeps the prefix but drops the inter-section narration and parses
         # only the first section; Dynamo preserves all surrounding natural text

--- a/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml
@@ -33,17 +33,24 @@ cases:
     tools:
     - *id001
     expected:
-      # Kimi tool-call turns are intermediate: official API content is empty
-      # while tool_calls are emitted, so post-wrapper narration is not final
-      # user-facing text. This matches vLLM/SGLang.
-      dynamo: &d_8_b
+      # normal_text is the model text minus the tool-call block: the
+      # post-wrapper narration is natural text and is preserved verbatim.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        normal_text: ' Let me know if you need more.'
+      vllm: &v_8_b
+        # vLLM/SGLang drop post-wrapper narration on a Kimi tool-call turn;
+        # Dynamo preserves it as normal_text.
+        reason: vLLM and SGLang drop post-wrapper narration on a Kimi tool-call turn; Dynamo preserves all surrounding natural text and emits the post-wrapper text as normal_text.
         calls:
         - name: get_weather
           arguments:
             location: Dallas
         normal_text: ''
-      vllm: *d_8_b
-      sglang: *d_8_b
+      sglang: *v_8_b
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -52,17 +59,24 @@ cases:
     tools:
     - *id001
     expected:
-      # Preserve prefix content emitted before tool_calls, but drop
-      # post-wrapper text because Kimi tool-call turns are intermediate; final
-      # user-facing content should come after tool results.
-      dynamo: &d_8_c
+      # normal_text is the model text minus the tool-call block: BOTH the prefix
+      # and the post-wrapper narration are preserved verbatim.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        normal_text: 'I''ll check the weather.  Let me know if you need more.'
+      vllm: &v_8_c
+        # vLLM/SGLang keep the prefix but drop the post-wrapper narration;
+        # Dynamo preserves all surrounding natural text.
+        reason: vLLM and SGLang keep the prefix but drop the post-wrapper narration; Dynamo preserves all surrounding natural text, so normal_text keeps both the prefix and the post-wrapper text.
         calls:
         - name: get_weather
           arguments:
             location: Dallas
         normal_text: 'I''ll check the weather. '
-      vllm: *d_8_c
-      sglang: *d_8_c
+      sglang: *v_8_c
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -71,10 +85,23 @@ cases:
     tools:
     - *id001
     expected:
-      # Multiple tool sections are still one intermediate Kimi tool-call turn:
-      # keep prefix content before the first section, but drop inter-wrapper
-      # narration until tool results produce the final user-facing answer.
-      dynamo: &d_8_d
+      # normal_text is the model text minus both tool-call blocks: the prefix and
+      # the inter-section narration are preserved verbatim between the removed
+      # blocks.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'First check Dallas.  Then check NYC. '
+      vllm:
+        # vLLM keeps the prefix but drops the inter-section narration and parses
+        # only the first section; Dynamo preserves all surrounding natural text
+        # and both calls.
+        reason: vLLM keeps the prefix but drops the inter-section narration; Dynamo preserves all surrounding natural text, so normal_text keeps the prefix and the inter-section text.
         calls:
         - name: get_weather
           arguments:
@@ -83,5 +110,15 @@ cases:
           arguments:
             location: NYC
         normal_text: 'First check Dallas. '
-      vllm: *d_8_d
-      sglang: *d_8_d
+      sglang:
+        # SGLang keeps the prefix but drops the inter-section narration; Dynamo
+        # preserves all surrounding natural text.
+        reason: SGLang keeps the prefix but drops the inter-section narration; Dynamo preserves all surrounding natural text, so normal_text keeps the prefix and the inter-section text.
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'First check Dallas. '

--- a/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.2.yaml
@@ -53,7 +53,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both: Done.'
       vllm:
         calls:
         - name: get_weather
@@ -63,7 +63,9 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-        reason: vLLM llama3_json drops leading normal_text before the python_tag token
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls (matching SGLang); vLLM drops all
+          normal_text. Non-parity by design.'
       sglang:
         calls:
         - name: get_weather
@@ -73,7 +75,6 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: Done.'
-        reason: preserves trailing text after final parsed JSON object
   TOOLCALLING.batch.2.d:
     description: Same-name twice (semicolon-separated)
     ref: dynamo

--- a/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.2.yaml
@@ -38,6 +38,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: dynamo
     model_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}} Done.'

--- a/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.8.yaml
@@ -44,20 +44,27 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text (matching SGLang); vLLM drops everything after the
+          parsed JSON object. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id002
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: Let me know if you need more.
-        reason: preserves trailing text after parsed JSON object
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
@@ -71,21 +78,22 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: I will check the weather. Let me know if you need more.
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-        reason: vLLM llama3_json drops leading normal_text before the python_tag token
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (matching SGLang); vLLM drops all normal_text. Non-parity
+          by design.'
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather. Let me know if you need more.
-        reason: preserves leading normal_text and trailing text around parsed JSON object
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -102,7 +110,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.
+        normal_text: I will check the weather. Then check LA weather.
       vllm:
         calls:
         - name: get_weather
@@ -112,7 +120,9 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-        reason: vLLM llama3_json drops leading normal_text before the python_tag token
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the python_tag + JSON-object blocks; vLLM
+          drops all normal_text. Non-parity by design.'
       sglang:
         calls:
         - name: get_weather
@@ -122,4 +132,7 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-        reason: uses next JSON object recovery and drops interstitial text between parsed calls
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text by stripping only the python_tag + JSON-object blocks; SGLang
+          uses next-JSON-object recovery and drops the interstitial text between the
+          parsed calls. Non-parity by design.'

--- a/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/llama3_json/TOOLCALLING.batch.8.yaml
@@ -39,6 +39,7 @@ cases:
         reason: preserves whitespace before python_tag in normal_text
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: dynamo
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Let me know if you need more.'
     tools:
@@ -67,6 +68,7 @@ cases:
         normal_text: Let me know if you need more.
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
     model_text: 'I will check the weather. <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Let me
       know if you need more.'
@@ -96,6 +98,7 @@ cases:
         normal_text: I will check the weather. Let me know if you need more.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Llama 3.x publishes only a prompt-format/chat-template spec (an encoder); its ''no prefix or suffix'' line instructs the model, not a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/prompt_format.md'
     ref: dynamo
     model_text: 'I will check the weather. <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Then check
       LA weather. <|python_tag|>{"name": "get_weather", "arguments": {"location": "LA"}}'

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.2.yaml
@@ -86,6 +86,7 @@ cases:
         reason: "SGLang parser preserves the newline separator between adjacent MiniMax tool-call wrappers (`</minimax:tool_call>\\n<minimax:tool_call>`)."
   TOOLCALLING.batch.2.c:
     description: Parallel with surrounding narration
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: dynamo
     model_text: |-
       Both: <minimax:tool_call>

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.2.yaml
@@ -108,9 +108,9 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
-      vllm: *id005
-      sglang:
+        normal_text: 'Both:  Done.'
+      sglang: *id005
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -118,8 +118,8 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:  Done.'
-        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
+        normal_text: 'Both: '
+        reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
@@ -58,6 +58,7 @@ cases:
       sglang: *id003
   TOOLCALLING.batch.4.d:
     description: Missing closing </invoke>
+    dynamo_note: 'Intentional exception to the recover/drop rule. The value "NYC" is delimiter-terminated so the rule would normally recover it, but the MiniMax-M2.1 spec publishes the parser regex invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL) (https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md) which requires </invoke>; a published spec wins over the generic rule (goal 1 over goal 5), so a missing </invoke> matches nothing and Dynamo emits no call. Wrapper markup is dropped, never leaked to normal_text.'
     ref: dynamo
     model_text: |-
       <minimax:tool_call>
@@ -70,7 +71,6 @@ cases:
       dynamo:
         calls: []
         normal_text: ''
-        reason: 'SPEC WINS over Dynamo''s generic recovery rule. The MiniMax-M2.1 tool-calling guide publishes the parser regexes (section "Manually Parsing Tool Call Results") at https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md and the published invoke regex requires BOTH fences -- invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL). The value "NYC" here is delimiter-terminated, so the generic rule would recover it, but a PUBLISHED SPEC OVERRIDES it: with </invoke> missing the published regex matches nothing, so Dynamo emits no call. Wrapper markup is dropped, never echoed to normal_text, so tool-call markers don''t leak to user content.'
       vllm:
         calls: []
         normal_text: |-

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
@@ -70,19 +70,7 @@ cases:
       dynamo:
         calls: []
         normal_text: ''
-        reason: |-
-          SPEC WINS over Dynamo's generic recovery rule. The MiniMax-M2.1
-          tool-calling guide publishes the parser regexes (section "Manually
-          Parsing Tool Call Results"):
-          https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
-          The published invoke regex requires BOTH fences:
-            invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL)
-          The value "NYC" here is delimiter-terminated, so the generic rule
-          (recover a value that is followed by a delimiter) would recover it --
-          but a PUBLISHED SPEC OVERRIDES the generic rule: with </invoke>
-          missing the published regex matches nothing, so Dynamo emits no call.
-          Wrapper markup is dropped, never echoed to normal_text, so tool-call
-          markers don't leak to user content.
+        reason: 'SPEC WINS over Dynamo''s generic recovery rule. The MiniMax-M2.1 tool-calling guide publishes the parser regexes (section "Manually Parsing Tool Call Results") at https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md and the published invoke regex requires BOTH fences -- invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL). The value "NYC" here is delimiter-terminated, so the generic rule would recover it, but a PUBLISHED SPEC OVERRIDES it: with </invoke> missing the published regex matches nothing, so Dynamo emits no call. Wrapper markup is dropped, never echoed to normal_text, so tool-call markers don''t leak to user content.'
       vllm:
         calls: []
         normal_text: |-

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.4.yaml
@@ -71,13 +71,18 @@ cases:
         calls: []
         normal_text: ''
         reason: |-
-          Strict per MiniMax-M2 reference parser
-          (https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md):
-          the published `<invoke name=(.*?)</invoke>` regex requires both
-          fences, so missing `</invoke>` yields no match and no recovered
-          call. Wrapper markup is intentionally dropped (not echoed to
-          normal_text) so tool-call protocol markers don't leak to
-          user-facing content.
+          SPEC WINS over Dynamo's generic recovery rule. The MiniMax-M2.1
+          tool-calling guide publishes the parser regexes (section "Manually
+          Parsing Tool Call Results"):
+          https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
+          The published invoke regex requires BOTH fences:
+            invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL)
+          The value "NYC" here is delimiter-terminated, so the generic rule
+          (recover a value that is followed by a delimiter) would recover it --
+          but a PUBLISHED SPEC OVERRIDES the generic rule: with </invoke>
+          missing the published regex matches nothing, so Dynamo emits no call.
+          Wrapper markup is dropped, never echoed to normal_text, so tool-call
+          markers don't leak to user content.
       vllm:
         calls: []
         normal_text: |-

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.8.yaml
@@ -32,6 +32,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: dynamo
     model_text: |-
       <minimax:tool_call>
@@ -58,6 +59,7 @@ cases:
         reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: dynamo
     model_text: |-
       I will check the weather. <minimax:tool_call>
@@ -84,6 +86,7 @@ cases:
         reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'MiniMax-M2 publishes extraction regexes for the tool-call block, but nothing about text after </minimax:tool_call> closes but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md'
     ref: dynamo
     model_text: |-
       I will check the weather. <minimax:tool_call>

--- a/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.8.yaml
@@ -47,15 +47,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
-      vllm: *id003
-      sglang:
+        normal_text: ' Let me know if you need more.'
+      sglang: *id003
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ' Let me know if you need more.'
-        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
+        normal_text: ''
+        reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -73,15 +73,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
-      vllm: *id004
-      sglang:
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      sglang: *id004
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.  Let me know if you need more.
-        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
+        normal_text: 'I will check the weather. '
+        reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -106,9 +106,9 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
-      vllm: *id005
-      sglang:
+        normal_text: 'I will check the weather.  Then check LA weather. '
+      sglang: *id005
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -116,5 +116,5 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather.  Then check LA weather. '
-        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
+        normal_text: 'I will check the weather. '
+        reason: "vLLM keeps only text before the first parsed MiniMax tool-call wrapper and drops the inter-call and trailing narration; Dynamo (like SGLang) strips only the tool-call markup and preserves the surrounding natural-language text verbatim."

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
@@ -41,6 +41,7 @@ cases:
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Mistral ships a reference decoder in mistral-common: content is only the tokens before the [TOOL_CALLS] control token and the remainder is parsed as the tool-call JSON array, so trailing prose is unrepresentable. Dynamo follows that decoder: text from [TOOL_CALLS] onward is dropped. Source: https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/experimental/tools.py'
     ref: dynamo
     model_text: 'Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}][/TOOL_CALLS] Done.'
@@ -56,7 +57,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:  Done.'
+        normal_text: 'Both:'
       vllm:
         reason: 'Dynamo preserves both the leading prefix and the trailing text
           ("Done.") around the parallel calls (only the [TOOL_CALLS] envelope is

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
@@ -56,8 +56,12 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
+        normal_text: 'Both:  Done.'
       vllm:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls (only the [TOOL_CALLS] envelope is
+          stripped); vLLM keeps the prefix (with its trailing space) and drops the
+          trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -69,7 +73,10 @@ cases:
       sglang:
         calls: []
         normal_text: 'Both:'
-        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+        reason: 'Two divergences. (1) Calls: SGLang MistralDetector returns calls=[]
+          on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits. (2) normal_text:
+          Dynamo preserves both the leading prefix and the trailing text ("Done.")
+          around the calls; SGLang keeps only the prefix. Non-parity by design.'
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
@@ -41,17 +41,28 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM drops everything after the parsed [TOOL_CALLS]
+          envelope. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id002
       sglang:
         calls: []
         normal_text: ''
-        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+        reason: 'Two divergences. (1) Calls: SGLang MistralDetector returns calls=[]
+          on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits. (2) normal_text:
+          Dynamo now preserves the trailing text after the envelope; SGLang drops it.
+          Non-parity by design.'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
@@ -65,8 +76,12 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the [TOOL_CALLS] envelope is stripped); vLLM
+          keeps the prefix (with its trailing space) and drops the trailing text.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -75,7 +90,10 @@ cases:
       sglang:
         calls: []
         normal_text: I will check the weather.
-        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+        reason: 'Two divergences. (1) Calls: SGLang MistralDetector returns calls=[]
+          on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits. (2) normal_text:
+          Dynamo preserves both the leading narration and the trailing text around
+          the envelope; SGLang keeps only the prefix. Non-parity by design.'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -86,11 +104,15 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Then check LA weather.'
       vllm:
         error: 'ValueError: Only one BOT token should have been outputted'
         reason: vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes
       sglang:
         calls: []
         normal_text: I will check the weather.
-        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits; it also trims the boundary whitespace Dynamo now preserves.
+        reason: 'Two divergences. (1) Calls: SGLang MistralDetector returns calls=[]
+          on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits. (2) normal_text:
+          Dynamo now preserves the inter-call narration ("Then check LA weather.") by
+          stripping only the [TOOL_CALLS] envelopes; SGLang keeps only the leading
+          prefix. Non-parity by design.'

--- a/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
@@ -35,6 +35,7 @@ cases:
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Mistral ships a reference decoder in mistral-common: content is only the tokens before the [TOOL_CALLS] control token and the remainder is parsed as the tool-call JSON array, so trailing prose is unrepresentable. Dynamo follows that decoder: text from [TOOL_CALLS] onward is dropped. Source: https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/experimental/tools.py'
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS] Let me know if you need
       more.'
@@ -46,7 +47,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: Let me know if you need more.
+        normal_text: ''
       vllm:
         reason: 'Dynamo now preserves the natural-language text that follows the tool
           call in normal_text; vLLM drops everything after the parsed [TOOL_CALLS]
@@ -65,6 +66,7 @@ cases:
           Non-parity by design.'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Mistral ships a reference decoder in mistral-common: content is only the tokens before the [TOOL_CALLS] control token and the remainder is parsed as the tool-call JSON array, so trailing prose is unrepresentable. Dynamo follows that decoder: text from [TOOL_CALLS] onward is dropped. Source: https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/experimental/tools.py'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
     model_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
       Let me know if you need more.'
@@ -76,7 +78,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather.  Let me know if you need more.'
+        normal_text: 'I will check the weather.'
       vllm:
         reason: 'Dynamo preserves both the leading narration and the trailing text
           around the tool call (only the [TOOL_CALLS] envelope is stripped); vLLM
@@ -96,6 +98,7 @@ cases:
           the envelope; SGLang keeps only the prefix. Non-parity by design.'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Mistral ships a reference decoder in mistral-common: content is only the tokens before the [TOOL_CALLS] control token and the remainder is parsed as the tool-call JSON array, so trailing prose is unrepresentable. Dynamo follows that decoder: text from [TOOL_CALLS] onward is dropped. Source: https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/experimental/tools.py'
     ref: dynamo
     model_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
       Then check LA weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]'
@@ -104,7 +107,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: 'I will check the weather.  Then check LA weather.'
+        normal_text: 'I will check the weather.'
       vllm:
         error: 'ValueError: Only one BOT token should have been outputted'
         reason: vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes

--- a/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.2.yaml
@@ -56,6 +56,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_deci'
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: dynamo
     model_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]</TOOLCALL> Done.'

--- a/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.2.yaml
@@ -71,7 +71,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both:  Done.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:

--- a/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.8.yaml
@@ -40,7 +40,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
+        normal_text: Let me know if you need more.
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
@@ -58,7 +58,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
@@ -73,7 +73,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Then check LA weather.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:

--- a/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.8.yaml
@@ -29,6 +29,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_deci'
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: dynamo
     model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL> Let me know if you need
       more.'
@@ -47,6 +48,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_deci'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: dynamo
     model_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
       Let me know if you need more.'
@@ -65,6 +67,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_deci'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Nemotron (Deci) publishes a system-prompt instruction telling the model not to add other text (encoder-side), but no published decoder rule for a parser but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1'
     ref: dynamo
     model_text: 'I will check the weather. <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
       Then check LA weather. <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>'

--- a/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.2.yaml
@@ -53,6 +53,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_nano'
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'NVIDIA publishes a reference decoder (nemotron_toolcall_parser_no_streaming.py) that defines content as model_output[:rfind("<TOOLCALL>")] — only text before the tool-call block — so text after the block is dropped. Dynamo follows that decoder. Source: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2/blob/main/nemotron_toolcall_parser_no_streaming.py'
     ref: dynamo
     model_text: |-
       Both: <tool_call>
@@ -81,7 +82,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: "Both: \n Done."
+        normal_text: 'Both:'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.2.yaml
@@ -81,7 +81,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
+        normal_text: "Both: \n Done."
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.8.yaml
@@ -36,6 +36,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_nano'
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'NVIDIA publishes a reference decoder (nemotron_toolcall_parser_no_streaming.py) that defines content as model_output[:rfind("<TOOLCALL>")] — only text before the tool-call block — so text after the block is dropped. Dynamo follows that decoder. Source: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2/blob/main/nemotron_toolcall_parser_no_streaming.py'
     ref: dynamo
     model_text: |-
       <tool_call>
@@ -53,13 +54,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ' Let me know if you need more.'
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'NVIDIA publishes a reference decoder (nemotron_toolcall_parser_no_streaming.py) that defines content as model_output[:rfind("<TOOLCALL>")] — only text before the tool-call block — so text after the block is dropped. Dynamo follows that decoder. Source: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2/blob/main/nemotron_toolcall_parser_no_streaming.py'
     ref: dynamo
     model_text: |-
       I will check the weather. <tool_call>
@@ -77,13 +79,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather.  Let me know if you need more.'
+        normal_text: 'I will check the weather.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'NVIDIA publishes a reference decoder (nemotron_toolcall_parser_no_streaming.py) that defines content as model_output[:rfind("<TOOLCALL>")] — only text before the tool-call block — so text after the block is dropped. Dynamo follows that decoder. Source: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2/blob/main/nemotron_toolcall_parser_no_streaming.py'
     ref: dynamo
     model_text: |-
       I will check the weather. <tool_call>
@@ -110,7 +113,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather.  Then check LA weather. '
+        normal_text: 'I will check the weather.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.8.yaml
@@ -53,7 +53,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
+        normal_text: ' Let me know if you need more.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
@@ -77,7 +77,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
@@ -110,7 +110,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
+        normal_text: 'I will check the weather.  Then check LA weather. '
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.2.yaml
@@ -54,8 +54,11 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both:  Done.'
       vllm:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls (only the functools array is stripped);
+          vLLM drops all normal_text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.2.yaml
@@ -39,6 +39,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: dynamo
     model_text: 'Both: functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}] Done.'

--- a/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.8.yaml
@@ -38,13 +38,21 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; vLLM drops everything after the parsed functools array.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   TOOLCALLING.batch.8.c:
@@ -60,8 +68,11 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Let me know if you need more.'
       vllm:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the functools array is stripped); vLLM keeps
+          only the prefix and drops the trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -85,8 +96,12 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather.  Then check LA weather.'
       vllm:
+        reason: 'Two divergences. (1) Calls: Dynamo recovers both functools arrays;
+          vLLM parses only the first. (2) normal_text: Dynamo preserves the inter-call
+          narration ("Then check LA weather.") by stripping only the functools-array
+          blocks, while vLLM keeps only the leading prefix. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:

--- a/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/phi4/TOOLCALLING.batch.8.yaml
@@ -33,6 +33,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: dynamo
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Let me know if you need more.'
     tools:
@@ -57,6 +58,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Let me know
       if you need more.'
@@ -82,6 +84,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Phi-4 publishes only the input/tool-definition format in the system prompt; no output decoder but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/microsoft/Phi-4-mini-instruct'
     ref: dynamo
     model_text: 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Then check
       LA weather. functools[{"name": "get_weather", "arguments": {"location": "LA"}}]'

--- a/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml
@@ -51,7 +51,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both:  Done.'
       vllm:
         calls: []
         normal_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'

--- a/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.2.yaml
@@ -37,6 +37,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: dynamo
     model_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'
     tools:

--- a/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.5.yaml
@@ -17,10 +17,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id001
         calls: []
         normal_text: '[get_weather(location="NYC")'
-      vllm: *id001
+        reason: 'Dynamo recovers: the call get_weather(location="NYC") is complete (closing ")") and only the outer "]" was truncated, so Dynamo closes the list and emits the call (recover/drop rule, parsers_v2/README.md goal 5). vLLM and SGLang leak the raw text instead.'
       sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing `]` without matching `[` open
@@ -54,11 +60,20 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: &id005
         calls: []
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time![get_weather(location="Boston"),
           get_weather(location="New York")
-      vllm: *id005
+        reason: 'Dynamo recovers both calls: each is complete (closing ")") and only the outer "]" was truncated, so Dynamo closes the list and emits them (recover/drop rule, parsers_v2/README.md goal 5); vLLM and SGLang leak the raw text instead.'
       sglang: *id005
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value

--- a/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml
@@ -44,7 +44,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
+        normal_text: Let me know if you need more.
       vllm:
         calls: []
         normal_text: '[get_weather(location="NYC")] Let me know if you need more.'
@@ -66,7 +66,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: I will check the weather.  Let me know if you need more.
       vllm:
         calls: []
         normal_text: I will check the weather. [get_weather(location="NYC")] Let me know if you need more.
@@ -88,10 +88,14 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.  Then check LA weather.
       vllm:
         calls: []
         normal_text: I will check the weather. [get_weather(location="NYC")] Then check LA weather. [get_weather(location="LA")]
       sglang:
+        reason: SGLang's PythonicDetector only parses a single leading bracket group, so two separate bracket groups make it bail with no calls and keep just the prefix; Dynamo parses each complete bracket group and preserves the inter-call narration as normal_text.
         calls: []
         normal_text: 'I will check the weather. '

--- a/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/pythonic/TOOLCALLING.batch.8.yaml
@@ -34,6 +34,7 @@ cases:
         normal_text: 'I will check the weather. '
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: dynamo
     model_text: '[get_weather(location="NYC")] Let me know if you need more.'
     tools:
@@ -56,6 +57,7 @@ cases:
         normal_text: ' Let me know if you need more.'
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: dynamo
     model_text: I will check the weather. [get_weather(location="NYC")] Let me know if you need more.
     tools:
@@ -78,6 +80,7 @@ cases:
         normal_text: I will check the weather.  Let me know if you need more.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Pythonic tool calls are terminal only by a prompt-side instruction — Meta''s Llama-4 prompt format tells the model it "SHOULD NOT include any other text in the response" — but there is no published parser rule that forbids or drops trailing text. That instruction constrains the model''s generation, not a decoder, and the model can still emit trailing prose; Dynamo preserves it rather than discard real user-facing content. Source: https://github.com/meta-llama/llama-models/blob/main/models/llama4/prompt_format.md'
     ref: dynamo
     model_text: I will check the weather. [get_weather(location="NYC")] Then check LA weather. [get_weather(location="LA")]
     tools:

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
@@ -46,6 +46,7 @@ cases:
     reason: Multi-call is covered by 2.a/2.c/2.d; no back-to-back fence pattern for this family.
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: dynamo
     model_text: |-
       Both: <tool_call>

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
@@ -57,7 +57,22 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        reason: 'Dynamo preserves both the leading prefix and the trailing text
+          ("Done.") around the parallel calls; only the two <tool_call> blocks are
+          stripped. SGLang keeps only the prefix and drops the trailing text.
+          Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -66,9 +81,6 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both:'
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id004
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
@@ -39,12 +39,15 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       sglang:
-        reason: 'Malformed JSON in a complete <tool_call> wrapper: Dynamo discards the
-          unparseable jail region (no leak); SGLang''s Qwen25Detector keys on a
-          "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
+        reason: 'allow_eof_recovery=true: Dynamo closes the unterminated JSON and recovers
+          the call (matching hermes; recover/drop rule). SGLang''s Qwen25Detector keys on
+          a "<tool_call>\n" prefix, so on this compact wrapper it detects nothing and
           returns the raw text. Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
@@ -77,11 +80,15 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       sglang:
-        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
-          design.'
+        reason: 'allow_eof_recovery=true: the JSON body is complete and only </tool_call> is
+          missing, so Dynamo recovers the call (matching hermes; recover/drop rule). SGLang
+          keeps raw. Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.4.e:

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
@@ -20,11 +20,15 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       sglang:
-        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
-          design.'
+        reason: 'allow_eof_recovery=true: the JSON body is complete and only </tool_call> is
+          missing, so Dynamo recovers the call (matching hermes; recover/drop rule). SGLang
+          keeps raw. Non-parity by design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.5.b:

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
@@ -39,15 +39,23 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        reason: 'Dynamo now preserves the natural-language text that follows the tool
+          call in normal_text; SGLang drops everything after the parsed <tool_call>
+          block. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -58,15 +66,23 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        reason: 'Dynamo preserves both the leading narration and the trailing text
+          around the tool call (only the <tool_call> block is stripped); SGLang keeps
+          only the prefix and drops the trailing text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather.
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id004
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -79,7 +95,21 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather.'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        reason: 'Dynamo preserves the inter-call narration ("Then check LA weather.")
+          in normal_text; only the two <tool_call> blocks are stripped. SGLang keeps
+          only the leading prefix and drops the inter-call text. Non-parity by design.'
         calls:
         - name: get_weather
           arguments:
@@ -88,6 +118,3 @@ cases:
           arguments:
             location: LA
         normal_text: I will check the weather.
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id005

--- a/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
@@ -31,6 +31,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: dynamo
     model_text: |-
       <tool_call>
@@ -58,6 +59,7 @@ cases:
         normal_text: ''
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: dynamo
     model_text: |-
       I will check the weather. <tool_call>
@@ -85,6 +87,7 @@ cases:
         normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Qwen2.5 publishes only a Hermes-style chat_template (an encoder; Qwen''s docs defer decoding to frameworks) but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json'
     ref: dynamo
     model_text: |-
       I will check the weather. <tool_call>

--- a/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml
@@ -51,6 +51,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.2.c:
     description: Parallel calls with surrounding narration
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: dynamo
     model_text: |-
       Both queries: <tool_call>

--- a/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml
@@ -71,7 +71,16 @@ cases:
     - *id002
     - *id003
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: "Both queries: \n Results above."
+      vllm: &id004
         calls:
         - name: get_weather
           arguments:
@@ -80,7 +89,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both queries: '
-      vllm: *id004
+        reason: "vLLM and SGLang keep only text before the first parsed tool call and drop the inter-call and trailing narration; Dynamo strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
       sglang: *id004
   TOOLCALLING.batch.2.d:
     description: Same-name twice (id distinctness)

--- a/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.8.yaml
@@ -34,6 +34,7 @@ cases:
       sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: dynamo
     model_text: |-
       <tool_call>
@@ -62,6 +63,7 @@ cases:
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: |-
       I will check the weather. <tool_call>
@@ -90,6 +92,7 @@ cases:
       sglang: *id004
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
+    dynamo_note: 'Qwen3-Coder publishes a reference parser and chat_template, but the parser does not assert the block is terminal and Qwen''s docs decline a formal parse spec but is silent on natural-language text that follows the tool-call block. The model can emit trailing or inter-call prose, and nothing in the spec dictates whether a parser keeps or drops it; both readings are defensible. Because dropping silently discards genuine user-facing assistant text, Dynamo keeps it — it strips only the tool-call markup and preserves the surrounding narration verbatim. No published rule is violated, because the spec does not address this case. Source: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py'
     ref: dynamo
     model_text: |-
       I will check the weather. <tool_call>

--- a/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.8.yaml
@@ -46,13 +46,19 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ' Let me know if you need more.'
+      vllm: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id003
+        reason: "vLLM and SGLang keep only text before the first parsed tool call and drop the trailing narration; Dynamo strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
       sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
@@ -68,13 +74,19 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+      vllm: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *id004
+        reason: "vLLM and SGLang keep only text before the first parsed tool call and drop the trailing narration; Dynamo strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
       sglang: *id004
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
@@ -96,7 +108,16 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather. '
+      vllm: &id005
         calls:
         - name: get_weather
           arguments:
@@ -105,5 +126,5 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *id005
+        reason: "vLLM and SGLang keep only text before the first parsed tool call and drop the inter-call and trailing narration; Dynamo strips only the tool-call markup and preserves the surrounding natural-language text verbatim."
       sglang: *id005

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -666,11 +666,19 @@ impl ToolCallConfig {
         // <parameter name="param_name">value</parameter>
         // </invoke>
         // </minimax:tool_call>
-        // Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
         //
-        // MiniMax uses strict inner invoke/parameter fences. Dynamo still
-        // recovers complete inner invokes when only the outer wrapper is
-        // missing or truncated so valid tool calls do not disappear.
+        // SPEC WINS over Dynamo's generic recovery rule. The MiniMax-M2.1
+        // tool-calling guide publishes the parser regexes (section "Manually
+        // Parsing Tool Call Results"):
+        //   https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
+        //   invoke_regex = re.compile(r"<invoke name=(.*?)</invoke>", re.DOTALL)
+        // That regex REQUIRES the closing </invoke> fence, so a missing
+        // </invoke> matches nothing -> no call, even though the value is
+        // delimiter-terminated and the generic rule would otherwise recover it
+        // (strict_match + allow_eof_recovery=false below). The spec is silent
+        // on the OUTER wrapper, so Dynamo DOES still recover a complete inner
+        // invoke when only <minimax:tool_call> is missing -- valid tool calls
+        // do not disappear.
         Self {
             parser_config: ParserConfig::Xml(XmlParserConfig {
                 tool_call_start_token: "<minimax:tool_call>".to_string(),

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -83,6 +83,14 @@ pub struct JsonParserConfig {
     /// tool-call markup to the user.
     #[serde(default)]
     pub discard_unparseable_wrapper: bool,
+
+    /// When true, the tool-call block is terminal per the model's published
+    /// reference decoder: normal_text is only the natural-language text before
+    /// the FIRST tool-call start marker; inter-call and trailing text are
+    /// dropped (markup never leaks). Default false preserves all surrounding
+    /// text.
+    #[serde(default)]
+    pub content_is_prefix_only: bool,
 }
 
 impl Default for JsonParserConfig {
@@ -99,6 +107,7 @@ impl Default for JsonParserConfig {
             strip_markup_on_recovery: false,
             allow_name_only_call: false,
             discard_unparseable_wrapper: false,
+            content_is_prefix_only: false,
         }
     }
 }
@@ -149,6 +158,14 @@ pub struct XmlParserConfig {
     /// one fires when function tags exist but the outer wrapper does not).
     #[serde(default)]
     pub backoff_when_no_wrapper: bool,
+
+    /// When true, the tool-call block is terminal per the model's published
+    /// reference decoder: normal_text is only the natural-language text before
+    /// the FIRST tool-call start marker; inter-call and trailing text are
+    /// dropped (markup never leaks). Default false preserves all surrounding
+    /// text.
+    #[serde(default)]
+    pub content_is_prefix_only: bool,
 }
 
 impl Default for XmlParserConfig {
@@ -164,6 +181,7 @@ impl Default for XmlParserConfig {
             strict_match: false,
             passthrough_when_no_function: false,
             backoff_when_no_wrapper: false,
+            content_is_prefix_only: false,
         }
     }
 }
@@ -204,6 +222,14 @@ pub struct DsmlParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// When true, the tool-call block is terminal per the model's published
+    /// reference decoder: normal_text is only the natural-language text before
+    /// the FIRST tool-call start marker; inter-call and trailing text are
+    /// dropped (markup never leaks). Default false preserves all surrounding
+    /// text.
+    #[serde(default)]
+    pub content_is_prefix_only: bool,
 }
 
 impl Default for DsmlParserConfig {
@@ -216,6 +242,7 @@ impl Default for DsmlParserConfig {
             parameter_prefix: "<｜DSML｜parameter name=".to_string(),
             parameter_end: "</｜DSML｜parameter>".to_string(),
             allow_eof_recovery: false,
+            content_is_prefix_only: false,
         }
     }
 }
@@ -286,6 +313,14 @@ pub struct KimiK2ParserConfig {
     pub call_end: String,
     /// Token separating function ID from JSON arguments (e.g., "<|tool_call_argument_begin|>")
     pub argument_begin: String,
+
+    /// When true, the tool-call block is terminal per the model's published
+    /// reference decoder: normal_text is only the natural-language text before
+    /// the FIRST tool-call start marker; inter-call and trailing text are
+    /// dropped (markup never leaks). Default false preserves all surrounding
+    /// text.
+    #[serde(default)]
+    pub content_is_prefix_only: bool,
 }
 
 impl Default for KimiK2ParserConfig {
@@ -304,6 +339,7 @@ impl Default for KimiK2ParserConfig {
             call_start: "<|tool_call_begin|>".to_string(),
             call_end: "<|tool_call_end|>".to_string(),
             argument_begin: "<|tool_call_argument_begin|>".to_string(),
+            content_is_prefix_only: false,
         }
     }
 }
@@ -485,6 +521,10 @@ impl ToolCallConfig {
                 // opener). Same flag nemotron_deci uses; base_json_parser.rs has
                 // the streaming-path detail.
                 strip_markup_on_recovery: true,
+                // mistral-common's reference decoder takes content as only the
+                // tokens before the [TOOL_CALLS] control token; trailing prose
+                // is unrepresentable, so the tool-call block is terminal.
+                content_is_prefix_only: true,
                 ..Default::default()
             }),
             structural_tag_builder: None,
@@ -590,6 +630,20 @@ impl ToolCallConfig {
         }
     }
 
+    /// Nemotron Nano shares Qwen3-Coder's `<tool_call><function=...>` XML wire
+    /// format, but NVIDIA's reference decoder
+    /// (nemotron_toolcall_parser_no_streaming.py) defines content as
+    /// `model_output[:rfind("<TOOLCALL>")]` — only the text before the tool-call
+    /// block — making the block terminal. So this config is identical to
+    /// `qwen3_coder()` except `content_is_prefix_only` is true.
+    pub fn nemotron_nano() -> Self {
+        let mut cfg = Self::qwen3_coder();
+        if let ParserConfig::Xml(xml) = &mut cfg.parser_config {
+            xml.content_is_prefix_only = true;
+        }
+        cfg
+    }
+
     pub fn jamba() -> Self {
         Self {
             parser_config: ParserConfig::Json(JsonParserConfig {
@@ -608,10 +662,11 @@ impl ToolCallConfig {
         }
     }
 
-    fn deepseek_dsml(block_name: &str) -> Self {
+    fn deepseek_dsml(block_name: &str, content_is_prefix_only: bool) -> Self {
         let dsml_config = DsmlParserConfig {
             block_start: format!("<｜DSML｜{}>", block_name),
             block_end: format!("</｜DSML｜{}>", block_name),
+            content_is_prefix_only,
             ..Default::default()
         };
         let structural_tag = StructuralTagBuilder::DsmlToolCalls(DsmlToolCallsConfig {
@@ -646,7 +701,9 @@ impl ToolCallConfig {
         // <｜DSML｜parameter name="param_name" string="true|false">value</｜DSML｜parameter>
         // </｜DSML｜invoke>
         // </｜DSML｜function_calls>
-        Self::deepseek_dsml("function_calls")
+        // V3.2's spec is silent on trailing text, so Dynamo preserves it
+        // (content_is_prefix_only = false).
+        Self::deepseek_dsml("function_calls", false)
     }
 
     pub fn deepseek_v4() -> Self {
@@ -656,7 +713,10 @@ impl ToolCallConfig {
         // <｜DSML｜parameter name="param_name" string="true|false">value</｜DSML｜parameter>
         // </｜DSML｜invoke>
         // </｜DSML｜tool_calls>
-        Self::deepseek_dsml("tool_calls")
+        // V4's reference decoder (encoding_dsv4.py::parse_message_from_completion_text)
+        // asserts no content after tool calls, making the tool-call block
+        // terminal: content is only the text before the block.
+        Self::deepseek_dsml("tool_calls", true)
     }
 
     pub fn minimax_m2() -> Self {
@@ -691,6 +751,7 @@ impl ToolCallConfig {
                 strict_match: true,
                 passthrough_when_no_function: false,
                 backoff_when_no_wrapper: true,
+                content_is_prefix_only: false,
             }),
             structural_tag_builder: None,
         }
@@ -713,7 +774,13 @@ impl ToolCallConfig {
         // <|tool_calls_section_end|>
         // Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
         Self {
-            parser_config: ParserConfig::KimiK2(KimiK2ParserConfig::default()),
+            parser_config: ParserConfig::KimiK2(KimiK2ParserConfig {
+                // Moonshot's reference decoder (extract_tool_call_info) defines
+                // content as the text before the tool-call section and never
+                // collects text after it, so the block is terminal.
+                content_is_prefix_only: true,
+                ..Default::default()
+            }),
             structural_tag_builder: None,
         }
     }

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -14,6 +14,11 @@ use uuid::Uuid;
 use super::super::config::DsmlParserConfig;
 use super::super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
+/// Byte spans of the source text occupied by tool-call MARKUP. The caller
+/// subtracts these from the text to assemble `normal_text` while keeping every
+/// other byte verbatim. Ascending, non-overlapping.
+type MarkupSpans = Vec<(usize, usize)>;
+
 /// DeepSeek V3.2 / V4 use DSML (DeepSeek Markup Language) format for tool calls.
 /// V3.2 wraps calls in `<｜DSML｜function_calls>`; V4 wraps them in
 /// `<｜DSML｜tool_calls>`. The inner invoke / parameter grammar is identical:
@@ -62,16 +67,17 @@ pub fn find_tool_call_end_position_dsml(chunk: &str, config: &DsmlParserConfig) 
 /// Parse DSML formatted tool calls from a message.
 ///
 /// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
-/// text BEFORE the first `<｜DSML｜tool_calls>` / `<｜DSML｜function_calls>`
-/// start marker. Text between blocks, after the last block, and any
-/// back-to-back-block content are all dropped — matching upstream vLLM
-/// (`vllm/tool_parsers/deepseek_v4_tool_parser.py` and the V3.2 sibling),
-/// which compute `content = model_output[:content_end]` where
-/// `content_end = model_output.find(self.tool_call_start_token)`.
+/// model text with each complete tool-call block removed (start marker through
+/// end marker), keeping ALL other text verbatim: the prefix before the first
+/// block, any text BETWEEN blocks, and any text AFTER the last block.
+/// Whitespace is preserved as-is. Only tool-call MARKUP is stripped — natural
+/// language is never dropped and markup never leaks. Cases:
+/// TOOLCALLING.batch.{8.b, 8.c, 8.d} carry inter-call / trailing narration.
 ///
-/// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
-/// after the wrapper across XML-style families; this aligns Dynamo to that
-/// behavior. Cases: TOOLCALLING.batch.{2.b, 2.c, 8.b, 8.c, 8.d}.
+/// Malformed or unrecoverable blocks keep the conservative drop-without-leak
+/// behavior: when a block-start is detected but no valid invokes parse, every
+/// byte from that block-start onward is suppressed so wire tags do not bleed
+/// into `normal_text`.
 pub fn try_tool_call_parse_dsml(
     message: &str,
     config: &DsmlParserConfig,
@@ -117,25 +123,25 @@ pub fn try_tool_call_parse_dsml(
 
     // Extract tool calls blocks. Finalize paths can opt into EOF recovery so
     // a missing outer block end still yields any complete inner invokes.
-    let tool_calls = extract_tool_calls(trimmed, config)?;
-
-    // Whether or not invokes parsed, normal_text is the prefix before the
-    // first block_start — mirrors vLLM's success path. On no-invokes the
-    // markup-leak warning still fires for the diagnostic trail.
-    let pre_block_span = &trimmed[..start_idx];
-    let pre_block_text = first_orphan_dsml_marker_index(pre_block_span, config)
-        .filter(|idx| pre_block_span[*idx..].starts_with(config.invoke_start_prefix.as_str()))
-        .map(|idx| pre_block_span[..idx].trim_end().to_string())
-        .unwrap_or_else(|| pre_block_span.to_string());
+    // `markup_spans` are the byte ranges holding tool-call markup; everything
+    // else in `trimmed` is natural text to preserve.
+    let (tool_calls, markup_spans) = extract_tool_calls(trimmed, config)?;
 
     if tool_calls.is_empty() {
         // A block-start was detected but no valid invokes parsed. Do NOT leak
-        // the DSML markup back to the client; emit a diagnostic with a prefix
-        // of the failed block.
+        // the DSML markup back to the client; suppress every byte from the
+        // first block_start onward and keep only the natural-text prefix.
+        // (Malformed/unrecoverable blocks keep this drop-without-leak contract.)
         //
         // Note: an unterminated block-start here means `block_regex` finds no
         // match at all, so any valid block *after* the unterminated one is
         // lost. This matches the pre-existing conservative P1-3 contract.
+        let pre_block_span = &trimmed[..start_idx];
+        let pre_block_text = first_orphan_dsml_marker_index(pre_block_span, config)
+            .filter(|idx| pre_block_span[*idx..].starts_with(config.invoke_start_prefix.as_str()))
+            .map(|idx| pre_block_span[..idx].trim_end().to_string())
+            .unwrap_or_else(|| pre_block_span.to_string());
+
         let failed = &trimmed[start_idx..];
         let prefix: String = failed.chars().take(120).collect();
         tracing::warn!(
@@ -147,24 +153,22 @@ pub fn try_tool_call_parse_dsml(
         return Ok((vec![], Some(pre_block_text)));
     }
 
-    // Success path: prefix-only contract — everything from the first block_start
-    // onward (the block(s) themselves plus any inter-block / trailing narration)
-    // is stripped from normal_text. Mirrors vLLM's
-    // `content = model_output[:content_end]`.
-    let stripped = &trimmed[start_idx..];
-    if !stripped.is_empty() {
-        let preview: String = stripped.chars().take(120).collect();
+    // Success path: strip ONLY the tool-call markup spans; keep all other text
+    // verbatim — prefix, inter-block narration, and trailing narration.
+    let normal_text = normal_text_minus_spans(trimmed, &markup_spans);
+    let stripped_bytes: usize = markup_spans.iter().map(|(s, e)| e - s).sum();
+    if stripped_bytes > 0 {
         tracing::debug!(
-            why = "prefix_only_contract",
+            why = "strip_markup_keep_text",
             n_calls = tool_calls.len(),
-            kept_prefix_bytes = pre_block_text.len(),
-            stripped_bytes = stripped.len(),
-            "DSML strip (success): kept prefix before first block_start; dropped parsed-block(s) + any inter-block / trailing narration. preview={:?}",
-            preview
+            n_markup_spans = markup_spans.len(),
+            kept_bytes = normal_text.len(),
+            stripped_bytes,
+            "DSML strip (success): removed tool-call markup spans; kept all surrounding natural text (prefix + inter-block + trailing)."
         );
     }
 
-    Ok((tool_calls, Some(pre_block_text)))
+    Ok((tool_calls, Some(normal_text)))
 }
 
 fn first_orphan_dsml_marker_index(text: &str, config: &DsmlParserConfig) -> Option<usize> {
@@ -181,26 +185,38 @@ fn first_orphan_dsml_marker_index(text: &str, config: &DsmlParserConfig) -> Opti
 }
 
 /// Extract all tool calls from DSML formatted text.
+///
+/// Returns the parsed calls plus the byte spans of `text` that hold tool-call
+/// MARKUP (start marker through end marker, and any orphan-recovered invoke
+/// tails). The caller subtracts these spans from `text` to assemble
+/// `normal_text` while keeping every other byte verbatim. Spans are produced in
+/// ascending, non-overlapping order because the cursor only moves forward.
 fn extract_tool_calls(
     text: &str,
     config: &DsmlParserConfig,
-) -> anyhow::Result<Vec<ToolCallResponse>> {
+) -> anyhow::Result<(Vec<ToolCallResponse>, MarkupSpans)> {
     let mut tool_calls = Vec::new();
+    let mut markup_spans: MarkupSpans = Vec::new();
     let mut cursor = 0;
 
     while cursor < text.len() {
         let Some(rel_start) = text[cursor..].find(config.block_start.as_str()) else {
-            if let Some((_, mut recovered)) =
+            if let Some((marker_idx, mut recovered)) =
                 recover_orphan_invokes_in_span(&text[cursor..], config)?
             {
+                // Orphan invoke(s) with no outer block: the recovered markup
+                // runs from the first inner marker to the end of the span.
+                markup_spans.push((cursor + marker_idx, text.len()));
                 tool_calls.append(&mut recovered);
             }
             break;
         };
         let abs_start = cursor + rel_start;
-        if let Some((_, mut recovered)) =
+        if let Some((marker_idx, mut recovered)) =
             recover_orphan_invokes_in_span(&text[cursor..abs_start], config)?
         {
+            // Orphan invoke(s) in the gap before the next outer block_start.
+            markup_spans.push((cursor + marker_idx, abs_start));
             tool_calls.append(&mut recovered);
         }
 
@@ -221,17 +237,42 @@ fn extract_tool_calls(
 
         let invokes = extract_invokes(block, config)?;
         tool_calls.extend(invokes);
+        // The whole outer block — start marker through end marker — is markup.
+        markup_spans.push((abs_start, next_cursor));
 
         cursor = next_cursor;
     }
 
-    Ok(tool_calls)
+    Ok((tool_calls, markup_spans))
 }
 
+/// Assemble `normal_text` by removing the markup `spans` from `text`, keeping
+/// every other byte verbatim. `spans` must be ascending and non-overlapping.
+fn normal_text_minus_spans(text: &str, spans: &[(usize, usize)]) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pos = 0;
+    for &(start, end) in spans {
+        if start > pos {
+            out.push_str(&text[pos..start]);
+        }
+        pos = end.max(pos);
+    }
+    if pos < text.len() {
+        out.push_str(&text[pos..]);
+    }
+    out
+}
+
+/// Recover complete bare invoke(s) inside `span` (no outer block wrapper).
+///
+/// On success returns `(marker_idx, calls)` where `marker_idx` is the byte
+/// offset within `span` of the first inner DSML marker — i.e. the start of the
+/// markup that the caller strips from `normal_text`. Everything in `span`
+/// before `marker_idx` is natural text and is preserved by the caller.
 fn recover_orphan_invokes_in_span(
     span: &str,
     config: &DsmlParserConfig,
-) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+) -> anyhow::Result<Option<(usize, Vec<ToolCallResponse>)>> {
     let Some(marker_idx) = first_orphan_dsml_marker_index(span, config) else {
         return Ok(None);
     };
@@ -255,10 +296,7 @@ fn recover_orphan_invokes_in_span(
         kept_prefix_bytes = marker_idx,
         "DSML recovery: recovered complete bare invoke(s) before a later outer block"
     );
-    Ok(Some((
-        span[..marker_idx].trim_end().to_string(),
-        tool_calls,
-    )))
+    Ok(Some((marker_idx, tool_calls)))
 }
 
 /// Extract individual invoke blocks from function_calls content
@@ -922,10 +960,10 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_block_drops_inter_and_trailing_text() {
+    fn test_multi_block_preserves_inter_and_trailing_text() {
         // Two complete DSML blocks with text before, between, and after.
-        // Both blocks must be parsed; only the pre-block prefix survives in
-        // normal_content — matches vLLM (drops inter / trailing).
+        // Both blocks must be parsed; ALL surrounding natural text survives in
+        // normal_text — only the tool-call markup spans are removed.
         let input = "pre <｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"a\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> middle <｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"b\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> tail";
 
         let config = get_v4_test_config();
@@ -935,7 +973,11 @@ mod tests {
         assert_eq!(calls[1].function.name, "b");
 
         let normal = normal.unwrap();
-        assert_eq!(normal, "pre ", "only pre-block text survives: {:?}", normal);
+        assert_eq!(
+            normal, "pre  middle  tail",
+            "prefix + inter-block + trailing text all survive: {:?}",
+            normal
+        );
         assert!(
             !normal.contains("<｜DSML｜"),
             "normal_content leaked DSML markup: {:?}",
@@ -966,10 +1008,14 @@ mod tests {
             "outer invoke name is matched first (non-greedy)"
         );
 
-        // After alignment to vLLM, normal_text is the prefix BEFORE the first
-        // block_start only — trailing text after the block is dropped.
+        // normal_text keeps the prefix before the block plus the trailing text
+        // after the block_end; only the matched markup span is removed.
         let normal = normal.unwrap();
-        assert_eq!(normal, "pre ", "only pre-block text survives: {:?}", normal);
+        assert_eq!(
+            normal, "pre  tail",
+            "prefix + trailing text survive; only the block markup is removed: {:?}",
+            normal
+        );
         assert!(
             !normal.contains("<｜DSML｜tool_calls>"),
             "normal_content leaked block_start: {:?}",

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -346,47 +346,64 @@ fn extract_invokes(
     Ok(invokes)
 }
 
-/// Parse parameters from invoke content
+/// Parse parameters from invoke content.
+///
+/// Each parameter region begins at `parameter_prefix` and ends at the next
+/// prefix, or at the end of the invoke body. The value runs from after the
+/// header `>` to its own `parameter_end` close tag if present, otherwise to
+/// the end of the region.
+///
+/// Recovering a value that has no `</｜DSML｜parameter>` close follows the
+/// recover/drop rule (see parsers_v2/README.md goal 5): the value is still
+/// terminated by the next marker — the next parameter, or `</｜DSML｜invoke>`,
+/// which bounds this content — so it is provably complete and we recover it
+/// (this is what fixes case 4.d). A value that ran to genuine end-of-stream
+/// has no terminating `</｜DSML｜invoke>`, so `extract_invokes` never matches
+/// the invoke and it never reaches this function — i.e. mid-value truncation
+/// (case 5.c) still drops, never guessed.
 fn parse_parameters(
     content: &str,
     config: &DsmlParserConfig,
 ) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
     let mut parameters = serde_json::Map::new();
 
-    // Build pattern with proper escaping
-    // Match: <｜DSML｜parameter name="param_name" string="true|false">value</｜DSML｜parameter>
-    // Note: parameter_prefix is "<｜DSML｜parameter name=" (no quotes, we add them in pattern)
-    let prefix_escaped = regex::escape(&config.parameter_prefix);
-    let end_escaped = regex::escape(&config.parameter_end);
+    let prefix = config.parameter_prefix.as_str();
+    let end = config.parameter_end.as_str();
 
-    // The `string="true|false"` attribute is optional: some model outputs omit it.
-    // When absent we best-effort parse the value (JSON → String fallback).
-    let param_pattern = format!(
-        r#"(?s){}\"([^"]+)\"(?:\s+string=\"(true|false)\")?\s*>(.*?){}"#,
-        prefix_escaped, end_escaped
-    );
+    // After the prefix (`<｜DSML｜parameter name=`): name="..." with an optional
+    // `string="true|false"` attribute, then `>`. We add the quotes here.
+    let header_regex = Regex::new(r#"^"([^"]+)"(?:\s+string="(true|false)")?\s*>"#)?;
 
-    let param_regex = Regex::new(&param_pattern)?;
+    let starts: Vec<usize> = content.match_indices(prefix).map(|(i, _)| i).collect();
+    for (i, &start) in starts.iter().enumerate() {
+        let region_end = starts.get(i + 1).copied().unwrap_or(content.len());
+        let after_prefix = &content[start + prefix.len()..region_end];
+        let Some(header) = header_regex.captures(after_prefix) else {
+            continue;
+        };
+        let param_name = header.get(1).unwrap().as_str().trim();
+        let string_attr = header.get(2).map(|m| m.as_str());
 
-    for param_match in param_regex.captures_iter(content) {
-        if let (Some(name_match), Some(value_match)) = (param_match.get(1), param_match.get(3)) {
-            let param_name = name_match.as_str().trim();
-            let param_value = value_match.as_str().trim();
+        // Value: from after the header `>` to its own close tag if present,
+        // else to the region boundary (the next marker that bounds it).
+        let value_region = &after_prefix[header.get(0).unwrap().end()..];
+        let raw_value = match value_region.find(end) {
+            Some(p) => &value_region[..p],
+            None => value_region,
+        };
+        let param_value = raw_value.trim();
 
-            // Parse value based on string attribute (if present).
-            // `string="true"` forces the String branch; every other case
-            // (`string="false"` or attribute omitted) tries JSON first and
-            // falls back to String.
-            let string_attr = param_match.get(2).map(|m| m.as_str());
-            let value = if string_attr == Some("true") {
-                serde_json::Value::String(param_value.to_string())
-            } else {
-                serde_json::from_str(param_value)
-                    .unwrap_or_else(|_| serde_json::Value::String(param_value.to_string()))
-            };
+        // `string="true"` forces the String branch; every other case
+        // (`string="false"` or attribute omitted) tries JSON first and falls
+        // back to String.
+        let value = if string_attr == Some("true") {
+            serde_json::Value::String(param_value.to_string())
+        } else {
+            serde_json::from_str(param_value)
+                .unwrap_or_else(|_| serde_json::Value::String(param_value.to_string()))
+        };
 
-            parameters.insert(param_name.to_string(), value);
-        }
+        parameters.insert(param_name.to_string(), value);
     }
 
     Ok(parameters)
@@ -500,9 +517,10 @@ mod tests {
     //   - (TOOLCALLING.batch.5  FIXED: batch/non-streaming finalize now recovers
     //     complete invokes when </｜DSML｜tool_calls> is absent, matching the
     //     stream-finalize path. Same class as Kimi K2 pre-PR #8208.)
-    //   - (TOOLCALLING.batch.4 missing-parameter-close & middle-invoke-truncation now
-    //     pinned: see test_parse_deepseek_v4_missing_parameter_close_loses_param,
-    //     test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next.)
+    //   - (TOOLCALLING.batch.4 missing-parameter-close FIXED: a value with no
+    //     </｜DSML｜parameter> close is recovered when it is delimiter-terminated by
+    //     </｜DSML｜invoke> — see test_parse_deepseek_v4_missing_parameter_close_recovers_param.
+    //     Middle-invoke-truncation still pinned: test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next.)
     // No customer-incident regression tests yet — V4 is hours old
     // (2026-04-24) and no bugs have been filed against it.
     // -------------------------------------------------------------------
@@ -1203,7 +1221,7 @@ mod tests {
     /// the raw value up to `</｜DSML｜invoke>`. Flip this test once fixed.
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml.
     #[test] // TOOLCALLING.batch.4, TOOLCALLING.fmt.3
-    fn test_parse_deepseek_v4_missing_parameter_close_loses_param() {
+    fn test_parse_deepseek_v4_missing_parameter_close_recovers_param() {
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"test\">\n\
 <｜DSML｜parameter name=\"x\" string=\"true\">value\n\
@@ -1212,14 +1230,18 @@ mod tests {
 
         let config = get_v4_test_config();
         let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
-        // PIN_ME: replace with observed behavior after first run.
         assert_eq!(calls.len(), 1);
         let (name, args) = extract_name_and_args(calls[0].clone());
         assert_eq!(name, "test");
-        assert!(
-            args.get("x").is_none(),
-            "Expected 'x' to be dropped because </｜DSML｜parameter> is missing; \
-             got args={args}"
+        // The value "value" has no </｜DSML｜parameter> close, but it is
+        // delimiter-terminated by </｜DSML｜invoke>, so the recover/drop rule
+        // recovers it (see parsers_v2/README.md goal 5). A value that ran to
+        // genuine EOF would leave the invoke unterminated, fail extract_invokes,
+        // and drop (see test_parse_deepseek_v4_missing_end_token_without_recovery
+        // and TOOLCALLING.batch.5.c).
+        assert_eq!(
+            args["x"], "value",
+            "Expected 'x' recovered (value terminated by </｜DSML｜invoke>); got args={args}"
         );
     }
 

--- a/parsers/src/tool_calling/dsml/parser.rs
+++ b/parsers/src/tool_calling/dsml/parser.rs
@@ -155,7 +155,23 @@ pub fn try_tool_call_parse_dsml(
 
     // Success path: strip ONLY the tool-call markup spans; keep all other text
     // verbatim — prefix, inter-block narration, and trailing narration.
-    let normal_text = normal_text_minus_spans(trimmed, &markup_spans);
+    //
+    // When `content_is_prefix_only` is set (e.g. DeepSeek-V4, whose reference
+    // decoder makes the block terminal), normal_text is ONLY the natural text
+    // before the FIRST tool-call markup span; inter-block and trailing text are
+    // dropped. The earliest markup-span start is the first marker (which may be
+    // a bare invoke that precedes the wrapped block_start, so we cannot just use
+    // `start_idx`).
+    let normal_text = if config.content_is_prefix_only {
+        let first_marker = markup_spans
+            .iter()
+            .map(|(s, _)| *s)
+            .min()
+            .unwrap_or(start_idx);
+        trimmed[..first_marker].to_string()
+    } else {
+        normal_text_minus_spans(trimmed, &markup_spans)
+    };
     let stripped_bytes: usize = markup_spans.iter().map(|(s, e)| e - s).sum();
     if stripped_bytes > 0 {
         tracing::debug!(

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -270,6 +270,7 @@ pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
 fn push_recovered_call(
     calls: &mut Vec<ToolCallResponse>,
     first_tool_start: &mut Option<usize>,
+    removed_spans: &mut Vec<(usize, usize)>,
     absolute_start: usize,
     recovered: (&str, &str, usize),
     tools: Option<&[ToolDefinition]>,
@@ -278,6 +279,9 @@ fn push_recovered_call(
     if first_tool_start.is_none_or(|idx| absolute_start < idx) {
         *first_tool_start = Some(absolute_start);
     }
+    // Record the byte span of the recovered call so the normal_text assembler
+    // can strip exactly this markup and keep the surrounding natural text.
+    removed_spans.push((absolute_start, absolute_start + recovered.2));
     tracing::warn!(
         why = reason,
         recovered_calls = 1,
@@ -295,6 +299,7 @@ fn recover_calls_in_span(
     tools: Option<&[ToolDefinition]>,
     calls: &mut Vec<ToolCallResponse>,
     first_tool_start: &mut Option<usize>,
+    removed_spans: &mut Vec<(usize, usize)>,
 ) -> anyhow::Result<()> {
     let mut cursor = 0usize;
 
@@ -327,6 +332,7 @@ fn recover_calls_in_span(
             push_recovered_call(
                 calls,
                 first_tool_start,
+                removed_spans,
                 span_offset + rel_start,
                 recovered,
                 tools,
@@ -344,16 +350,25 @@ fn recover_calls_in_span(
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
 ///
 /// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
-/// text BEFORE the first `<|tool_call>` start marker, trimmed of whitespace.
-/// Text between calls, after the last call, and truncated-incomplete-call
-/// tails are all dropped — matching upstream vLLM
-/// (`vllm/tool_parsers/gemma4_tool_parser.py::extract_tool_calls`) which
-/// computes `content = model_output[:content_end].strip()` where
-/// `content_end = model_output.find(self.tool_call_start_token)`.
+/// model text with each complete tool-call block (start marker `<|tool_call>`
+/// through end marker `<tool_call|>`) removed, keeping ALL other text:
+/// the prefix before the first call, the text BETWEEN calls, and the text
+/// AFTER the last call. Interior whitespace is preserved as-is (only the
+/// outermost ends are trimmed, matching the rest of the parser family); only
+/// tool-call markup is stripped, natural text is never dropped, and markup
+/// never leaks.
 ///
-/// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
-/// after the wrapper across XML-style families; this aligns Dynamo to that
-/// behavior. Cases: TOOLCALLING.batch.{2.c, 8.b, 8.c, 8.d}.
+/// This is a deliberate divergence from upstream vLLM
+/// (`vllm/tool_parsers/gemma4_tool_parser.py::extract_tool_calls`, which keeps
+/// only `model_output[:content_end].strip()`, i.e. the prefix before the first
+/// marker) and from SGLang (which also drops trailing narration). Dynamo
+/// preserves the surrounding narration so a model that sandwiches a tool call
+/// between sentences doesn't silently lose the user-visible text. Cases:
+/// TOOLCALLING.batch.{2.c, 8.b, 8.c, 8.d}.
+///
+/// Malformed / unrecoverable / truncated tool-call markup keeps its no-leak
+/// drop behavior: a gap that still contains gemma4 markup tokens after the
+/// complete calls are removed is suppressed rather than echoed verbatim.
 ///
 /// The `}<tool_call|>` adjacency requirement in the regex means embedded
 /// `<tool_call|>` literals inside string-typed args (e.g. a `description`
@@ -366,6 +381,9 @@ pub fn try_tool_call_parse_gemma4(
     let regex = tool_call_regex();
     let mut calls = Vec::new();
     let mut first_tool_start = None;
+    // Byte spans of every complete (parsed or recovered) tool-call block, used
+    // to subtract markup from the assembled normal_text below.
+    let mut removed_spans: Vec<(usize, usize)> = Vec::new();
     let mut cursor = 0usize;
 
     for caps in regex.captures_iter(message) {
@@ -377,8 +395,10 @@ pub fn try_tool_call_parse_gemma4(
                 tools,
                 &mut calls,
                 &mut first_tool_start,
+                &mut removed_spans,
             )?;
             first_tool_start.get_or_insert(m.start());
+            removed_spans.push((m.start(), m.end()));
             cursor = m.end();
         }
         let name = caps.name("name").map(|m| m.as_str()).unwrap_or_default();
@@ -397,22 +417,23 @@ pub fn try_tool_call_parse_gemma4(
         tools,
         &mut calls,
         &mut first_tool_start,
+        &mut removed_spans,
     )?;
 
-    // No-leak contract for `normal_text`:
-    //   - Success path (≥1 call extracted): prefix BEFORE the first
-    //     `<|tool_call>` start marker — mirrors vLLM's
-    //     `content = model_output[:content_end].strip()`. Inter-call,
-    //     trailing, and truncation tails after a successful call are dropped.
+    // `normal_text` assembly:
+    //   - Success path (≥1 call extracted): concatenate the text outside every
+    //     complete tool-call block — prefix, inter-call narration, and trailing
+    //     narration — preserving whitespace verbatim. A gap that still contains
+    //     gemma4 markup tokens (`<|tool_call>`, `<tool_call|>`, `<|"|>`) is a
+    //     malformed / truncated / unrecoverable remnant; it is dropped so
+    //     tool-call markup never leaks into normal_text.
     //   - Recovery path (zero calls extracted): if the message contains ANY
-    //     gemma4 markup token (`<|tool_call>`, `<tool_call|>`, `<|"|>`),
-    //     return empty — Dynamo intentionally diverges from vLLM's
-    //     exception-fallback (which echoes raw bytes) so tool-call markup
-    //     never leaks into normal_text on malformed / truncated / orphan-
-    //     close / no-body inputs. Cases flagged by the parity table's `↯`:
+    //     gemma4 markup token, return empty — Dynamo intentionally diverges
+    //     from vLLM's exception-fallback (which echoes raw bytes) so tool-call
+    //     markup never leaks on malformed / truncated / orphan-close / no-body
+    //     inputs. Cases flagged by the parity table's `↯`:
     //     TOOLCALLING.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
-    //   - Plain-text path (zero calls AND no markup): return the message
-    //     as-is.
+    //   - Plain-text path (zero calls AND no markup): return the message as-is.
     let has_markup = message.contains(TOOL_CALL_START)
         || message.contains(TOOL_CALL_END)
         || message.contains(STRING_DELIM);
@@ -436,29 +457,46 @@ pub fn try_tool_call_parse_gemma4(
             message.trim().to_string()
         }
     } else {
-        // Success: prefix-only contract — drop everything from the first
-        // `<|tool_call>` onward (inter-call text, trailing narration,
-        // truncation tails). Mirrors vLLM's
-        // `content = model_output[:content_end].strip()`.
-        match first_tool_start {
-            Some(idx) => {
-                let stripped = &message[idx..];
-                let preview: String = stripped.chars().take(120).collect();
-                tracing::debug!(
-                    why = "prefix_only_contract",
-                    n_calls = calls.len(),
-                    kept_prefix_bytes = idx,
-                    stripped_bytes = stripped.len(),
-                    "gemma4 strip (success): kept prefix before first <|tool_call>; dropped parsed-call(s) + any inter-call / trailing narration. preview={:?}",
-                    preview
-                );
-                message[..idx].trim().to_string()
+        // Success: keep every gap between/around the complete tool-call blocks.
+        removed_spans.sort_unstable();
+        let mut kept = String::new();
+        let mut prev_end = 0usize;
+        for &(start, end) in &removed_spans {
+            // Spans are non-overlapping and sorted; guard against any pathological
+            // overlap so we never slice on a stale offset.
+            if start >= prev_end {
+                push_natural_text_gap(&mut kept, &message[prev_end..start]);
             }
-            None => String::new(),
+            prev_end = prev_end.max(end);
         }
+        push_natural_text_gap(&mut kept, &message[prev_end..]);
+        // Trim only the outermost ends (interior whitespace stays verbatim) to
+        // match the dynamo normal_text convention used across this family.
+        kept.trim().to_string()
     };
 
     Ok((calls, Some(normal_text)))
+}
+
+/// Append a single inter-call / surrounding gap to the accumulated normal_text.
+/// A gap that still contains gemma4 tool-call markup is a malformed / truncated
+/// remnant (e.g. an incomplete trailing call that never closed) — drop it so
+/// markup never leaks. Natural text is appended verbatim, whitespace included.
+fn push_natural_text_gap(kept: &mut String, gap: &str) {
+    if gap.is_empty() {
+        return;
+    }
+    if gap.contains(TOOL_CALL_START) || gap.contains(TOOL_CALL_END) || gap.contains(STRING_DELIM) {
+        let preview: String = gap.chars().take(120).collect();
+        tracing::warn!(
+            why = "dropped_markup_gap",
+            stripped_bytes = gap.len(),
+            "gemma4 strip (success): dropped a gap that still contained gemma4 markup (malformed/truncated remnant) to prevent leak into normal_text. preview={:?}",
+            preview
+        );
+        return;
+    }
+    kept.push_str(gap);
 }
 
 // ---------------------------------------------------------------------------
@@ -826,12 +864,42 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    #[test] // TOOLCALLING.batch.8.c — prefix narration preserved, trailing dropped (matches vLLM)
+    #[test] // TOOLCALLING.batch.8.c — prefix AND trailing narration both preserved;
+    // only the tool-call block is stripped. Interior whitespace (the double
+    // space left where the block was removed) is kept verbatim; outer ends are
+    // trimmed. Dynamo intentionally diverges from vLLM/SGLang, which drop the
+    // trailing narration.
     fn parse_with_surrounding_text() {
         let input = r#"Sure thing. <|tool_call>call:f{x:1}<tool_call|> All set."#;
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(normal, Some("Sure thing.".to_string()));
+        assert_eq!(normal, Some("Sure thing.  All set.".to_string()));
+    }
+
+    #[test] // TOOLCALLING.batch.8.b — narration only AFTER the call is preserved
+    // (vLLM/SGLang drop it; Dynamo keeps it).
+    fn parse_trailing_text_only_preserved() {
+        let input = r#"<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Let me know if you need more."#;
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(normal, Some("Let me know if you need more.".to_string()));
+    }
+
+    #[test] // TOOLCALLING.batch.8.d — narration BETWEEN two calls is preserved;
+    // both calls extracted, inter-call text kept verbatim, outer ends trimmed.
+    fn parse_inter_call_text_preserved() {
+        let input = concat!(
+            "I will check the weather. ",
+            "<|tool_call>call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+            " Then check LA weather. ",
+            "<|tool_call>call:get_weather{location:<|\"|>LA<|\"|>}<tool_call|>",
+        );
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            normal,
+            Some("I will check the weather.  Then check LA weather.".to_string())
+        );
     }
 
     #[test] // TOOLCALLING.batch.3 — no tool calls at all

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -137,33 +137,54 @@ fn parse_recoverable_call_at(
     }
 
     let open_brace = after_start_offset + CALL_PREFIX.len() + name_len;
-    let close_brace = find_balanced_args_end(input, open_brace)?;
-    let args_start = open_brace + 1;
-    let args_raw = &input[args_start..close_brace];
-    let after_args = &input[close_brace + 1..];
 
-    if after_args.starts_with(TOOL_CALL_END) {
-        return Some((name, args_raw, close_brace + 1 + TOOL_CALL_END.len()));
+    // Locate the close sentinel (canonical <tool_call|> or the mismatched
+    // </tool_call>) in a slice -> (relative offset, sentinel length).
+    let close_sentinel = |s: &str| -> Option<(usize, usize)> {
+        s.find(TOOL_CALL_END)
+            .map(|p| (p, TOOL_CALL_END.len()))
+            .or_else(|| {
+                s.find(MISMATCHED_TOOL_CALL_END)
+                    .map(|p| (p, MISMATCHED_TOOL_CALL_END.len()))
+            })
+    };
+
+    // Normal path: a balanced `}` ends the args object.
+    if let Some(close_brace) = find_balanced_args_end(input, open_brace) {
+        let args_raw = &input[open_brace + 1..close_brace];
+        let after_args = &input[close_brace + 1..];
+        if after_args.starts_with(TOOL_CALL_END) {
+            return Some((name, args_raw, close_brace + 1 + TOOL_CALL_END.len()));
+        }
+        // Support either close sentinel: Gemma 4 sometimes emits the mismatched
+        // </tool_call> instead of <tool_call|>; the call body is complete, so
+        // recover either way and consume the stray close (recover/drop rule,
+        // parsers_v2/README.md goal 5).
+        if after_args.starts_with(MISMATCHED_TOOL_CALL_END) {
+            return Some((
+                name,
+                args_raw,
+                close_brace + 1 + MISMATCHED_TOOL_CALL_END.len(),
+            ));
+        }
+        if allow_missing_end && after_args.trim().is_empty() {
+            return Some((name, args_raw, close_brace + 1));
+        }
+        return None;
     }
 
-    // Support either close sentinel: Gemma 4 sometimes emits the mismatched
-    // </tool_call> instead of the canonical <tool_call|>. The call body is
-    // already complete here (balanced args brace, string values delimited by
-    // <|"|>), so recover it either way and consume the stray close marker so it
-    // never leaks into normal_text (recover/drop rule, parsers_v2/README.md goal 5).
-    if after_args.starts_with(MISMATCHED_TOOL_CALL_END) {
-        return Some((
-            name,
-            args_raw,
-            close_brace + 1 + MISMATCHED_TOOL_CALL_END.len(),
-        ));
+    // Recovery path: the closing `}` was truncated (e.g. 4.b). Recover only if a
+    // close sentinel follows the open brace AND every <|"|> string in the body is
+    // closed (balanced delimiters). An odd count means the last value was
+    // truncated mid-string, which must drop (recover/drop rule).
+    let rest = &input[open_brace..];
+    let (sent_rel, sent_len) = close_sentinel(rest)?;
+    let sentinel_pos = open_brace + sent_rel;
+    let args_raw = &input[open_brace + 1..sentinel_pos];
+    if args_raw.matches(STRING_DELIM).count() % 2 != 0 {
+        return None;
     }
-
-    if allow_missing_end && after_args.trim().is_empty() {
-        return Some((name, args_raw, close_brace + 1));
-    }
-
-    None
+    Some((name, args_raw, sentinel_pos + sent_len))
 }
 
 fn is_call_prefix_boundary(input: &str, idx: usize) -> bool {

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -22,6 +22,9 @@ use super::super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
 pub(crate) const TOOL_CALL_START: &str = "<|tool_call>";
 pub(crate) const TOOL_CALL_END: &str = "<tool_call|>";
+/// Mismatched close sentinel Gemma 4 sometimes emits instead of `<tool_call|>`.
+/// Accepted as an alternative end so a complete call body recovers either way.
+pub(crate) const MISMATCHED_TOOL_CALL_END: &str = "</tool_call>";
 pub(crate) const STRING_DELIM: &str = "<|\"|>";
 pub(crate) const CALL_PREFIX: &str = "call:";
 
@@ -141,6 +144,19 @@ fn parse_recoverable_call_at(
 
     if after_args.starts_with(TOOL_CALL_END) {
         return Some((name, args_raw, close_brace + 1 + TOOL_CALL_END.len()));
+    }
+
+    // Support either close sentinel: Gemma 4 sometimes emits the mismatched
+    // </tool_call> instead of the canonical <tool_call|>. The call body is
+    // already complete here (balanced args brace, string values delimited by
+    // <|"|>), so recover it either way and consume the stray close marker so it
+    // never leaks into normal_text (recover/drop rule, parsers_v2/README.md goal 5).
+    if after_args.starts_with(MISMATCHED_TOOL_CALL_END) {
+        return Some((
+            name,
+            args_raw,
+            close_brace + 1 + MISMATCHED_TOOL_CALL_END.len(),
+        ));
     }
 
     if allow_missing_end && after_args.trim().is_empty() {

--- a/parsers/src/tool_calling/gemma4/parser.rs
+++ b/parsers/src/tool_calling/gemma4/parser.rs
@@ -181,7 +181,7 @@ fn parse_recoverable_call_at(
     let (sent_rel, sent_len) = close_sentinel(rest)?;
     let sentinel_pos = open_brace + sent_rel;
     let args_raw = &input[open_brace + 1..sentinel_pos];
-    if args_raw.matches(STRING_DELIM).count() % 2 != 0 {
+    if !args_raw.matches(STRING_DELIM).count().is_multiple_of(2) {
         return None;
     }
     Some((name, args_raw, sentinel_pos + sent_len))

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -644,16 +644,22 @@ pub fn try_tool_call_parse_basic_json(
                             // token is present — but keeps the type total). Drop
                             // any residual start marker so malformed markup never
                             // leaks (single-token families have no end token).
-                            normal_text = match normal_text_single_token(&normal_text, start_token)
-                            {
-                                Some(stripped) => {
-                                    let dropped = drop_residual_markup(
-                                        &stripped,
-                                        tool_call_start_tokens.iter().map(String::as_str),
-                                    );
-                                    apply_boundary_trim(dropped, start_token)
+                            normal_text = if config.content_is_prefix_only {
+                                // Terminal-block families (reference decoder):
+                                // content is only the text before the FIRST
+                                // start marker; inter-call/trailing dropped.
+                                prefix_normal_text
+                            } else {
+                                match normal_text_single_token(&normal_text, start_token) {
+                                    Some(stripped) => {
+                                        let dropped = drop_residual_markup(
+                                            &stripped,
+                                            tool_call_start_tokens.iter().map(String::as_str),
+                                        );
+                                        apply_boundary_trim(dropped, start_token)
+                                    }
+                                    None => prefix_normal_text,
                                 }
-                                None => prefix_normal_text,
                             };
                             json = content;
 
@@ -688,22 +694,29 @@ pub fn try_tool_call_parse_basic_json(
                             // Then drop any residual marker (a dangling unterminated
                             // opener or orphan close) so malformed markup never
                             // leaks into normal_text.
-                            normal_text = match normal_text_outside_spans(
-                                &normal_text,
-                                start_token,
-                                end_token,
-                            ) {
-                                Some(stripped) => {
-                                    let dropped = drop_residual_markup(
-                                        &stripped,
-                                        tool_call_start_tokens
-                                            .iter()
-                                            .chain(tool_call_end_tokens.iter())
-                                            .map(String::as_str),
-                                    );
-                                    apply_boundary_trim(dropped, start_token)
+                            normal_text = if config.content_is_prefix_only {
+                                // Terminal-block families (reference decoder):
+                                // content is only the text before the FIRST
+                                // start marker; inter-call/trailing dropped.
+                                prefix_normal_text
+                            } else {
+                                match normal_text_outside_spans(
+                                    &normal_text,
+                                    start_token,
+                                    end_token,
+                                ) {
+                                    Some(stripped) => {
+                                        let dropped = drop_residual_markup(
+                                            &stripped,
+                                            tool_call_start_tokens
+                                                .iter()
+                                                .chain(tool_call_end_tokens.iter())
+                                                .map(String::as_str),
+                                        );
+                                        apply_boundary_trim(dropped, start_token)
+                                    }
+                                    None => prefix_normal_text,
                                 }
-                                None => prefix_normal_text,
                             };
                             json = content;
 

--- a/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/src/tool_calling/json/base_json_parser.rs
@@ -175,6 +175,131 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
     Some(format!("[{}]", items.join(",")))
 }
 
+/// Build `normal_text` for the single-token families (`<|python_tag|>`, `functools`)
+/// by removing each tool-call block — the `start_token` plus the JSON value(s)
+/// that follow it — and keeping ALL surrounding natural text verbatim: the
+/// prefix before the first marker, text BETWEEN a JSON body and the next marker,
+/// and text AFTER the last call.
+///
+/// These families have no end token, so a "complete block" ends at the close of
+/// the JSON the block carries. This walks the same byte spans
+/// `handle_single_token_tool_calls` consumes (StreamDeserializer for `{...}`
+/// runs, `rfind(']')` for `[...]` arrays), so the markup it strips and the calls
+/// the parser emits agree. Returns `None` when the start token is absent (caller
+/// falls back), and only segments that yielded at least one parsed JSON value
+/// contribute their trailing remainder — a stray start token with no valid JSON
+/// keeps the current drop-without-leak behavior.
+fn normal_text_single_token(input: &str, start_token: &str) -> Option<String> {
+    if start_token.is_empty() || !input.contains(start_token) {
+        return None;
+    }
+
+    let mut out = String::new();
+    let mut first = true;
+    for seg in input.split(start_token) {
+        if first {
+            // Text before the first start token is the prefix — keep verbatim.
+            out.push_str(seg);
+            first = false;
+            continue;
+        }
+        // `seg` is the text after a start token. Find where the JSON value(s)
+        // the block carries end; everything past that is natural text.
+        let trimmed_start = seg.trim_start();
+        let leading_ws = &seg[..seg.len() - trimmed_start.len()];
+        if trimmed_start.starts_with('{') {
+            let mut remaining = trimmed_start;
+            let mut consumed_any = false;
+            loop {
+                let mut stream =
+                    serde_json::Deserializer::from_str(remaining).into_iter::<Box<RawValue>>();
+                match stream.next() {
+                    Some(Ok(rv)) => {
+                        let raw = rv.get();
+                        if raw.is_empty() {
+                            break;
+                        }
+                        consumed_any = true;
+                        let after = remaining[raw.len()..].trim_start();
+                        if let Some(rest) = after.strip_prefix(';') {
+                            remaining = rest.trim_start();
+                        } else {
+                            remaining = after;
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            if consumed_any {
+                // `remaining` is the trailing text after the JSON run. Keep it
+                // only when it is natural language. A leftover that begins (after
+                // trimming) with a JSON delimiter is NOT natural text:
+                //   • `{` / `[` — another tool-call object/array the model began
+                //     but left malformed/truncated (e.g. `{a};{b,truncated`), so
+                //     the parser recovered only the complete leading call(s);
+                //   • `]` / `}` / `,` / `;` — stray JSON-close / separator residue
+                //     from a malformed block (e.g. a bare `{...}]`).
+                // Either way it is markup-shape residue, not prose, and must not
+                // leak; drop it (drop-without-leak), matching the parser's call
+                // recovery for the same input.
+                let lead = remaining.trim_start();
+                if !lead.starts_with(['{', '[', ']', '}', ',', ';']) {
+                    out.push_str(remaining);
+                }
+            } else {
+                // No JSON parsed from this segment — preserve the leading
+                // whitespace + segment as natural text (the start token was
+                // present but carried no call).
+                out.push_str(leading_ws);
+                out.push_str(trimmed_start);
+            }
+        } else if trimmed_start.starts_with('[') {
+            if let Some(pos) = trimmed_start.rfind(']') {
+                let candidate = trimmed_start[..=pos].trim();
+                if serde_json::from_str::<Vec<Box<RawValue>>>(candidate).is_ok() {
+                    // Keep everything after the closing ']' as natural text.
+                    out.push_str(&trimmed_start[pos + 1..]);
+                } else {
+                    out.push_str(leading_ws);
+                    out.push_str(trimmed_start);
+                }
+            } else {
+                out.push_str(leading_ws);
+                out.push_str(trimmed_start);
+            }
+        } else {
+            // Segment carried no JSON object/array. The current parser drops it
+            // (no call recovered); keep that drop-without-leak behavior here too
+            // rather than re-surfacing a stray start token's tail.
+        }
+    }
+    Some(out)
+}
+
+/// After complete tool-call spans are removed, any tool-call MARKER still
+/// present in the assembled `normal_text` is malformed framing — an
+/// unterminated opener whose end marker never arrived, or an orphan close with
+/// no opener. The model's natural text never contains these markers, and a
+/// complete span between two markers was already removed, so a residual marker
+/// can only be malformed markup. Drop everything from the first residual marker
+/// onward so the markup never leaks (drop-without-leak), keeping the clean
+/// natural text before it.
+fn drop_residual_markup<'a, I>(text: &str, markers: I) -> String
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let cut = markers
+        .into_iter()
+        .filter(|m| !m.is_empty())
+        .filter_map(|m| text.find(m))
+        .min();
+    match cut {
+        Some(idx) => text[..idx].to_string(),
+        None => text.to_string(),
+    }
+}
+
 /// Attempt to repair JSON truncated by max_tokens / EOS. Walks the input
 /// tracking string state and brace/bracket nesting; on EOF closes any
 /// open string and pops outstanding closers. Returns `Some(repaired)` only
@@ -257,6 +382,60 @@ fn recover_leading_complete_objects(json: &str) -> Vec<String> {
         }
     }
     out
+}
+
+/// Build `normal_text` for the two-token (`<start>...<end>`) families by
+/// removing every complete tool-call span — start marker through end marker —
+/// and keeping ALL surrounding natural text verbatim: the prefix before the
+/// first call, text BETWEEN consecutive calls, and text AFTER the last call.
+///
+/// Only complete `start_token(.*?)end_token` spans are removed (lazy match,
+/// `dot_matches_new_line` so multi-line JSON bodies are spanned), mirroring how
+/// `extract_tool_call_content` locates the calls it parses. Markup is therefore
+/// the only thing stripped — natural language is never dropped, and a markup
+/// marker never leaks. A trailing unterminated `<start>` with no matching
+/// `<end>` is malformed framing handled by the recovery paths, not here, so it
+/// is left for the prefix-only fallback.
+///
+/// Returns `None` when no complete span is present (the caller falls back to the
+/// prefix-only behavior used for malformed / unrecoverable framing).
+fn normal_text_outside_spans(input: &str, start_token: &str, end_token: &str) -> Option<String> {
+    if start_token.is_empty() || end_token.is_empty() {
+        return None;
+    }
+    let escaped_start = regex::escape(start_token);
+    let escaped_end = regex::escape(end_token);
+    let pattern = format!(r"{}(?s:.*?){}", escaped_start, escaped_end);
+    let regex = RegexBuilder::new(&pattern).build().ok()?;
+
+    let mut out = String::new();
+    let mut last_end = 0usize;
+    let mut matched = false;
+    for m in regex.find_iter(input) {
+        matched = true;
+        out.push_str(&input[last_end..m.start()]);
+        last_end = m.end();
+    }
+    if !matched {
+        return None;
+    }
+    out.push_str(&input[last_end..]);
+    Some(out)
+}
+
+/// Apply the family's boundary-whitespace rule to the assembled `normal_text`.
+/// The mistral family (`[TOOL_CALLS]`) preserves the boundary space to match
+/// vLLM; every other JSON family trims the outer whitespace — the same split
+/// `try_parse_normal_text` applies to the prefix, kept here so the span-removed
+/// result keeps each family's long-standing boundary contract while the new
+/// inter-call / trailing text it now preserves is left untouched (only outer
+/// whitespace is affected; internal spacing is verbatim).
+fn apply_boundary_trim(text: String, start_token: &str) -> String {
+    if start_token == "[TOOL_CALLS]" {
+        text
+    } else {
+        text.trim().to_string()
+    }
 }
 
 fn try_parse_normal_text(input: &str, start_token: &str) -> String {
@@ -437,7 +616,9 @@ pub fn try_tool_call_parse_basic_json(
         // Try all combinations of start and end tokens
         'outer: for start_token in tool_call_start_tokens.iter() {
             for end_token in tool_call_end_tokens.iter() {
-                let new_normal_text = try_parse_normal_text(&normal_text, start_token);
+                // Prefix before the first marker — the malformed-framing fallback
+                // when no complete tool-call span is found below.
+                let prefix_normal_text = try_parse_normal_text(&normal_text, start_token);
 
                 // Process based on token types
                 match (start_token.is_empty(), end_token.is_empty()) {
@@ -456,9 +637,25 @@ pub fn try_tool_call_parse_basic_json(
                                 found_start_token_with_no_valid_json = true;
                             }
 
+                            // Preserve prefix + between-call + trailing natural
+                            // text by removing only the start-token + JSON-value
+                            // blocks; fall back to prefix-only if the span walk
+                            // finds no marker (shouldn't happen here — the start
+                            // token is present — but keeps the type total). Drop
+                            // any residual start marker so malformed markup never
+                            // leaks (single-token families have no end token).
+                            normal_text = match normal_text_single_token(&normal_text, start_token)
+                            {
+                                Some(stripped) => {
+                                    let dropped = drop_residual_markup(
+                                        &stripped,
+                                        tool_call_start_tokens.iter().map(String::as_str),
+                                    );
+                                    apply_boundary_trim(dropped, start_token)
+                                }
+                                None => prefix_normal_text,
+                            };
                             json = content;
-                            // For single token case, use the normal text we extracted earlier
-                            normal_text = new_normal_text;
 
                             break 'outer; // Found content, exit early
                         }
@@ -483,8 +680,32 @@ pub fn try_tool_call_parse_basic_json(
                                 found_start_token_with_no_valid_json = true;
                             }
 
+                            // Preserve prefix + between-call + trailing natural
+                            // text by removing only the complete `<start>...<end>`
+                            // spans. When no complete span is present (e.g. an
+                            // unterminated opener recovered via EOF), fall back to
+                            // the prefix-only text — the malformed-framing path.
+                            // Then drop any residual marker (a dangling unterminated
+                            // opener or orphan close) so malformed markup never
+                            // leaks into normal_text.
+                            normal_text = match normal_text_outside_spans(
+                                &normal_text,
+                                start_token,
+                                end_token,
+                            ) {
+                                Some(stripped) => {
+                                    let dropped = drop_residual_markup(
+                                        &stripped,
+                                        tool_call_start_tokens
+                                            .iter()
+                                            .chain(tool_call_end_tokens.iter())
+                                            .map(String::as_str),
+                                    );
+                                    apply_boundary_trim(dropped, start_token)
+                                }
+                                None => prefix_normal_text,
+                            };
                             json = content;
-                            normal_text = new_normal_text;
 
                             break 'outer; // Found content, exit early
                         }

--- a/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -123,6 +123,73 @@ fn normal_text_before_wrapper_start(message: &str, config: &JsonParserConfig) ->
         .unwrap_or_default()
 }
 
+/// DeepSeek control tokens that must never leak into `normal_text`: the four
+/// tool-call markers plus the `<｜end▁of▁sentence｜>` EOS sentinel. A marker still
+/// present in the assembled `normal_text` (after complete spans are removed) is
+/// malformed framing — an unterminated wrapper, an orphan close, a stray
+/// inner/outer marker, or the trailing EOS token — and is dropped so protocol
+/// tokens never reach user-visible content.
+const DEEPSEEK_MARKERS: [&str; 5] = [
+    "<｜tool▁calls▁begin｜>",
+    "<｜tool▁calls▁end｜>",
+    "<｜tool▁call▁begin｜>",
+    "<｜tool▁call▁end｜>",
+    "<｜end▁of▁sentence｜>",
+];
+
+/// Build `normal_text` by removing every complete tool-call block — the
+/// `start_token` through `end_token` span — and keeping ALL surrounding natural
+/// text verbatim: the prefix before the first call, text BETWEEN consecutive
+/// wrappers, and text AFTER the last call. Only complete `start(.*?)end` spans
+/// are removed (lazy, multi-line), so a truncated wrapper with no matching close
+/// is left for the prefix-only fallback. Any DeepSeek marker still present after
+/// span removal is malformed framing and is dropped from its first occurrence
+/// onward (drop-without-leak). Returns `None` when no complete span is present
+/// (caller falls back to `normal_text_before_wrapper_start`).
+fn normal_text_outside_spans(message: &str, start_token: &str, end_token: &str) -> Option<String> {
+    if start_token.is_empty() || end_token.is_empty() {
+        return None;
+    }
+    let escaped_start = regex::escape(start_token);
+    let escaped_end = regex::escape(end_token);
+    let pattern = format!(r"{}(?s:.*?){}", escaped_start, escaped_end);
+    let regex = RegexBuilder::new(&pattern).build().ok()?;
+
+    let mut out = String::new();
+    let mut last_end = 0usize;
+    let mut matched = false;
+    for m in regex.find_iter(message) {
+        matched = true;
+        out.push_str(&message[last_end..m.start()]);
+        last_end = m.end();
+    }
+    if !matched {
+        return None;
+    }
+    out.push_str(&message[last_end..]);
+
+    // Drop any residual marker (malformed framing) so markup never leaks; the
+    // surrounding natural-language whitespace is preserved verbatim.
+    let cut = DEEPSEEK_MARKERS.iter().filter_map(|m| out.find(m)).min();
+    if let Some(idx) = cut {
+        out.truncate(idx);
+    }
+    Some(out)
+}
+
+/// `normal_text` for the success path: strip the complete outer
+/// `<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>` wrapper spans (preserving text
+/// between and after them), falling back to the prefix-only text when no
+/// complete wrapper close is present (truncated / EOF-recovery framing).
+fn normal_text_outside_wrapper(message: &str, config: &JsonParserConfig) -> String {
+    config
+        .tool_call_start_tokens
+        .iter()
+        .zip(config.tool_call_end_tokens.iter())
+        .find_map(|(start, end)| normal_text_outside_spans(message, start, end))
+        .unwrap_or_else(|| normal_text_before_wrapper_start(message, config))
+}
+
 fn wrapper_start_index(message: &str, config: &JsonParserConfig) -> Option<usize> {
     config
         .tool_call_start_tokens
@@ -199,7 +266,17 @@ pub fn parse_tool_calls_deepseek_v3_1(
                     stripped_bytes = trimmed.len(),
                     "DeepSeek V3.1 parser recovered bare inner tool-call block and suppressed parser markup from normal_text"
                 );
-                return Ok((tool_calls, Some(normal_text)));
+                // Preserve prefix + between-call + trailing natural text by
+                // removing only the complete inner `<｜tool▁call▁begin｜>...
+                // <｜tool▁call▁end｜>` spans, falling back to the prefix-only text
+                // when no complete inner span is present.
+                let bare_normal_text = normal_text_outside_spans(
+                    trimmed,
+                    "<｜tool▁call▁begin｜>",
+                    "<｜tool▁call▁end｜>",
+                )
+                .unwrap_or(normal_text);
+                return Ok((tool_calls, Some(bare_normal_text)));
             }
             tracing::warn!(
                 why = "bare_deepseek_v31_call_without_outer_wrapper",
@@ -254,7 +331,13 @@ pub fn parse_tool_calls_deepseek_v3_1(
         return Ok((vec![], Some(normal_text)));
     }
 
-    Ok((tool_calls, Some(normal_text)))
+    // Success: at least one complete wrapper parsed. Preserve prefix +
+    // between-wrapper + trailing natural text by removing only the complete
+    // outer wrapper spans.
+    Ok((
+        tool_calls,
+        Some(normal_text_outside_wrapper(trimmed, config)),
+    ))
 }
 
 pub fn detect_tool_call_start_deepseek_v3_1(chunk: &str, config: &JsonParserConfig) -> bool {

--- a/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -134,6 +134,73 @@ fn normal_text_before_wrapper_start(message: &str, config: &JsonParserConfig) ->
         .unwrap_or_default()
 }
 
+/// DeepSeek control tokens that must never leak into `normal_text`: the four
+/// tool-call markers plus the `<｜end▁of▁sentence｜>` EOS sentinel. A marker still
+/// present in the assembled `normal_text` (after complete spans are removed) is
+/// malformed framing — an unterminated wrapper, an orphan close, a stray
+/// inner/outer marker, or the trailing EOS token — and is dropped so protocol
+/// tokens never reach user-visible content.
+const DEEPSEEK_MARKERS: [&str; 5] = [
+    "<｜tool▁calls▁begin｜>",
+    "<｜tool▁calls▁end｜>",
+    "<｜tool▁call▁begin｜>",
+    "<｜tool▁call▁end｜>",
+    "<｜end▁of▁sentence｜>",
+];
+
+/// Build `normal_text` by removing every complete tool-call block — the
+/// `start_token` through `end_token` span — and keeping ALL surrounding natural
+/// text verbatim: the prefix before the first call, text BETWEEN consecutive
+/// wrappers, and text AFTER the last call. Only complete `start(.*?)end` spans
+/// are removed (lazy, multi-line), so a truncated wrapper with no matching close
+/// is left for the prefix-only fallback. Any DeepSeek marker still present after
+/// span removal is malformed framing and is dropped from its first occurrence
+/// onward (drop-without-leak). Returns `None` when no complete span is present
+/// (caller falls back to `normal_text_before_wrapper_start`).
+fn normal_text_outside_spans(message: &str, start_token: &str, end_token: &str) -> Option<String> {
+    if start_token.is_empty() || end_token.is_empty() {
+        return None;
+    }
+    let escaped_start = regex::escape(start_token);
+    let escaped_end = regex::escape(end_token);
+    let pattern = format!(r"{}(?s:.*?){}", escaped_start, escaped_end);
+    let regex = RegexBuilder::new(&pattern).build().ok()?;
+
+    let mut out = String::new();
+    let mut last_end = 0usize;
+    let mut matched = false;
+    for m in regex.find_iter(message) {
+        matched = true;
+        out.push_str(&message[last_end..m.start()]);
+        last_end = m.end();
+    }
+    if !matched {
+        return None;
+    }
+    out.push_str(&message[last_end..]);
+
+    // Drop any residual marker (malformed framing) so markup never leaks; the
+    // surrounding natural-language whitespace is preserved verbatim.
+    let cut = DEEPSEEK_MARKERS.iter().filter_map(|m| out.find(m)).min();
+    if let Some(idx) = cut {
+        out.truncate(idx);
+    }
+    Some(out)
+}
+
+/// `normal_text` for the success path: strip the complete outer
+/// `<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>` wrapper spans (preserving text
+/// between and after them), falling back to the prefix-only text when no
+/// complete wrapper close is present (truncated / EOF-recovery framing).
+fn normal_text_outside_wrapper(message: &str, config: &JsonParserConfig) -> String {
+    config
+        .tool_call_start_tokens
+        .iter()
+        .zip(config.tool_call_end_tokens.iter())
+        .find_map(|(start, end)| normal_text_outside_spans(message, start, end))
+        .unwrap_or_else(|| normal_text_before_wrapper_start(message, config))
+}
+
 fn wrapper_start_index(message: &str, config: &JsonParserConfig) -> Option<usize> {
     config
         .tool_call_start_tokens
@@ -210,7 +277,17 @@ pub fn parse_tool_calls_deepseek_v3(
                     stripped_bytes = trimmed.len(),
                     "DeepSeek V3 parser recovered bare inner tool-call block and suppressed parser markup from normal_text"
                 );
-                return Ok((tool_calls, Some(normal_text)));
+                // Preserve prefix + between-call + trailing natural text by
+                // removing only the complete inner `<｜tool▁call▁begin｜>...
+                // <｜tool▁call▁end｜>` spans, falling back to the prefix-only text
+                // when no complete inner span is present.
+                let bare_normal_text = normal_text_outside_spans(
+                    trimmed,
+                    "<｜tool▁call▁begin｜>",
+                    "<｜tool▁call▁end｜>",
+                )
+                .unwrap_or(normal_text);
+                return Ok((tool_calls, Some(bare_normal_text)));
             }
             tracing::warn!(
                 why = "bare_deepseek_v3_call_without_outer_wrapper",
@@ -265,7 +342,13 @@ pub fn parse_tool_calls_deepseek_v3(
         return Ok((vec![], Some(normal_text)));
     }
 
-    Ok((tool_calls, Some(normal_text)))
+    // Success: at least one complete wrapper parsed. Preserve prefix +
+    // between-wrapper + trailing natural text by removing only the complete
+    // outer wrapper spans.
+    Ok((
+        tool_calls,
+        Some(normal_text_outside_wrapper(trimmed, config)),
+    ))
 }
 
 pub fn detect_tool_call_start_deepseek_v3(chunk: &str, config: &JsonParserConfig) -> bool {
@@ -589,7 +672,11 @@ mod tests {
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
-        assert_eq!(content, Some("Before ".to_string()));
+        // The recovered call's inner span is stripped and the trailing orphan
+        // <｜tool▁call▁end｜> markers are dropped from their first occurrence
+        // without leaking; the natural-text whitespace between the call and the
+        // orphans is preserved verbatim ("Before " + the inter-token newline).
+        assert_eq!(content, Some("Before \n".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_weather");

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -2071,7 +2071,10 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
-        assert_eq!(content, Some("".to_string()));
+        // Only the <tool_call>...</tool_call> span is stripped; the stray trailing
+        // text after the closing marker is preserved verbatim (trimmed at the
+        // boundary), so the lone `"` here survives as normal_text.
+        assert_eq!(content, Some("\"".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_weather");
@@ -2299,7 +2302,8 @@ fahrenheit
             .await
             .unwrap();
 
-        assert_eq!(content, Some("".to_string()));
+        // The `\n` between the two tool-call blocks is preserved as normal_text.
+        assert_eq!(content, Some("\n".to_string()));
         validate_weather_tool_calls(&result, &[("Dallas", "TX"), ("Orlando", "FL")]);
     }
 
@@ -3143,9 +3147,14 @@ fahrenheit
         let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
+        // normal_text preserves both the prefix and the text after the call;
+        // only the `<tool_call>…</tool_call>` markup is stripped.
         assert_eq!(
             content,
-            Some("I'll help you check the weather. ".to_string())
+            Some(
+                "I'll help you check the weather.  Let me get that information for you."
+                    .to_string()
+            )
         );
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -3185,7 +3194,9 @@ fahrenheit
         let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
-        assert_eq!(content, Some("".to_string()));
+        // The `\n` between the two `</tool_call>`/`<tool_call>` blocks is
+        // natural text and is preserved; only the markup is stripped.
+        assert_eq!(content, Some("\n".to_string()));
         assert_eq!(result.len(), 2);
 
         let (name1, args1) = extract_name_and_args(result[0].clone());
@@ -3339,7 +3350,8 @@ Seattle
         let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
-        assert_eq!(content, Some("".to_string()));
+        // Two `\n` inter-call separators are preserved; only markup is stripped.
+        assert_eq!(content, Some("\n\n".to_string()));
         assert_eq!(result.len(), 3);
 
         let cities = ["Dallas", "Orlando", "Seattle"];
@@ -3387,7 +3399,8 @@ weather forecasting
             detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
                 .await
                 .unwrap();
-        assert_eq!(content, Some("".to_string()));
+        // The `\n` between the two tool-call blocks is preserved.
+        assert_eq!(content, Some("\n".to_string()));
         assert_eq!(result.len(), 2);
 
         let (name1, args1) = extract_name_and_args(result[0].clone());

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -57,7 +57,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("gemma4", ToolCallConfig::gemma4());
         map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
-        map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
+        map.insert("nemotron_nano", ToolCallConfig::nemotron_nano()); // nemotron nano follows qwen3_coder format but its reference decoder makes the tool-call block terminal (content is prefix-only)
         map.insert("qwen25", ToolCallConfig::qwen25()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes but never leaks markup; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
         map
     })

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -148,10 +148,13 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     let recovery_config = match &base.parser_config {
         ParserConfig::Json(c) => {
             let mut c = c.clone();
-            // qwen25 opts out of EOF recovery so unterminated calls are dropped,
-            // not salvaged. Keyed by name (not a config field) to keep the
-            // exported JsonParserConfig stable for downstream callers.
-            c.allow_eof_recovery = parser_key != "qwen25";
+            // Recover a complete-but-unterminated call when the outer end token
+            // never arrived (recover/drop rule, parsers_v2/README.md goal 5):
+            // a delimiter-terminated JSON body recovers; a body truncated
+            // mid-value fails to parse and still drops. qwen25 used to opt out
+            // to match vLLM, but vLLM is a peer, not a published spec, so it
+            // now recovers like hermes.
+            c.allow_eof_recovery = true;
             ParserConfig::Json(c)
         }
         ParserConfig::Xml(c) => {
@@ -164,8 +167,15 @@ pub async fn detect_and_parse_tool_call_with_recovery(
             c.allow_eof_recovery = true;
             ParserConfig::Dsml(c)
         }
-        // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
-        // (drop the call when </tool_call> is missing).
+        ParserConfig::Glm47(c) => {
+            let mut c = c.clone();
+            // Recover a complete-but-unterminated GLM call when </tool_call>
+            // never arrived (recover/drop rule, parsers_v2/README.md goal 5).
+            // Previously omitted to match vLLM/SGLang, but that is a peer, not
+            // a published spec, so GLM now recovers like the other families.
+            c.allow_eof_recovery = true;
+            ParserConfig::Glm47(c)
+        }
         // Other parsers don't have an EOF-recovery flag — pass through.
         other => other.clone(),
     };

--- a/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -31,13 +31,27 @@ fn strip_text(message: &str) -> String {
         .replace("<|python_end|>", "")
 }
 
-fn get_regex_matches(message: &str) -> Vec<String> {
+/// Byte ranges of every tool-call block the regex matches, in order. This is the
+/// single source of truth for "where the tool-call markup is": call parsing maps
+/// each range to its parsed calls, and `normal_text` is built by removing these
+/// ranges (keeping prefix, inter-call, and trailing text exactly as written).
+fn get_regex_match_ranges(message: &str) -> Vec<std::ops::Range<usize>> {
     let re = get_pythonic_regex();
-    let mut matches = Vec::new();
-    for cap in re.find_iter(message) {
-        matches.push(cap.as_str().to_string());
+    re.find_iter(message).map(|m| m.range()).collect()
+}
+
+/// Remove the given (already sorted, non-overlapping) byte ranges from `message`,
+/// keeping every other byte verbatim. This is how we build `normal_text`: the
+/// model text minus each complete tool-call block, whitespace preserved as-is.
+fn strip_ranges(message: &str, ranges: &[std::ops::Range<usize>]) -> String {
+    let mut out = String::with_capacity(message.len());
+    let mut cursor = 0;
+    for r in ranges {
+        out.push_str(&message[cursor..r.start]);
+        cursor = r.end;
     }
-    matches
+    out.push_str(&message[cursor..]);
+    out
 }
 
 pub fn parse_tool_calls(src: &str) -> anyhow::Result<Vec<ToolCallResponse>> {
@@ -171,22 +185,34 @@ pub fn try_tool_call_parse_pythonic(
         return Ok((vec![], Some(String::new())));
     }
 
-    let matches = get_regex_matches(&stripped);
-    if matches.is_empty() {
+    let ranges = get_regex_match_ranges(&stripped);
+    if ranges.is_empty() {
         return Ok((vec![], Some(stripped)));
     }
 
-    let tool_response = parse_tool_calls(&matches[0]);
+    // Parse every complete tool-call block, not just the first, so multiple
+    // back-to-back bracket groups are all surfaced as calls. IDs are reassigned
+    // sequentially because `parse_tool_calls` numbers per block (call-1, ...).
+    let mut tool_calls = Vec::new();
+    for r in &ranges {
+        let block = &stripped[r.clone()];
+        // A malformed/unparseable block keeps the current drop-without-leak
+        // behavior: its markup is stripped from `normal_text` (below) and no
+        // call is emitted. Only propagate hard errors that aren't recoverable.
+        let calls = parse_tool_calls(block)?;
+        tool_calls.extend(calls);
+    }
+    for (idx, call) in tool_calls.iter_mut().enumerate() {
+        call.id = format!("call-{}", idx + 1);
+    }
 
-    // normal text is everything before the first match
-    let normal_text = stripped
-        .split(&matches[0])
-        .next()
-        .unwrap() // Safety: `split()` always returns at least one element (the string before the first delimiter, or the entire string if delimiter not found)
-        .trim()
-        .to_string();
+    // `normal_text` is the model text with each complete tool-call block removed,
+    // keeping ALL other text verbatim: prefix, text between calls, and trailing
+    // text. Whitespace is preserved as-is (only the outer trim, matching the
+    // pre-existing contract, is applied).
+    let normal_text = strip_ranges(&stripped, &ranges).trim().to_string();
 
-    Ok((tool_response?, Some(normal_text)))
+    Ok((tool_calls, Some(normal_text)))
 }
 
 pub fn detect_tool_call_start_pythonic(chunk: &str) -> bool {
@@ -227,11 +253,20 @@ mod tests {
         assert_eq!(stripped, "foo(a=1, b=2)");
     }
 
+    /// Extract the matched tool-call substrings via the byte ranges, mirroring
+    /// how the parser locates each block.
+    fn matched_blocks(message: &str) -> Vec<String> {
+        get_regex_match_ranges(message)
+            .into_iter()
+            .map(|r| message[r].to_string())
+            .collect()
+    }
+
     #[test] // helper
     fn test_get_regex_matches_simple_case() {
         // Simple Case
         let message = "[foo(a=1, b=2), bar(x=3)]";
-        let matches = get_regex_matches(message);
+        let matches = matched_blocks(message);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0], "[foo(a=1, b=2), bar(x=3)]");
     }
@@ -240,7 +275,7 @@ mod tests {
     fn test_get_regex_matches_text_before_and_after() {
         // Spacing in arg and value and text before and after
         let message = "Hey yo ! [foo(a=1, b=2), bar(x= 3)] Hey yo";
-        let matches = get_regex_matches(message);
+        let matches = matched_blocks(message);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0], "[foo(a=1, b=2), bar(x= 3)]");
     }
@@ -249,7 +284,7 @@ mod tests {
     fn test_get_regex_matches_new_line_in_arg_and_value() {
         // New Line in Arg and value
         let message = "Hey \n yo ! [foo(a=1,b=2), \n bar(x=3)] Hey yo";
-        let matches = get_regex_matches(message);
+        let matches = matched_blocks(message);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0], "[foo(a=1,b=2), \n bar(x=3)]");
     }
@@ -258,7 +293,7 @@ mod tests {
     fn test_get_regex_matches_no_call() {
         // No Call
         let message = "Hey yo !";
-        let matches = get_regex_matches(message);
+        let matches = matched_blocks(message);
         assert_eq!(matches.len(), 0);
     }
 
@@ -284,7 +319,9 @@ mod tests {
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
-        assert_eq!(content, Some("Hey yo !".to_string()));
+        // Trailing text after the call is preserved verbatim (only the call
+        // markup is stripped); inner whitespace is kept as-is.
+        assert_eq!(content, Some("Hey yo !  Hey yo".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -301,7 +338,8 @@ mod tests {
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
         let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
-        assert_eq!(content, Some("Hey \n yo !".to_string()));
+        // Trailing text after the call is preserved verbatim.
+        assert_eq!(content, Some("Hey \n yo !  Hey yo".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -311,6 +349,53 @@ mod tests {
         let (name, args) = extract_name_and_args(result[1].clone());
         assert_eq!(name, "bar");
         assert_eq!(args["x"], 3);
+    }
+
+    #[test] // TOOLCALLING.batch.8.b
+    fn test_parse_tool_call_parse_pythonic_trailing_text_only() {
+        // Narration AFTER the only tool call must be preserved as normal_text.
+        let message = r#"[get_weather(location="NYC")] Let me know if you need more."#;
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
+        assert_eq!(content, Some("Let me know if you need more.".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    #[test] // TOOLCALLING.batch.8.c
+    fn test_parse_tool_call_parse_pythonic_sandwich_text() {
+        // Narration both before and after the call: both halves are preserved,
+        // the call markup is removed, and the internal whitespace stays as-is.
+        let message = r#"I will check the weather. [get_weather(location="NYC")] Let me know if you need more."#;
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
+        assert_eq!(
+            content,
+            Some("I will check the weather.  Let me know if you need more.".to_string())
+        );
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    #[test] // TOOLCALLING.batch.8.d
+    fn test_parse_tool_call_parse_pythonic_inter_call_text() {
+        // Narration BETWEEN two tool-call blocks: both blocks are parsed and the
+        // inter-call prose is preserved verbatim as normal_text.
+        let message = r#"I will check the weather. [get_weather(location="NYC")] Then check LA weather. [get_weather(location="LA")]"#;
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
+        assert_eq!(
+            content,
+            Some("I will check the weather.  Then check LA weather.".to_string())
+        );
+        assert_eq!(result.len(), 2);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+        let (name, args) = extract_name_and_args(result[1].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "LA");
     }
 
     #[test] // TOOLCALLING.batch.3

--- a/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -19,7 +19,12 @@ static PYTHONIC_REGEX: OnceLock<Regex> = OnceLock::new();
 fn get_pythonic_regex() -> &'static Regex {
     PYTHONIC_REGEX.get_or_init(|| {
         // Format Structure: [tool1(arg1=val1, arg2=val2), tool2(arg1=val3)]
-        let pattern = r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*?,\s*)*([a-zA-Z]+\w*=.*?\s?)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*?,\s*)*([a-zA-Z]+\w*=.*?\s*)?\)\s*)+\]";
+        // The trailing `]` is optional at end-of-text so a complete call list
+        // whose closing `]` was truncated still recovers (recover/drop rule,
+        // parsers_v2/README.md goal 5). A call missing its own `)` is still
+        // dropped, since each call requires `\)` — so mid-value truncation
+        // (no closing paren) never recovers.
+        let pattern = r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*?,\s*)*([a-zA-Z]+\w*=.*?\s?)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*?,\s*)*([a-zA-Z]+\w*=.*?\s*)?\)\s*)+(?:\]|\z)";
         Regex::new(pattern).expect("Failed to compile pythonic regex pattern")
     })
 }
@@ -195,11 +200,21 @@ pub fn try_tool_call_parse_pythonic(
     // sequentially because `parse_tool_calls` numbers per block (call-1, ...).
     let mut tool_calls = Vec::new();
     for r in &ranges {
-        let block = &stripped[r.clone()];
+        let raw = &stripped[r.clone()];
+        // The regex allows a complete call list whose trailing `]` was truncated
+        // (recover/drop rule); the Python AST parser needs balanced brackets, so
+        // close it before parsing. A call missing its own `)` never matched the
+        // regex, so this only completes the outer list, never a partial call.
+        let trimmed = raw.trim_end();
+        let block = if trimmed.ends_with(']') {
+            trimmed.to_string()
+        } else {
+            format!("{trimmed}]")
+        };
         // A malformed/unparseable block keeps the current drop-without-leak
         // behavior: its markup is stripped from `normal_text` (below) and no
         // call is emitted. Only propagate hard errors that aren't recoverable.
-        let calls = parse_tool_calls(block)?;
+        let calls = parse_tool_calls(&block)?;
         tool_calls.extend(calls);
     }
     for (idx, call) in tool_calls.iter_mut().enumerate() {

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -161,6 +161,14 @@ pub fn try_tool_call_parse_glm47(
 }
 
 /// Extract tool calls and normal text from message.
+///
+/// `normal_text` is the model text with each complete tool-call block removed
+/// (from its `<tool_call>` start through its `</tool_call>` end), keeping ALL
+/// other text verbatim: the prefix before the first call, text BETWEEN calls,
+/// and text AFTER the last call. Whitespace is preserved as-is. Only tool-call
+/// markup is stripped — natural text is never dropped and markup never leaks
+/// into normal_text. Malformed / unrecoverable blocks (missing fences, truncated
+/// tails) keep the drop-without-leak behavior.
 fn extract_tool_calls(
     text: &str,
     config: &Glm47ParserConfig,
@@ -203,25 +211,24 @@ fn extract_tool_calls(
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
             let gap = &text[cursor..abs_start];
+            // Preserve ALL surrounding natural-language text — the prefix before
+            // the first <tool_call>, text BETWEEN calls, and (in the no-more-calls
+            // arm below) text AFTER the last call. Only tool-call markup is
+            // stripped: recover_bare_glm47_calls_in_span pulls a bare call out of
+            // the gap and keeps its `prefix` prose; orphan_glm47_prefix drops a
+            // stray wire marker but keeps the text before it. The gap text is kept
+            // regardless of whether calls have already been parsed, so inter-call
+            // narration is no longer dropped.
             if let Some((prefix, mut parsed_calls)) =
                 recover_bare_glm47_calls_in_span(gap, config, tools)?
             {
-                if calls.is_empty() {
-                    normal_parts.push(prefix);
-                }
+                normal_parts.push(prefix);
                 calls.append(&mut parsed_calls);
-            } else if calls.is_empty() {
-                if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
-                    normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
-                } else {
-                    normal_parts.push(gap.to_string());
-                }
+            } else if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
+                normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
+            } else {
+                normal_parts.push(gap.to_string());
             }
-
-            // Only surface normal text that precedes the first parsed call.
-            // Text after any </tool_call> is not response content; matches the
-            // convention ported into the generic XML parser by PR #9350 and
-            // vLLM's glm47_moe_tool_parser.
 
             // Find the corresponding end token
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -300,21 +307,21 @@ fn extract_tool_calls(
                 break;
             }
         } else {
-            // No more tool calls
+            // No more tool calls: this gap is the text AFTER the last </tool_call>
+            // (or the whole message when no call was found). Preserve it verbatim,
+            // stripping only tool-call markup (bare-call recovery keeps its prose
+            // prefix; orphan_glm47_prefix drops a stray wire marker but keeps the
+            // text before it).
             let gap = &text[cursor..];
             if let Some((prefix, mut parsed_calls)) =
                 recover_bare_glm47_calls_in_span(gap, config, tools)?
             {
-                if calls.is_empty() {
-                    normal_parts.push(prefix);
-                }
+                normal_parts.push(prefix);
                 calls.append(&mut parsed_calls);
-            } else if calls.is_empty() {
-                if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
-                    normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
-                } else {
-                    normal_parts.push(gap.to_string());
-                }
+            } else if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
+                normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
+            } else {
+                normal_parts.push(gap.to_string());
             }
             break;
         }
@@ -979,7 +986,8 @@ mod tests {
     // TOOLCALLING.batch.13 — a tool call whose function is NOT in the request's
     // tools list is still emitted (parsing and validation are separate concerns;
     // the serving layer rejects unknown tools). The wire markup must not leak
-    // into normal_text, and surrounding prose is preserved.
+    // into normal_text, and ALL surrounding prose (prefix AND trailing) is
+    // preserved with only the tool-call block removed.
     #[test] // TOOLCALLING.batch.13
     fn test_unknown_tool_passes_through_no_tag_leak() {
         let config = get_test_config();
@@ -1004,9 +1012,47 @@ mod tests {
             !text.contains("<tool_call>") && !text.contains("<arg_key>"),
             "Wire-format tags must not leak into normal_text, got: {text}"
         );
-        assert!(
-            text.contains("Here is the result:"),
-            "Prefix prose must be preserved, got: {text}"
+        // The prefix before the call AND the trailing text after </tool_call> are
+        // both kept verbatim; only the tool-call block is removed.
+        assert_eq!(
+            text, "Here is the result:  done",
+            "Prefix and trailing prose must both be preserved, got: {text}"
+        );
+    }
+
+    // Trailing narration after the last </tool_call> is preserved as normal_text
+    // (it used to be dropped). Only the tool-call block is stripped.
+    #[test]
+    fn test_trailing_text_after_tool_call_preserved() {
+        let config = get_test_config();
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call> Let me know if you need more.";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            normal_text,
+            Some(" Let me know if you need more.".to_string()),
+            "Trailing narration after the tool call must be preserved verbatim"
+        );
+    }
+
+    // Narration BETWEEN two tool calls is preserved (it used to be dropped after
+    // the first parsed call). The prefix, the inter-call text, and the trailing
+    // text are all kept; only the two tool-call blocks are removed.
+    #[test]
+    fn test_inter_call_text_preserved() {
+        let config = get_test_config();
+        let message = "I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call> Then check LA weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            normal_text,
+            Some("I will check the weather.  Then check LA weather. ".to_string()),
+            "Prefix + inter-call narration must be preserved; only the call blocks are stripped"
         );
     }
 

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -631,12 +631,23 @@ fn parse_tool_call_block(
         }
     }
 
-    // Validate function against tools if provided
-    if let Some(tools_list) = tools {
-        let tool_exists = tools_list.iter().any(|t| t.name == function_name);
-        if !tool_exists {
-            anyhow::bail!("Function '{}' not found in available tools", function_name);
-        }
+    // A tool call for a function not in the request's tools list is still
+    // emitted, not dropped. The parser's job is to extract what the model
+    // produced; validation/rejection belongs to the serving layer. The model
+    // may legitimately reference a tool the caller adds later, or one baked into
+    // its chat template, and dropping it silently hides a real call. This
+    // matches vLLM (which passes the call through) and the other Dynamo parsers
+    // (kimi_k2 / xml / gemma4 already warn-and-pass-through here). We log for
+    // visibility only.
+    if let Some(tools_list) = tools
+        && !tools_list.iter().any(|t| t.name == function_name)
+    {
+        warn!(
+            function = %function_name,
+            why = "tool_not_in_request_tool_list",
+            "GLM-4.7 tool call references a function not in the request's tools list; \
+             passing it through (serving layer validates)"
+        );
     }
 
     Ok(ToolCallResponse {
@@ -965,9 +976,12 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.c, TOOLCALLING.batch.13 in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.13.yaml, tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.8.yaml.
-    #[test] // TOOLCALLING.batch.4, TOOLCALLING.batch.8
-    fn test_unparseable_block_dropped_no_tag_leak() {
+    // TOOLCALLING.batch.13 — a tool call whose function is NOT in the request's
+    // tools list is still emitted (parsing and validation are separate concerns;
+    // the serving layer rejects unknown tools). The wire markup must not leak
+    // into normal_text, and surrounding prose is preserved.
+    #[test] // TOOLCALLING.batch.13
+    fn test_unknown_tool_passes_through_no_tag_leak() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
@@ -975,26 +989,24 @@ mod tests {
             strict: None,
         }];
 
-        // Tool call block references a function not in the tools list — the
-        // whole block (including <tool_call>...<arg_key>...<arg_value>... wire
-        // markup) must be dropped, not leaked through normal_text.
         let message = "Here is the result: <tool_call>unknown_func<arg_key>x</arg_key><arg_value>1</arg_value></tool_call> done";
         let (calls, normal_text) =
             try_tool_call_parse_glm47(message, &config, Some(&tools)).unwrap();
 
-        assert_eq!(calls.len(), 0);
-        let text = normal_text.unwrap();
-        assert!(
-            !text.contains("unknown_func"),
-            "Unparseable block must be dropped to avoid tag leakage, got: {text}"
+        assert_eq!(
+            calls.len(),
+            1,
+            "unknown tool is passed through, not dropped"
         );
+        assert_eq!(calls[0].function.name, "unknown_func");
+        let text = normal_text.unwrap();
         assert!(
             !text.contains("<tool_call>") && !text.contains("<arg_key>"),
             "Wire-format tags must not leak into normal_text, got: {text}"
         );
         assert!(
-            text.contains("Here is the result:") && text.contains("done"),
-            "Surrounding prose must be preserved, got: {text}"
+            text.contains("Here is the result:"),
+            "Prefix prose must be preserved, got: {text}"
         );
     }
 

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -264,7 +264,19 @@ fn extract_tool_calls(
                 // signal that a real tool call was emitted.
                 let block = &text[abs_start..];
                 let arg_key_start = &config.arg_key_start;
-                if config.allow_eof_recovery && block.contains(arg_key_start.as_str()) {
+                // Recover only if the trailing <arg_value> is delimiter-
+                // terminated: a value followed by a marker (`<`) is complete,
+                // but one that runs to end-of-stream may be truncated mid-token
+                // (recover/drop rule, parsers_v2/README.md goal 5) — e.g.
+                // `<arg_value>N` could be a cut-off `NYC`, so drop it.
+                let value_terminated = match block.rfind(config.arg_value_start.as_str()) {
+                    Some(p) => block[p + config.arg_value_start.len()..].contains('<'),
+                    None => true,
+                };
+                if config.allow_eof_recovery
+                    && block.contains(arg_key_start.as_str())
+                    && value_terminated
+                {
                     match parse_tool_call_block(block, config, tools) {
                         Ok(parsed_call) => {
                             calls.push(parsed_call);
@@ -284,15 +296,18 @@ fn extract_tool_calls(
                         }
                     }
                 } else {
-                    // Either recovery disabled (production default for GLM-4.7)
-                    // or no <arg_key> in the tail (so this is plausibly not a
-                    // real tool call at all, just a stray <tool_call> token).
+                    // Recovery disabled (streaming jail), or no <arg_key> in the
+                    // tail (not a real tool call), or the trailing value runs to
+                    // end-of-stream with no terminating marker (truncated
+                    // mid-token).
                     let reason = if !config.allow_eof_recovery {
-                        "allow_eof_recovery=false (production default for GLM-4.7 to match \
-                         vLLM/SGLang on truncated tool calls)"
-                    } else {
+                        "allow_eof_recovery=false (streaming jail path; finalize recovers)"
+                    } else if !block.contains(arg_key_start.as_str()) {
                         "no <arg_key> in the tail after the <tool_call> start fence, so the \
                          block does not look like a structurally-real GLM-4.7 tool call"
+                    } else {
+                        "trailing <arg_value> runs to end-of-stream with no terminating marker, \
+                         so the value may be truncated mid-token; dropped per the recover/drop rule"
                     };
                     warn!(
                         why = %reason,

--- a/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -596,11 +596,20 @@ fn parse_tool_call_block(
     let arg_value_start_escaped = regex::escape(&config.arg_value_start);
     let arg_value_end_escaped = regex::escape(&config.arg_value_end);
 
-    // Pattern to match: <arg_key>key</arg_key><arg_value>value</arg_value>
+    // Pattern: <arg_key>key</arg_key><arg_value>value(</arg_value> | end-of-block)
+    // The `</arg_value>` close is treated as OPTIONAL. A final value whose close
+    // tag was dropped (mismatched/missing fences — batch case 4.d
+    // `<arg_value>NYC</tool_call>`, whose trailing `</tool_call>` is stripped
+    // before this regex, leaving the value at end-of-block) is recovered by
+    // terminating at `\z` instead of being dropped to empty args. `</arg_value>`
+    // is listed first so a well-formed value (including a multi-line one) still
+    // terminates exactly there; `\z` only applies when the close tag is absent.
+    // (The `regex` crate has no lookahead, so the terminator is a plain
+    // alternation of the close tag and the end-of-text anchor.)
     // (?s) enables dotall mode so (.*?) matches across newlines — required
     // because models often emit multi-line content in arg values.
     let pattern = format!(
-        r"(?s){}([^<]+){}{}(.*?){}",
+        r"(?s){}([^<]+){}{}(.*?)(?:{}|\z)",
         arg_key_start_escaped, arg_key_end_escaped, arg_value_start_escaped, arg_value_end_escaped
     );
 
@@ -900,6 +909,23 @@ mod tests {
 
         let (calls, _) = result.unwrap();
         assert_eq!(calls.len(), 0);
+    }
+
+    // TOOLCALLING.batch.4.d — missing `</arg_value>` close tag: the value runs
+    // straight into the outer `</tool_call>`. The arg-value close is optional, so
+    // the value is recovered (terminated by the outer close / end-of-block)
+    // instead of being dropped to empty args.
+    #[test] // TOOLCALLING.batch.4
+    fn test_recover_arg_value_missing_close_tag() {
+        let config = get_test_config();
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>";
+
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: HashMap<String, Value> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args.get("location").unwrap().as_str().unwrap(), "NYC");
     }
 
     // Recovery for missing outer </tool_call> (max_tokens / EOS truncation):

--- a/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -159,44 +159,6 @@ fn find_section_end(
     best
 }
 
-/// True for prefix-only narration before a tool section where vLLM preserves
-/// the wrapper-adjacent trailing space (TOOLCALLING.batch.8.a).
-fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[String]) -> bool {
-    let mut non_empty_parts = normal_parts
-        .iter()
-        .enumerate()
-        .filter(|(_, part)| !part.trim().is_empty());
-
-    matches!(
-        non_empty_parts.next(),
-        Some((0, part)) if part.chars().next_back().is_some_and(|ch| ch.is_whitespace())
-    ) && non_empty_parts.next().is_none()
-}
-
-/// True when the first visible normal text appears only after a parsed tool
-/// section, so the intermediate Kimi tool-call turn should expose no content
-/// (TOOLCALLING.batch.8.b).
-fn should_drop_post_tool_text_without_prefix(normal_parts: &[String]) -> bool {
-    normal_parts
-        .iter()
-        .enumerate()
-        .find(|(_, part)| !part.trim().is_empty())
-        .is_some_and(|(idx, _)| idx != 0)
-}
-
-/// True when there is prefix narration before the first tool section plus
-/// post-wrapper or inter-wrapper narration that should be dropped for Kimi
-/// tool-call turns (TOOLCALLING.batch.2.c, 8.c, 8.d).
-fn should_drop_post_tool_text_after_prefix(normal_parts: &[String]) -> bool {
-    normal_parts
-        .first()
-        .is_some_and(|prefix| !prefix.trim().is_empty())
-        && normal_parts
-            .iter()
-            .skip(1)
-            .any(|part| !part.trim().is_empty())
-}
-
 /// Extract tool calls and normal text from message.
 ///
 /// ## Difference from Moonshot's reference implementation
@@ -301,30 +263,23 @@ fn extract_tool_calls(
     }
 
     let joined_normal_text = normal_parts.join("");
-    let normal_text =
-        if !calls.is_empty() && should_drop_post_tool_text_without_prefix(&normal_parts) {
-            // Kimi tool-call responses are intermediate assistant turns: the
-            // official API flow treats content as empty while tool_calls are
-            // emitted, then asks the client to execute tools before returning
-            // final user-facing content. Match vLLM/SGLang by not surfacing
-            // post-wrapper text when there is no prefix narration.
-            String::new()
-        } else if !calls.is_empty() && should_drop_post_tool_text_after_prefix(&normal_parts) {
-            // Kimi tool-call responses are intermediate assistant turns even
-            // when a single section contains multiple calls or a turn contains
-            // multiple sections. Preserve only the prefix emitted before the
-            // first tool section and drop post-wrapper/inter-wrapper text;
-            // final user-facing content should be produced after tool results.
-            normal_parts[0].trim_start().to_string()
-        } else if !calls.is_empty() && should_preserve_vllm_prefix_trailing_space(&normal_parts) {
-            // vLLM preserves wrapper-adjacent trailing whitespace when the
-            // response has only prefix narration before a Kimi tool section.
-            // Keep this compatibility path narrow to avoid changing Dynamo's
-            // existing handling of post-wrapper/inter-wrapper narration.
-            normal_parts[0].trim_start().to_string()
-        } else {
-            joined_normal_text.trim().to_string()
-        };
+    let normal_text = if calls.is_empty() {
+        // No tool calls parsed: this is plain content. Trim leading/trailing
+        // whitespace so whitespace-only inputs collapse to "" (matches the
+        // no-tool-call and empty-section fixtures).
+        joined_normal_text.trim().to_string()
+    } else {
+        // Tool calls parsed: `normal_text` is the model text with each complete
+        // tool-call block (section_begin through section_end, or to EOF when
+        // section_end is missing) removed, keeping ALL surrounding natural
+        // language verbatim — prefix, text BETWEEN sections, and text AFTER the
+        // last section. `normal_parts` already holds exactly those gaps (the
+        // section blocks were skipped, never pushed), so joining them yields the
+        // model text minus tool-call markup with whitespace preserved as-is.
+        // Malformed/unrecoverable blocks are handled by the bare-call recovery
+        // paths above, which strip their markup without leaking it.
+        joined_normal_text
+    };
     Ok((normal_text, calls))
 }
 
@@ -548,20 +503,25 @@ mod tests {
         assert_eq!(args1["timezone"], "EST");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.c in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.8.yaml.
+    // TOOLCALLING.batch.8.c — narration both before and after a tool section.
+    // normal_text is the model text minus the tool-call block, so BOTH the
+    // prefix and the post-wrapper text are preserved verbatim.
     #[test] // TOOLCALLING.batch.8.c
-    fn test_parse_keeps_prefix_drops_post_tool_text() {
+    fn test_parse_keeps_prefix_and_post_tool_text() {
         let config = default_config();
         let input = r#"I'll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
 
         let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(normal, Some("I'll help you with that. ".to_string()));
+        assert_eq!(
+            normal,
+            Some("I'll help you with that.  Let me check.".to_string())
+        );
     }
 
     #[test] // TOOLCALLING.batch.8.a
-    fn test_parse_preserves_vllm_prefix_trailing_space() {
+    fn test_parse_preserves_prefix_trailing_space() {
         let config = default_config();
         let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>"#;
 
@@ -571,17 +531,21 @@ mod tests {
         assert_eq!(normal, Some("I'll check the weather. ".to_string()));
     }
 
+    // Trailing whitespace after the tool section is natural text and is
+    // preserved verbatim (whitespace is kept as-is per the normal_text RULE).
     #[test] // TOOLCALLING.batch.8.a
-    fn test_parse_prefix_only_ignores_post_wrapper_whitespace() {
+    fn test_parse_preserves_post_wrapper_whitespace() {
         let config = default_config();
         let input = r#"I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>   "#;
 
         let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(normal, Some("I'll check the weather. ".to_string()));
+        assert_eq!(normal, Some("I'll check the weather.    ".to_string()));
     }
 
+    // TOOLCALLING.batch.2.c — prefix + post-wrapper narration around parallel
+    // calls in one section; both are preserved verbatim.
     #[test] // TOOLCALLING.batch.2.c
     fn test_parse_parallel_calls_with_surrounding_text() {
         let config = default_config();
@@ -591,11 +555,13 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[1].function.name, "get_time");
-        assert_eq!(normal, Some("I will check both. ".to_string()));
+        assert_eq!(normal, Some("I will check both.  Done.".to_string()));
     }
 
+    // TOOLCALLING.batch.8.d — two tool sections; the inter-section narration is
+    // natural text and is preserved verbatim between the removed blocks.
     #[test] // TOOLCALLING.batch.8.d
-    fn test_parse_multiple_sections_drops_inter_wrapper_text() {
+    fn test_parse_multiple_sections_keep_inter_wrapper_text() {
         let config = default_config();
         let input = r#"First check Dallas. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Then check NYC. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;
 
@@ -603,18 +569,23 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[1].function.name, "get_weather");
-        assert_eq!(normal, Some("First check Dallas. ".to_string()));
+        assert_eq!(
+            normal,
+            Some("First check Dallas.  Then check NYC. ".to_string())
+        );
     }
 
+    // TOOLCALLING.batch.8.b — narration only after the tool section; the
+    // post-wrapper text is preserved verbatim (there is no prefix).
     #[test] // TOOLCALLING.batch.8.b
-    fn test_parse_drops_post_tool_text_without_prefix() {
+    fn test_parse_keeps_post_tool_text_without_prefix() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check."#;
 
         let (calls, normal) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(normal, Some("".to_string()));
+        assert_eq!(normal, Some(" Let me check.".to_string()));
     }
 
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.6.yaml.

--- a/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -215,6 +215,14 @@ fn extract_tool_calls(
         return Ok((text[..marker_idx].trim().to_string(), calls));
     }
 
+    // When the family's reference decoder makes the tool-call section terminal
+    // (Moonshot's extract_tool_call_info), normal_text is ONLY the text before
+    // the FIRST tool-call marker; inter-section and trailing text are dropped.
+    // We track that marker offset and apply the truncation at the end, but only
+    // when a tool call was actually parsed (plain text with no calls is kept).
+    let prefix_only = config.content_is_prefix_only;
+    let mut first_marker_idx: Option<usize> = None;
+
     while cursor < text.len() {
         if let Some((start_pos, _start_len)) = find_section_start(text, cursor, config) {
             let abs_start = cursor + start_pos;
@@ -222,10 +230,20 @@ fn extract_tool_calls(
             if let Some((prefix, mut recovered)) =
                 recover_bare_kimi_calls_in_span(gap, config, tools)?
             {
+                // A bare call inside the gap — the first tool-call marker is
+                // inside this gap, before `prefix`'s trailing markup. Track its
+                // offset as cursor + (gap length consumed before the marker).
+                if first_marker_idx.is_none() {
+                    first_marker_idx =
+                        first_orphan_kimi_marker_index(gap, config).map(|i| cursor + i);
+                }
                 normal_parts.push(prefix);
                 calls.append(&mut recovered);
             } else {
                 normal_parts.push(gap.to_string());
+            }
+            if first_marker_idx.is_none() {
+                first_marker_idx = Some(abs_start);
             }
 
             // Add text before tool call section to normal parts.
@@ -253,6 +271,10 @@ fn extract_tool_calls(
             if let Some((prefix, mut recovered)) =
                 recover_bare_kimi_calls_in_span(gap, config, tools)?
             {
+                if first_marker_idx.is_none() {
+                    first_marker_idx =
+                        first_orphan_kimi_marker_index(gap, config).map(|i| cursor + i);
+                }
                 normal_parts.push(prefix);
                 calls.append(&mut recovered);
             } else {
@@ -260,6 +282,15 @@ fn extract_tool_calls(
             }
             break;
         }
+    }
+
+    // Terminal-block families: once a tool call exists, normal_text collapses to
+    // the text before the FIRST marker. Plain text (no calls) is untouched.
+    if prefix_only
+        && !calls.is_empty()
+        && let Some(idx) = first_marker_idx
+    {
+        return Ok((text[..idx].to_string(), calls));
     }
 
     let joined_normal_text = normal_parts.join("");

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -207,18 +207,17 @@ fn extract_tool_calls(
             if let Some((prefix, mut recovered_calls)) =
                 recover_bare_xml_calls_in_span(gap, config, tools)?
             {
-                if calls.is_empty() {
-                    normal_text.push_str(&prefix);
-                }
+                normal_text.push_str(&prefix);
                 calls.append(&mut recovered_calls);
-            } else if calls.is_empty() {
+            } else {
                 normal_text.push_str(gap);
             }
 
-            // Qwen3-Coder-style templates allow natural language before the
-            // tool call, but text after the tool-call block is not response
-            // content. Keep scanning for additional calls, but only surface
-            // normal text that precedes the first parsed call.
+            // Preserve ALL natural-language text — prefix, text between calls,
+            // and text after the last call — and strip only the tool-call
+            // markup (start marker through end marker). The gap before this
+            // start token is appended above unconditionally; the block markup
+            // itself is skipped when the cursor advances past `abs_end`.
 
             // Find the corresponding end token.
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -252,22 +251,26 @@ fn extract_tool_calls(
                     calls.append(&mut parsed_calls);
                     break;
                 }
-                if calls.is_empty() && !looks_like_tool_call {
+                // No end marker and either no tool-call structure or
+                // unrecoverable: a `<start_token>` with no closing markup is
+                // natural text, not strippable markup, so preserve it verbatim.
+                // Malformed/unrecoverable tool-call blocks keep the
+                // drop-without-leak behavior (nothing appended).
+                if !looks_like_tool_call {
                     normal_text.push_str(&text[abs_start..]);
                 }
                 break;
             }
         } else {
-            // No more tool calls.
+            // No more tool calls — preserve the trailing text after the last
+            // parsed call verbatim (RULE: only tool-call markup is stripped).
             let gap = &text[cursor..];
             if let Some((prefix, mut recovered_calls)) =
                 recover_bare_xml_calls_in_span(gap, config, tools)?
             {
-                if calls.is_empty() {
-                    normal_text.push_str(&prefix);
-                }
+                normal_text.push_str(&prefix);
                 calls.append(&mut recovered_calls);
-            } else if calls.is_empty() {
+            } else {
                 normal_text.push_str(gap);
             }
             break;
@@ -998,7 +1001,12 @@ Dallas
             try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(normal, Some("I'll help you with that. ".to_string()));
+        // normal_text keeps both the prefix and the text after the block;
+        // only the `<tool_call>…</tool_call>` markup is removed.
+        assert_eq!(
+            normal,
+            Some("I'll help you with that.  Let me check that for you.".to_string())
+        );
     }
 
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.2.yaml.

--- a/parsers/src/tool_calling/xml/parser.rs
+++ b/parsers/src/tool_calling/xml/parser.rs
@@ -199,6 +199,14 @@ fn extract_tool_calls(
     let start_token = &config.tool_call_start_token;
     let end_token = &config.tool_call_end_token;
 
+    // When the family's reference decoder makes the tool-call block terminal,
+    // normal_text is ONLY the text before the FIRST start marker; inter-call
+    // gaps and trailing text are dropped (markup never leaks). We track the
+    // marker offset and truncate at the end, but only when a call is actually
+    // parsed (plain text with no calls is preserved).
+    let prefix_only = config.content_is_prefix_only;
+    let mut first_marker_idx: Option<usize> = None;
+
     while cursor < text.len() {
         // Find next tool call start.
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
@@ -207,10 +215,17 @@ fn extract_tool_calls(
             if let Some((prefix, mut recovered_calls)) =
                 recover_bare_xml_calls_in_span(gap, config, tools)?
             {
+                if first_marker_idx.is_none() {
+                    first_marker_idx =
+                        prefix_before_orphan_xml_marker_index(gap, config).map(|i| cursor + i);
+                }
                 normal_text.push_str(&prefix);
                 calls.append(&mut recovered_calls);
             } else {
                 normal_text.push_str(gap);
+            }
+            if first_marker_idx.is_none() {
+                first_marker_idx = Some(abs_start);
             }
 
             // Preserve ALL natural-language text — prefix, text between calls,
@@ -268,6 +283,10 @@ fn extract_tool_calls(
             if let Some((prefix, mut recovered_calls)) =
                 recover_bare_xml_calls_in_span(gap, config, tools)?
             {
+                if first_marker_idx.is_none() {
+                    first_marker_idx =
+                        prefix_before_orphan_xml_marker_index(gap, config).map(|i| cursor + i);
+                }
                 normal_text.push_str(&prefix);
                 calls.append(&mut recovered_calls);
             } else {
@@ -275,6 +294,15 @@ fn extract_tool_calls(
             }
             break;
         }
+    }
+
+    // Terminal-block families: once a tool call exists, normal_text collapses to
+    // the text before the FIRST marker. Plain text (no calls) is untouched.
+    if prefix_only
+        && !calls.is_empty()
+        && let Some(idx) = first_marker_idx
+    {
+        return Ok((text[..idx].trim().to_string(), calls));
     }
 
     let normal_text = if calls.is_empty() {
@@ -285,7 +313,10 @@ fn extract_tool_calls(
     Ok((normal_text, calls))
 }
 
-fn prefix_before_orphan_xml_marker(text: &str, config: &XmlParserConfig) -> Option<String> {
+/// Byte offset of the first XML tool-call marker in `text`, or `None` if none
+/// is present. Shared by `prefix_before_orphan_xml_marker` and the
+/// prefix-only (terminal-block) truncation in `extract_tool_calls`.
+fn prefix_before_orphan_xml_marker_index(text: &str, config: &XmlParserConfig) -> Option<usize> {
     [
         config.tool_call_end_token.as_str(),
         config.function_start_token.as_str(),
@@ -296,7 +327,10 @@ fn prefix_before_orphan_xml_marker(text: &str, config: &XmlParserConfig) -> Opti
     .into_iter()
     .filter_map(|marker| text.find(marker))
     .min()
-    .map(|idx| text[..idx].trim().to_string())
+}
+
+fn prefix_before_orphan_xml_marker(text: &str, config: &XmlParserConfig) -> Option<String> {
+    prefix_before_orphan_xml_marker_index(text, config).map(|idx| text[..idx].trim().to_string())
 }
 
 fn recover_bare_xml_calls_in_span(
@@ -1306,6 +1340,7 @@ NYC
             strict_match: true,
             passthrough_when_no_function: false,
             backoff_when_no_wrapper: true,
+            content_is_prefix_only: false,
         };
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 
@@ -1516,6 +1551,7 @@ NYC
             strict_match: true,
             passthrough_when_no_function: false,
             backoff_when_no_wrapper: true,
+            content_is_prefix_only: false,
         }
     }
 

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -23,6 +23,18 @@ const PARAMETER_END: &str = "</｜DSML｜parameter>";
 /// `name` delta is emitted immediately before the `arguments` delta (both once
 /// the call closes), so consumers still coalesce the two by `tool_index` — the
 /// same wire shape Harmony uses (`name`-first, then arguments fragment).
+///
+/// `normal_text` keeps natural-language text from COMPLETE tool-call blocks
+/// verbatim — prefix before the first block, text BETWEEN blocks, and text
+/// AFTER the last block — and strips only the block markup. This matches the v1
+/// batch DSML parser's "remove the complete-block markup spans, keep surrounding
+/// text" rule (cases 2.b/2.c/8.b/8.c/8.d).
+///
+/// `suppress_normal_text` is the latch that distinguishes the two contracts:
+/// it is cleared when a COMPLETE block closes (so the next inter/trailing text
+/// flows through) but stays LATCHED through degraded recovery (bare invoke /
+/// orphan markers), preserving the v1 batch parser's drop-without-leak behavior
+/// for malformed/unrecoverable input.
 pub struct DeepSeekV4ToolStreamParser {
     buffer: String,
     in_block: bool,
@@ -85,7 +97,6 @@ impl DeepSeekV4ToolStreamParser {
                 });
                 self.next_index += 1;
                 self.open_invoke = None;
-                self.suppress_normal_text = true;
                 continue;
             }
 
@@ -96,9 +107,12 @@ impl DeepSeekV4ToolStreamParser {
                         .find(INVOKE_START_PREFIX)
                         .is_some_and(|start| start < end);
                     if !invoke_before_end {
+                        // Complete block fully closed: drop its markup and resume
+                        // keeping natural text (inter-block / trailing). Any later
+                        // block re-enters `in_block` and re-suppresses its markup.
                         self.buffer.drain(..end + BLOCK_END.len());
                         self.in_block = false;
-                        self.suppress_normal_text = true;
+                        self.suppress_normal_text = false;
                         continue;
                     }
                 }
@@ -143,6 +157,9 @@ impl DeepSeekV4ToolStreamParser {
             };
 
             let Some((start, marker)) = next_marker else {
+                // Outside any block / open invoke: keep natural text verbatim
+                // unless suppression is latched (degraded recovery). Retain a
+                // trailing partial-marker so we don't emit half a fence mid-stream.
                 let keep = if flush {
                     0
                 } else {
@@ -159,6 +176,8 @@ impl DeepSeekV4ToolStreamParser {
             };
 
             if start > 0 {
+                // Text before the next marker: natural text (prefix / inter-block /
+                // trailing), kept verbatim unless suppression is latched.
                 if !self.suppress_normal_text {
                     out.normal_text.push_str(&self.buffer[..start]);
                 }
@@ -173,6 +192,10 @@ impl DeepSeekV4ToolStreamParser {
                 }
                 Marker::BareInvoke => match self.open_invoke_header()? {
                     Some(tool_index) => {
+                        // Degraded recovery: latch suppression so the orphan
+                        // markup tail around a bare invoke is dropped, not leaked
+                        // (matches the v1 batch recovery contract).
+                        self.suppress_normal_text = true;
                         tracing::warn!(
                             why = "dsv4_bare_invoke_recovery",
                             tool_index,
@@ -210,7 +233,6 @@ impl DeepSeekV4ToolStreamParser {
         self.buffer.drain(..header_len);
         let tool_index = self.next_index;
         self.open_invoke = Some((tool_index, name));
-        self.suppress_normal_text = true;
         Ok(Some(tool_index))
     }
 }

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -464,6 +464,32 @@ mod tests {
     }
 
     #[test]
+    fn recovers_value_when_parameter_close_missing() {
+        // Conformance 4.d: </｜DSML｜parameter> missing but </｜DSML｜invoke>
+        // present (invoke-terminated). Must recover the value, not emit {}.
+        let input = "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+        let out = parse_chunks(&[input]);
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1, "one push: {:?}", merged.calls);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
+    fn recovers_value_when_parameter_close_missing_char_by_char() {
+        // Same 4.d input fed one Unicode scalar at a time — the harshest
+        // streaming split. The call must still recover NYC, not {}.
+        let input = "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+        let chunks: Vec<String> = input.chars().map(|c| c.to_string()).collect();
+        let refs: Vec<&str> = chunks.iter().map(|s| s.as_str()).collect();
+        let out = parse_chunks(&refs);
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1, "char-by-char: {:?}", merged.calls);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
     fn suppresses_invoke_header_truncated_mid_header() {
         // The header itself never closes, so nothing is emitted at all.
         let out = parse_chunks(&["<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weat"]);

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -320,8 +320,20 @@ fn parse_parameters(body: &str) -> anyhow::Result<Map<String, Value>> {
         };
         let attrs = &body[attrs_start..attrs_start + header_end_rel];
         let value_start = attrs_start + header_end_rel + 1;
-        let Some(value_end_rel) = body[value_start..].find(PARAMETER_END) else {
-            break;
+        // Value ends at its own close tag if present, otherwise at the next
+        // parameter or the end of the invoke body. drain() only calls this once
+        // </｜DSML｜invoke> has streamed (a call truncated before its close is
+        // dropped upstream), so the body is delimiter-terminated and a value
+        // with no </｜DSML｜parameter> close is still recoverable (recover/drop
+        // rule, matches v1's parse_parameters and keeps v1/v2 in agreement).
+        let rest = &body[value_start..];
+        let end_close = rest.find(PARAMETER_END);
+        let end_next = rest.find(PARAMETER_PREFIX);
+        let value_end_rel = match (end_close, end_next) {
+            (Some(c), Some(n)) => c.min(n),
+            (Some(c), None) => c,
+            (None, Some(n)) => n,
+            (None, None) => rest.len(),
         };
         let raw_value = body[value_start..value_start + value_end_rel].trim();
         let value = if attrs.contains(r#"string="true""#) {
@@ -330,7 +342,11 @@ fn parse_parameters(body: &str) -> anyhow::Result<Map<String, Value>> {
             serde_json::from_str(raw_value).unwrap_or_else(|_| Value::String(raw_value.to_string()))
         };
         params.insert(name.to_string(), value);
-        cursor = value_start + value_end_rel + PARAMETER_END.len();
+        cursor = if end_close == Some(value_end_rel) {
+            value_start + value_end_rel + PARAMETER_END.len()
+        } else {
+            value_start + value_end_rel
+        };
     }
     Ok(params)
 }

--- a/parsers_v2/src/tool_calling/dsml.rs
+++ b/parsers_v2/src/tool_calling/dsml.rs
@@ -107,12 +107,16 @@ impl DeepSeekV4ToolStreamParser {
                         .find(INVOKE_START_PREFIX)
                         .is_some_and(|start| start < end);
                     if !invoke_before_end {
-                        // Complete block fully closed: drop its markup and resume
-                        // keeping natural text (inter-block / trailing). Any later
-                        // block re-enters `in_block` and re-suppresses its markup.
+                        // Complete block fully closed: drop its markup. DeepSeek-V4's
+                        // reference decoder (encoding_dsv4.py) makes the tool-call
+                        // block TERMINAL — content is only the text before the first
+                        // block, and it asserts no text follows the calls. So once a
+                        // block has been entered, suppression stays LATCHED: all
+                        // inter-block and trailing natural text is dropped (markup
+                        // never leaks). This matches the v1 batch parser's
+                        // `content_is_prefix_only` contract for deepseek_v4.
                         self.buffer.drain(..end + BLOCK_END.len());
                         self.in_block = false;
-                        self.suppress_normal_text = false;
                         continue;
                     }
                 }


### PR DESCRIPTION
> [!WARNING]
> **PUNTING on the behavior change — this is not ready to land as a behavior change.**
>
> The drop-vs-preserve-surrounding-text change here only lands in the **batch** path. Shipping it for real requires updating **both batch and stream together**, which is out of scope for this PR:
>
> - All 48 fixture changes are `TOOLCALLING.batch.*` — no `.stream.*` fixtures are touched.
> - `content_is_prefix_only` is consumed only in the batch parsers (`base_json_parser.rs`, `dsml/parser.rs`, `xml/parser.rs`, `kimi_k2_parser.rs`), plus `deepseek_v4`'s v2 stream (`parsers_v2/tool_calling/dsml.rs`). For `kimi_k2`, `mistral`, and `nemotron_nano` the stream path is **not** updated — so batch would drop trailing/inter-call text while stream keeps it, and the same model would answer differently depending on `stream=true`/`false`.
> - Making the four terminal families consistent means wiring `content_is_prefix_only` through the v1 jail stream path (and v2 where applicable) and recapturing the `.stream.*` fixtures too. That is the follow-up; until batch and stream move together, the behavior change stays parked.

---

Linear: [DIS-2271](https://linear.app/nvidia/issue/DIS-2271/add-v2-streaming-tool-call-parsers-for-gemma-4-glm-kimi-k2-minimax-m2)

#### Examples — what changes for the user

When a model writes plain text around a tool call, do we keep it in the reply or drop it? It depends on what the model's own spec says.

**We DROP the surrounding text** (the model's spec says nothing belongs after a tool call):
- `deepseek_v4`, sandwich: `I will check the weather.` → tool call → `Let me know if you need more.` ⇒ we return `I will check the weather. ` and drop the trailing sentence.
- `kimi_k2`, two calls with narration between ⇒ we return only `First check Dallas.` and drop the wedged text.

**We KEEP the surrounding text** (spec is silent — dropping would throw away what the model wrote):
- `glm47`, same sandwich ⇒ we return `I will check the weather.  Let me know if you need more.`
- `gemma4`, two calls with narration between ⇒ we keep `I will check the weather.  Then check LA weather.`

Same cases on both sides: the model's spec decides, not the shape of the input.

#### Overview:

This PR makes v1 tool-call parsers keep natural-language text around a tool call when the model's spec is silent, and drop it for the four families whose published decoder defines the reply as only the text before the tool calls (`deepseek_v4`, `kimi_k2`, `mistral`, `nemotron_nano`).

#### Details:

- Adds a shared `content_is_prefix_only` flag (default off) across the json/xml/dsml/kimi parser configs; the four terminal families opt in. `nemotron_nano` split into its own config (it had been sharing `qwen3_coder`, which must keep preserving).
- The v2 `deepseek_v4` streaming parser latches suppression after the first block so streaming matches the batch behavior.
- Every narration case (`2.b/2.c`, `8.b/c/d`, batch + stream) carries a `dynamo_note` citing the per-model spec basis, shown in the conformance tooltip.

#### Verification:

`cargo test -p dynamo-conformance-fixtures-v2` (3 parity binaries), `dynamo-parsers` (624), `dynamo-parsers-v2` (32) all green; preserve-families show zero non-note value changes.

#### Where should the reviewer start?

`parsers/src/tool_calling/config.rs`, then `parsers/src/tool_calling/xml/parser.rs`

/coderabbit profile chill

