### PR TITLE
ci: label external-contribution PRs and skip conformance comment on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -21,3 +21,23 @@ jobs:
         with:
           task_types: '["feat", "fix", "docs", "test", "ci", "refactor", "perf", "chore", "revert", "style", "build"]'
           add_label: 'true'
+
+  external-contribution:
+    name: Label external contributions
+    # Fork PRs only, on open.
+    if: ${{ github.event.action == 'opened' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add external-contribution label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["external-contribution"]
+            });


### PR DESCRIPTION
Add an external-contribution job to the Lint PR workflow that labels fork PRs on open.

Also guard the conformance-table comment step so it only runs for same-repo PRs; fork PRs receive a read-only token under pull_request, so the gh pr comment call was failing with 'Resource not accessible by integration'. The render and artifact-upload steps still run for forks.

closes: OPS-7444