### PR TITLE
feat: Add MiniMax M3 tool-calling, reasoning, and conformance coverage

### DIFF
--- a/conformance/reasoning/fixtures/minimax_m3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/minimax_m3/REASONING.batch.yaml
@@ -4,42 +4,100 @@
 family: minimax_m3
 model_label: MiniMax M3
 mode: batch
+refs:
+  local: &local_ref 'MiniMax M3 <mm:think> reasoning grammar; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: *local_ref
+    model_text: ''
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: ''
+      vllm: &vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang: &sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
+    ref: *local_ref
     model_text: plain answer
     expected:
-      dynamo: &plain
+      dynamo:
         reasoning_text: ''
         normal_text: plain answer
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.batch.2.a:
     description: Single MiniMax M3 reasoning block
+    ref: *local_ref
     model_text: <mm:think>thinking</mm:think>
     expected:
-      dynamo: &thinking_only
+      dynamo:
         reasoning_text: thinking
         normal_text: ''
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.2.b:
+    description: Normal prefix before a MiniMax M3 reasoning block
+    ref: *local_ref
+    model_text: Before <mm:think>thinking</mm:think>
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: Before
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.batch.2.c:
     description: MiniMax M3 reasoning followed by normal answer text
+    ref: *local_ref
     model_text: <mm:think>compute it</mm:think>The answer is 42.
     expected:
       dynamo:
         reasoning_text: compute it
         normal_text: The answer is 42.
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.2.d:
+    description: Normal text around a MiniMax M3 reasoning block
+    ref: *local_ref
+    model_text: Before <mm:think>thinking</mm:think> after
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: Before  after
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.2.e:
+    description: Empty MiniMax M3 reasoning block
+    ref: *local_ref
+    model_text: <mm:think></mm:think>Direct answer.
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: Direct answer.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.2.f:
+    description: Complex MiniMax M3 reasoning content with newlines and marker-looking text
+    ref: *local_ref
+    model_text: |-
+      <mm:think>Line 1
+      JSON-ish: {"x": [1, true]}
+      Marker-like: <mm:thinking>not a close</mm:thinking></mm:think>Done.
+    expected:
+      dynamo:
+        reasoning_text: |-
+          Line 1
+          JSON-ish: {"x": [1, true]}
+          Marker-like: <mm:thinking>not a close</mm:thinking>
+        normal_text: Done.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.batch.3.a:
     description: Reasoning followed by downstream MiniMax M3 tool-call text
