### PR TITLE
fix(renderer): render Gemma4 reasoning segments

### DIFF
--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -96,9 +96,18 @@ struct HfTokenizerConfigJsonFormatter {
     /// When true, strip tool definitions from the chat template when tool_choice is "none".
     /// This prevents models from generating raw XML tool calls in the content field.
     exclude_tools_when_tool_choice_none: bool,
-    /// True if the chat template natively references `reasoning_content`.
-    /// When true, skip injection — the template handles it.
-    template_handles_reasoning: bool,
+    /// True if the `default` template natively references `reasoning_content`.
+    /// When true and rendering through `default`, skip injection — the template
+    /// handles it. Tracked separately for `default` and `tool_use` because HF
+    /// configs may register different sources for each: Gemma4's `tool_use`
+    /// template is adapted by `normalize_chat_template_source` to read
+    /// `reasoning_content`, while its `default` template is not. A single global
+    /// flag would wrongly suppress injection on the untouched `default` path and
+    /// silently drop prior assistant reasoning on no-tool renders.
+    default_template_handles_reasoning: bool,
+    /// True if the `tool_use` template natively references `reasoning_content`.
+    /// See `default_template_handles_reasoning` for rationale.
+    tool_use_template_handles_reasoning: bool,
     /// Per-family placeholder template for image content parts when flattening
     /// mixed text+image content arrays into a single string (`preserve_arrays`
     /// = false path). `{n}` in the template is substituted with the 1-based

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -449,11 +449,22 @@ impl HfTokenizerConfigJsonFormatter {
             detect_image_placeholder_template(&env)
         };
 
-        // Detect if the template natively handles reasoning_content (e.g. Nemotron, Qwen3).
-        // If so, we must NOT inject <think> blocks — the template does it itself.
-        let template_handles_reasoning = env
-            .templates()
-            .any(|(_, tmpl)| tmpl.source().contains("reasoning_content"));
+        // Detect if a given template natively handles reasoning_content (e.g.
+        // Nemotron, Qwen3, or a Gemma4 tool template adapted by
+        // `normalize_chat_template_source`). If so, we must NOT inject <think>
+        // blocks for that template — it renders reasoning itself. Per-template
+        // (default vs tool_use) because HF configs can register different sources
+        // for each: Gemma4 adapts only its `tool_use` template to read
+        // `reasoning_content`, so a global `any()` flag would wrongly suppress
+        // injection on the untouched `default` path and silently drop reasoning.
+        let template_handles_reasoning = |name: &str| -> bool {
+            env.templates()
+                .find(|(n, _)| *n == name)
+                .map(|(_, tmpl)| tmpl.source().contains("reasoning_content"))
+                .unwrap_or(false)
+        };
+        let default_template_handles_reasoning = template_handles_reasoning("default");
+        let tool_use_template_handles_reasoning = template_handles_reasoning("tool_use");
 
         // Detect if a given template branches on `tool_call.arguments is string` (Qwen3, Hermes).
         // Such templates render a JSON-string `arguments` field verbatim; if we pre-parse
@@ -482,7 +493,8 @@ impl HfTokenizerConfigJsonFormatter {
             supports_add_generation_prompt: supports_add_generation_prompt.unwrap_or(false),
             requires_content_arrays,
             exclude_tools_when_tool_choice_none,
-            template_handles_reasoning,
+            default_template_handles_reasoning,
+            tool_use_template_handles_reasoning,
             image_placeholder_template,
             default_template_handles_tool_calls_arguments_string,
             tool_use_template_handles_tool_calls_arguments_string,

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -278,10 +278,6 @@ fn is_gemma4_reasoning_field_template_source(source: &str) -> bool {
 /// segment i is emitted immediately before tool_call i, and the optional
 /// trailing segment is emitted after the final tool call.
 fn adapt_gemma4_reasoning_template_source(source: &str) -> String {
-    if !is_gemma4_reasoning_field_template_source(source) {
-        return source.to_string();
-    }
-
     const OLD_REASONING_BLOCK: &str = "{%- if message.get('reasoning') and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
         {{- '<|channel>thought\\n' + message['reasoning'] + '\\n<channel|>'}}
     {%- endif -%}";
@@ -330,9 +326,13 @@ fn adapt_gemma4_reasoning_template_source(source: &str) -> String {
 }
 
 fn normalize_chat_template_source(source: &str) -> String {
-    adapt_gemma4_reasoning_template_source(&normalize_dict_method_calls(
-        &remove_known_non_jinja2_tags(source),
-    ))
+    let source = normalize_dict_method_calls(&remove_known_non_jinja2_tags(source));
+
+    if is_gemma4_reasoning_field_template_source(&source) {
+        adapt_gemma4_reasoning_template_source(&source)
+    } else {
+        source
+    }
 }
 
 impl JinjaEnvironment {

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -262,6 +262,79 @@ fn normalize_jinja_code_segment(segment: &str) -> String {
     out
 }
 
+/// Detects the Gemma4 tool template shape that replays assistant thinking from
+/// the upstream/vLLM-style `message.reasoning` field.
+fn is_gemma4_reasoning_field_template_source(source: &str) -> bool {
+    source.contains("<|channel>thought")
+        && source.contains("<|tool_call>call:")
+        && (source.contains("message.get('reasoning')")
+            || source.contains("message.get(\"reasoning\")"))
+        && !source.contains("reasoning_content")
+}
+
+/// The stock template has a single `message.reasoning` block before the
+/// tool-call loop. Dynamo can carry reasoning as N+1 segments around N tool
+/// calls, so the renderer patches that known template shape at load time:
+/// segment i is emitted immediately before tool_call i, and the optional
+/// trailing segment is emitted after the final tool call.
+fn adapt_gemma4_reasoning_template_source(source: &str) -> String {
+    if !is_gemma4_reasoning_field_template_source(source) {
+        return source.to_string();
+    }
+
+    const OLD_REASONING_BLOCK: &str = "{%- if message.get('reasoning') and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\\n' + message['reasoning'] + '\\n<channel|>'}}
+    {%- endif -%}";
+    const NEW_REASONING_BLOCK: &str = "{%- set dyn_gemma4_reasoning_value = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set dyn_gemma4_reasoning_segments = [] -%}
+    {%- if dyn_gemma4_reasoning_value is string -%}
+        {%- set dyn_gemma4_reasoning_segments = [dyn_gemma4_reasoning_value] -%}
+    {%- elif dyn_gemma4_reasoning_value is sequence -%}
+        {%- set dyn_gemma4_reasoning_segments = dyn_gemma4_reasoning_value -%}
+    {%- endif -%}
+    {%- if dyn_gemma4_reasoning_value and not message.get('tool_calls') -%}
+        {%- for dyn_gemma4_reasoning_segment in dyn_gemma4_reasoning_segments -%}
+            {%- if dyn_gemma4_reasoning_segment -%}
+                {{- '<|channel>thought\\n' + dyn_gemma4_reasoning_segment + '\\n<channel|>'}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}";
+    const OLD_TOOL_LOOP_START: &str = "{%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}";
+    const NEW_TOOL_LOOP_START: &str = "{%- for tool_call in message['tool_calls'] -%}
+                    {%- set dyn_gemma4_reasoning_segment = dyn_gemma4_reasoning_segments[loop.index0] | default('') -%}
+                    {%- if dyn_gemma4_reasoning_segment -%}
+                        {{- '<|channel>thought\\n' + dyn_gemma4_reasoning_segment + '\\n<channel|>'}}
+                    {%- endif -%}
+                    {%- set function = tool_call['function'] -%}";
+    const OLD_TOOL_LOOP_END: &str = "{{- '}<tool_call|>' -}}
+                {%- endfor -%}";
+    const NEW_TOOL_LOOP_END: &str = "{{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set dyn_gemma4_trailing_reasoning = dyn_gemma4_reasoning_segments[message['tool_calls'] | length] | default('') -%}
+                {%- if dyn_gemma4_trailing_reasoning -%}
+                    {{- '<|channel>thought\\n' + dyn_gemma4_trailing_reasoning + '\\n<channel|>'}}
+                {%- endif -%}";
+
+    if !source.contains(OLD_REASONING_BLOCK)
+        || !source.contains(OLD_TOOL_LOOP_START)
+        || !source.contains(OLD_TOOL_LOOP_END)
+    {
+        return source.to_string();
+    }
+
+    source
+        .replace(OLD_REASONING_BLOCK, NEW_REASONING_BLOCK)
+        .replace(OLD_TOOL_LOOP_START, NEW_TOOL_LOOP_START)
+        .replace(OLD_TOOL_LOOP_END, NEW_TOOL_LOOP_END)
+}
+
+fn normalize_chat_template_source(source: &str) -> String {
+    adapt_gemma4_reasoning_template_source(&normalize_dict_method_calls(
+        &remove_known_non_jinja2_tags(source),
+    ))
+}
+
 impl JinjaEnvironment {
     fn env(self) -> Environment<'static> {
         self.env
@@ -327,8 +400,7 @@ impl HfTokenizerConfigJsonFormatter {
                     supports_add_generation_prompt = Some(true);
                 }
                 // Remove known non-standard tags before validation (they don't affect output)
-                let template_cleaned =
-                    normalize_dict_method_calls(&remove_known_non_jinja2_tags(x));
+                let template_cleaned = normalize_chat_template_source(x);
                 env.add_template_owned("default", template_cleaned.clone())?;
                 env.add_template_owned("tool_use", template_cleaned)?;
             }
@@ -353,8 +425,7 @@ impl HfTokenizerConfigJsonFormatter {
                             supports_add_generation_prompt = Some(false);
                         }
                         // Remove known non-standard tags before validation (they don't affect output)
-                        let template_cleaned =
-                            normalize_dict_method_calls(&remove_known_non_jinja2_tags(v));
+                        let template_cleaned = normalize_chat_template_source(v);
                         env.add_template_owned(k.to_string(), template_cleaned)?;
                     }
                 }

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -478,17 +478,20 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         // and only for the `tool_calls[].function.arguments` field. Legacy
         // `function_call.arguments` lives outside that branch and is always
         // normalized.
-        let (template_name, template_handles_tool_calls_args_string) = if has_tools {
-            (
-                "tool_use",
-                self.tool_use_template_handles_tool_calls_arguments_string,
-            )
-        } else {
-            (
-                "default",
-                self.default_template_handles_tool_calls_arguments_string,
-            )
-        };
+        let (template_name, template_handles_tool_calls_args_string, template_handles_reasoning) =
+            if has_tools {
+                (
+                    "tool_use",
+                    self.tool_use_template_handles_tool_calls_arguments_string,
+                    self.tool_use_template_handles_reasoning,
+                )
+            } else {
+                (
+                    "default",
+                    self.default_template_handles_tool_calls_arguments_string,
+                    self.default_template_handles_reasoning,
+                )
+            };
 
         // Pre-parse JSON-string `arguments` into objects — but only for templates
         // that unconditionally `| tojson` them. Templates that branch on
@@ -508,7 +511,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         // the template doesn't handle it natively. Templates like Nemotron and
         // Qwen3 reference reasoning_content directly in their Jinja logic; injecting
         // would produce duplicate <think> blocks.
-        if !self.template_handles_reasoning {
+        if !template_handles_reasoning {
             inject_reasoning_content_into_messages(&mut messages_for_template);
         }
 
@@ -1999,7 +2002,7 @@ NORMAL_MODE
     fn test_gemma4_template_renders_reasoning_content_segments_around_tool_calls() {
         let formatter = make_gemma4_tool_formatter_for_tests();
         assert!(
-            formatter.template_handles_reasoning,
+            formatter.tool_use_template_handles_reasoning,
             "Gemma4 template adaptation should make reasoning_content native"
         );
 
@@ -2079,6 +2082,62 @@ NORMAL_MODE
         );
         assert!(!rendered.contains("<think>"));
         assert!(!rendered.contains("reasoning_content"));
+    }
+
+    /// Regression: when a config ships a separate non-tool `default` template
+    /// (dict form), adapting only the `tool_use` template to read
+    /// `reasoning_content` must NOT suppress `<think>` injection on the
+    /// `default` path. A global `any()` flag would flip true off the adapted
+    /// `tool_use` template and silently drop reasoning on no-tool renders.
+    #[test]
+    fn test_reasoning_flag_is_per_template_not_global() {
+        // Plain default template: renders content, never mentions reasoning_content
+        // and lacks the Gemma4 fingerprint, so it is left untouched.
+        const PLAIN_DEFAULT: &str = "{{ bos_token }}{%- for message in messages -%}\
+            {{ message['role'] }}: {{ message['content'] }}\n{%- endfor -%}";
+
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": [
+                {"default": PLAIN_DEFAULT},
+                {"tool_use": gemma4_tool_template_for_tests()},
+            ]
+        }))
+        .unwrap();
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        // The adapted Gemma4 tool_use template handles reasoning natively; the
+        // untouched plain default template does not. The flag must reflect that
+        // per-template split, not a global OR across both.
+        assert!(
+            formatter.tool_use_template_handles_reasoning,
+            "adapted gemma4 tool_use template should handle reasoning natively"
+        );
+        assert!(
+            !formatter.default_template_handles_reasoning,
+            "plain default template does not reference reasoning_content"
+        );
+
+        // A no-tools request routes to `default`. Reasoning must still be injected
+        // as a <think> block — not silently dropped by the tool_use template's flag.
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "gemma4-test",
+            "messages": [
+                {"role": "user", "content": "answer directly"},
+                {
+                    "role": "assistant",
+                    "content": "Direct answer.",
+                    "reasoning_content": "Private thought."
+                }
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+        assert!(
+            rendered.contains("<think>Private thought.</think>Direct answer."),
+            "reasoning must be injected on the no-tool default path, got: {rendered}"
+        );
     }
 
     #[test]
