### PR TITLE
fix(tokenizers): guard decodestream::step against utf-8 char-boundary panic

### DIFF
--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -367,7 +367,18 @@ impl DecodeStream {
 
         let new_text = new_result.as_str();
         if new_text.len() > prefix_text.len() && !new_result.is_partial() {
-            let emitted = new_text[prefix_text.len()..].to_string();
+            // If the decode window starts on an incomplete multi-byte sequence,
+            // `prefix_text` contains a U+FFFD replacement char and
+            // `prefix_text.len()` may not be a char boundary in `new_text`;
+            // slicing there panics. Roll back to the nearest char boundary, then
+            // strip the replacement char. Mirrors `Sequence::append_token_id`.
+            let mut prefix_text_len = prefix_text.len();
+            while !new_text.is_char_boundary(prefix_text_len) && prefix_text_len > 0 {
+                prefix_text_len -= 1;
+            }
+            let emitted = new_text[prefix_text_len..]
+                .to_string()
+                .replace('\u{FFFD}', "");
 
             self.prefix_offset = self.read_offset;
             self.read_offset = self.all_token_ids.len();

--- a/tokenizers/tests/decode_stream_utf8_boundary.rs
+++ b/tokenizers/tests/decode_stream_utf8_boundary.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Reproduction: UTF-8 char-boundary panic in `DecodeStream::step`.
+//
+// `step` slices the freshly decoded text at `new_text[prefix_text.len()..]`
+// without checking that `prefix_text.len()` is a char boundary. When a decode
+// window begins on orphaned multi-byte continuation bytes, `prefix_text` starts
+// with a U+FFFD replacement char and the byte offset lands *inside* a multi-byte
+// char in `new_text`, panicking with "byte index N is not a char boundary".
+//
+// The sibling `Sequence::append_token_id` already guards this (walks the split
+// point back to a char boundary, then strips U+FFFD); `DecodeStream::step` does
+// not. This test drives the bundled TinyLlama tokenizer with a minimal 3-token
+// sequence that triggers it.
+
+use dynamo_tokenizers::Tokenizer;
+
+const TINYLLAMA: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../llm/tests/data/sample-models/TinyLlama_v1.1/tokenizer.json"
+);
+
+#[test]
+fn decode_stream_handles_multibyte_boundary() {
+    let tokenizer = Tokenizer::from_file(TINYLLAMA).expect("load TinyLlama tokenizer");
+    let mut stream = tokenizer.decode_stream(&[], false);
+
+    // Minimal reproducing sequence (found by fuzzing the real tokenizer).
+    let mut out = String::new();
+    for id in [9u32, 248, 14259] {
+        // Pre-fix: this panics on the third token with
+        //   "byte index 1 is not a char boundary; it is inside '\u{FFFD}'".
+        if let Some(chunk) = stream.step(id).expect("step should not error") {
+            out.push_str(&chunk);
+        }
+    }
+
+    // Only reached once the boundary is handled safely.
+    assert!(out.ends_with("wir"), "unexpected decode output: {out:?}");
+}


### PR DESCRIPTION
## Summary

`DecodeStream::step` slices the freshly decoded text at a raw byte offset (`new_text[prefix_text.len()..]`) without checking that the offset is a UTF-8 char boundary. When a streaming decode window begins on orphaned multi-byte continuation bytes (common with CJK / emoji output, especially byte-fallback tokenizers), `prefix_text` contains a `U+FFFD` replacement char and `prefix_text.len()` lands inside a multi-byte character in `new_text`, so the slice panics:

```
byte index N is not a char boundary; it is inside '\u{FFFD}' (bytes ..) of ...
```

In a server this surfaces as an HTTP 500 from `/v1/chat/completions` (the generation finishes, then the detokenizer task panics during streaming).

The sibling `Sequence::append_token_id` already handles this exact case (it walks the split point back to a char boundary and strips `U+FFFD`). `DecodeStream::step` was missed. This PR applies the same guard.

## Root cause

`tokenizers/src/lib.rs`, `DecodeStream::step`:

```rust
let emitted = new_text[prefix_text.len()..].to_string(); // panics: not a char boundary
```

vs the guarded `Sequence::append_token_id` in the same file:

```rust
let mut prefix_text_len = prefix_text.len();
while !new_text.is_char_boundary(prefix_text_len) && prefix_text_len > 0 {
    prefix_text_len -= 1;
}
let new_text = new_text[prefix_text_len..].to_string().replace('\u{FFFD}', "");
```

## Reproduction

Minimal, deterministic, and offline (uses the repo-bundled TinyLlama tokenizer, which has byte-fallback tokens). Added as `tokenizers/tests/decode_stream_utf8_boundary.rs`:

```rust
let tokenizer = Tokenizer::from_file(TINYLLAMA)?;
let mut stream = tokenizer.decode_stream(&[], false);
for id in [9u32, 248, 14259] {
    stream.step(id)?; // third token panics before this fix
}
```

Before the fix, `cargo test -p dynamo-tokenizers` fails:

```
thread 'decode_stream_handles_multibyte_boundary' panicked at tokenizers/src/lib.rs:370:
byte index 1 is not a char boundary; it is inside '\u{FFFD}' (bytes 0..3) of `\u{FFFD}\u{FFFD} wir`
test result: FAILED. 0 passed; 1 failed
```

The 3-token sequence was found by fuzzing random token streams (byte-fallback + normal vocab) through the real tokenizer, then minimized.

## The fix

Mirror `Sequence::append_token_id`: roll `prefix_text.len()` back to the nearest char boundary before slicing, and strip the leftover `U+FFFD`. This only changes behavior on the previously-panicking boundary case; normal output is unaffected.

## Test plan

`cargo fmt --check`, `cargo clippy -p dynamo-tokenizers --tests -- -D warnings`, and `cargo test -p dynamo-tokenizers` all pass (toolchain 1.93.1):

```
test decode_stream_handles_multibyte_boundary ... ok
test result: ok. 46 passed; 0 failed   (unit)
test result: ok.  8 passed; 0 failed   (cache_correctness)
test result: ok.  1 passed; 0 failed   (decode_stream_utf8_boundary)
```

## Note on sync direction

CONTRIBUTING.md says crate-source changes normally originate in `ai-dynamo/dynamo` `lib/tokenizers/` and sync one-way into this repo. `ai-dynamo/dynamo` `main` no longer exposes `lib/tokenizers/` publicly (it consumes the published `dynamo-tokenizers = "=1.3.2"`), so this PR is opened here against the living source. Happy to re-route or mirror it wherever maintainers prefer.
