### PR TITLE
feat(GUI): add transpose to the table for better model comparison

### DIFF
--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -316,3 +316,70 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .tt-h-call { color: #fb923c; }
 .tt-h-stop { color: #f87171; }
 .tt-h-other { color: #22d3ee; }
+
+/* ---- Transpose view (DIS-2280) ----
+   A client-side transposed mirror of the conformance table: models become
+   columns (names rotated CCW 90°, bottom-up, to save horizontal space) and
+   test cases become rows. The transposed <table> is built in JS by cloning the
+   server-rendered cells, so every data cell keeps its data-cmp payload and the
+   compare engine (applyCtl) recolors it for free — the mirror lives in the same
+   panel, so applyCtl's cell query already covers it. */
+.transpose-table { display: none; }
+body.transpose-mode .tab-panel.active table[data-parity-table]:not([data-transpose-table]) { display: none; }
+body.transpose-mode .tab-panel.active .transpose-table { display: table; }
+/* Bottom-up vertical model headers (rotated CCW). Keep the container horizontal
+   and rotate each line independently; otherwise the model and family spans share
+   one vertical writing-mode box and the shorter line cannot bottom-align itself. */
+.transpose-table th.tcol-model {
+  background: #f5f5f5;
+  text-align: center;
+  padding: 6px 2px 0.5em;
+  vertical-align: bottom;
+  font-family: -apple-system, system-ui, sans-serif;
+  font-size: 12px;
+  position: relative;
+}
+.transpose-table th.tcol-model:hover,
+.transpose-table th.tcol-model:focus-within { z-index: 2000; }
+.transpose-table .tcol-model-inner { display: inline-block; vertical-align: bottom; }
+.transpose-table th.tcol-model .tcol-model-label {
+  display: inline-flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 0;
+  vertical-align: bottom;
+}
+.transpose-table .tcol-model-line,
+.transpose-table .tcol-model-name,
+.transpose-table .tcol-model-family {
+  writing-mode: sideways-lr;
+  white-space: nowrap;
+  display: inline-block;
+  line-height: 1;
+}
+.transpose-table .tcol-model-name { font-weight: 600; }
+/* No forced color: the cloned parser markup keeps its own styling (the parser-
+   source link stays clickable, the parser-base text stays muted). */
+.transpose-table .tcol-model-family { font-size: 11px; font-family: ui-monospace, monospace; }
+.transpose-table .tcol-model-family a { color: inherit; text-decoration: none; }
+.transpose-table .tcol-model-family a:hover { text-decoration: underline; }
+/* Width is view-dependent: Overview shows only a color block, so narrow the model
+   columns hard; Details shows the compare marker text, so let each column
+   shrink-wrap to its content (make the marker in-flow, click-anchor out of flow). */
+body.view-overview .transpose-table td.cell,
+body.view-overview .transpose-table th.tcol-model { width: 30px; min-width: 30px; max-width: 30px; }
+body.view-details .transpose-table td.cell,
+body.view-details .transpose-table th.tcol-model { width: auto; min-width: 22px; max-width: none; }
+body.view-details .transpose-table td.cell { padding: 3px 2px; }
+body.view-details .transpose-table td.cell .cell-marker,
+body.view-details .transpose-table td.cell .cmp-marker { position: static; }
+body.view-details .transpose-table td.cell > a { position: absolute; inset: 0; }
+.transpose-table th.tcorner-case,
+.transpose-table th.tsection-col { background: #f5f5f5; vertical-align: bottom; }
+.transpose-table th.tsection-col { font-family: -apple-system, system-ui, sans-serif; font-size: 12px; }
+.transpose-table th.trow-case { white-space: nowrap; text-align: left; font-weight: 600; }
+.transpose-table th.trow-case a { color: inherit; text-decoration: none; }
+.transpose-table th.trow-case a:hover { background: #ffd; }
+/* Case-group banner rows reuse the original tr.section band, but centered: in the
+   transposed layout they span the full model width, so left-aligned reads lost. */
+.transpose-table tr.section td { background: #eef; font-weight: bold; text-align: center; padding-left: 0.5ch; padding-right: 0.5ch; }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -136,6 +136,9 @@
     // reference-aware "not implemented" note). The v1 parity page has data-cmp only, so
     // match either — otherwise v1 cells never get colored.
     panel.querySelectorAll('td.cell[data-cmp], td.cell[data-family]').forEach(function (cell) {
+      // Cloned cells in the transposed mirror get colored like any other cell,
+      // but must not be tallied into the overview counts (they'd double them).
+      const countThis = !cell.closest('[data-transpose-table]');
       let cmp = {};
       const raw = cell.getAttribute('data-cmp');
       if (raw) { try { cmp = JSON.parse(raw); } catch (e) { return; } }
@@ -145,17 +148,17 @@
       if (base && ni && ni.families.indexOf(fam) === -1) {
         cell.classList.add('cmp-na'); if (marker) { marker.textContent = 'x'; }
         setWhy(cell, ni.label + ' is not yet implemented for family “' + fam + '”');
-        counts.na++; toggleCands(cell, active, base); return;
+        if (countThis) { counts.na++; } toggleCands(cell, active, base); return;
       }
       setWhy(cell, '');
       const bd = base ? cmp[base] : null;
       if (!base) {
         cell.classList.add('cmp-nobase'); if (marker) { marker.textContent = ''; }
-        counts.na++; toggleCands(cell, active, base); return;
+        if (countThis) { counts.na++; } toggleCands(cell, active, base); return;
       }
       if (!bd || bd.na === 1) {
         cell.classList.add('cmp-na'); if (marker) { marker.textContent = 'n/a'; }
-        counts.na++; toggleCands(cell, active, base); return;
+        if (countThis) { counts.na++; } toggleCands(cell, active, base); return;
       }
       // Unavailable candidates never count toward the diff; still shown in tooltip.
       const avail = shown.map(function (k) { return cmp[k]; }).filter(function (o) { return o && o.na !== 1; });
@@ -172,7 +175,7 @@
       if (marker) { marker.textContent = (leak ? '↯' : '') + txt; }
       // Color = leak only: red = Reference leaks markup, green = clean.
       cell.classList.add(leak ? 'cmp-leak' : 'cmp-eq');
-      if (leak) { counts.problem++; } else { counts.ok++; }
+      if (countThis) { if (leak) { counts.problem++; } else { counts.ok++; } }
       toggleCands(cell, active, base);
     });
     panel.querySelectorAll('[data-overview-count]').forEach(function (el) {
@@ -311,6 +314,8 @@
       const versioned = panel.dataset.hasVersions === 'true';
       const counts = {ok: 0, problem: 0, todo: 0, na: 0};
       panel.querySelectorAll('td.cell').forEach(function (cell) {
+        // Skip cloned cells in the transposed mirror; they'd double the tally.
+        if (cell.closest('[data-transpose-table]')) { return; }
         const alias = legacyParserAliases[parser];
         // On a versioned tab, prefer the active version's status; fall back to the
         // pinned attr (and legacy alias) for cells without per-version data.
@@ -645,9 +650,13 @@
     ttip.style.opacity = '';
   }
 
-  document.querySelectorAll('td.cell, td.parser').forEach(function (cell) {
+  function attachTooltip(cell) {
     const ttip = cell.querySelector('.ttip');
     if (!ttip) return;
+    // cloneNode copies the wired flag; guard so re-wiring a clone is a no-op and
+    // originals aren't double-wired.
+    if (cell.dataset.ttipWired === '1') return;
+    cell.dataset.ttipWired = '1';
 
     let showTimer = null;
     let hideTimer = null;
@@ -702,5 +711,245 @@
     cell.addEventListener('pointerleave', scheduleHide);
     cell.addEventListener('focusin', scheduleShow);
     cell.addEventListener('focusout', scheduleHide);
-  });
+  }
+  document.querySelectorAll('td.cell, td.parser').forEach(attachTooltip);
+
+  // ---- Transpose view (DIS-2280) ----
+  // Build a transposed mirror of each panel's table on demand: models become
+  // columns (rotated CCW headers), test cases become rows. Data cells are cloned
+  // from the server-rendered table, so they keep their data-cmp payload and the
+  // compare/coloring engine (applyCtl) recolors them for free — the mirror lives
+  // in the same panel, so applyCtl's cell query already covers it.
+  const transposeToggle = document.querySelector('[data-transpose-toggle]');
+
+  function readTransposeMode() {
+    const requested = new URLSearchParams(window.location.search).get('transpose');
+    return requested === '1' || requested === 'true';
+  }
+
+  function updateTransposeUrl(enabled) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('transpose');
+    if (enabled) {
+      url.searchParams.set('transpose', '1');
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function buildTransposed(table) {
+    const head = table.tHead;
+    const headRows = head ? Array.from(head.rows) : [];
+    const body = table.tBodies[0];
+    if (headRows.length < 2 || !body) {
+      return null;
+    }
+
+    // Case-group key -> human label (from the group-header toggle buttons).
+    const groupLabel = {};
+    Array.from(headRows[0].querySelectorAll('th.case-group')).forEach(function (th) {
+      const btn = th.querySelector('[data-col-label]');
+      groupLabel[th.dataset.colControlGroup] = btn ? btn.dataset.colLabel : th.textContent.trim();
+    });
+    // Ordered sub-cases (the new rows). Each carries its case-group key.
+    const subThs = Array.from(headRows[1].querySelectorAll('th.case-sub'));
+
+    // Models (the new columns), grouped by the body's section banners.
+    const models = [];
+    let curSection = null;
+    Array.from(body.rows).forEach(function (row) {
+      if (row.classList.contains('section')) {
+        curSection = row.textContent.trim();
+        return;
+      }
+      const modelTd = row.querySelector('td.model');
+      if (!modelTd) return;
+      models.push({
+        name: modelTd.textContent.trim(),
+        section: curSection,
+        parserTd: row.querySelector('td.parser'),
+        cells: Array.from(row.querySelectorAll('td.cell'))
+      });
+    });
+    if (!models.length) {
+      return null;
+    }
+    const nModels = models.length;
+
+    const out = document.createElement('table');
+    out.className = 'transpose-table';
+    out.setAttribute('data-transpose-table', '');
+
+    const outHead = out.createTHead();
+
+    // Optional model-section banner row (e.g. "Top-N models" / "Others").
+    const sections = [];
+    models.forEach(function (m) {
+      const last = sections[sections.length - 1];
+      if (last && last.label === m.section) {
+        last.count += 1;
+      } else {
+        sections.push({label: m.section, count: 1});
+      }
+    });
+    if (sections.some(function (s) { return s.label; })) {
+      const r0 = outHead.insertRow();
+      const corner = document.createElement('th');
+      corner.className = 'tcorner-case';
+      r0.appendChild(corner);
+      sections.forEach(function (s) {
+        const th = document.createElement('th');
+        th.className = 'tsection-col';
+        th.colSpan = s.count;
+        th.textContent = s.label || '';
+        r0.appendChild(th);
+      });
+    }
+
+    // Rotated model-name header row. The corner cell labels the case axis with
+    // the panel's case prefix (e.g. "Case TOOLCALLING.batch.*"), rotated the same
+    // way as the model names.
+    const r1 = outHead.insertRow();
+    const cornerCase = document.createElement('th');
+    cornerCase.className = 'tcol-model tcorner-case';
+    let prefix = (table.dataset.casePrefix || '').trim();
+    const mode = (table.dataset.mode || '').trim();
+    // Tool-calling prefixes already carry the case namespace ("TOOLCALLING.batch.");
+    // reasoning's is family-only ("REASONING."), where the namespace is the mode.
+    // Splice the mode in only for that family-only case.
+    if (mode && prefix.split('.').filter(Boolean).length === 1) {
+      prefix = prefix + mode + '.';
+    }
+    const caseLabel = document.createElement('span');
+    caseLabel.className = 'tcol-model-label';
+    const caseLabelLine = document.createElement('span');
+    caseLabelLine.className = 'tcol-model-line';
+    caseLabelLine.textContent = prefix ? ('Case ' + prefix + '*') : 'Case';
+    caseLabel.appendChild(caseLabelLine);
+    const cornerInner = document.createElement('div');
+    cornerInner.className = 'tcol-model-inner';
+    cornerInner.appendChild(caseLabel);
+    cornerCase.appendChild(cornerInner);
+    r1.appendChild(cornerCase);
+    models.forEach(function (m) {
+      const th = document.createElement('th');
+      th.className = 'tcol-model';
+      const label = document.createElement('span');
+      label.className = 'tcol-model-label';
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'tcol-model-name';
+      nameSpan.textContent = m.name;
+      label.appendChild(nameSpan);
+      // Second line: the tool-calling family, lifted from the original parser
+      // cell (without its tooltip). Clone the markup (not just text) so the
+      // parser-source link stays clickable, exactly like the non-transposed view.
+      if (m.parserTd) {
+        const famClone = m.parserTd.cloneNode(true);
+        const famTip = famClone.querySelector('.ttip');
+        if (famTip) famTip.remove();
+        if (famClone.textContent.trim()) {
+          const famSpan = document.createElement('span');
+          famSpan.className = 'tcol-model-family';
+          while (famClone.firstChild) {
+            famSpan.appendChild(famClone.firstChild);
+          }
+          label.appendChild(famSpan);
+        }
+      }
+      const inner = document.createElement('div');
+      inner.className = 'tcol-model-inner';
+      inner.appendChild(label);
+      th.appendChild(inner);
+      // Same hover tooltip as the original parser cell.
+      const srcTip = m.parserTd && m.parserTd.querySelector('.ttip');
+      if (srcTip) {
+        const tipClone = srcTip.cloneNode(true);
+        th.appendChild(tipClone);
+        attachTooltip(th);
+      }
+      r1.appendChild(th);
+    });
+
+    // One body row per sub-case, with a section banner when the group changes.
+    const outBody = out.createTBody();
+    let curGroup = null;
+    subThs.forEach(function (subTh, idx) {
+      const group = subTh.dataset.colHideGroup;
+      if (group !== curGroup) {
+        curGroup = group;
+        const sr = outBody.insertRow();
+        sr.className = 'section';
+        if (group) { sr.setAttribute('data-col-hide-group', group); }
+        const td = document.createElement('td');
+        td.colSpan = 1 + nModels;
+        td.textContent = groupLabel[group] || group || '';
+        sr.appendChild(td);
+      }
+      const tr = outBody.insertRow();
+      // Carry the case-group key so applyColumnState hides this row (and its section
+      // banner) when that group is collapsed via the column toggles — keeps the
+      // transposed view in sync with the original table's show/hide state.
+      if (group) { tr.setAttribute('data-col-hide-group', group); }
+      const caseTh = document.createElement('th');
+      caseTh.className = 'trow-case';
+      const link = subTh.querySelector('a');
+      caseTh.appendChild(link ? link.cloneNode(true) : document.createTextNode(subTh.textContent.trim()));
+      tr.appendChild(caseTh);
+      models.forEach(function (m) {
+        const src = m.cells[idx];
+        if (src) {
+          const clone = src.cloneNode(true);
+          clone.classList.remove('col-hidden');
+          clone.removeAttribute('data-col-hide-group');
+          // cloneNode copies the "already wired" flag; clear it so the clone
+          // gets its own tooltip listeners.
+          clone.removeAttribute('data-ttip-wired');
+          delete clone.dataset.ttipWired;
+          tr.appendChild(clone);
+          attachTooltip(clone);
+        } else {
+          const td = document.createElement('td');
+          td.className = 'cell na';
+          tr.appendChild(td);
+        }
+      });
+    });
+
+    return out;
+  }
+
+  function ensureTransposed(panel) {
+    if (panel.querySelector('table[data-transpose-table]')) return;
+    const orig = panel.querySelector('table[data-parity-table]');
+    if (!orig) return;
+    const transposed = buildTransposed(orig);
+    if (transposed) {
+      orig.insertAdjacentElement('afterend', transposed);
+      // Color the freshly-cloned cells with the panel's current Reference/Compare
+      // selection (applyCtl covers the mirror since it lives in the panel).
+      if (panelCtl(panel)) { applyCtl(panel); }
+      // Apply the current column-collapse state so a case group hidden in the
+      // original table stays hidden (as rows) in the freshly-built mirror.
+      applyColumnState(visibleColumns, false);
+    }
+  }
+
+  function applyTransposeMode(enabled, shouldUpdateUrl) {
+    document.body.classList.toggle('transpose-mode', Boolean(enabled));
+    if (transposeToggle) {
+      transposeToggle.checked = Boolean(enabled);
+    }
+    if (enabled) {
+      document.querySelectorAll('.tab-panel').forEach(ensureTransposed);
+    }
+    if (shouldUpdateUrl) {
+      updateTransposeUrl(Boolean(enabled));
+    }
+  }
+
+  applyTransposeMode(readTransposeMode(), false);
+  if (transposeToggle) {
+    transposeToggle.addEventListener('change', function () {
+      applyTransposeMode(transposeToggle.checked, true);
+    });
+  }
 })();

--- a/conformance/utils/src/conformance_table.html.j2
+++ b/conformance/utils/src/conformance_table.html.j2
@@ -21,6 +21,7 @@
 {% endfor %}
 <span class="tabs-right">
   <label class="checkbox-option cmp-detailed"><input type="checkbox" data-view-detailed> Detailed</label>
+  <label class="checkbox-option cmp-transpose"><input type="checkbox" data-transpose-toggle> Transpose</label>
   <button type="button" class="cmp-reset" data-reset title="Clear all selections and reload defaults">Reset</button>
 </span>
 </div>
@@ -30,7 +31,7 @@
 {% if panel.candidates %}
 {% include "_compare_bar.html.j2" %}
 {% endif %}
-<table data-parity-table>
+<table data-parity-table data-case-prefix="{{ panel.case_prefix|default('')|e }}" data-mode="{{ panel.mode|default('')|e }}">
 <thead>
 <tr>{{ panel.group_headers|safe }}</tr>
 <tr>{{ panel.sub_headers|safe }}</tr>

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -180,3 +180,123 @@ def test_overview_hides_compare_column(driver):
     assert ref_box_visible() is True, "REF picker must still show in Overview"
     set_detailed(True)
     assert cmp_box_visible() is True, "CMP column should reappear in Details"
+
+
+def _click_tab(driver, panel_id):
+    driver.execute_script(
+        "document.querySelector(arguments[0]).click();",
+        f'.tab-button[data-tab-target="{panel_id}"]',
+    )
+    time.sleep(0.2)
+
+
+def _set_transpose(driver, on):
+    driver.execute_script(
+        "const t=document.querySelector('[data-transpose-toggle]');"
+        "if(t && t.checked!==arguments[0]){t.checked=arguments[0]; t.dispatchEvent(new Event('change'));}",
+        on,
+    )
+    time.sleep(0.2)
+
+
+def test_transpose_builds_mirror_and_colors(driver):
+    """Toggling Transpose builds a mirror in the active panel: models become rotated
+    columns (th.tcol-model), cases become rows (th.trow-case), and the cloned cells
+    are colored by the SAME compare engine (cmp-eq/cmp-leak/cmp-na) — not left blank.
+    This is the DIS-2280 integration with #98's reference/compare model."""
+    _click_tab(driver, "tab-toolcalling-batch")
+    _set_transpose(driver, True)
+    info = driver.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active');
+        const tt = p.querySelector('table[data-transpose-table]');
+        if (!tt) return {built:false};
+        const cells = tt.querySelectorAll('td.cell');
+        let colored = 0;
+        cells.forEach(function (c) {
+          if (c.classList.contains('cmp-eq') || c.classList.contains('cmp-leak') || c.classList.contains('cmp-na')) colored++;
+        });
+        return {
+          built: true,
+          models: tt.querySelectorAll('th.tcol-model').length,
+          rows: tt.querySelectorAll('th.trow-case').length,
+          cells: cells.length,
+          colored: colored,
+        };
+        """
+    )
+    assert info["built"], "transposed mirror table was not built"
+    assert info["models"] > 1, "expected multiple rotated model columns"
+    assert info["rows"] > 1, "expected multiple case rows"
+    assert info["cells"] > 0 and info["colored"] == info["cells"], (
+        f"every cloned cell should be colored by applyCtl, got {info['colored']}/{info['cells']}"
+    )
+
+
+def test_transpose_does_not_double_overview_counts(driver):
+    """The mirror's cloned cells must not inflate the overview counts (both applyCtl
+    and updateOverviewStats skip cells inside [data-transpose-table])."""
+    _click_tab(driver, "tab-toolcalling-batch")
+    _set_transpose(driver, False)
+    counts = "const p=document.querySelector('.tab-panel.active');return Array.from(p.querySelectorAll('[data-overview-count]')).map(function(e){return e.textContent;});"
+    before = driver.execute_script(counts)
+    _set_transpose(driver, True)
+    after = driver.execute_script(counts)
+    assert before == after, f"overview counts changed when transposing: {before} -> {after}"
+
+
+def test_transpose_recolors_on_reference_change(driver):
+    """Picking a different Reference recolors the mirror too — applyCtl covers it
+    because the mirror lives in the same panel."""
+    _click_tab(driver, "tab-toolcalling-batch")
+    _set_transpose(driver, True)
+    snap = "const tt=document.querySelector('.tab-panel.active table[data-transpose-table]');return Array.from(tt.querySelectorAll('td.cell')).map(function(c){return c.className;});"
+    before = driver.execute_script(snap)
+    changed = driver.execute_script(
+        """
+        const ctl = document.querySelector('.tab-panel.active .cmpctl');
+        const refs = Array.from(ctl.querySelectorAll('input.cmp-ref'));
+        const other = refs.find(function (r) { return !r.checked && !r.disabled; });
+        if (!other) return false;
+        other.checked = true;
+        other.dispatchEvent(new Event('change', {bubbles: true}));
+        return true;
+        """
+    )
+    assert changed, "no alternate Reference available to select"
+    time.sleep(0.3)
+    after = driver.execute_script(snap)
+    assert before != after, "transposed cells did not recolor when the Reference changed"
+
+
+def test_transpose_honors_collapsed_case_group(driver):
+    """A case group collapsed via the column toggle in the original table stays hidden
+    (as rows) in the transposed mirror — the mirror carries data-col-hide-group and
+    re-applies the column state on build (regression: #87 review)."""
+    _click_tab(driver, "tab-toolcalling-batch")
+    _set_transpose(driver, False)
+    key = driver.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active');
+        const subKeys = new Set(Array.from(p.querySelectorAll('th.case-sub[data-col-hide-group]'))
+          .map(function (e) { return e.dataset.colHideGroup; }));
+        const btn = Array.from(p.querySelectorAll('[data-col-toggle]'))
+          .find(function (b) { return subKeys.has(b.dataset.colToggle); });
+        if (!btn) return null;
+        btn.click();  // collapse this case group
+        return btn.dataset.colToggle;
+        """
+    )
+    assert key, "no case-group column toggle found"
+    _set_transpose(driver, True)
+    hidden = driver.execute_script(
+        """
+        const key = arguments[0];
+        const tt = document.querySelector('.tab-panel.active table[data-transpose-table]');
+        const rows = tt.querySelectorAll('tr[data-col-hide-group="' + key + '"]');
+        if (!rows.length) return null;
+        return Array.from(rows).every(function (r) { return r.classList.contains('col-hidden'); });
+        """,
+        key,
+    )
+    assert hidden is True, f"transposed rows for collapsed group {key} should be hidden"

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -998,3 +998,22 @@ def test_compare_bar_renders_when_candidate_lacks_label_html() -> None:
         }
     )
     assert "cmprow-label" in html and "X (batch)" in html
+
+
+def test_transpose_feature_is_wired() -> None:
+    """DIS-2280 Transpose: the toggle, the JS mirror builder, and the CSS all ship
+    in the assets, and the JS integrates with #98's compare engine (applyCtl) rather
+    than the removed per-parser status model."""
+    tmpl = (SRC / "conformance_table.html.j2").read_text(encoding="utf-8")
+    js = (SRC / "assets" / "conformance.js").read_text(encoding="utf-8")
+    css = (SRC / "assets" / "conformance.css").read_text(encoding="utf-8")
+    # toolbar checkbox + case-axis data attrs the mirror's corner label reads
+    assert "data-transpose-toggle" in tmpl
+    assert "data-case-prefix" in tmpl and "data-mode" in tmpl
+    # JS builder + integration with the compare engine
+    assert "buildTransposed" in js and "data-transpose-table" in js
+    assert "if (panelCtl(panel)) { applyCtl(panel); }" in js  # recolor the mirror
+    assert "!cell.closest('[data-transpose-table]')" in js     # don't double-count
+    # CSS shows the mirror in transpose mode and hides the original
+    assert "body.transpose-mode" in css and ".transpose-table" in css
+    assert "sideways-lr" in css  # rotated bottom-up model headers


### PR DESCRIPTION
#### Overview:

Adds a **Transpose** checkbox to the Conformance v2 table so a single model can be scanned down one column instead of across the very wide sub-case axis. When enabled, the active panel's table is mirrored: **models become columns** (names rotated CCW 90°, bottom-up, to save width) and **test cases become rows**, grouped by case-group banners with the Top-N/Others grouping kept as a spanning header. ([DIS-2280](https://linear.app/nvidia/issue/DIS-2280))

**This is a pure GUI/rendering change** — no fixtures and no parser/conformance data changed; the pass/fail results are identical to `main`, only the presentation differs.

#### Example:

Transpose view, TC v2 (batch), Details: http://keivenc-linux.nvidia.com/dynamo/frontend-crates4/conformance/CONFORMANCE_v2.87.html?view=details&transpose=1&tab=tab-toolcalling-batch

Before (need to scroll to the right):
<img width="2179" height="542" alt="image" src="https://github.com/user-attachments/assets/deecda48-74a8-489f-a347-ed5c52575e48" />

After user selects the Transpose option:
<img width="985" height="1197" alt="image" src="https://github.com/user-attachments/assets/4f9a47b9-9ca3-4dd2-96e7-1b8aa7a71828" />

#### Details:

- The transposed table is built in JS by **cloning the server-rendered cells** into the same panel, so the compare engine (`applyCtl`) colors the mirror for free and recolors it whenever the **Reference/Compare** selection changes — no parallel data to keep in sync; the Python renderer stays the single source of truth for cell HTML. Built lazily on first enable, per tab; state persists via `?transpose=1`.
- Vertical model headers use `writing-mode: sideways-lr` (real CCW, no transform) with per-line rotation and `inline-flex; align-items: flex-end`, so the model name and its tool-calling family bottom-align flush at the cell bottom.
- Overview counts are guarded against double-counting: both `applyCtl` and `updateOverviewStats` skip cells inside `[data-transpose-table]`. Widths are view-scoped: narrow color blocks in Overview, auto-sized marker columns in Details.

#### Verification:

`python3 -m pytest conformance/utils/tests/` → 45 passed, including Selenium browser tests that assert the mirror builds and its cells are colored, the overview counts aren't doubled, and the mirror recolors when the Reference changes. Driven in headless Chrome across all tabs (overview + details).

#### Where should the reviewer start?

`conformance/utils/src/assets/conformance.js` (the `buildTransposed` / `ensureTransposed` / `applyTransposeMode` block), then `conformance/utils/src/assets/conformance.css` and `conformance/utils/src/conformance_table.html.j2`.

/coderabbit profile chill