@@ -2265,7 +2324,8 @@ NORMAL_MODE
         let formatter = make_test_formatter();
 
         // Formatter uses a simple template that doesn't reference reasoning_content
-        assert!(!formatter.template_handles_reasoning);
+        assert!(!formatter.default_template_handles_reasoning);
+        assert!(!formatter.tool_use_template_handles_reasoning);
 
         let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
             "model": "test-model",
@@ -2310,7 +2370,8 @@ NORMAL_MODE
             HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
 
         // Verify detection worked
-        assert!(formatter.template_handles_reasoning);
+        assert!(formatter.default_template_handles_reasoning);
+        assert!(formatter.tool_use_template_handles_reasoning);
 
         let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
             "model": "test-model",
@@ -2445,7 +2506,7 @@ NORMAL_MODE
     fn test_qwen3_thinking_template_flags_detected() {
         let formatter = qwen3_thinking_formatter();
         assert!(
-            formatter.template_handles_reasoning,
+            formatter.tool_use_template_handles_reasoning,
             "template references reasoning_content directly"
         );
         // The Qwen3-Thinking template is registered as both `default` and

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -1818,6 +1818,58 @@ NORMAL_MODE
         .unwrap()
     }
 
+    fn gemma4_tool_template_for_tests() -> &'static str {
+        r#"
+{{ bos_token }}
+{%- set loop_messages = messages -%}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- for message in loop_messages -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {{- '<|turn>' + role + '\n' }}
+
+    {%- if message.get('reasoning') and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + message['reasoning'] + '\n<channel|>'}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- value -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {{- message['content'] -}}
+            {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endfor -%}
+"#
+    }
+
+    fn make_gemma4_tool_formatter_for_tests() -> HfTokenizerConfigJsonFormatter {
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": gemma4_tool_template_for_tests()
+        }))
+        .unwrap();
+        HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap()
+    }
+
     /// Helper to build a request with tools and optional tool_choice.
     fn request_with_tool_choice(tool_choice: &str) -> NvCreateChatCompletionRequest {
         serde_json::from_value(serde_json::json!({
@@ -1941,6 +1993,92 @@ NORMAL_MODE
         // tool_calls should be untouched
         assert!(assistant.get("tool_calls").is_some());
         assert_eq!(assistant["tool_calls"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_gemma4_template_renders_reasoning_content_segments_around_tool_calls() {
+        let formatter = make_gemma4_tool_formatter_for_tests();
+        assert!(
+            formatter.template_handles_reasoning,
+            "Gemma4 template adaptation should make reasoning_content native"
+        );
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "gemma4-test",
+            "messages": [
+                {"role": "user", "content": "inspect two things"},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning_content": [
+                        "Think before the first call.",
+                        "Think before the second call.",
+                        "Think after both calls."
+                    ],
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {
+                                "name": "first_tool",
+                                "arguments": "{\"path\":\".\"}"
+                            }
+                        },
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "second_tool",
+                                "arguments": "{\"path\":\"/tmp\"}"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+
+        let expected = concat!(
+            "<|channel>thought\nThink before the first call.\n<channel|>",
+            "<|tool_call>call:first_tool{path:.}<tool_call|>",
+            "<|channel>thought\nThink before the second call.\n<channel|>",
+            "<|tool_call>call:second_tool{path:/tmp}<tool_call|>",
+            "<|channel>thought\nThink after both calls.\n<channel|>"
+        );
+        assert!(
+            rendered.contains(expected),
+            "Gemma4 reasoning segments should stay adjacent to their tool calls, got: {rendered}"
+        );
+        assert!(!rendered.contains("<think>"));
+        assert!(!rendered.contains("reasoning_content"));
+    }
+
+    #[test]
+    fn test_gemma4_template_renders_reasoning_content_without_tool_calls() {
+        let formatter = make_gemma4_tool_formatter_for_tests();
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "gemma4-test",
+            "messages": [
+                {"role": "user", "content": "answer directly"},
+                {
+                    "role": "assistant",
+                    "content": "Direct answer.",
+                    "reasoning_content": "Private thought."
+                }
+            ]
+        }))
+        .unwrap();
+
+        let rendered = formatter.render(&request).unwrap();
+
+        assert!(
+            rendered.contains("<|channel>thought\nPrivate thought.\n<channel|>Direct answer."),
+            "Gemma4 reasoning_content should render in the thought channel, got: {rendered}"
+        );
+        assert!(!rendered.contains("<think>"));
+        assert!(!rendered.contains("reasoning_content"));
     }
 
     #[test]


### PR DESCRIPTION

## Summary

Gemma4 tool templates still expect prior assistant thinking in the upstream/vLLM-style `message.reasoning` field, while Dynamo can preserve Anthropic/Claude-style prior thinking as segmented OpenAI `reasoning_content`.

This patch adapts the Gemma4 tool template during renderer template normalization, so `reasoning_content` is rendered in Gemma4's native thought channel instead of falling back to generic `<think>...</think>` injection.


The original Dynamo PR was https://github.com/ai-dynamo/dynamo/pull/9812. Its baseline runtime failure was:

```text
/v1/messages replay with assistant thinking + tool_use followed by user tool_result
before: HTTP 500 during template rendering
after: HTTP 200 and generation proceeds
```

The reason is that Gemma4's tool template only handled flat string thinking through `message.reasoning`, while Dynamo can keep thinking as segmented `reasoning_content`, for example:

```json
"reasoning_content": [
  "thinking before tool 1",
  "thinking before tool 2",
  "thinking after tool calls"
]
```

On current `frontend-crates/main`, the generic reasoning fallback can avoid some hard failures by injecting `<think>...</think>` into `message.content`, but that is still wrong for Gemma4:

- it does not use Gemma4's `<|channel>thought ... <channel|>` format
- it cannot preserve segment-to-tool-call placement
- it can replay all reasoning away from the tool call it originally preceded

## Render Logic Change

For Gemma4 tool templates that still use `message.get('reasoning')` and do not reference `reasoning_content`, the renderer now patches the template source during `normalize_chat_template_source`.

For an assistant message with N tool calls and N+1 reasoning segments:

- segment `i` is emitted immediately before `tool_calls[i]`
- the optional trailing segment is emitted after the final tool call
- string-valued reasoning still renders as one Gemma4 thought block
- raw `reasoning_content` is not leaked into the rendered prompt
- generic `<think>` fallback is skipped because the adapted template now handles reasoning natively

Expected rendered ordering covered by the new test:

```text
<|channel>thought
Think before the first call.
<channel|><|tool_call>call:first_tool{path:.}<tool_call|><|channel>thought
Think before the second call.
<channel|><|tool_call>call:second_tool{path:/tmp}<tool_call|><|channel>thought
Think after both calls.
<channel|>
```

## Codex CLI Verification

Verified with serving Gemma4 model:

```bash
vllm serve google/gemma-4-E2B-it \
  --served-model-name gemma4 \
  --max-model-len 32768 \
  --enable-auto-tool-choice \
  --tool-call-parser gemma4 \
  --reasoning-parser gemma4 \
  --chat-template /templates/gemma4_tool.jinja
```

Codex CLI command:

```bash
DYNAMO_API_KEY=dummy codex \
  -c model_provider='dynamo' \
  -m gemma4 \
  --sandbox danger-full-access \
  --ask-for-approval never \
  exec \
  --skip-git-repo-check \
  -C /tmp \
  --output-last-message /tmp/codex-gemma4-pr9812.out \
  --json \
  'Use the shell tool to run `printf codex-gemma4-ok`. Then answer with exactly the command output and nothing else.'
```

The Codex session successfully used the tool execution path:

```json
{"type":"item.started","item":{"type":"command_execution","command":"/bin/zsh -lc 'printf codex-gemma4-ok'"}}
{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"codex-gemma4-ok","exit_code":0,"status":"completed"}}
```

Final Codex output contained the expected command result:

```text
Output:
codex-gemma4-ok
```
