### PR TITLE
chore(docs): remove outdated code location guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,3 @@ cargo fmt --all -- --check
 cargo machete
 cargo deny --all-features check bans licenses
 ```
-
-## Where the code lives
-
-These crates currently mirror `lib/{protocols,tokenizers,parsers,renderer}/` from [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo). The sync is **one-way (dynamo → frontend-crates) and manual** for now — see [`scripts/sync-from-dynamo.sh`](./scripts/sync-from-dynamo.sh) to check for upstream changes.
-
-> **Heads up:** this mirroring is temporary. Over the next few weeks we plan to **remove the sync entirely and make this repository the source of truth** for these crates — dynamo will then depend on the published crates rather than the other way around. Until that cutover lands, treat dynamo as upstream and land crate changes there first.


### PR DESCRIPTION
## Summary

- Remove the obsolete **Where the code lives** section from the README.

## Context

Dynamo has completed the cutover from local workspace copies to the crates published from this repository:

- Parsers: [ai-dynamo/dynamo#10423](https://github.com/ai-dynamo/dynamo/pull/10423)
- Protocols: [ai-dynamo/dynamo#10882](https://github.com/ai-dynamo/dynamo/pull/10882)
- Tokenizers: [ai-dynamo/dynamo#10897](https://github.com/ai-dynamo/dynamo/pull/10897)
- Renderer: [ai-dynamo/dynamo#10898](https://github.com/ai-dynamo/dynamo/pull/10898)

Those PRs removed the corresponding local crates from the Dynamo workspace and switched its path dependencies to published registry versions maintained here. The temporary one-way mirroring guidance in the README is therefore no longer accurate.

## Impact

Documentation-only. This prevents contributors from being directed to Dynamo as the source of truth for these crates.

## Validation

- `git diff --check`