+    ref: *local_ref
     model_text: |-
       <mm:think>choose the weather tool</mm:think>]<]minimax[>[<tool_call>
       ]<]minimax[>[<invoke name="get_weather">
@@ -55,29 +113,66 @@ cases:
           ]<]minimax[>[<location>NYC]<]minimax[>[</location>
           ]<]minimax[>[</invoke>
           ]<]minimax[>[</tool_call>
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text is not configured for MiniMax M3
+    ref: *local_ref
+    reason: MiniMax M3 uses explicit <mm:think> spans and has no configured downstream tool-call escape while a reasoning span is still open; missing-end recovery is covered by REASONING.batch.5.
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to MiniMax M3
+    ref: *local_ref
+    reason: MiniMax M3 does not use Harmony commentary channels; visible text and downstream tool handoff use MiniMax-specific think and namespace-token tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to MiniMax M3
+    ref: *local_ref
+    reason: MiniMax M3 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use MiniMax namespace-token XML markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to MiniMax M3
+    ref: *local_ref
+    reason: MiniMax M3 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by <mm:think> tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to MiniMax M3
+    ref: *local_ref
+    reason: MiniMax M3 has no Harmony channel protocol, so mixed analysis, commentary tool-call, and final-channel sequencing is outside its grammar.
   REASONING.batch.4:
     description: Dangling end marker without an opening MiniMax M3 think tag
+    ref: *local_ref
     model_text: reason</mm:think>answer
     expected:
       dynamo:
         reasoning_text: reason
         normal_text: answer
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
+    ref: *local_ref
     model_text: <mm:think>partial reasoning
     expected:
       dynamo:
         reasoning_text: partial reasoning
         normal_text: ''
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.6.a:
+    description: Multiple MiniMax M3 reasoning spans are concatenated
+    ref: *local_ref
+    model_text: <mm:think>first</mm:think> middle <mm:think>second</mm:think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.batch.6.b:
+    description: Stray MiniMax M3 end marker after a complete reasoning span
+    ref: *local_ref
+    model_text: <mm:think>preamble</mm:think>body</mm:think>answer
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: bodyanswer
+        reason: Parser-owned dangling close syntax is stripped from normal_text after the complete reasoning span.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable

--- a/conformance/reasoning/fixtures/minimax_m3/REASONING.batch.yaml
+++ b/conformance/reasoning/fixtures/minimax_m3/REASONING.batch.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without reasoning markers
+    model_text: plain answer
+    expected:
+      dynamo: &plain
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.batch.2.a:
+    description: Single MiniMax M3 reasoning block
+    model_text: <mm:think>thinking</mm:think>
+    expected:
+      dynamo: &thinking_only
+        reasoning_text: thinking
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.batch.2.c:
+    description: MiniMax M3 reasoning followed by normal answer text
+    model_text: <mm:think>compute it</mm:think>The answer is 42.
+    expected:
+      dynamo:
+        reasoning_text: compute it
+        normal_text: The answer is 42.
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream MiniMax M3 tool-call text
+    model_text: |-
+      <mm:think>choose the weather tool</mm:think>]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    expected:
+      dynamo:
+        reasoning_text: choose the weather tool
+        normal_text: |-
+          ]<]minimax[>[<tool_call>
+          ]<]minimax[>[<invoke name="get_weather">
+          ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+          ]<]minimax[>[</invoke>
+          ]<]minimax[>[</tool_call>
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.batch.4:
+    description: Dangling end marker without an opening MiniMax M3 think tag
+    model_text: reason</mm:think>answer
+    expected:
+      dynamo:
+        reasoning_text: reason
+        normal_text: answer
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    model_text: <mm:think>partial reasoning
+    expected:
+      dynamo:
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.

--- a/conformance/reasoning/fixtures/minimax_m3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/minimax_m3/REASONING.stream.yaml
@@ -4,9 +4,25 @@
 family: minimax_m3
 model_label: MiniMax M3
 mode: stream
+refs:
+  local: &local_ref 'MiniMax M3 <mm:think> reasoning grammar; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: *local_ref
+    chunks:
+    - ''
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: ''
+      vllm: &vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang: &sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
   REASONING.stream.1.b:
     description: Plain text without reasoning markers
+    ref: *local_ref
     chunks:
     - plain
     - ' answer'
@@ -14,12 +30,11 @@ cases:
       dynamo:
         reasoning_text: ''
         normal_text: plain answer
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.stream.2.a:
     description: MiniMax M3 reasoning split across chunks
+    ref: *local_ref
     chunks:
     - <mm:think>rea
     - son</mm:think>answer
@@ -27,12 +42,74 @@ cases:
       dynamo:
         reasoning_text: reason
         normal_text: answer
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.stream.2.b:
+    description: Multiple MiniMax M3 reasoning spans across chunks
+    ref: *local_ref
+    chunks:
+    - <mm:think>first</mm:think>
+    - ' middle '
+    - <mm:think>second</mm:think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.stream.2.c:
+    description: Prompt-prefilled close marker after a complete MiniMax M3 span
+    ref: *local_ref
+    chunks:
+    - <mm:think>preamble</mm:think>
+    - body</mm:think>
+    - answer
+    expected:
+      dynamo:
+        reasoning_text: preamblebody
+        normal_text: answer
+        reason: MiniMax M3 enables dangling-end recovery, so a later unpaired </mm:think> chunk is treated as a prompt-prefilled reasoning close.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.stream.3.a:
+    description: MiniMax M3 start marker split across chunks
+    ref: *local_ref
+    chunks:
+    - <mm:thi
+    - nk>thinking</mm:think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.stream.3.b:
+    description: MiniMax M3 end marker split across chunks
+    ref: *local_ref
+    chunks:
+    - <mm:think>thinking</mm:
+    - think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  REASONING.stream.3.c:
+    description: Partial MiniMax M3 start-marker prefix later becomes normal text
+    ref: *local_ref
+    chunks:
+    - plain <mm:th
+    - esis answer
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: plain <mm:thesis answer
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.stream.4:
     description: Dangling MiniMax M3 end marker split across chunks
+    ref: *local_ref
     chunks:
     - reason</mm:
     - think>answer
@@ -40,19 +117,16 @@ cases:
       dynamo:
         reasoning_text: reason
         normal_text: answer
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   REASONING.stream.4.a:
     description: Close marker only is stripped as prompt-prefilled reasoning close
+    ref: *local_ref
     chunks:
     - </mm:think>I'll check the content of both files.
     expected:
       dynamo:
         reasoning_text: ''
         normal_text: I'll check the content of both files.
-      vllm:
-        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
-      sglang:
-        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable

--- a/conformance/reasoning/fixtures/minimax_m3/REASONING.stream.yaml
+++ b/conformance/reasoning/fixtures/minimax_m3/REASONING.stream.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: stream
+cases:
+  REASONING.stream.1.b:
+    description: Plain text without reasoning markers
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.stream.2.a:
+    description: MiniMax M3 reasoning split across chunks
+    chunks:
+    - <mm:think>rea
+    - son</mm:think>answer
+    expected:
+      dynamo:
+        reasoning_text: reason
+        normal_text: answer
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.stream.4:
+    description: Dangling MiniMax M3 end marker split across chunks
+    chunks:
+    - reason</mm:
+    - think>answer
+    expected:
+      dynamo:
+        reasoning_text: reason
+        normal_text: answer
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+  REASONING.stream.4.a:
+    description: Close marker only is stripped as prompt-prefilled reasoning close
+    chunks:
+    - </mm:think>I'll check the content of both files.
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: I'll check the content of both files.
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 reasoning parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 reasoning parser yet.

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.1.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.1.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Streaming fixture (per-chunk, per-impl). MiniMax M3 is present in the
+# stream-v2 matrix, but no pinned peer/local v2 stream parser is available yet.
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.1:
+    description: 'Single tool call (happy path)'
+    ref: 'derived from TOOLCALLING.batch.1'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.10.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.10.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.10:
+    description: 'Duplicate calls (same name twice)'
+    ref: 'derived from TOOLCALLING.batch.10'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>LA]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.13.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.13.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.13:
+    description: 'Unknown tool name absent from supplied tools'
+    ref: 'derived from TOOLCALLING.batch.13'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="unknown_tool">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.3.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.3.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.3:
+    description: 'No tool call (plain text)'
+    ref: 'derived from TOOLCALLING.batch.3'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: 'Hello, how can I help you today?'
+    - delta_text: ''
+      finish_reason: stop

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.5.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.5.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.5.a:
+    description: 'Missing outer tool_call close, complete invoke is recovered at EOF'
+    ref: 'derived from TOOLCALLING.batch.5.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.7.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.7.yaml
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.7.a:
+    description: 'Standard scalar types (string + int + bool)'
+    ref: 'derived from TOOLCALLING.batch.7.a'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="book_flight">
+        ]<]minimax[>[<destination>Paris]<]minimax[>[</destination>
+        ]<]minimax[>[<passengers>2]<]minimax[>[</passengers>
+        ]<]minimax[>[<first_class>true]<]minimax[>[</first_class>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.streamv2.7.b:
+    description: 'Unicode + XML entity unescape in string value'
+    ref: 'derived from TOOLCALLING.batch.7.b'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>Tōkyō &quot;central&quot; &amp; west]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.streamv2.7.c:
+    description: 'Schema mismatch — string value where schema declares integer'
+    ref: 'derived from TOOLCALLING.batch.7.c'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="set_temperature">
+        ]<]minimax[>[<celsius>twenty]<]minimax[>[</celsius>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.streamv2.7.d:
+    description: 'Nested object + array represented as nested MiniMax XML tags'
+    ref: 'derived from TOOLCALLING.batch.7.d'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+            items:
+              type: integer
+          config:
+            type: object
+            properties:
+              nested:
+                type: boolean
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="process_data">
+        ]<]minimax[>[<items>]<]minimax[>[<item>1]<]minimax[>[</item>]<]minimax[>[<item>2]<]minimax[>[</item>]<]minimax[>[<item>3]<]minimax[>[</item>]<]minimax[>[</items>
+        ]<]minimax[>[<config>]<]minimax[>[<nested>true]<]minimax[>[</nested>]<]minimax[>[</config>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.streamv2.7.e:
+    description: 'Large / deep nested MiniMax XML argument payload'
+    ref: 'derived from TOOLCALLING.batch.7.e'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+            properties:
+              regions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    scores:
+                      type: array
+                      items:
+                        type: integer
+              flags:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  retry:
+                    type:
+                    - 'null'
+                    - string
+              empty:
+                type: object
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="process_data">
+        ]<]minimax[>[<payload>]<]minimax[>[<regions>]<]minimax[>[<item>]<]minimax[>[<name>west]<]minimax[>[</name>]<]minimax[>[<scores>]<]minimax[>[<item>1]<]minimax[>[</item>]<]minimax[>[<item>2]<]minimax[>[</item>]<]minimax[>[<item>3]<]minimax[>[</item>]<]minimax[>[</scores>]<]minimax[>[</item>]<]minimax[>[<item>]<]minimax[>[<name>east]<]minimax[>[</name>]<]minimax[>[<scores>]<]minimax[>[<item>4]<]minimax[>[</item>]<]minimax[>[<item>5]<]minimax[>[</item>]<]minimax[>[<item>6]<]minimax[>[</item>]<]minimax[>[</scores>]<]minimax[>[</item>]<]minimax[>[</regions>]<]minimax[>[<flags>]<]minimax[>[<enabled>true]<]minimax[>[</enabled>]<]minimax[>[<retry>null]<]minimax[>[</retry>]<]minimax[>[</flags>]<]minimax[>[<empty>]<]minimax[>[</empty>]<]minimax[>[</payload>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+  TOOLCALLING.streamv2.7.f:
+    description: 'Numeric precision edge preserves integer-like number literal'
+    ref: 'derived from TOOLCALLING.batch.7.f'
+    tools:
+    - name: set_limit
+      parameters:
+        type: object
+        properties:
+          count:
+            type: number
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="set_limit">
+        ]<]minimax[>[<count>9007199254740993]<]minimax[>[</count>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls

--- a/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.9.yaml
+++ b/conformance/toolcalling/fixtures-stream-v2/minimax_m3/TOOLCALLING.streamv2.9.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: 'MiniMax M3'
+mode: streamv2
+captured_with:
+  vllm_rust: 'v0.23.0 78743ab5bffd381e88f97e1c8ba20473b0ae6d75'
+  vllm_python: '0.23.0'
+  sglang_python: '0.5.12.post1'
+cases:
+  TOOLCALLING.streamv2.9.a:
+    description: 'Empty model text'
+    ref: 'derived from TOOLCALLING.batch.9.a'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: ''
+      finish_reason: stop
+  TOOLCALLING.streamv2.9.b:
+    description: 'Blank / whitespace-only model text'
+    ref: 'derived from TOOLCALLING.batch.9.b'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    unavailable:
+      dynamo_rust: 'Dynamo parser v2 TC streaming not yet implemented for this family; vLLM Python/SGLang per-chunk output is the target to match.'
+      vllm_rust: 'vLLM Rust v0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      vllm_python: 'vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.'
+      sglang_python: 'SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.'
+    chunks:
+    - delta_text: '   '
+    - delta_text: ''
+      finish_reason: stop

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.2.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.2.yaml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  TOOLCALLING.batch.2.a:
+    description: Two invokes inside one tool_call wrapper
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_time">
+      ]<]minimax[>[<timezone>EST]<]minimax[>[</timezone>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - &weather_tool
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &time_tool
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &weather_time_calls
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: &m3_vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &m3_sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.2.b:
+    description: Two invokes adjacent inside one tool_call wrapper
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">]<]minimax[>[<location>NYC]<]minimax[>[</location>]<]minimax[>[</invoke>]<]minimax[>[<invoke name="get_time">]<]minimax[>[<timezone>EST]<]minimax[>[</timezone>]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    - *time_tool
+    expected:
+      dynamo: *weather_time_calls
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.2.c:
+    description: Parallel invokes with surrounding narration
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      Both: ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_time">
+      ]<]minimax[>[<timezone>EST]<]minimax[>[</timezone>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call> Done.
+    tools:
+    - *weather_tool
+    - *time_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.2.d:
+    description: Same function name twice inside one tool_call wrapper
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>LA]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.4.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.4.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  TOOLCALLING.batch.4.a:
+    description: Tool_call wrapper with garbage body
+    ref: MiniMax M3 parser malformed-input recovery contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      not a valid invoke
+      ]<]minimax[>[</tool_call>
+    tools:
+    - &weather_tool
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &empty_parse
+        calls: []
+        normal_text: ''
+      vllm: &m3_vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &m3_sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.4.b:
+    description: Invalid JSON object in schema-declared object parameter falls back to string
+    ref: MiniMax M3 schema-aware scalar coercion
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="configure">
+      ]<]minimax[>[<settings>{"mode": "fast"]<]minimax[>[</settings>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: configure
+      parameters:
+        type: object
+        properties:
+          settings:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: configure
+          arguments:
+            settings: '{"mode": "fast"'
+        normal_text: ''
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.4.c:
+    description: Invoke without name attribute
+    ref: MiniMax M3 parser malformed-input recovery contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke>
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo: *empty_parse
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.4.d:
+    description: Missing closing invoke tag
+    ref: MiniMax M3 parser malformed-input recovery contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo: *empty_parse
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.4.e:
+    description: Malformed-prefix recovery is not applicable to this family's syntax
+    reason: |-
+      TOOLCALLING.batch.4.e is specific to raw JSON-object scanners where a malformed JSON-looking prefix may be followed by a complete object. MiniMax M3 uses namespace-prefixed XML tags, so malformed wrapper coverage lives in TOOLCALLING.batch.4.a through 4.d.
+  TOOLCALLING.batch.4.f:
+    description: Tool-name XML tag case is not applicable to this family's syntax
+    reason: |-
+      TOOLCALLING.batch.4.f is specific to Qwen3-Coder XML syntax, where the model may emit a tool-name tag such as <terminal> instead of the required <function=Terminal> opener. MiniMax M3 uses <invoke name="...">.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.6.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.6.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  TOOLCALLING.batch.6.a:
+    description: Invoke with no parameter tags
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_time">
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - &time_tool
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      dynamo: &empty_args_call
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      vllm: &m3_vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &m3_sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.6.b:
+    description: Invoke with whitespace-only body
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_time">
+
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *time_tool
+    expected:
+      dynamo: *empty_args_call
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.6.c:
+    description: Invoke with empty body on one line
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_time">]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *time_tool
+    expected:
+      dynamo: *empty_args_call
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.7.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.7.yaml
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+mode: batch
+cases:
+  TOOLCALLING.batch.7.a:
+    description: Standard scalar types (string + int + bool)
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="book_flight">
+      ]<]minimax[>[<destination>Paris]<]minimax[>[</destination>
+      ]<]minimax[>[<passengers>2]<]minimax[>[</passengers>
+      ]<]minimax[>[<first_class>true]<]minimax[>[</first_class>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.7.b:
+    description: Unicode + XML entity unescape in string value
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>Tōkyō &quot;central&quot; &amp; west]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central" & west
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="set_temperature">
+      ]<]minimax[>[<celsius>twenty]<]minimax[>[</celsius>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: twenty
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.7.d:
+    description: Nested object + array represented as nested MiniMax XML tags
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="process_data">
+      ]<]minimax[>[<items>]<]minimax[>[<item>1]<]minimax[>[</item>]<]minimax[>[<item>2]<]minimax[>[</item>]<]minimax[>[<item>3]<]minimax[>[</item>]<]minimax[>[</items>
+      ]<]minimax[>[<config>]<]minimax[>[<nested>true]<]minimax[>[</nested>]<]minimax[>[</config>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+            items:
+              type: integer
+          config:
+            type: object
+            properties:
+              nested:
+                type: boolean
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.7.e:
+    description: Large / deep nested MiniMax XML argument payload
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="process_data">
+      ]<]minimax[>[<payload>]<]minimax[>[<regions>]<]minimax[>[<item>]<]minimax[>[<name>west]<]minimax[>[</name>]<]minimax[>[<scores>]<]minimax[>[<item>1]<]minimax[>[</item>]<]minimax[>[<item>2]<]minimax[>[</item>]<]minimax[>[<item>3]<]minimax[>[</item>]<]minimax[>[</scores>]<]minimax[>[</item>]<]minimax[>[<item>]<]minimax[>[<name>east]<]minimax[>[</name>]<]minimax[>[<scores>]<]minimax[>[<item>4]<]minimax[>[</item>]<]minimax[>[<item>5]<]minimax[>[</item>]<]minimax[>[<item>6]<]minimax[>[</item>]<]minimax[>[</scores>]<]minimax[>[</item>]<]minimax[>[</regions>]<]minimax[>[<flags>]<]minimax[>[<enabled>true]<]minimax[>[</enabled>]<]minimax[>[<retry>null]<]minimax[>[</retry>]<]minimax[>[</flags>]<]minimax[>[<empty>]<]minimax[>[</empty>]<]minimax[>[</payload>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+            properties:
+              regions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    scores:
+                      type: array
+                      items:
+                        type: integer
+              flags:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  retry:
+                    type:
+                    - 'null'
+                    - string
+              empty:
+                type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.7.f:
+    description: Numeric precision edge preserves integer-like number literal
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="set_limit">
+      ]<]minimax[>[<count>9007199254740993]<]minimax[>[</count>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - name: set_limit
+      parameters:
+        type: object
+        properties:
+          count:
+            type: number
+    expected:
+      dynamo:
+        calls:
+        - name: set_limit
+          arguments:
+            count: 9007199254740993
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.8.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.8.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  TOOLCALLING.batch.8.a:
+    description: Narration before tool call only
+    ref: MiniMax M3 parser prefix-text contract
+    model_text: |-
+      I will check the weather. ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - &weather_tool
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &weather_with_prefix
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      vllm: &m3_vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &m3_sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.8.b:
+    description: Narration after tool call only
+    ref: MiniMax M3 parser trailing-text contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call> Let me know if you need more.
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.8.c:
+    description: Narration both before and after tool call
+    ref: MiniMax M3 parser prefix/trailing-text contract
+    model_text: |-
+      I will check the weather. ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call> Let me know if you need more.
+    tools:
+    - *weather_tool
+    expected:
+      dynamo: *weather_with_prefix
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable
+  TOOLCALLING.batch.8.d:
+    description: Narration between multiple invokes inside one tool_call wrapper
+    ref: MiniMax M3 namespace-token XML tool-call grammar
+    model_text: |-
+      I will check both cities. ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      Then check LA.
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>LA]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check both cities. '
+      vllm: *m3_vllm_unavailable
+      sglang: *m3_sglang_unavailable

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
@@ -137,14 +137,86 @@ cases:
       sglang:
         unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
   TOOLCALLING.batch.13.c:
-    description: Mixed known and unknown calls not applicable
+    description: Mixed known and unknown calls
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="unknown_tool">
+      ]<]minimax[>[<location>LA]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.13.a:
+    description: Unknown-only call under default parser behavior
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="unknown_tool">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.13.b:
+    description: Explicit forward-unknown-tools mode is not applicable
     reason: |-
-      This case is not applicable to minimax_m3 until peer MiniMax M3 mixed known/unknown behavior is captured in the pinned conformance engines.
+      MiniMax M3's Dynamo parser does not have a separate forward-unknown-tools mode; default behavior already forwards syntactically valid calls by name.
+  TOOLCALLING.batch.13.d:
+    description: Unknown native index is not applicable
+    reason: |-
+      MiniMax M3 tool calls identify functions by the <invoke name="..."> attribute, not by ordinal or registry index.
   TOOLCALLING.batch.30:
     description: Separator-character case not applicable
     reason: |-
       This case is not applicable to minimax_m3 because it uses namespace-prefixed XML tags, not delimiter-separated call bodies.
+  TOOLCALLING.batch.30.a:
+    description: Call separator inside argument string is not applicable
+    reason: |-
+      MiniMax M3 does not use delimiter-separated call bodies; argument values are bounded by namespace-prefixed XML tags.
+  TOOLCALLING.batch.30.b:
+    description: Structural delimiter inside argument string is not applicable
+    reason: |-
+      MiniMax M3 does not use delimiter depth tracking over delimiter-separated JSON call bodies; nested values are represented as nested namespace-prefixed XML tags.
+  TOOLCALLING.batch.30.c:
+    description: Tool-call marker text inside argument string is not applicable
+    reason: |-
+      MiniMax M3 argument boundaries are explicit namespace-prefixed XML tags. Literal marker-like text must be escaped by the model/template rather than parsed as a delimiter-separated string hazard.
   TOOLCALLING.batch.31:
     description: Multi-call separator-character case not applicable
     reason: |-
       This case is not applicable to minimax_m3 because it uses namespace-prefixed XML tags, not delimiter-separated call bodies.
+  TOOLCALLING.batch.31.a:
+    description: Separator character before real inter-call separator is not applicable
+    reason: |-
+      MiniMax M3 represents multiple calls as multiple <invoke name="..."> blocks inside one outer tool_call wrapper, not with separator characters between calls.
+  TOOLCALLING.batch.31.b:
+    description: Nested delimiter before later calls is not applicable
+    reason: |-
+      MiniMax M3 nested structures are encoded as nested namespace-prefixed XML tags, so delimiter-state regressions for JSON/string separators do not apply.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: batch
+cases:
+  TOOLCALLING.batch.1:
+    description: Single tool call (happy path)
+    ref: MiniMax M3 chat_template.jinja tool-call markup
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - &weather_tool
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &weather_call
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.5.a:
+    description: Missing outer tool_call close, complete invoke is recovered at EOF
+    ref: Dynamo MiniMax M3 parser EOF recovery contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo: *weather_call
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.9.a:
+    description: Empty model text
+    model_text: ''
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.9.b:
+    description: Blank / whitespace-only model text
+    model_text: '   '
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>LA]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.13:
+    description: Unknown tool name absent from supplied tools
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="unknown_tool">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to minimax_m3 until peer MiniMax M3 mixed known/unknown behavior is captured in the pinned conformance engines.
+  TOOLCALLING.batch.30:
+    description: Separator-character case not applicable
+    reason: |-
+      This case is not applicable to minimax_m3 because it uses namespace-prefixed XML tags, not delimiter-separated call bodies.
+  TOOLCALLING.batch.31:
+    description: Multi-call separator-character case not applicable
+    reason: |-
+      This case is not applicable to minimax_m3 because it uses namespace-prefixed XML tags, not delimiter-separated call bodies.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.batch.yaml
@@ -62,6 +62,133 @@ cases:
         unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
       sglang:
         unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.5.b:
+    description: Closing outer tool_call without matching open
+    ref: Dynamo MiniMax M3 orphan-inner recovery contract
+    model_text: |-
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo: *weather_call
+      vllm: &vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: Dynamo MiniMax M3 parser EOF recovery contract
+    model_text: |-
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NY
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  TOOLCALLING.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: Dynamo MiniMax M3 parser EOF recovery contract
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>Boston]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>New York]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  TOOLCALLING.batch.5.e:
+    description: Multi-call, last call truncated mid-argument value
+    ref: Dynamo MiniMax M3 parser EOF recovery contract
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>Boston]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>New York
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  TOOLCALLING.batch.5.f:
+    description: Bare valid invoke before a complete wrapped call
+    ref: Dynamo MiniMax M3 orphan-inner recovery contract
+    model_text: |-
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+      ]<]minimax[>[<tool_call>
+      ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>Boston]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  TOOLCALLING.batch.5.g:
+    description: Closing outer tool_call without matching open after prefix prose
+    ref: Dynamo MiniMax M3 orphan-inner recovery contract
+    model_text: |-
+      I will check that. ]<]minimax[>[<invoke name="get_weather">
+      ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+      ]<]minimax[>[</invoke>
+      ]<]minimax[>[</tool_call>
+    tools:
+    - *weather_tool
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check that. '
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
   TOOLCALLING.batch.9.a:
     description: Empty model text
     model_text: ''

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.1.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from TOOLCALLING.batch.1
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &weather_tools
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &weather_call
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from TOOLCALLING.batch.1
+    chunks:
+    - delta_text: |
+        ]<]minimax[>[<tool_call>
+    - delta_text: |
+        ]<]minimax[>[<invoke name="get_weather">
+    - delta_text: ']<]minimax[>[<location>'
+    - delta_text: NYC
+    - delta_text: ']<]minimax[>[</location>'
+    - delta_text: |
+        ]<]minimax[>[</invoke>
+    - delta_text: ']<]minimax[>[</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *weather_tools
+    expected:
+      dynamo: *weather_call
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.2.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.2.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: stream
+cases:
+  TOOLCALLING.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from TOOLCALLING.batch.2.a
+    chunks:
+    - delta_text: |
+        ]<]minimax[>[<tool_call>
+    - delta_text: |
+        ]<]minimax[>[<invoke name="get_weather">
+    - delta_text: ']<]minimax[>[<location>'
+    - delta_text: NYC
+    - delta_text: |
+        ]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+    - delta_text: |
+        ]<]minimax[>[<invoke name="get_time">
+    - delta_text: ']<]minimax[>[<timezone>'
+    - delta_text: EST
+    - delta_text: |
+        ]<]minimax[>[</timezone>
+        ]<]minimax[>[</invoke>
+    - delta_text: ']<]minimax[>[</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.3.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.3.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: stream
+cases:
+  TOOLCALLING.stream.3:
+    description: Tool-call start marker split across chunk boundaries
+    ref: derived from TOOLCALLING.batch.1
+    chunks:
+    - delta_text: ']<]'
+    - delta_text: |-
+        minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang:
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.

--- a/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.4.yaml
+++ b/conformance/toolcalling/fixtures/minimax_m3/TOOLCALLING.stream.4.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m3
+model_label: MiniMax M3
+mode: stream
+cases:
+  TOOLCALLING.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from TOOLCALLING.batch.5.a
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+    - delta_text: ''
+      finish_reason: stop
+    tools: &weather_tools
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &weather_call
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &vllm_unavailable
+        unavailable: vLLM Python 0.23.0 in this conformance harness does not include the MiniMax M3 tool parser yet.
+      sglang: &sglang_unavailable
+        unavailable: SGLang 0.5.12.post1 in this conformance harness does not include the MiniMax M3 detector yet.
+  TOOLCALLING.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from TOOLCALLING.batch.5.c
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<tool_call>
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NY
+    - delta_text: ''
+      finish_reason: stop
+    tools: *weather_tools
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable
+  TOOLCALLING.stream.4.c:
+    description: Inner invoke payload without required outer tool_call wrapper, followed by close-marker spam
+    ref: derived from TOOLCALLING.stream.4.c
+    chunks:
+    - delta_text: |-
+        ]<]minimax[>[<invoke name="get_weather">
+        ]<]minimax[>[<location>NYC]<]minimax[>[</location>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</invoke>
+        ]<]minimax[>[</invoke>
+    - delta_text: ''
+      finish_reason: length
+    tools: *weather_tools
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *vllm_unavailable
+      sglang: *sglang_unavailable

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -205,6 +205,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .tt-c6 { color: #22d3ee; }
 .tt-c7 { color: #f87171; }
 .tt-orphan { background: #7f1d1d; color: #fecaca; padding: 0 2px; border-radius: 2px; }
+.tt-ns { color: #6b7280; }  /* MiniMax `]<]minimax[>[` namespace token: muted decoration */
 .tt-h { padding: 0 1px; border-radius: 2px; }
 .tt-h-token { font-weight: 700; }
 .tt-h-start { color: #fbbf24; }

--- a/conformance/utils/src/fixtures.py
+++ b/conformance/utils/src/fixtures.py
@@ -85,6 +85,7 @@ def _build_family_inheritance(
         ("Dsml", None): "dsml/parser.rs",
         ("Glm47", None): "xml/glm47_parser.rs",
         ("KimiK2", None): "xml/kimi_k2_parser.rs",
+        ("MiniMaxM3", None): "xml/minimax_m3_parser.rs",
         ("Gemma4", None): "gemma4/parser.rs",
     }
     base_label = {
@@ -100,6 +101,7 @@ def _build_family_inheritance(
         ("Dsml", None): "dsml::parser (shared via deepseek_dsml() factory)",
         ("Glm47", None): "glm47_parser (standalone; filed under xml/)",
         ("KimiK2", None): "kimi_k2_parser (standalone; filed under xml/)",
+        ("MiniMaxM3", None): "minimax_m3_parser (standalone; filed under xml/)",
         ("Gemma4", None): "gemma4::parser (standalone)",
     }
 

--- a/conformance/utils/src/parser_families.yaml
+++ b/conformance/utils/src/parser_families.yaml
@@ -25,6 +25,7 @@ families:
   kimi_k2:        {vllm_python: kimi_k2,        vllm_rust: kimi_k2,      sglang_python: kimi_k2,     dynamo_v2: null,        preferred_input: text}
   llama3_json:    {vllm_python: llama3_json,    vllm_rust: llama3_json,  sglang_python: llama3,      dynamo_v2: null,        preferred_input: text}
   minimax_m2:     {vllm_python: minimax_m2,     vllm_rust: minimax_m2,   sglang_python: minimax-m2,  dynamo_v2: null,        preferred_input: text}
+  minimax_m3:     {vllm_python: minimax_m3,     vllm_rust: null,         sglang_python: minimax-m3,  dynamo_v2: null,        preferred_input: text}
   mistral:        {vllm_python: mistral,        vllm_rust: mistral,      sglang_python: mistral,     dynamo_v2: null,        preferred_input: text}
   nemotron_deci:  {vllm_python: hermes,         vllm_rust: hermes,       sglang_python: null,        dynamo_v2: null,        preferred_input: text}
   nemotron_nano:  {vllm_python: hermes,         vllm_rust: hermes,       sglang_python: null,        dynamo_v2: null,        preferred_input: text}

--- a/conformance/utils/tests/parity/common.py
+++ b/conformance/utils/tests/parity/common.py
@@ -94,6 +94,7 @@ TOP_N_TOOL_CALLING_FAMILIES = [
     "harmony",
     "kimi_k2",
     "minimax_m2",
+    "minimax_m3",
     "qwen3_coder",
 ]
 
@@ -124,6 +125,7 @@ _FAMILY_TO_VLLM_REASONING = {
     "kimi_k25": "kimi_k2",
     "mistral": "mistral",
     "minimax_append_think": "minimax_m2_append_think",
+    "minimax_m3": "minimax_m3",
     "nemotron_deci": "glm45",
     "qwen3": "qwen3",
 }

--- a/conformance/utils/tests/parity/markup.py
+++ b/conformance/utils/tests/parity/markup.py
@@ -9,10 +9,20 @@ import html as html_lib
 import re
 from typing import Any
 
-# Matches both `<...>` and the Mistral-style `[NAME]`/`[/NAME]` form.
+# MiniMax M3 prefixes every structural tag with the `]<]minimax[>[` namespace
+# special token (tokenizer id 200058), e.g. `]<]minimax[>[<tool_call>`. It must
+# be matched as one whole token *before* the generic `<...>` rule, otherwise the
+# inner `<]minimax[>` is mis-split into a red orphan tag with stray `]`/`[`
+# around it. The token carries no open/close semantics, so it is colored as
+# muted namespace decoration (`tt-ns`) rather than a paired or orphan tag.
+_MINIMAX_NS_TOKEN = "]<]minimax[>["
+_NS_CLASS = "tt-ns"
+
+# Matches the MiniMax namespace token (first, so it wins over `<...>`), then
+# `<...>`, then the Mistral-style `[NAME]`/`[/NAME]` form.
 # Brackets only match ALL-CAPS-underscore names so JSON arrays
 # (e.g. `[{...}]`, `[1, 2]`) don't get false-matched as tags.
-_TAG_RE = re.compile(r"<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
+_TAG_RE = re.compile(r"\]<\]minimax\[>\[|<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
 
 # Two coloring schemes share one cycling palette:
 #   * Paired open/close: every matched pair gets a *fresh* palette index, so
@@ -185,6 +195,10 @@ def _colorize_xml(text: str) -> str:
         if m.start() > last:
             pieces.append(html_lib.escape(text[last : m.start()]))
         tok = m.group(0)
+        if tok == _MINIMAX_NS_TOKEN:
+            pieces.append(f'<span class="{_NS_CLASS}">{html_lib.escape(tok)}</span>')
+            last = m.end()
+            continue
         kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
         esc = html_lib.escape(tok)
         if kind is None:
@@ -253,8 +267,13 @@ def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
     intervals: list[dict[str, Any]] = []
     stack: list[tuple[str, int]] = []
     for match in _TAG_RE.finditer(text):
-        idx = len(intervals)
         tok = match.group(0)
+        if tok == _MINIMAX_NS_TOKEN:
+            intervals.append(
+                {"start": match.start(), "end": match.end(), "class": _NS_CLASS}
+            )
+            continue
+        idx = len(intervals)
         kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
         intervals.append({"start": match.start(), "end": match.end(), "class": None})
         if kind is None:

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -225,6 +225,15 @@ _FAMILY_METADATA = {
         "rust_enum": "ReasoningParserType::MiniMaxAppendThink",
         "implementation": "MiniMaxAppendThinkParser",
     },
+    "minimax_m3": {
+        "models": ["MiniMax M3"],
+        "rust_enum": "ReasoningParserType::MiniMaxM3",
+        "implementation": (
+            "BasicReasoningParser `<mm:think>` / `</mm:think>`, "
+            "dangling-end recovery"
+        ),
+        "aliases": ["minimax-m3"],
+    },
     "gemma4": {
         "models": ["Google Gemma 4 thinking models"],
         "rust_enum": "ReasoningParserType::Gemma4",
@@ -375,6 +384,20 @@ _REASONING_MODE_METADATA = {
         "static": [
             "MiniMaxAppendThinkParser",
             "parser-specific content wrapper behavior",
+        ],
+    },
+    "minimax_m3": {
+        "label": "explicit M3 markers",
+        "control": "frontend-tunable",
+        "summary": (
+            "MiniMax M3 reasoning uses explicit `<mm:think>` markers, with "
+            "dangling-end recovery for prompt-prefilled reasoning starts."
+        ),
+        "static": [
+            "BasicReasoningParser `<mm:think>` / `</mm:think>`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+            "recover_dangling_end=true",
         ],
     },
     "gemma4": {

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -106,6 +106,7 @@ PARSER_TO_REASONING_FAMILY = {
     "harmony": "gpt_oss",
     "kimi_k2": "kimi_k25",
     "minimax_m2": "minimax_append_think",
+    "minimax_m3": "minimax_m3",
     "mistral": "mistral",
     "nemotron_deci": "nemotron_deci",
     "nemotron_nano": "deepseek_r1",

--- a/conformance/utils/tests/parity/toolcalling/sglang.py
+++ b/conformance/utils/tests/parity/toolcalling/sglang.py
@@ -39,6 +39,12 @@ from sglang.srt.function_call.llama32_detector import (
 from sglang.srt.function_call.minimax_m2 import (
     MinimaxM2Detector,  # type: ignore[import-untyped]
 )
+try:
+    from sglang.srt.function_call.minimax_m3 import (
+        MinimaxM3Detector,  # type: ignore[import-untyped]
+    )
+except ImportError:  # SGLang 0.5.12.post1 lacks this detector.
+    MinimaxM3Detector = None  # type: ignore[assignment]
 from sglang.srt.function_call.mistral_detector import (
     MistralDetector,  # type: ignore[import-untyped]
 )
@@ -68,6 +74,7 @@ _FAMILY_TO_SGLANG_DETECTOR = {
     "harmony": GptOssDetector,
     "llama3_json": Llama32Detector,
     "minimax_m2": MinimaxM2Detector,
+    "minimax_m3": MinimaxM3Detector,
     "pythonic": PythonicDetector,
     "hermes": HermesDetector,
     "mistral": MistralDetector,

--- a/conformance/utils/tests/parity/toolcalling/table.py
+++ b/conformance/utils/tests/parity/toolcalling/table.py
@@ -197,6 +197,7 @@ def _build_family_inheritance(
         ("Dsml", None): "dsml/parser.rs",
         ("Glm47", None): "xml/glm47_parser.rs",
         ("KimiK2", None): "xml/kimi_k2_parser.rs",
+        ("MiniMaxM3", None): "xml/minimax_m3_parser.rs",
         ("Gemma4", None): "gemma4/parser.rs",
     }
     base_label = {
@@ -212,6 +213,7 @@ def _build_family_inheritance(
         ("Dsml", None): "dsml::parser (shared via deepseek_dsml() factory)",
         ("Glm47", None): "glm47_parser (standalone; filed under xml/)",
         ("KimiK2", None): "kimi_k2_parser (standalone; filed under xml/)",
+        ("MiniMaxM3", None): "minimax_m3_parser (standalone; filed under xml/)",
         ("Gemma4", None): "gemma4::parser (standalone)",
     }
 

--- a/conformance/utils/tests/parity/toolcalling/vllm.py
+++ b/conformance/utils/tests/parity/toolcalling/vllm.py
@@ -224,6 +224,7 @@ _FAMILY_TO_VLLM_KEY = {
     "kimi_k2": "kimi_k2",
     "qwen3_coder": "qwen3_coder",
     "minimax_m2": "minimax_m2",
+    "minimax_m3": "minimax_m3",
     "glm47": "glm47",
     "deepseek_v3_1": "deepseek_v31",
     "deepseek_v3": "deepseek_v3",

--- a/parsers/src/reasoning/base_parser.rs
+++ b/parsers/src/reasoning/base_parser.rs
@@ -61,6 +61,15 @@ pub struct BasicReasoningParser {
     stream_reasoning: bool,
     _buffer: String,
     stripped_think_start: bool,
+    /// When true, a close marker seen in the streaming "not in reasoning" branch
+    /// without a visible opener triggers dangling-end recovery: the text before
+    /// the marker is emitted as reasoning rather than stripped to normal text.
+    /// Models whose chat template pre-fills the opening reasoning marker (e.g.
+    /// MiniMax M3's `<mm:think>`) need this so the prefix is not misclassified
+    /// when `set_in_reasoning` was not called. The batch path recovers dangling
+    /// ends for every delimiter pair already; this flag only gates the
+    /// streaming path so existing `<think>` stray-close stripping is preserved.
+    recover_dangling_end: bool,
     /// Optional marker that force-exits reasoning mode when encountered inside a
     /// reasoning block (e.g. Kimi-K2/K2.5 models sometimes emit
     /// `<|tool_calls_section_begin|>` without first closing `</think>`).
@@ -81,6 +90,7 @@ impl BasicReasoningParser {
             stream_reasoning,
             _buffer: String::new(),
             stripped_think_start: false,
+            recover_dangling_end: false,
             tool_start_token: None,
         }
     }
@@ -89,6 +99,13 @@ impl BasicReasoningParser {
     /// block.
     pub fn with_tool_start_token(mut self, token: impl Into<String>) -> Self {
         self.tool_start_token = Some(token.into());
+        self
+    }
+
+    /// Enables streaming dangling-end recovery: a close marker without a visible
+    /// opener routes the preceding text to reasoning instead of normal text.
+    pub fn with_dangling_end_recovery(mut self) -> Self {
+        self.recover_dangling_end = true;
         self
     }
 }
@@ -357,63 +374,68 @@ impl ReasoningParser for BasicReasoningParser {
                     break;
                 }
             } else {
-                // Not in reasoning. Look for the next <think> block, but also detect
-                // a stray </think> (unmatched close marker) and drop it: parser-owned
-                // syntax must never reach normal_text per the lossless-split contract.
+                // Not in reasoning. Look for the next open marker, but also
+                // handle close markers that appear without a visible opener.
                 let think_pos = current_text.find(self.think_start_token.as_str());
-                let stray_close_pos = current_text.find(self.think_end_token.as_str());
-                match (think_pos, stray_close_pos) {
-                    (Some(s), Some(e)) if s <= e => {
+                let end_pos = current_text.find(self.think_end_token.as_str());
+
+                if let Some(start_pos) = think_pos {
+                    let start_before_end = match end_pos {
+                        Some(end_pos) => start_pos <= end_pos,
+                        None => true,
+                    };
+                    if start_before_end {
                         // <think> arrives first → enter reasoning.
-                        accumulated_normal.push_str(&current_text[..s]);
-                        let after_start = s + self.think_start_token.len();
+                        accumulated_normal.push_str(&current_text[..start_pos]);
+                        let after_start = start_pos + self.think_start_token.len();
                         self._buffer = current_text[after_start..].to_string();
                         self._in_reasoning = true;
                         self.stripped_think_start = true;
                         continue;
-                    }
-                    (Some(s), None) => {
-                        // Only <think> remains; enter reasoning.
-                        accumulated_normal.push_str(&current_text[..s]);
-                        let after_start = s + self.think_start_token.len();
-                        self._buffer = current_text[after_start..].to_string();
-                        self._in_reasoning = true;
-                        self.stripped_think_start = true;
-                        continue;
-                    }
-                    (_, Some(e)) => {
-                        // Stray </think> arrives before the next <think> (or with no
-                        // opener remaining). Drop the marker, keep the text on either
-                        // side, stay in normal mode. Mirrors the batch path so a
-                        // pattern like `<o>A</c>B</c>C<o>D</c>E` does not leak the
-                        // middle stray close even when a later opener is in buffer.
-                        accumulated_normal.push_str(&current_text[..e]);
-                        let after_end = e + self.think_end_token.len();
-                        self._buffer = current_text[after_end..].to_string();
-                        continue;
-                    }
-                    (None, None) => {
-                        // No complete marker — check for partial at end of buffer.
-                        // The partial could be a prefix of either <think> or </think>
-                        // (both start with `<`), so check both and use the wider overlap.
-                        // Require overlap >= 2 so a lone `<` passes through for tool call
-                        // XML tags like `<invoke>` or `<minimax:tool_call>`.
-                        let ol_start = overlap(&current_text, &self.think_start_token);
-                        let ol_end = overlap(&current_text, &self.think_end_token);
-                        let ol = ol_start.max(ol_end);
-                        if ol >= 2 {
-                            let safe_end = current_text.len() - ol;
-                            if safe_end > 0 {
-                                accumulated_normal.push_str(&current_text[..safe_end]);
-                            }
-                            self._buffer = current_text[safe_end..].to_string();
-                        } else {
-                            accumulated_normal.push_str(&current_text);
-                            self._buffer.clear();
-                        }
-                        break;
                     }
                 }
+
+                if let Some(end_pos) = end_pos {
+                    // A close marker with no preceding opener. With dangling-end
+                    // recovery the prefix is reasoning (the opener was implicit,
+                    // e.g. a prompt-prefilled `<mm:think>`); otherwise drop the
+                    // marker and keep the surrounding text as normal so a stray
+                    // `</think>` between two spans does not leak.
+                    if self.recover_dangling_end {
+                        accumulated_reasoning.push_str(&current_text[..end_pos]);
+                    } else {
+                        accumulated_normal.push_str(&current_text[..end_pos]);
+                    }
+                    let after_end = end_pos + self.think_end_token.len();
+                    self._buffer = current_text[after_end..].to_string();
+                    self._in_reasoning = false;
+                    self.stripped_think_start = false;
+                    continue;
+                }
+
+                // No complete marker — check for partial at end of buffer.
+                // The partial could be a prefix of either <think> or </think>
+                // (both start with `<`), so check both and use the wider overlap.
+                // Require overlap >= 2 so a lone `<` passes through for tool call
+                // XML tags like `<invoke>` or `<minimax:tool_call>`.
+                let ol_start = overlap(&current_text, &self.think_start_token);
+                let ol_end = overlap(&current_text, &self.think_end_token);
+                let ol = ol_start.max(ol_end);
+                if ol >= 2 {
+                    let safe_end = current_text.len() - ol;
+                    if safe_end > 0 {
+                        if self.recover_dangling_end && ol_end > ol_start {
+                            accumulated_reasoning.push_str(&current_text[..safe_end]);
+                        } else {
+                            accumulated_normal.push_str(&current_text[..safe_end]);
+                        }
+                    }
+                    self._buffer = current_text[safe_end..].to_string();
+                } else {
+                    accumulated_normal.push_str(&current_text);
+                    self._buffer.clear();
+                }
+                break;
             }
         }
 

--- a/parsers/src/reasoning/mod.rs
+++ b/parsers/src/reasoning/mod.rs
@@ -69,6 +69,11 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
             "minimax_append_think",
             ReasoningParserType::MiniMaxAppendThink,
         );
+        // MiniMax M3 thinking blocks use `<mm:think>...</mm:think>`. The chat
+        // template pre-fills the opener, so the completion typically emits only
+        // the closing marker; dangling-end recovery handles that.
+        map.insert("minimax_m3", ReasoningParserType::MiniMaxM3);
+        map.insert("minimax-m3", ReasoningParserType::MiniMaxM3);
         // Gemma 4 thinking models: reasoning is wrapped in `<|channel>...<channel|>`
         // with a `thought\n` role label that this parser strips. Pair with
         // `--dyn-tool-call-parser gemma4` for end-to-end Gemma 4 support.
@@ -167,6 +172,9 @@ pub enum ReasoningParserType {
     Mistral,
     Granite,
     MiniMaxAppendThink,
+    /// MiniMax M3 thinking models. `<mm:think>...</mm:think>` delimiters with
+    /// streaming dangling-end recovery (the chat template pre-fills the opener).
+    MiniMaxM3,
     /// Google Gemma 4 thinking models. Custom `<|channel>...<channel|>`
     /// delimiters with a `thought\n` role-label prefix stripped by the parser.
     Gemma4,
@@ -274,6 +282,17 @@ impl ReasoningParserType {
             ReasoningParserType::MiniMaxAppendThink => ReasoningParserWrapper {
                 parser: Box::new(MiniMaxAppendThinkParser::new()),
             },
+            ReasoningParserType::MiniMaxM3 => ReasoningParserWrapper {
+                parser: Box::new(
+                    BasicReasoningParser::new(
+                        "<mm:think>".into(),
+                        "</mm:think>".into(),
+                        false,
+                        true,
+                    )
+                    .with_dangling_end_recovery(),
+                ),
+            },
             ReasoningParserType::Gemma4 => ReasoningParserWrapper {
                 parser: Box::new(Gemma4ReasoningParser::new()),
             },
@@ -330,12 +349,86 @@ mod tests {
             "nemotron_v3",
             "glm45",
             "minimax_append_think",
+            "minimax_m3",
+            "minimax-m3",
             "gemma4",
             "gemma-4",
         ];
         for parser in available_parsers {
             assert!(parsers.contains(&parser));
         }
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_detect_and_parse() {
+        for parser_name in ["minimax_m3", "minimax-m3"] {
+            let mut parser = ReasoningParserType::get_reasoning_parser_from_name(parser_name);
+            let result =
+                parser.detect_and_parse_reasoning("<mm:think>thinking</mm:think>answer", &[]);
+            assert_eq!(result.reasoning_text, "thinking");
+            assert_eq!(result.normal_text, "answer");
+        }
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+
+        let r1 = parser.parse_reasoning_streaming_incremental("<mm:think>rea", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("son</mm:think>answer", &[]);
+
+        assert_eq!(
+            format!("{}{}", r1.reasoning_text, r2.reasoning_text),
+            "reason"
+        );
+        assert_eq!(format!("{}{}", r1.normal_text, r2.normal_text), "answer");
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming_with_prompt_prefilled_start_marker() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+        parser.set_in_reasoning(true);
+
+        let result = parser.parse_reasoning_streaming_incremental("reason</mm:think>answer", &[]);
+
+        assert_eq!(result.reasoning_text, "reason");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_detect_and_parse_dangling_end_marker() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+        let result = parser.detect_and_parse_reasoning("reason</mm:think>answer", &[]);
+
+        assert_eq!(result.reasoning_text, "reason");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming_dangling_end_marker() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+
+        let r1 = parser.parse_reasoning_streaming_incremental("reason</mm:", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("think>answer", &[]);
+
+        assert_eq!(
+            format!("{}{}", r1.reasoning_text, r2.reasoning_text),
+            "reason"
+        );
+        assert_eq!(format!("{}{}", r1.normal_text, r2.normal_text), "answer");
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming_close_marker_only_is_stripped() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+
+        let result = parser.parse_reasoning_streaming_incremental(
+            "</mm:think>I'll check the content of both files.",
+            &[],
+        );
+
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "I'll check the content of both files.");
     }
 
     #[test] // REASONING.batch.2.c

--- a/parsers/src/reasoning/mod.rs
+++ b/parsers/src/reasoning/mod.rs
@@ -431,6 +431,53 @@ mod tests {
         assert_eq!(result.normal_text, "I'll check the content of both files.");
     }
 
+    #[test] // MiniMax M3
+    fn test_minimax_m3_detect_and_parse_multiple_spans() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+        let result = parser.detect_and_parse_reasoning(
+            "<mm:think>first</mm:think> middle <mm:think>second</mm:think> done",
+            &[],
+        );
+
+        assert_eq!(result.reasoning_text, "firstsecond");
+        assert_eq!(result.normal_text, "middle  done");
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming_prompt_prefilled_close_after_complete_span() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+
+        let r1 = parser.parse_reasoning_streaming_incremental("<mm:think>preamble</mm:think>", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("body</mm:think>", &[]);
+        let r3 = parser.parse_reasoning_streaming_incremental("answer", &[]);
+
+        assert_eq!(
+            format!(
+                "{}{}{}",
+                r1.reasoning_text, r2.reasoning_text, r3.reasoning_text
+            ),
+            "preamblebody"
+        );
+        assert_eq!(
+            format!("{}{}{}", r1.normal_text, r2.normal_text, r3.normal_text),
+            "answer"
+        );
+    }
+
+    #[test] // MiniMax M3
+    fn test_minimax_m3_streaming_partial_start_prefix_becomes_normal_text() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m3");
+
+        let r1 = parser.parse_reasoning_streaming_incremental("plain <mm:th", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("esis answer", &[]);
+
+        assert_eq!(format!("{}{}", r1.reasoning_text, r2.reasoning_text), "");
+        assert_eq!(
+            format!("{}{}", r1.normal_text, r2.normal_text),
+            "plain <mm:thesis answer"
+        );
+    }
+
     #[test] // REASONING.batch.2.c
     fn test_deepseek_v4_detect_and_parse() {
         for parser_name in ["deepseek_v4", "deepseek-v4", "deepseekv4"] {

--- a/parsers/src/tool_calling/config.rs
+++ b/parsers/src/tool_calling/config.rs
@@ -308,6 +308,37 @@ impl Default for KimiK2ParserConfig {
     }
 }
 
+/// Configuration for MiniMax M3 namespace-token XML tool calls.
+///
+/// Format:
+/// ```text
+/// ]<]minimax[>[<tool_call>
+/// ]<]minimax[>[<invoke name="function_name">]<]minimax[>[<param>value]<]minimax[>[</param>]<]minimax[>[</invoke>
+/// ]<]minimax[>[</tool_call>
+/// ```
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct MiniMaxM3ParserConfig {
+    /// Namespace token emitted before each XML-ish tag.
+    pub namespace_token: String,
+    /// Tool-call block tag name.
+    pub tool_call_tag: String,
+
+    /// See [`JsonParserConfig::allow_eof_recovery`]. Streaming jails MUST
+    /// leave this `false`.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
+}
+
+impl Default for MiniMaxM3ParserConfig {
+    fn default() -> Self {
+        Self {
+            namespace_token: "]<]minimax[>[".to_string(),
+            tool_call_tag: "tool_call".to_string(),
+            allow_eof_recovery: false,
+        }
+    }
+}
+
 /// Parser-specific configuration
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -320,6 +351,7 @@ pub enum ParserConfig {
     Dsml(DsmlParserConfig),
     KimiK2(KimiK2ParserConfig),
     Glm47(Glm47ParserConfig),
+    MiniMaxM3(MiniMaxM3ParserConfig),
     /// Gemma 4 uses a custom non-JSON grammar with bare keys, `<|"|>` string
     /// delimiters, and fixed `<|tool_call>...<tool_call|>` markers. No
     /// configuration is required at runtime — markers are not user-tunable.
@@ -354,6 +386,12 @@ impl ParserConfig {
                 tokens.push(config.call_start.clone());
                 tokens
             }
+            ParserConfig::MiniMaxM3(config) => {
+                vec![format!(
+                    "{}<{}>",
+                    config.namespace_token, config.tool_call_tag
+                )]
+            }
             ParserConfig::Gemma4 => {
                 vec![crate::tool_calling::gemma4::TOOL_CALL_START.to_string()]
             }
@@ -372,6 +410,12 @@ impl ParserConfig {
             ParserConfig::Dsml(config) => vec![config.block_end.clone()],
             ParserConfig::Glm47(config) => vec![config.tool_call_end.clone()],
             ParserConfig::KimiK2(config) => config.section_end_variants.clone(),
+            ParserConfig::MiniMaxM3(config) => {
+                vec![format!(
+                    "{}</{}>",
+                    config.namespace_token, config.tool_call_tag
+                )]
+            }
             ParserConfig::Gemma4 => vec![crate::tool_calling::gemma4::TOOL_CALL_END.to_string()],
         }
     }
@@ -684,6 +728,19 @@ impl ToolCallConfig {
                 passthrough_when_no_function: false,
                 backoff_when_no_wrapper: true,
             }),
+            structural_tag_builder: None,
+        }
+    }
+
+    pub fn minimax_m3() -> Self {
+        // MiniMax-M3 format:
+        // ]<]minimax[>[<tool_call>
+        // ]<]minimax[>[<invoke name="function_name">]<]minimax[>[<param>value]<]minimax[>[</param>]<]minimax[>[</invoke>
+        // ]<]minimax[>[</tool_call>
+        // This differs from MiniMax-M2: parameter names are tag names, and the
+        // MiniMax namespace token is emitted before every tag.
+        Self {
+            parser_config: ParserConfig::MiniMaxM3(MiniMaxM3ParserConfig::default()),
             structural_tag_builder: None,
         }
     }

--- a/parsers/src/tool_calling/mod.rs
+++ b/parsers/src/tool_calling/mod.rs
@@ -36,7 +36,8 @@ pub enum ToolChoice {
 
 // Re-export main types and functions for convenience
 pub use config::{
-    JsonParserConfig, KimiK2ParserConfig, ParserConfig, ToolCallConfig, XmlParserConfig,
+    JsonParserConfig, KimiK2ParserConfig, MiniMaxM3ParserConfig, ParserConfig, ToolCallConfig,
+    XmlParserConfig,
 };
 pub use dsml::try_tool_call_parse_dsml;
 pub use gemma4::try_tool_call_parse_gemma4;

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -56,6 +56,9 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("minimax_m2", ToolCallConfig::minimax_m2());
         map.insert("minimax_m3", ToolCallConfig::minimax_m3());
         map.insert("minimax-m3", ToolCallConfig::minimax_m3());
+        // `_nom` is a legacy Day-0 deployment parser-name alias used by
+        // earlier MiniMax M3 Dynamo manifests; public MiniMax M3 artifacts
+        // define one tool-call grammar, so behavior is intentionally identical.
         map.insert("minimax_m3_nom", ToolCallConfig::minimax_m3());
         map.insert("minimax-m3-nom", ToolCallConfig::minimax_m3());
         map.insert("glm47", ToolCallConfig::glm47());
@@ -3679,5 +3682,24 @@ weather forecasting
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_weather");
         assert_eq!(args["city"], "Seattle");
+    }
+
+    #[tokio::test]
+    async fn test_minimax_m3_recovers_bare_invoke_without_outer_tool_call() {
+        let input = r#"prefix ]<]minimax[>[<invoke name="get_weather">
+]<]minimax[>[<location>NYC]<]minimax[>[</location>
+]<]minimax[>[</invoke>
+]<]minimax[>[</invoke>"#;
+
+        let (result, content) =
+            detect_and_parse_tool_call_with_recovery(input, Some("minimax-m3"), None)
+                .await
+                .unwrap();
+
+        assert_eq!(content, Some("prefix".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
     }
 }

--- a/parsers/src/tool_calling/parsers.rs
+++ b/parsers/src/tool_calling/parsers.rs
@@ -22,9 +22,11 @@ use super::pythonic::{
 };
 use super::response::ToolCallResponse;
 use super::xml::{
-    detect_tool_call_start_glm47, detect_tool_call_start_kimi_k2, detect_tool_call_start_xml,
+    detect_tool_call_start_glm47, detect_tool_call_start_kimi_k2,
+    detect_tool_call_start_minimax_m3, detect_tool_call_start_xml,
     find_tool_call_end_position_glm47, find_tool_call_end_position_kimi_k2,
-    find_tool_call_end_position_xml, try_tool_call_parse_glm47, try_tool_call_parse_kimi_k2,
+    find_tool_call_end_position_minimax_m3, find_tool_call_end_position_xml,
+    try_tool_call_parse_glm47, try_tool_call_parse_kimi_k2, try_tool_call_parse_minimax_m3,
     try_tool_call_parse_xml,
 };
 use std::collections::HashMap;
@@ -52,6 +54,10 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("qwen3_coder", ToolCallConfig::qwen3_coder());
         map.insert("jamba", ToolCallConfig::jamba());
         map.insert("minimax_m2", ToolCallConfig::minimax_m2());
+        map.insert("minimax_m3", ToolCallConfig::minimax_m3());
+        map.insert("minimax-m3", ToolCallConfig::minimax_m3());
+        map.insert("minimax_m3_nom", ToolCallConfig::minimax_m3());
+        map.insert("minimax-m3-nom", ToolCallConfig::minimax_m3());
         map.insert("glm47", ToolCallConfig::glm47());
         map.insert("kimi_k2", ToolCallConfig::kimi_k2());
         map.insert("gemma4", ToolCallConfig::gemma4());
@@ -106,6 +112,11 @@ pub async fn try_tool_call_parse(
         ParserConfig::KimiK2(kimi_config) => {
             let (results, normal_content) =
                 try_tool_call_parse_kimi_k2(message, kimi_config, tools)?;
+            Ok((results, normal_content))
+        }
+        ParserConfig::MiniMaxM3(minimax_config) => {
+            let (results, normal_content) =
+                try_tool_call_parse_minimax_m3(message, minimax_config, tools)?;
             Ok((results, normal_content))
         }
         ParserConfig::Gemma4 => {
@@ -163,6 +174,11 @@ pub async fn detect_and_parse_tool_call_with_recovery(
             let mut c = c.clone();
             c.allow_eof_recovery = true;
             ParserConfig::Dsml(c)
+        }
+        ParserConfig::MiniMaxM3(c) => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::MiniMaxM3(c)
         }
         // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
         // (drop the call when </tool_call> is missing).
@@ -260,6 +276,9 @@ pub fn detect_tool_call_start(chunk: &str, parser_str: Option<&str>) -> anyhow::
             }
             ParserConfig::KimiK2(kimi_config) => {
                 Ok(detect_tool_call_start_kimi_k2(chunk, kimi_config))
+            }
+            ParserConfig::MiniMaxM3(minimax_config) => {
+                Ok(detect_tool_call_start_minimax_m3(chunk, minimax_config))
             }
             ParserConfig::Gemma4 => Ok(detect_tool_call_start_gemma4(chunk)),
         },
@@ -372,6 +391,9 @@ pub fn find_tool_call_end_position(chunk: &str, parser_str: Option<&str>) -> Opt
             ParserConfig::KimiK2(kimi_config) => {
                 find_tool_call_end_position_kimi_k2(chunk, kimi_config)
             }
+            ParserConfig::MiniMaxM3(minimax_config) => Some(
+                find_tool_call_end_position_minimax_m3(chunk, minimax_config),
+            ),
             ParserConfig::Gemma4 => find_tool_call_end_position_gemma4(chunk),
         },
         None => Some(chunk.len()),
@@ -413,6 +435,10 @@ mod tests {
             "jamba",
             "nemotron_nano",
             "minimax_m2",
+            "minimax_m3",
+            "minimax-m3",
+            "minimax_m3_nom",
+            "minimax-m3-nom",
             "glm47",
             "kimi_k2",
             "gemma4",
@@ -3620,5 +3646,38 @@ weather forecasting
         assert_eq!(name, "batch_process");
         assert!(args["items"].is_array());
         assert_eq!(args["items"], serde_json::json!([1, 2, 3, 4, 5]));
+    }
+
+    #[tokio::test]
+    async fn test_minimax_m3_simple_tool_call() {
+        let input = r#"I'll check. ]<]minimax[>[<tool_call>
+]<]minimax[>[<invoke name="get_weather">]<]minimax[>[<location>San Francisco]<]minimax[>[</location>]<]minimax[>[<unit>celsius]<]minimax[>[</unit>]<]minimax[>[</invoke>
+]<]minimax[>[</tool_call> trailing text"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("minimax_m3"), None)
+            .await
+            .unwrap();
+        assert_eq!(content, Some("I'll check. ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "San Francisco");
+        assert_eq!(args["unit"], "celsius");
+    }
+
+    #[tokio::test]
+    async fn test_minimax_m3_stream_finalize_recovers_complete_invoke_without_outer_close() {
+        let input = r#"prefix ]<]minimax[>[<tool_call>
+]<]minimax[>[<invoke name="get_weather">]<]minimax[>[<city>Seattle]<]minimax[>[</city>]<]minimax[>[</invoke>"#;
+
+        let (result, content) =
+            detect_and_parse_tool_call_with_recovery(input, Some("minimax-m3"), None)
+                .await
+                .unwrap();
+
+        assert_eq!(content, Some("prefix ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["city"], "Seattle");
     }
 }

--- a/parsers/src/tool_calling/xml/minimax_m3_parser.rs
+++ b/parsers/src/tool_calling/xml/minimax_m3_parser.rs
@@ -199,7 +199,7 @@ fn parse_parameters(
         let value_end = value_start + value_end_rel;
         let raw_value = &body[value_start..value_end];
         let schema = param_config.get(parameter_name);
-        let value = parse_parameter_value(raw_value, schema);
+        let value = parse_parameter_value(raw_value, schema, config);
         insert_parameter(&mut parameters, parameter_name.to_string(), value);
 
         cursor = value_end + parameter_end.len();
@@ -225,17 +225,25 @@ fn insert_parameter(parameters: &mut Map<String, Value>, key: String, value: Val
 }
 
 // Chooses scalar conversion or nested XML parsing based on whether the value contains M3 tags.
-fn parse_parameter_value(raw: &str, schema: Option<&Value>) -> Value {
-    if raw.contains("]<]minimax[>[<") {
-        parse_nested_minimax_xml(raw, schema.cloned())
+fn parse_parameter_value(
+    raw: &str,
+    schema: Option<&Value>,
+    config: &MiniMaxM3ParserConfig,
+) -> Value {
+    if raw.contains(parameter_start(config).as_str()) {
+        parse_nested_minimax_xml(raw, schema.cloned(), config)
     } else {
         convert_scalar_value(raw, schema)
     }
 }
 
 // Parses nested parameter bodies such as arrays of `<item>` objects into JSON values.
-fn parse_nested_minimax_xml(raw: &str, schema: Option<Value>) -> Value {
-    let chunks: Vec<&str> = raw.split("]<]minimax[>[").collect();
+fn parse_nested_minimax_xml(
+    raw: &str,
+    schema: Option<Value>,
+    config: &MiniMaxM3ParserConfig,
+) -> Value {
+    let chunks: Vec<&str> = raw.split(config.namespace_token.as_str()).collect();
     let leading_text = chunks.first().copied().unwrap_or_default();
     let root_value = if schema_has_type(schema.as_ref(), "array")
         && chunks

--- a/parsers/src/tool_calling/xml/minimax_m3_parser.rs
+++ b/parsers/src/tool_calling/xml/minimax_m3_parser.rs
@@ -1,0 +1,605 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::{Map, Number, Value};
+use uuid::Uuid;
+
+use super::super::ToolDefinition;
+use super::super::config::MiniMaxM3ParserConfig;
+use super::parsed_value::{coerce_integer_literal, raw_number_literal};
+use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
+
+const MIN_PARTIAL_TOOL_CALL_START_LEN: usize = 3;
+
+// Used by the streaming jail to detect a complete or split MiniMax M3 tool-call opener.
+pub fn detect_tool_call_start_minimax_m3(chunk: &str, config: &MiniMaxM3ParserConfig) -> bool {
+    let tool_call_start = tool_call_start(config);
+
+    if chunk.contains(tool_call_start.as_str()) {
+        return true;
+    }
+
+    for (i, _) in tool_call_start.char_indices().skip(1) {
+        if i < MIN_PARTIAL_TOOL_CALL_START_LEN {
+            continue;
+        }
+        if chunk.ends_with(&tool_call_start[..i]) {
+            return true;
+        }
+    }
+
+    false
+}
+
+// Used by streaming jail to split the completed tool-call block from trailing content.
+pub fn find_tool_call_end_position_minimax_m3(
+    chunk: &str,
+    config: &MiniMaxM3ParserConfig,
+) -> usize {
+    let tool_call_end = tool_call_end(config);
+    chunk
+        .find(tool_call_end.as_str())
+        .map(|pos| pos + tool_call_end.len())
+        .unwrap_or(chunk.len())
+}
+
+// Main entry point: strips normal prefix text and turns M3 tool markup into tool-call responses.
+pub fn try_tool_call_parse_minimax_m3(
+    message: &str,
+    config: &MiniMaxM3ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let Some(start_pos) = message.find(tool_call_start(config).as_str()) else {
+        return Ok((vec![], Some(message.to_string())));
+    };
+
+    let prefix = message[..start_pos].to_string();
+    let block_start = start_pos + tool_call_start(config).len();
+    let tool_call_end = tool_call_end(config);
+    let (block, complete) =
+        if let Some(end_rel) = message[block_start..].find(tool_call_end.as_str()) {
+            let block_end = block_start + end_rel;
+            (&message[block_start..block_end], true)
+        } else {
+            (&message[block_start..], false)
+        };
+
+    if !complete && !config.allow_eof_recovery {
+        return Ok((vec![], Some(prefix)));
+    }
+
+    let calls = parse_invokes(block, config, tools)?;
+    Ok((calls, Some(prefix)))
+}
+
+// Builds the configured outer tool-call start marker.
+fn tool_call_start(config: &MiniMaxM3ParserConfig) -> String {
+    format!("{}<{}>", config.namespace_token, config.tool_call_tag)
+}
+
+// Builds the configured outer tool-call end marker.
+fn tool_call_end(config: &MiniMaxM3ParserConfig) -> String {
+    format!("{}</{}>", config.namespace_token, config.tool_call_tag)
+}
+
+// Builds the marker that introduces an individual function invocation before attributes.
+fn invoke_start(config: &MiniMaxM3ParserConfig) -> String {
+    format!("{}<invoke", config.namespace_token)
+}
+
+// Builds the marker that closes an individual function invocation.
+fn invoke_end(config: &MiniMaxM3ParserConfig) -> String {
+    format!("{}</invoke>", config.namespace_token)
+}
+
+// Builds the shared namespace prefix that starts any M3 XML-ish tag.
+fn parameter_start(config: &MiniMaxM3ParserConfig) -> String {
+    format!("{}<", config.namespace_token)
+}
+
+// Extracts one or more `<invoke name="...">` blocks from the outer tool-call block.
+fn parse_invokes(
+    block: &str,
+    config: &MiniMaxM3ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Vec<ToolCallResponse>> {
+    let invoke_start = invoke_start(config);
+    let invoke_end = invoke_end(config);
+    let mut calls = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(start_rel) = block[cursor..].find(invoke_start.as_str()) {
+        let tag_attrs_start = cursor + start_rel + invoke_start.len();
+        let Some(tag_end_rel) = block[tag_attrs_start..].find('>') else {
+            break;
+        };
+        let tag_attrs = &block[tag_attrs_start..tag_attrs_start + tag_end_rel];
+        let function_name = parse_invoke_name(tag_attrs);
+        let body_start = tag_attrs_start + tag_end_rel + 1;
+        let Some(body_end_rel) = block[body_start..].find(invoke_end.as_str()) else {
+            break;
+        };
+        let body_end = body_start + body_end_rel;
+        let function_body = &block[body_start..body_end];
+
+        if let Some(function_name) = function_name
+            && !function_name.is_empty()
+        {
+            let arguments = parse_parameters(&function_name, function_body, config, tools)?;
+            calls.push(ToolCallResponse {
+                id: format!("call-{}", Uuid::new_v4()),
+                tp: ToolCallType::Function,
+                function: CalledFunction {
+                    name: function_name,
+                    arguments: serde_json::to_string(&Value::Object(arguments))?,
+                },
+            });
+        }
+
+        cursor = body_end + invoke_end.len();
+    }
+
+    Ok(calls)
+}
+
+// Reads the `name` attribute from `<invoke ...>` using vLLM-compatible quoting variants.
+fn parse_invoke_name(tag_attrs: &str) -> Option<String> {
+    let attrs = tag_attrs.trim_start();
+    let after_name = attrs.strip_prefix("name")?.trim_start();
+    let value = after_name.strip_prefix('=')?.trim_start();
+
+    if let Some(value) = value.strip_prefix('"') {
+        return value.find('"').map(|end| value[..end].trim().to_string());
+    }
+    if let Some(value) = value.strip_prefix('\'') {
+        return value.find('\'').map(|end| value[..end].trim().to_string());
+    }
+
+    let end = value.find(char::is_whitespace).unwrap_or(value.len());
+    if end == 0 {
+        None
+    } else {
+        Some(value[..end].trim().to_string())
+    }
+}
+
+// Extracts MiniMax M3 parameter tags, where each parameter name is the tag name itself.
+fn parse_parameters(
+    function_name: &str,
+    body: &str,
+    config: &MiniMaxM3ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Map<String, Value>> {
+    let parameter_start = parameter_start(config);
+    let param_config = get_arguments_config(function_name, tools);
+    let mut parameters = Map::new();
+    let mut cursor = 0;
+
+    while let Some(start_rel) = body[cursor..].find(parameter_start.as_str()) {
+        let start = cursor + start_rel + parameter_start.len();
+        if body[start..].starts_with('/') {
+            cursor = start + 1;
+            continue;
+        }
+
+        let Some(name_end_rel) = body[start..].find('>') else {
+            break;
+        };
+        let parameter_name = &body[start..start + name_end_rel];
+        if parameter_name.is_empty() || parameter_name.contains(char::is_whitespace) {
+            cursor = start + name_end_rel + 1;
+            continue;
+        }
+
+        let value_start = start + name_end_rel + 1;
+        let parameter_end = format!("{}</{}>", config.namespace_token, parameter_name);
+        let Some(value_end_rel) = body[value_start..].find(parameter_end.as_str()) else {
+            break;
+        };
+        let value_end = value_start + value_end_rel;
+        let raw_value = &body[value_start..value_end];
+        let schema = param_config.get(parameter_name);
+        let value = parse_parameter_value(raw_value, schema);
+        insert_parameter(&mut parameters, parameter_name.to_string(), value);
+
+        cursor = value_end + parameter_end.len();
+    }
+
+    Ok(parameters)
+}
+
+// Preserves duplicate XML tags by collecting repeated values into arrays.
+fn insert_parameter(parameters: &mut Map<String, Value>, key: String, value: Value) {
+    if let Some(existing) = parameters.remove(&key) {
+        let merged = match existing {
+            Value::Array(mut values) => {
+                values.push(value);
+                Value::Array(values)
+            }
+            existing => Value::Array(vec![existing, value]),
+        };
+        parameters.insert(key, merged);
+    } else {
+        parameters.insert(key, value);
+    }
+}
+
+// Chooses scalar conversion or nested XML parsing based on whether the value contains M3 tags.
+fn parse_parameter_value(raw: &str, schema: Option<&Value>) -> Value {
+    if raw.contains("]<]minimax[>[<") {
+        parse_nested_minimax_xml(raw, schema.cloned())
+    } else {
+        convert_scalar_value(raw, schema)
+    }
+}
+
+// Parses nested parameter bodies such as arrays of `<item>` objects into JSON values.
+fn parse_nested_minimax_xml(raw: &str, schema: Option<Value>) -> Value {
+    let chunks: Vec<&str> = raw.split("]<]minimax[>[").collect();
+    let leading_text = chunks.first().copied().unwrap_or_default();
+    let root_value = if schema_has_type(schema.as_ref(), "array")
+        && chunks
+            .get(1)
+            .is_some_and(|chunk| chunk.starts_with("<item>"))
+    {
+        Some(StackValue::Array(Vec::new()))
+    } else {
+        Some(StackValue::Object(Map::new()))
+    };
+    let mut stack = vec![StackItem {
+        tag: None,
+        value: root_value,
+        texts: if leading_text.is_empty() {
+            Vec::new()
+        } else {
+            vec![leading_text.to_string()]
+        },
+        schema,
+    }];
+
+    for (chunk_index, chunk) in chunks.iter().enumerate().skip(1) {
+        if chunk.starts_with("</") {
+            let (tag, trailing_text) = split_end_tag_chunk(chunk);
+            while stack.len() > 1 {
+                let item = stack.pop().expect("stack has child item");
+                let matched = item.tag.as_deref() == Some(tag.as_str());
+                stack
+                    .last_mut()
+                    .expect("stack has parent item")
+                    .append(item);
+                if matched {
+                    break;
+                }
+            }
+            if !trailing_text.is_empty() {
+                stack
+                    .last_mut()
+                    .expect("stack has current item")
+                    .append_text(trailing_text);
+            }
+        } else if chunk.starts_with('<') {
+            let (tag, trailing_text) = split_start_tag_chunk(chunk);
+            if tag.is_empty() {
+                continue;
+            }
+            let child_schema = stack
+                .last()
+                .expect("stack has current item")
+                .schema_for_child(tag.as_str());
+            let child_value = if schema_has_type(child_schema.as_ref(), "array")
+                && chunks
+                    .get(chunk_index + 1)
+                    .is_some_and(|next| next.starts_with("<item>"))
+            {
+                Some(StackValue::Array(Vec::new()))
+            } else if schema_has_type(child_schema.as_ref(), "object") {
+                Some(StackValue::Object(Map::new()))
+            } else {
+                None
+            };
+            stack.push(StackItem {
+                tag: Some(tag),
+                value: child_value,
+                texts: if trailing_text.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![trailing_text.to_string()]
+                },
+                schema: child_schema,
+            });
+        } else if !chunk.is_empty() {
+            stack
+                .last_mut()
+                .expect("stack has current item")
+                .append_text(chunk);
+        }
+    }
+
+    while stack.len() > 1 {
+        let item = stack.pop().expect("stack has child item");
+        stack
+            .last_mut()
+            .expect("stack has parent item")
+            .append(item);
+    }
+
+    stack.pop().expect("root item exists").into_value()
+}
+
+// Splits a start-tag chunk into its tag name and any text after `>`.
+fn split_start_tag_chunk(chunk: &str) -> (String, &str) {
+    let Some(gt) = chunk.find('>') else {
+        return (chunk.trim_start_matches('<').to_string(), "");
+    };
+    (chunk[1..gt].to_string(), &chunk[gt + 1..])
+}
+
+// Splits an end-tag chunk into its tag name and any text after `>`.
+fn split_end_tag_chunk(chunk: &str) -> (String, &str) {
+    let Some(gt) = chunk.find('>') else {
+        return (chunk.trim_start_matches("</").to_string(), "");
+    };
+    (chunk[2..gt].to_string(), &chunk[gt + 1..])
+}
+
+#[derive(Debug)]
+enum StackValue {
+    Object(Map<String, Value>),
+    Array(Vec<Value>),
+}
+
+#[derive(Debug)]
+struct StackItem {
+    tag: Option<String>,
+    value: Option<StackValue>,
+    texts: Vec<String>,
+    schema: Option<Value>,
+}
+
+impl StackItem {
+    // Converts a stack node into the JSON value it represents.
+    fn into_value(self) -> Value {
+        match self.value {
+            None => convert_scalar_value(self.texts.join("").as_str(), self.schema.as_ref()),
+            Some(StackValue::Object(mut map)) => {
+                if !self.texts.is_empty() {
+                    let mut text_key = "$text".to_string();
+                    while map.contains_key(&text_key) {
+                        text_key = format!("${text_key}");
+                    }
+                    map.insert(text_key, Value::String(self.texts.join("")));
+                }
+                Value::Object(map)
+            }
+            Some(StackValue::Array(values)) => Value::Array(values),
+        }
+    }
+
+    // Attaches a completed child node to the current object, array, or implicit object.
+    fn append(&mut self, item: StackItem) {
+        let key = item.tag.clone().unwrap_or_default();
+        let value = item.into_value();
+        match self.value.as_mut() {
+            None => {
+                let mut map = Map::new();
+                map.insert(key, value);
+                self.value = Some(StackValue::Object(map));
+            }
+            Some(StackValue::Object(map)) => insert_parameter(map, key, value),
+            Some(StackValue::Array(values)) => values.push(value),
+        }
+    }
+
+    // Adds text to the current node, coercing array items through item schema when available.
+    fn append_text(&mut self, text: &str) {
+        if let Some(StackValue::Array(values)) = self.value.as_mut() {
+            let item_schema = schema_array_item(self.schema.as_ref());
+            values.push(convert_scalar_value(text, item_schema.as_ref()));
+        } else {
+            self.texts.push(text.to_string());
+        }
+    }
+
+    // Finds the schema that should be used for a nested child tag.
+    fn schema_for_child(&self, tag: &str) -> Option<Value> {
+        if tag == "item"
+            && let Some(item_schema) = schema_array_item(self.schema.as_ref())
+        {
+            return Some(item_schema);
+        }
+
+        let schema = self.schema.as_ref()?;
+        if let Some(child_schema) = schema
+            .get("properties")
+            .and_then(|properties| properties.get(tag))
+        {
+            return Some(child_schema.clone());
+        }
+
+        schema
+            .get("additionalProperties")
+            .filter(|additional| additional.is_object())
+            .cloned()
+    }
+}
+
+// Looks up the selected tool's parameter schema so parsed strings can be type-coerced.
+fn get_arguments_config(func_name: &str, tools: Option<&[ToolDefinition]>) -> Map<String, Value> {
+    let Some(tools) = tools else {
+        return Map::new();
+    };
+
+    for tool in tools {
+        if tool.name == func_name {
+            let Some(params) = &tool.parameters else {
+                return Map::new();
+            };
+            if let Some(properties) = params.get("properties").and_then(Value::as_object) {
+                return properties.clone();
+            }
+            if let Some(params_obj) = params.as_object() {
+                return params_obj.clone();
+            }
+            return Map::new();
+        }
+    }
+
+    tracing::warn!("Tool '{}' is not defined in the tools list.", func_name);
+    Map::new()
+}
+
+// Converts a scalar XML text value into the schema-expected JSON type when possible.
+fn convert_scalar_value(raw: &str, schema: Option<&Value>) -> Value {
+    let value = html_unescape(raw);
+    let trimmed = value.trim();
+    if trimmed.eq_ignore_ascii_case("null") {
+        return Value::Null;
+    }
+
+    let Some(schema) = schema else {
+        return Value::String(value);
+    };
+
+    if schema_has_type(Some(schema), "string") || schema_has_type(Some(schema), "enum") {
+        return Value::String(value);
+    }
+    if schema_has_type(Some(schema), "integer") {
+        return coerce_integer_literal(trimmed)
+            .and_then(|parsed| serde_json::to_value(parsed).ok())
+            .unwrap_or(Value::String(value));
+    }
+    if schema_has_type(Some(schema), "number") {
+        if let Some(parsed) = coerce_integer_literal(trimmed)
+            && let Ok(json) = serde_json::to_value(parsed)
+        {
+            return json;
+        }
+        if let Ok(number) = trimmed.parse::<f64>()
+            && let Some(number) = Number::from_f64(number)
+        {
+            return Value::Number(number);
+        }
+        if let Some(parsed) = raw_number_literal(trimmed)
+            && let Ok(json) = serde_json::to_value(parsed)
+        {
+            return json;
+        }
+        return Value::String(value);
+    }
+    if schema_has_type(Some(schema), "boolean") {
+        return match trimmed.to_ascii_lowercase().as_str() {
+            "true" => Value::Bool(true),
+            "1" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            "0" => Value::Bool(false),
+            _ => Value::String(value),
+        };
+    }
+    if schema_has_type(Some(schema), "object") {
+        if trimmed.is_empty() {
+            return Value::Object(Map::new());
+        }
+        if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+            return json;
+        }
+    }
+    if schema_has_type(Some(schema), "array") {
+        if trimmed.is_empty() {
+            return Value::Array(Vec::new());
+        }
+        if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+            return json;
+        }
+    }
+
+    Value::String(value)
+}
+
+// Checks JSON Schema `type`, `anyOf`, and `oneOf` for a target primitive/container type.
+fn schema_has_type(schema: Option<&Value>, expected: &str) -> bool {
+    let Some(schema) = schema else {
+        return false;
+    };
+    if let Some(ty) = schema.get("type") {
+        if ty.as_str() == Some(expected) {
+            return true;
+        }
+        if let Some(types) = ty.as_array()
+            && types.iter().any(|ty| ty.as_str() == Some(expected))
+        {
+            return true;
+        }
+    }
+    for key in ["anyOf", "oneOf"] {
+        if let Some(options) = schema.get(key).and_then(Value::as_array)
+            && options
+                .iter()
+                .any(|option| schema_has_type(Some(option), expected))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+// Finds the schema for array elements, including schemas wrapped in `anyOf` or `oneOf`.
+fn schema_array_item(schema: Option<&Value>) -> Option<Value> {
+    schema
+        .and_then(|schema| schema.get("items"))
+        .cloned()
+        .or_else(|| {
+            schema.and_then(|schema| {
+                for key in ["anyOf", "oneOf"] {
+                    if let Some(options) = schema.get(key).and_then(Value::as_array) {
+                        for option in options {
+                            if let Some(items) = option.get("items") {
+                                return Some(items.clone());
+                            }
+                        }
+                    }
+                }
+                None
+            })
+        })
+}
+
+// Decodes common XML/HTML entities so tool arguments receive the intended literal text.
+fn html_unescape(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&#39;", "'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_tool_call_start_minimax_m3_rejects_short_suffix_false_positives() {
+        let config = MiniMaxM3ParserConfig::default();
+
+        assert!(!detect_tool_call_start_minimax_m3(
+            "See reference [1]",
+            &config
+        ));
+        assert!(!detect_tool_call_start_minimax_m3(
+            "ordinary text ending in ]",
+            &config
+        ));
+        assert!(!detect_tool_call_start_minimax_m3(
+            "ordinary text ending in ]<",
+            &config
+        ));
+        assert!(detect_tool_call_start_minimax_m3(
+            "split opener ]<]",
+            &config
+        ));
+        assert!(detect_tool_call_start_minimax_m3(
+            "full opener ]<]minimax[>[<tool_call>",
+            &config
+        ));
+    }
+}

--- a/parsers/src/tool_calling/xml/minimax_m3_parser.rs
+++ b/parsers/src/tool_calling/xml/minimax_m3_parser.rs
@@ -14,16 +14,23 @@ const MIN_PARTIAL_TOOL_CALL_START_LEN: usize = 3;
 // Used by the streaming jail to detect a complete or split MiniMax M3 tool-call opener.
 pub fn detect_tool_call_start_minimax_m3(chunk: &str, config: &MiniMaxM3ParserConfig) -> bool {
     let tool_call_start = tool_call_start(config);
+    let invoke_start = invoke_start(config);
 
-    if chunk.contains(tool_call_start.as_str()) {
-        return true;
+    for token in [tool_call_start.as_str(), invoke_start.as_str()] {
+        if chunk.contains(token) || chunk_ends_with_partial_m3_marker(chunk, token) {
+            return true;
+        }
     }
 
-    for (i, _) in tool_call_start.char_indices().skip(1) {
+    false
+}
+
+fn chunk_ends_with_partial_m3_marker(chunk: &str, marker: &str) -> bool {
+    for (i, _) in marker.char_indices().skip(1) {
         if i < MIN_PARTIAL_TOOL_CALL_START_LEN {
             continue;
         }
-        if chunk.ends_with(&tool_call_start[..i]) {
+        if chunk.ends_with(&marker[..i]) {
             return true;
         }
     }
@@ -50,10 +57,29 @@ pub fn try_tool_call_parse_minimax_m3(
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let Some(start_pos) = message.find(tool_call_start(config).as_str()) else {
+        if let Some(marker_idx) = first_orphan_minimax_m3_marker_index(message, config) {
+            if let Some((prefix, calls)) = recover_orphan_invokes_in_span(message, config, tools)? {
+                return Ok((calls, Some(prefix)));
+            }
+            return Ok((vec![], Some(message[..marker_idx].trim_end().to_string())));
+        }
         return Ok((vec![], Some(message.to_string())));
     };
 
-    let prefix = message[..start_pos].to_string();
+    let pre_block_span = &message[..start_pos];
+    let (prefix, mut calls) = if let Some((prefix, recovered)) =
+        recover_orphan_invokes_in_span(pre_block_span, config, tools)?
+    {
+        (prefix, recovered)
+    } else if let Some(marker_idx) = first_orphan_minimax_m3_marker_index(pre_block_span, config) {
+        (
+            pre_block_span[..marker_idx].trim_end().to_string(),
+            Vec::new(),
+        )
+    } else {
+        (pre_block_span.to_string(), Vec::new())
+    };
+
     let block_start = start_pos + tool_call_start(config).len();
     let tool_call_end = tool_call_end(config);
     let (block, complete) =
@@ -68,7 +94,7 @@ pub fn try_tool_call_parse_minimax_m3(
         return Ok((vec![], Some(prefix)));
     }
 
-    let calls = parse_invokes(block, config, tools)?;
+    calls.extend(parse_invokes(block, config, tools)?);
     Ok((calls, Some(prefix)))
 }
 
@@ -95,6 +121,46 @@ fn invoke_end(config: &MiniMaxM3ParserConfig) -> String {
 // Builds the shared namespace prefix that starts any M3 XML-ish tag.
 fn parameter_start(config: &MiniMaxM3ParserConfig) -> String {
     format!("{}<", config.namespace_token)
+}
+
+fn first_orphan_minimax_m3_marker_index(
+    text: &str,
+    config: &MiniMaxM3ParserConfig,
+) -> Option<usize> {
+    [
+        tool_call_end(config),
+        invoke_start(config),
+        invoke_end(config),
+        parameter_start(config),
+    ]
+    .iter()
+    .filter_map(|marker| text.find(marker.as_str()))
+    .min()
+}
+
+fn recover_orphan_invokes_in_span(
+    span: &str,
+    config: &MiniMaxM3ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    let Some(marker_idx) = first_orphan_minimax_m3_marker_index(span, config) else {
+        return Ok(None);
+    };
+
+    let marker_tail = &span[marker_idx..];
+    if !marker_tail.starts_with(invoke_start(config).as_str()) {
+        return Ok(None);
+    }
+    if !marker_tail.contains(tool_call_end(config).as_str()) && !config.allow_eof_recovery {
+        return Ok(None);
+    }
+
+    let calls = parse_invokes(marker_tail, config, tools)?;
+    if calls.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some((span[..marker_idx].trim_end().to_string(), calls)))
 }
 
 // Extracts one or more `<invoke name="...">` blocks from the outer tool-call block.
@@ -585,6 +651,20 @@ fn html_unescape(s: &str) -> String {
 mod tests {
     use super::*;
 
+    fn recovery_config() -> MiniMaxM3ParserConfig {
+        MiniMaxM3ParserConfig {
+            allow_eof_recovery: true,
+            ..Default::default()
+        }
+    }
+
+    fn call_name_and_args(call: &ToolCallResponse) -> (String, Value) {
+        (
+            call.function.name.clone(),
+            serde_json::from_str(&call.function.arguments).expect("valid JSON arguments"),
+        )
+    }
+
     #[test]
     fn detect_tool_call_start_minimax_m3_rejects_short_suffix_false_positives() {
         let config = MiniMaxM3ParserConfig::default();
@@ -609,5 +689,94 @@ mod tests {
             "full opener ]<]minimax[>[<tool_call>",
             &config
         ));
+        assert!(detect_tool_call_start_minimax_m3(
+            "bare invoke ]<]minimax[>[<invoke",
+            &config
+        ));
+        assert!(detect_tool_call_start_minimax_m3(
+            "split bare invoke ]<]minimax[>[<inv",
+            &config
+        ));
+    }
+
+    #[test]
+    fn recovers_complete_bare_invoke_without_outer_tool_call() {
+        let config = recovery_config();
+        let input = r#"prefix ]<]minimax[>[<invoke name="get_weather">
+]<]minimax[>[<location>NYC]<]minimax[>[</location>
+]<]minimax[>[</invoke>
+]<]minimax[>[</invoke>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_minimax_m3(input, &config, None).unwrap();
+
+        assert_eq!(normal_text.as_deref(), Some("prefix"));
+        assert_eq!(calls.len(), 1);
+        let (name, args) = call_name_and_args(&calls[0]);
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    #[test]
+    fn non_recovery_path_strips_bare_invoke_without_claiming_call() {
+        let config = MiniMaxM3ParserConfig::default();
+        let input = r#"prefix ]<]minimax[>[<invoke name="get_weather">
+]<]minimax[>[<location>NYC]<]minimax[>[</location>
+]<]minimax[>[</invoke>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_minimax_m3(input, &config, None).unwrap();
+
+        assert!(calls.is_empty());
+        assert_eq!(normal_text.as_deref(), Some("prefix"));
+    }
+
+    #[test]
+    fn strips_incomplete_bare_invoke_marker_tail() {
+        let config = recovery_config();
+        let input = r#"prefix ]<]minimax[>[<invoke name="get_weather">
+]<]minimax[>[<location>NY"#;
+
+        let (calls, normal_text) = try_tool_call_parse_minimax_m3(input, &config, None).unwrap();
+
+        assert!(calls.is_empty());
+        assert_eq!(normal_text.as_deref(), Some("prefix"));
+    }
+
+    #[test]
+    fn parses_nested_arguments_with_custom_namespace_token() {
+        let config = MiniMaxM3ParserConfig {
+            namespace_token: "NS|".to_string(),
+            ..recovery_config()
+        };
+        let input = r#"NS|<tool_call>
+NS|<invoke name="create_order">
+NS|<shipping>NS|<city>SingaporeNS|</city>NS|<zip>18956NS|</zip>NS|</shipping>
+NS|</invoke>
+NS|</tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "create_order".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "shipping": {
+                        "type": "object",
+                        "properties": {
+                            "city": { "type": "string" },
+                            "zip": { "type": "integer" }
+                        }
+                    }
+                }
+            })),
+            strict: None,
+        }];
+
+        let (calls, normal_text) =
+            try_tool_call_parse_minimax_m3(input, &config, Some(&tools)).unwrap();
+
+        assert_eq!(normal_text.as_deref(), Some(""));
+        assert_eq!(calls.len(), 1);
+        let (name, args) = call_name_and_args(&calls[0]);
+        assert_eq!(name, "create_order");
+        assert_eq!(args["shipping"]["city"], "Singapore");
+        assert_eq!(args["shipping"]["zip"], 18956);
     }
 }

--- a/parsers/src/tool_calling/xml/mod.rs
+++ b/parsers/src/tool_calling/xml/mod.rs
@@ -3,6 +3,7 @@
 
 mod glm47_parser;
 mod kimi_k2_parser;
+mod minimax_m3_parser;
 mod parsed_value;
 mod parser;
 
@@ -13,6 +14,10 @@ pub use glm47_parser::{
 pub use kimi_k2_parser::{
     detect_tool_call_start_kimi_k2, find_tool_call_end_position_kimi_k2,
     try_tool_call_parse_kimi_k2,
+};
+pub use minimax_m3_parser::{
+    detect_tool_call_start_minimax_m3, find_tool_call_end_position_minimax_m3,
+    try_tool_call_parse_minimax_m3,
 };
 pub use parser::{
     detect_tool_call_start_xml, find_tool_call_end_position_xml, try_tool_call_parse_xml,


### PR DESCRIPTION
## Description

This adds MiniMax M3 support to the frontend parser crates and conformance matrix.

MiniMax M3 uses a namespace-token XML-ish tool-call format:

```text
]<]minimax[>[<tool_call>
]<]minimax[>[<invoke name="get_weather">
]<]minimax[>[<location>NYC]<]minimax[>[</location>
]<]minimax[>[</invoke>
]<]minimax[>[</tool_call>
```

It also uses `<mm:think>...</mm:think>` reasoning markers, where the opener can
be prompt-prefilled by the chat template.

## Changes

- Added `minimax_m3` / `minimax-m3` tool-call parser registration.
- Added `MiniMaxM3ParserConfig` and `ParserConfig::MiniMaxM3`.
- Added a MiniMax M3 parser for:
  - namespace-prefixed tool-call blocks
  - `<invoke name="...">` calls
  - parameter tags where tag names are argument names
  - duplicate parameter tags as arrays
  - schema-based scalar coercion
  - nested MiniMax XML object/array payloads
  - EOF recovery for complete invokes with a missing outer close
- Added `minimax_m3` / `minimax-m3` reasoning parser registration.
- Added opt-in streaming dangling-end recovery for MiniMax M3 reasoning, so
  `reason</mm:think>answer` is parsed as reasoning plus answer when the opener
  was prompt-prefilled.
- Added MiniMax M3 conformance coverage:
  - tool-calling batch fixtures
  - tool-calling stream-v2 inventory fixtures
  - reasoning batch fixtures
  - reasoning stream fixtures
  - Top-N table/registry metadata
- Wired MiniMax M3 into the vLLM/SGLang conformance wrappers, with pinned peer
  engines marked unavailable where they do not yet expose M3 parsers.

## Notes

- TC stream-v2 coverage for MiniMax M3 is table/inventory coverage only. It marks
  `dynamo_rust`, `vllm_rust`, `vllm_python`, and `sglang_python` unavailable for
  now.
- This PR does not add a real `parsers_v2` MiniMax M3 streaming parser.

## Validation

### Rust parser coverage

Targeted MiniMax M3 parser tests:

```bash
cargo test --locked -p dynamo-parsers minimax_m3 -- --nocapture
```

This covers:

- MiniMax M3 reasoning parser registration for both `minimax_m3` and
  `minimax-m3`.
- Batch reasoning extraction for visible `<mm:think>...</mm:think>` spans.
- Streaming reasoning extraction across split chunks.
- Prompt-prefilled reasoning opener behavior:
  `reason</mm:think>answer`.
- Dangling end-marker recovery in batch and streaming paths.
- Close-marker-only streaming case where the close marker is stripped and does
  not leak into normal text.
- MiniMax M3 tool-call parsing for the namespace-token XML format.
- EOF recovery for a complete `<invoke>` when the outer `tool_call` close is
  missing.
- Streaming jail start detection regression:
  normal text ending in `]` or `]<` does not trigger MiniMax M3 tool-call mode,
  while `]<]` and the full opener still do.

### Live E2E validation

In addition to the repo-local parser/conformance tests above, these
frontend-crates changes were built into the downstream Dynamo vLLM runtime image
and exercised in a live K8s deployment. Used `vllm/vllm-openai:minimax-m3` vllm base container.
