### PR TITLE
feat(parsers): move streaming tool-call jail into dynamo-parsers (DIS-2296, part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,11 @@ dependencies = [
 name = "dynamo-parsers"
 version = "3.0.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
+ "async-stream",
+ "dynamo-protocols",
+ "futures",
  "num-traits",
  "openai-harmony",
  "regex",

--- a/parsers/Cargo.toml
+++ b/parsers/Cargo.toml
@@ -27,5 +27,14 @@ openai-harmony.workspace = true
 rustpython-parser.workspace = true
 num-traits.workspace = true
 
+# Streaming tool-call jail (ported from dynamo lib/llm). The jail wraps the
+# streaming parsers, so it needs the OpenAI chat stream protocol types plus the
+# async-stream/futures combinators. dynamo-protocols has no dependencies, so
+# dynamo-parsers -> dynamo-protocols stays acyclic.
+dynamo-protocols = { workspace = true }
+async-stream.workspace = true
+futures.workspace = true
+aho-corasick.workspace = true
+
 [dev-dependencies]
 rstest.workspace = true

--- a/parsers/src/tool_calling/jail/annotated.rs
+++ b/parsers/src/tool_calling/jail/annotated.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal `Annotated<R>` stream wrapper.
+//!
+//! The streaming tool-call jail was ported from dynamo `lib/llm`, where the
+//! stream item is `dynamo_runtime::protocols::annotated::Annotated<R>`.
+//! frontend-crates cannot depend on `dynamo-runtime` (dynamo depends on these
+//! crates, not the other way around), so the jail carries its own minimal copy
+//! of the wrapper. It preserves the fields the jail reads and forwards — the
+//! stream payload plus the `id`/`event`/`comment` metadata — so dynamo can map
+//! its own `Annotated` to and from this type at its boundary after the move.
+//!
+//! The dynamo-runtime `error` field is `Option<DynamoError>`; the jail never
+//! constructs an error (every literal is `error: None`), so this copy uses
+//! `Option<String>` and avoids pulling in the dynamo error type.
+
+use serde::{Deserialize, Serialize};
+
+/// A stream item plus optional annotation metadata.
+///
+/// Mirrors `dynamo_runtime::protocols::annotated::Annotated` for the fields the
+/// jail depends on.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Annotated<R> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<R>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/parsers/src/tool_calling/jail/mod.rs
+++ b/parsers/src/tool_calling/jail/mod.rs
@@ -35,7 +35,7 @@ use dynamo_protocols::types::{
     FunctionCallStream, FunctionType, Role,
 };
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::tool_calling::config::{JsonParserConfig, ParserConfig};
@@ -175,6 +175,45 @@ fn create_choice_stream(
         },
         finish_reason,
         logprobs,
+    }
+}
+
+/// Build a single-choice terminal chunk from a prior response used as a template.
+///
+/// Ported with the jail from dynamo `chat_completions.rs`; adapted to the shared
+/// `CreateChatCompletionStreamResponse` (no `Nv` newtype / `llm_metrics`). Used by
+/// `fix_finish_reason` to synthesize a `tool_calls` finish_reason chunk when the
+/// upstream stream ended without one.
+fn stream_choice_chunk_from_template(
+    template: &CreateChatCompletionStreamResponse,
+    index: u32,
+    content: Option<dynamo_protocols::types::ChatCompletionMessageContent>,
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    finish_reason: Option<FinishReason>,
+) -> Annotated<CreateChatCompletionStreamResponse> {
+    let mut response = template.clone();
+    response.usage = None;
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role: None,
+            content,
+            tool_calls,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs: None,
+    };
+    response.choices = vec![choice];
+    Annotated {
+        data: Some(response),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
     }
 }
 
@@ -1483,17 +1522,37 @@ impl JailedStream {
     where
         S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
     {
+        let _ = named_tool_active;
+        let _ = &jail_mode;
         stream! {
             tokio::pin!(input_stream);
             let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
+            // Choices that already received a finish_reason during the stream — used by
+            // the backstop below to avoid synthesizing a duplicate.
+            let mut terminated: HashSet<u32> = HashSet::new();
+            // Last response, kept (with choices cleared) as a template for a synthesized
+            // finish_reason chunk when the stream ended without one.
+            let mut template: Option<CreateChatCompletionStreamResponse> = None;
+            // Choices for which this post-processor has already emitted a synthetic
+            // terminal chunk. Tracking this per choice allows a later tool-call choice
+            // to terminate even if an earlier empty-choices chunk emitted nothing.
+            let mut synthesized: HashSet<u32> = HashSet::new();
 
             while let Some(mut response) = input_stream.next().await {
-                // Track if any choice emitted tool calls
+                // Track if any choice emitted tool calls, and which already terminated.
                 if let Some(ref data) = response.data {
                     for choice in &data.choices {
                         if choice.delta.tool_calls.is_some() {
                             has_tool_calls_per_choice.insert(choice.index, true);
                         }
+                        if choice.finish_reason.is_some() {
+                            terminated.insert(choice.index);
+                        }
+                    }
+                    {
+                        let mut t = data.clone();
+                        t.choices.clear();
+                        template = Some(t);
                     }
                 }
 
@@ -1509,7 +1568,6 @@ impl JailedStream {
                                 // choice, finish_reason MUST be "tool_calls" — regardless of
                                 // whether tool_choice was "auto", "required", or a named
                                 // function.
-                                let _ = named_tool_active;
                                 match &jail_mode {
                                     JailMode::MarkerBased => {
                                         if has_tool_calls {
@@ -1528,7 +1586,65 @@ impl JailedStream {
                     }
                 }
 
+                // OpenAI stream ordering: the terminal finish_reason chunk must precede
+                // the usage-only chunk. When a chunk with no choices arrives (the
+                // frontend's compliance usage chunk, or any other empty-choices chunk)
+                // and tool-call choices are still missing a finish_reason, synthesize
+                // their terminal `ToolCalls` chunks *before* yielding this one.
+                let is_empty_choices = response
+                    .data
+                    .as_ref()
+                    .is_some_and(|d| d.choices.is_empty());
+                if is_empty_choices && let Some(template) = &template {
+                    let mut indices: Vec<_> = has_tool_calls_per_choice
+                        .iter()
+                        .filter_map(|(index, has)| {
+                            (*has && !terminated.contains(index) && !synthesized.contains(index))
+                                .then_some(*index)
+                        })
+                        .collect();
+                    indices.sort_unstable();
+                    for index in indices {
+                        yield stream_choice_chunk_from_template(
+                            template,
+                            index,
+                            None,
+                            None,
+                            Some(FinishReason::ToolCalls),
+                        );
+                        synthesized.insert(index);
+                    }
+                }
+
                 yield response;
+            }
+
+            // Backstop: the stream ended without a finish_reason AND without an
+            // empty-choices/usage chunk to anchor the synthesized terminal chunks
+            // before (e.g. the engine dropped the terminal signal and the frontend
+            // never emitted a usage chunk). Emit one trailing `ToolCalls` chunk per
+            // tool-call choice that never received a finish_reason. Strict OpenAI
+            // clients wait for a non-null finish_reason before considering a tool call
+            // complete; without this they hang until their client-side timeout.
+            if let Some(template) = template {
+                let mut indices: Vec<_> = has_tool_calls_per_choice
+                    .iter()
+                    .filter_map(|(index, has)| {
+                        (*has && !terminated.contains(index) && !synthesized.contains(index))
+                            .then_some(*index)
+                    })
+                    .collect();
+                indices.sort_unstable();
+                for index in indices {
+                    yield stream_choice_chunk_from_template(
+                        &template,
+                        index,
+                        None,
+                        None,
+                        Some(FinishReason::ToolCalls),
+                    );
+                    synthesized.insert(index);
+                }
             }
         }
     }
@@ -2160,6 +2276,235 @@ mod tests {
             all_text.contains("Done!"),
             "Trailing text 'Done!' should appear in output. Got text: {:?}",
             all_text
+        );
+    }
+
+    // --- #11045: synthesize tool_calls finish_reason when the stream lacks one ---
+    // (ported from dynamo; adapted to the shared `Create` type — no `llm_metrics`)
+
+    fn usage_only_chunk() -> Annotated<CreateChatCompletionStreamResponse> {
+        Annotated {
+            data: Some(CreateChatCompletionStreamResponse {
+                id: "id-42".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "test-model".to_string(),
+                choices: vec![],
+                usage: Some(dynamo_protocols::types::CompletionUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                    total_tokens: 15,
+                    prompt_tokens_details: None,
+                    completion_tokens_details: None,
+                }),
+                service_tier: None,
+                system_fingerprint: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Build one data chunk whose choices have already emitted tool-call deltas.
+    fn tool_call_choices_chunk(indices: &[u32]) -> Annotated<CreateChatCompletionStreamResponse> {
+        let mut chunk = text_chunk("");
+        let data = chunk.data.as_mut().expect("tool-call response data");
+        #[allow(deprecated)]
+        {
+            data.choices = indices
+                .iter()
+                .map(|index| ChatChoiceStream {
+                    index: *index,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: None,
+                        tool_calls: Some(vec![ChatCompletionMessageToolCallChunk {
+                            index: 0,
+                            id: Some(format!("call-{index}")),
+                            r#type: Some(FunctionType::Function),
+                            function: Some(FunctionCallStream {
+                                name: Some(format!("tool_{index}")),
+                                arguments: Some("{}".to_string()),
+                            }),
+                        }]),
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                })
+                .collect();
+        }
+        chunk
+    }
+
+    fn heartbeat() -> Annotated<CreateChatCompletionStreamResponse> {
+        Annotated {
+            data: None,
+            id: None,
+            event: None,
+            comment: Some(vec!["heartbeat".to_string()]),
+            error: None,
+        }
+    }
+
+    fn final_finish_reason(
+        responses: &[Annotated<CreateChatCompletionStreamResponse>],
+    ) -> Option<FinishReason> {
+        responses
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| d.choices.iter())
+            .filter_map(|c| c.finish_reason)
+            .next_back()
+    }
+
+    #[tokio::test]
+    async fn jail_synthesizes_tool_calls_finish_reason_when_stream_lacks_one() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
+        let output_stream = jail.apply_with_finish_reason(Box::pin(stream::iter(chunks)));
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(
+            !tool_calls.is_empty(),
+            "expected the hermes tool call to be parsed: {tool_calls:?}"
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+        assert_eq!(
+            final_finish_reason(&responses),
+            Some(FinishReason::ToolCalls),
+            "backstop must synthesize ToolCalls when the stream ended without a finish_reason"
+        );
+    }
+
+    #[tokio::test]
+    async fn jail_does_not_synthesize_finish_reason_for_text_only_stream() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+        let chunks = vec![text_chunk("hello world"), text_chunk("")];
+        let output_stream = jail.apply_with_finish_reason(Box::pin(stream::iter(chunks)));
+        let responses: Vec<_> = output_stream.collect().await;
+        assert!(
+            collect_tool_calls(&responses).is_empty(),
+            "no tool calls expected"
+        );
+        assert_eq!(
+            final_finish_reason(&responses),
+            None,
+            "text-only stream with no upstream finish_reason must not get a synthetic one"
+        );
+    }
+
+    #[tokio::test]
+    async fn jail_synthesizes_tool_calls_before_usage_only_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+        let chunks = vec![
+            heartbeat(),
+            text_chunk(
+                "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+            ),
+            usage_only_chunk(),
+        ];
+        let output_stream = jail.apply_with_finish_reason(Box::pin(stream::iter(chunks)));
+        let responses: Vec<_> = output_stream.collect().await;
+        assert_eq!(
+            responses
+                .first()
+                .and_then(|response| response.comment.clone()),
+            Some(vec!["heartbeat".to_string()]),
+            "leading non-data annotations must pass through unchanged"
+        );
+        assert!(
+            !collect_tool_calls(&responses).is_empty(),
+            "expected the hermes tool call"
+        );
+        assert_eq!(
+            final_finish_reason(&responses),
+            Some(FinishReason::ToolCalls)
+        );
+        // The ToolCalls terminal chunk must precede the usage-only chunk.
+        let finish_pos = responses.iter().position(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.choices
+                    .iter()
+                    .any(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+            })
+        });
+        let usage_pos = responses.iter().position(|r| {
+            r.data
+                .as_ref()
+                .is_some_and(|d| d.usage.is_some() && d.choices.is_empty())
+        });
+        let finish_pos = finish_pos.expect("no ToolCalls chunk emitted");
+        let usage_pos = usage_pos.expect("no usage-only chunk in output");
+        assert!(
+            finish_pos < usage_pos,
+            "ToolCalls chunk at {finish_pos} must precede the usage chunk at {usage_pos}"
+        );
+        let finish_data = responses[finish_pos].data.as_ref().unwrap();
+        assert!(
+            finish_data.usage.is_none(),
+            "synthesized ToolCalls chunk must not repeat usage data"
+        );
+    }
+
+    #[tokio::test]
+    async fn jail_synthesizes_late_tool_choices_in_index_order() {
+        let chunks = vec![
+            usage_only_chunk(),
+            tool_call_choices_chunk(&[2, 0, 1]),
+            usage_only_chunk(),
+        ];
+        let responses: Vec<_> =
+            JailedStream::fix_finish_reason(stream::iter(chunks), JailMode::MarkerBased, false)
+                .collect()
+                .await;
+        let usage_positions: Vec<_> = responses
+            .iter()
+            .enumerate()
+            .filter_map(|(position, response)| {
+                response
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data.choices.is_empty() && data.usage.is_some())
+                    .then_some(position)
+            })
+            .collect();
+        assert_eq!(
+            usage_positions.len(),
+            2,
+            "both empty-choices chunks must pass through"
+        );
+        let terminals: Vec<_> = responses
+            .iter()
+            .enumerate()
+            .flat_map(|(position, response)| {
+                response.data.iter().flat_map(move |data| {
+                    data.choices.iter().filter_map(move |choice| {
+                        (choice.finish_reason == Some(FinishReason::ToolCalls))
+                            .then_some((position, choice.index))
+                    })
+                })
+            })
+            .collect();
+        assert_eq!(
+            terminals
+                .iter()
+                .map(|(_, index)| *index)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "synthetic terminal chunks must be deterministic"
+        );
+        assert!(
+            terminals.iter().all(|(position, _)| {
+                usage_positions[0] < *position && *position < usage_positions[1]
+            }),
+            "terminal chunks must follow the early empty response and precede the final usage response"
         );
     }
 }

--- a/parsers/src/tool_calling/jail/mod.rs
+++ b/parsers/src/tool_calling/jail/mod.rs
@@ -1,0 +1,2165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo **v1** tool-call handling: the *jail-and-batch* mechanism.
+//!
+//! The jail buffers ("jails") the model's streamed output until it can decide
+//! whether a span is a tool call, then **batch-parses** the accumulated text
+//! and emits the result — it accumulates, then parses, rather than parsing
+//! token-by-token. This is the v1 path and is **being deprecated**: the
+//! pure-streaming v2 parser under `../parsers_v2/` is under development and will
+//! fully replace it, at which point this v1 crate is removed outright.
+//!
+//! This module is a relocation, not a rewrite: it was moved from dynamo
+//! `lib/llm/src/protocols/openai/chat_completions/jail.rs` so all of v1 lives
+//! in one repo during the transition. v1 behavior is unchanged.
+
+// TODO: Deprecate this when v2 streaming (../parsers_v2/) fully replaces v1 —
+// at that point the jail-and-batch mechanism and this whole v1 crate are removed.
+
+pub mod annotated;
+mod prefix_matcher;
+
+use async_stream::stream;
+// These are all shared `dynamo-*` types, which is why moving the jail here is
+// safe. The jail's inputs and outputs are defined once in `dynamo-protocols`
+// (and `ToolDefinition` etc. in `dynamo-parsers`), and dynamo consumes the exact
+// same published crates — there is no duplicated definition and nothing to
+// drift, so a change lands in one place and both the jail (here) and dynamo pick
+// it up on the next version bump. The only dynamo-local layers are the
+// `Nv{inner, nvext}` newtype and dynamo-runtime's `Annotated`, which dynamo
+// re-wraps at its own boundary after the move.
+use dynamo_protocols::types::{
+    ChatChoiceLogprobs, ChatChoiceStream, ChatCompletionMessageToolCallChunk,
+    ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse, FinishReason,
+    FunctionCallStream, FunctionType, Role,
+};
+use futures::{Stream, StreamExt};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::tool_calling::config::{JsonParserConfig, ParserConfig};
+use crate::tool_calling::gemma4::split_partial_call_prefix_gemma4;
+use crate::tool_calling::json::try_tool_call_parse_basic_json;
+use crate::tool_calling::parsers::get_tool_parser_map;
+use crate::tool_calling::{
+    detect_tool_call_start, find_tool_call_end_position, try_tool_call_parse_aggregate,
+    try_tool_call_parse_aggregate_finalize,
+};
+
+pub use self::annotated::Annotated;
+use self::prefix_matcher::{MarkerMatcher, MatchResult};
+
+fn is_harmony_parser(parser: Option<&str>) -> bool {
+    parser == Some("harmony")
+}
+
+fn contains_harmony_protocol(text: &str) -> bool {
+    text.contains("<|channel|>")
+}
+
+/// Represents what a choice wants to emit after processing content
+#[derive(Debug, Clone)]
+pub enum ChoiceEmission {
+    /// Pass through content unchanged (choice is not jailed)
+    PassThrough(ChatChoiceStream),
+    /// Emit parsed tool calls (choice finished jailing with tool calls)
+    ToolCall(ChatChoiceStream),
+    /// Emit accumulated content (choice finished jailing without tool calls)
+    Content(ChatChoiceStream),
+    /// Emit trailing content after tool call end (choice has trailing after unjail)
+    Trailing(ChatChoiceStream),
+}
+
+impl ChoiceEmission {
+    /// Extract the ChatChoiceStream from any emission type
+    pub fn into_choice(self) -> ChatChoiceStream {
+        match self {
+            ChoiceEmission::PassThrough(choice) => choice,
+            ChoiceEmission::ToolCall(choice) => choice,
+            ChoiceEmission::Content(choice) => choice,
+            ChoiceEmission::Trailing(choice) => choice,
+        }
+    }
+
+    /// Get the choice index
+    pub fn index(&self) -> u32 {
+        match self {
+            ChoiceEmission::PassThrough(choice) => choice.index,
+            ChoiceEmission::ToolCall(choice) => choice.index,
+            ChoiceEmission::Content(choice) => choice.index,
+            ChoiceEmission::Trailing(choice) => choice.index,
+        }
+    }
+
+    /// Get mutable access to the underlying choice.
+    fn choice_mut(&mut self) -> &mut ChatChoiceStream {
+        match self {
+            ChoiceEmission::PassThrough(choice) => choice,
+            ChoiceEmission::ToolCall(choice) => choice,
+            ChoiceEmission::Content(choice) => choice,
+            ChoiceEmission::Trailing(choice) => choice,
+        }
+    }
+}
+
+/// Configuration for jail detection and parsing
+#[derive(Debug, Clone)]
+pub struct JailConfig<'a> {
+    pub jail_start_sequences: &'a [String],
+    pub jail_end_sequences: &'a [String],
+    pub tool_call_parser: Option<&'a str>,
+}
+
+/// Jail activation mode
+#[derive(Debug, Clone, PartialEq)]
+pub enum JailMode {
+    /// Traditional: wait for start marker, then jail
+    MarkerBased,
+    /// Immediate: start jailed from first token (for tool_choice)
+    Immediate { format: ToolChoiceFormat },
+}
+
+/// Format for tool_choice immediate jail mode
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolChoiceFormat {
+    /// tool_choice=named: expect single object {"location": "Paris", ...}
+    SingleObject { tool_name: String },
+    /// tool_choice=required: expect array [{name:"search", parameters:{...}}, ...]
+    ArrayOfTools,
+}
+
+/// State tracking for an individual choice during jail processing
+#[derive(Debug, Clone)]
+struct ChoiceJailState {
+    /// The choice index (0, 1, 2, ...)
+    index: u32,
+    /// Whether this choice is currently jailed
+    is_jailed: bool,
+    /// Accumulated content for this choice while jailed
+    accumulated_content: String,
+    /// Accumulated logprobs for this choice while jailed.
+    /// Logprobs from each jailed chunk are appended so the full token-level
+    /// log-probability information is preserved when the jail emits.
+    accumulated_logprobs: Option<ChatChoiceLogprobs>,
+    /// Buffer for partial marker matches across chunks
+    partial_match_buffer: String,
+    /// Stream finish reason
+    stream_finish_reason: Option<FinishReason>,
+    /// Number of tool calls already emitted for this choice
+    emitted_tool_calls_count: usize,
+    /// Reasoning content collected while waiting for a suitable emission.
+    pending_reasoning_content: Option<String>,
+}
+
+fn create_choice_stream(
+    index: u32,
+    role: Option<Role>,
+    content: &str,
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    finish_reason: Option<FinishReason>,
+    logprobs: Option<ChatChoiceLogprobs>,
+) -> ChatChoiceStream {
+    #[allow(deprecated)]
+    ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role,
+            content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                content.to_string(),
+            )),
+            tool_calls,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs,
+    }
+}
+
+impl ChoiceJailState {
+    /// Create a new jail state for a choice
+    fn new(index: u32, starts_jailed: bool) -> Self {
+        Self {
+            index,
+            is_jailed: starts_jailed,
+            accumulated_content: String::new(),
+            accumulated_logprobs: None,
+            partial_match_buffer: String::new(),
+            stream_finish_reason: None,
+            emitted_tool_calls_count: 0,
+            pending_reasoning_content: None,
+        }
+    }
+
+    /// Add content and logprobs to this choice's accumulation
+    fn accumulate(&mut self, content: &str, logprobs: Option<&ChatChoiceLogprobs>) {
+        if self.is_jailed {
+            self.accumulated_content.push_str(content);
+            // Accumulate logprobs so they are preserved across jailed chunks.
+            if let Some(lp) = logprobs {
+                let state_lps = self.accumulated_logprobs.get_or_insert(ChatChoiceLogprobs {
+                    content: None,
+                    refusal: None,
+                });
+                if let Some(content_lps) = &lp.content {
+                    state_lps
+                        .content
+                        .get_or_insert_with(Vec::new)
+                        .extend(content_lps.clone());
+                }
+                if let Some(refusal_lps) = &lp.refusal {
+                    state_lps
+                        .refusal
+                        .get_or_insert_with(Vec::new)
+                        .extend(refusal_lps.clone());
+                }
+            }
+        }
+    }
+
+    /// Consume the accumulated logprobs, replacing them with `None`.
+    fn take_accumulated_logprobs(&mut self) -> Option<ChatChoiceLogprobs> {
+        self.accumulated_logprobs.take()
+    }
+
+    /// End jailing and return the accumulated content
+    fn end_jail(&mut self) -> String {
+        self.is_jailed = false;
+        self.accumulated_logprobs = None;
+        std::mem::take(&mut self.accumulated_content)
+    }
+
+    fn handle_trailing_content(
+        &mut self,
+        content: &str,
+        choice: &ChatChoiceStream,
+        jail_stream: &JailedStream,
+        emissions: &mut Vec<ChoiceEmission>,
+    ) {
+        if content.is_empty() {
+            return;
+        }
+
+        if let MatchResult::Partial {
+            prefix, partial, ..
+        } = jail_stream.marker_matcher.process_chunk(content, "")
+        {
+            if !prefix.is_empty() {
+                #[allow(deprecated)]
+                let trailing_choice = create_choice_stream(
+                    choice.index,
+                    choice.delta.role,
+                    &prefix,
+                    None,
+                    None,
+                    choice.logprobs.clone(),
+                );
+                emissions.push(ChoiceEmission::Trailing(trailing_choice));
+            }
+            self.partial_match_buffer = partial;
+            return;
+        }
+
+        if let Some((prefix, partial)) = jail_stream.split_partial_tool_call_start(content) {
+            if !prefix.is_empty() {
+                #[allow(deprecated)]
+                let trailing_choice = create_choice_stream(
+                    choice.index,
+                    choice.delta.role,
+                    prefix,
+                    None,
+                    None,
+                    choice.logprobs.clone(),
+                );
+                emissions.push(ChoiceEmission::Trailing(trailing_choice));
+            }
+            self.partial_match_buffer = partial.to_string();
+        } else if jail_stream.should_start_jail(content) {
+            self.is_jailed = true;
+            self.accumulated_content = content.to_string();
+            self.accumulated_logprobs = None;
+        } else {
+            #[allow(deprecated)]
+            let trailing_choice = create_choice_stream(
+                choice.index,
+                choice.delta.role,
+                content,
+                None,
+                choice.finish_reason,
+                choice.logprobs.clone(),
+            );
+            emissions.push(ChoiceEmission::Trailing(trailing_choice));
+        }
+    }
+
+    /// Process incoming content and return what should be emitted (if anything)
+    async fn process_content(
+        &mut self,
+        choice: &ChatChoiceStream,
+        content: &str,
+        jail_stream: &JailedStream,
+    ) -> Vec<ChoiceEmission> {
+        let mut emissions = Vec::new();
+        if !self.is_jailed {
+            // Use the marker matcher to detect complete/partial markers
+            let match_result = jail_stream
+                .marker_matcher
+                .process_chunk(content, &self.partial_match_buffer);
+
+            match match_result {
+                MatchResult::Complete {
+                    prefix,
+                    marker,
+                    suffix,
+                    ..
+                } => {
+                    let prefix_has_harmony_protocol =
+                        is_harmony_parser(jail_stream.tool_call_parser.as_deref())
+                            && contains_harmony_protocol(&prefix);
+
+                    // Emit prefix if any
+                    if !prefix.is_empty() && !prefix_has_harmony_protocol {
+                        #[allow(deprecated)]
+                        let prefix_choice = create_choice_stream(
+                            choice.index,
+                            choice.delta.role,
+                            &prefix,
+                            None,
+                            choice.finish_reason,
+                            choice.logprobs.clone(),
+                        );
+                        emissions.push(ChoiceEmission::PassThrough(prefix_choice));
+                    }
+
+                    // Build the potential full content
+                    let full_content = if prefix_has_harmony_protocol {
+                        format!("{}{}{}", prefix, marker, suffix)
+                    } else {
+                        format!("{}{}", marker, suffix)
+                    };
+
+                    // Check if this already contains the end marker
+                    let (should_end, split_pos) = jail_stream.should_end_jail(&full_content).await;
+                    self.partial_match_buffer.clear();
+
+                    if should_end {
+                        // Complete tool call found in this chunk
+                        let (jailed_part, trailing_part) = full_content.split_at(split_pos);
+
+                        // Create the tool call choice
+                        let tool_choice = jail_stream
+                            .create_tool_call_choice(
+                                choice.index,
+                                jailed_part,
+                                choice,
+                                self.emitted_tool_calls_count,
+                                false, // streaming early-exit, no EOF recovery
+                            )
+                            .await;
+
+                        if tool_choice.delta.tool_calls.is_some() {
+                            if let Some(ref tool_calls) = tool_choice.delta.tool_calls {
+                                self.emitted_tool_calls_count += tool_calls.len();
+                            }
+                            emissions.push(ChoiceEmission::ToolCall(tool_choice));
+                        } else {
+                            emissions.push(ChoiceEmission::Content(tool_choice));
+                        }
+
+                        // Handle trailing content if any
+                        self.handle_trailing_content(
+                            trailing_part,
+                            choice,
+                            jail_stream,
+                            &mut emissions,
+                        );
+                    } else {
+                        // Start jailing with the marker and suffix
+                        self.is_jailed = true;
+                        self.accumulated_content = full_content;
+                        // Seed accumulated logprobs with this chunk's logprobs
+                        self.accumulated_logprobs = choice.logprobs.clone();
+                    }
+                }
+
+                MatchResult::Partial {
+                    prefix,
+                    partial,
+                    possible_patterns,
+                } => {
+                    if is_harmony_parser(jail_stream.tool_call_parser.as_deref())
+                        && contains_harmony_protocol(&prefix)
+                    {
+                        self.is_jailed = true;
+                        self.accumulated_content = format!("{}{}", prefix, partial);
+                        self.accumulated_logprobs = choice.logprobs.clone();
+                        self.partial_match_buffer.clear();
+                        return emissions;
+                    }
+
+                    // Emit the safe prefix
+                    if !prefix.is_empty() {
+                        #[allow(deprecated)]
+                        let prefix_choice = create_choice_stream(
+                            choice.index,
+                            choice.delta.role,
+                            &prefix,
+                            None,
+                            choice.finish_reason,
+                            choice.logprobs.clone(),
+                        );
+                        emissions.push(ChoiceEmission::PassThrough(prefix_choice));
+                    }
+
+                    // Hold the partial for next chunk
+                    self.partial_match_buffer = partial;
+
+                    tracing::trace!(
+                        "Choice {} holding partial '{}' for patterns: {:?}",
+                        choice.index,
+                        self.partial_match_buffer,
+                        possible_patterns
+                    );
+                }
+
+                MatchResult::None { content } => {
+                    if let Some((prefix, partial)) =
+                        jail_stream.split_partial_tool_call_start(&content)
+                    {
+                        if !prefix.is_empty() {
+                            #[allow(deprecated)]
+                            let prefix_choice = create_choice_stream(
+                                choice.index,
+                                choice.delta.role,
+                                prefix,
+                                None,
+                                None,
+                                choice.logprobs.clone(),
+                            );
+                            emissions.push(ChoiceEmission::PassThrough(prefix_choice));
+                        }
+                        self.partial_match_buffer = partial.to_string();
+                    } else if jail_stream.should_start_jail(&content) {
+                        // Start jailing with the combined content
+                        self.is_jailed = true;
+                        self.accumulated_content = content;
+                        // Seed accumulated logprobs with this chunk's logprobs
+                        self.accumulated_logprobs = choice.logprobs.clone();
+                        self.partial_match_buffer.clear();
+                    } else {
+                        // No markers - emit everything
+                        if !content.is_empty() {
+                            #[allow(deprecated)]
+                            let pass_through_choice = create_choice_stream(
+                                choice.index,
+                                choice.delta.role,
+                                &content,
+                                None,
+                                choice.finish_reason,
+                                choice.logprobs.clone(),
+                            );
+                            emissions.push(ChoiceEmission::PassThrough(pass_through_choice));
+                        }
+                        self.partial_match_buffer.clear();
+                    }
+                }
+            }
+        } else {
+            // Already jailed - accumulate content AND logprobs, then check for unjail
+            self.accumulate(content, choice.logprobs.as_ref());
+
+            let (should_end, split_pos) =
+                jail_stream.should_end_jail(&self.accumulated_content).await;
+
+            if should_end {
+                // Take accumulated logprobs before borrowing accumulated_content
+                let jail_logprobs = self.take_accumulated_logprobs();
+
+                // Split the content
+                let (jailed_part, trailing_part) = self.accumulated_content.split_at(split_pos);
+                let trailing_owned = trailing_part.to_string();
+                let jailed_owned = jailed_part.to_string();
+
+                // Create the unjailed choice, using accumulated logprobs
+                let mut unjailed_choice = jail_stream
+                    .create_tool_call_choice(
+                        choice.index,
+                        &jailed_owned,
+                        choice,
+                        self.emitted_tool_calls_count,
+                        false, // streaming unjail, no EOF recovery
+                    )
+                    .await;
+                unjailed_choice.logprobs = jail_logprobs;
+
+                // Determine emission type based on whether tool calls were parsed
+                if unjailed_choice.delta.tool_calls.is_some() {
+                    if let Some(ref tool_calls) = unjailed_choice.delta.tool_calls {
+                        self.emitted_tool_calls_count += tool_calls.len();
+                    }
+                    emissions.push(ChoiceEmission::ToolCall(unjailed_choice));
+                } else {
+                    emissions.push(ChoiceEmission::Content(unjailed_choice));
+                }
+
+                // End jailing before processing trailing content
+                self.end_jail();
+
+                // Handle trailing content if any
+                self.handle_trailing_content(&trailing_owned, choice, jail_stream, &mut emissions);
+            }
+            // If not unjailing, don't emit anything (still accumulating)
+        }
+        emissions
+    }
+
+    /// Finalize any remaining content when stream ends
+    async fn finalize(&mut self, jail_stream: &JailedStream) -> Option<ChoiceEmission> {
+        if self.is_jailed && !self.accumulated_content.is_empty() {
+            // Create a dummy choice for the method call
+            #[allow(deprecated)]
+            let dummy_choice = create_choice_stream(
+                self.index,
+                Some(Role::Assistant),
+                &self.accumulated_content,
+                None,
+                self.stream_finish_reason, // For the accumulated content, assign the original stream finish reason, otherwise it will get lost
+                self.accumulated_logprobs.clone(),
+            );
+
+            let mut final_choice = jail_stream
+                .create_tool_call_choice(
+                    self.index,
+                    &self.accumulated_content,
+                    &dummy_choice,
+                    self.emitted_tool_calls_count,
+                    true, // finalize: enable EOF recovery for missing-end-token / truncated-JSON
+                )
+                .await;
+            // Attach the full accumulated logprobs to the final choice
+            final_choice.logprobs = self.take_accumulated_logprobs();
+
+            // Preserve any pending reasoning content collected while jailed.
+            if let Some(pending_reasoning) = self.pending_reasoning_content.take() {
+                if let Some(existing_reasoning) = final_choice.delta.reasoning_content.as_mut() {
+                    existing_reasoning.push_str(&pending_reasoning);
+                } else {
+                    final_choice.delta.reasoning_content = Some(pending_reasoning);
+                }
+            }
+
+            if let Some(ref tool_calls) = final_choice.delta.tool_calls {
+                self.emitted_tool_calls_count += tool_calls.len();
+            }
+
+            // End jailing
+            self.end_jail();
+
+            // Determine emission type
+            if final_choice.delta.tool_calls.is_some() {
+                Some(ChoiceEmission::ToolCall(final_choice))
+            } else {
+                Some(ChoiceEmission::Content(final_choice))
+            }
+        } else if !self.partial_match_buffer.is_empty() {
+            let content = std::mem::take(&mut self.partial_match_buffer);
+            let choice = create_choice_stream(
+                self.index,
+                Some(Role::Assistant),
+                &content,
+                None,
+                self.stream_finish_reason,
+                None,
+            );
+            Some(ChoiceEmission::Content(choice))
+        } else {
+            None
+        }
+    }
+}
+
+/// Collection of choice jail states with deterministic ordering
+#[derive(Debug, Clone)]
+struct ChoiceJailStateCollection {
+    /// Vec of states, always kept sorted by choice index for deterministic iteration
+    states: Vec<ChoiceJailState>,
+}
+
+impl ChoiceJailStateCollection {
+    /// Create a new empty collection
+    fn new() -> Self {
+        Self { states: Vec::new() }
+    }
+
+    /// Get or create state for a choice index
+    fn get_or_create_state(&mut self, index: u32, starts_jailed: bool) -> &mut ChoiceJailState {
+        // Find the position where this index should be
+        match self.states.binary_search_by_key(&index, |s| s.index) {
+            Ok(pos) => {
+                // Found existing state
+                &mut self.states[pos]
+            }
+            Err(insert_pos) => {
+                // Need to create new state
+                let new_state = ChoiceJailState::new(index, starts_jailed);
+                self.states.insert(insert_pos, new_state);
+                &mut self.states[insert_pos]
+            }
+        }
+    }
+}
+
+/// Emission mode for handling multiple choices
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EmissionMode {
+    /// Pack multiple choices in the same chunk (default, matches original behavior)
+    #[default]
+    Packed,
+    /// Emit one choice per chunk for OpenAI compatibility
+    SingleChoicePerChunk,
+}
+
+/// A stream transformer that can "jail" tokens based on configurable start/end sequences
+/// When jailed, tokens are accumulated rather than yielded immediately
+/// When the jail ends (via end sequence or stream completion), accumulated content is processed and released
+pub struct JailedStream {
+    jail_start_sequences: Vec<String>,
+    jail_end_sequences: Vec<String>,
+    tool_call_parser: Option<String>,
+    /// When set, only tool calls with this name are emitted (enforces tool_choice=named
+    /// when a tool_call_parser is active and the parser-aware MarkerBased path is used).
+    named_tool_name: Option<String>,
+    tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
+    emission_mode: EmissionMode,
+    marker_matcher: MarkerMatcher,
+    jail_mode: JailMode,
+}
+
+impl JailedStream {
+    /// Create a new builder for configuring a JailedStream
+    pub fn builder() -> JailedStreamBuilder {
+        JailedStreamBuilder::new()
+    }
+
+    /// Whether the jail starts already-jailed (tool_choice=required/named path).
+    fn is_immediate(&self) -> bool {
+        matches!(self.jail_mode, JailMode::Immediate { .. })
+    }
+
+    /// Apply jail stream transformation with finish_reason fix
+    /// This is a convenience method that applies both apply() and fix_finish_reason()
+    pub fn apply_with_finish_reason<S>(
+        self,
+        stream: S,
+    ) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+    where
+        S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        let jail_mode = self.jail_mode.clone();
+        let named_tool_active = self.named_tool_name.is_some();
+        let jailed_stream = self.apply(stream);
+        JailedStream::fix_finish_reason(jailed_stream, jail_mode, named_tool_active)
+    }
+
+    /// Apply the jail transformation to a stream of chat completion responses
+    /// Consumes self and returns the transformed stream
+    pub fn apply<S>(
+        self,
+        stream: S,
+    ) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+    where
+        S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        // Use the stream! macro for cleaner async stream processing
+        stream! {
+            // State variables - clean architecture with choice state collection
+            let mut choice_states = ChoiceJailStateCollection::new();
+            // Track Annotated metadata for preservation
+            let mut last_annotated_id: Option<String> = None;
+            let mut last_annotated_event: Option<String> = None;
+            let mut last_annotated_comment: Option<Vec<String>> = None;
+            // Track stream response metadata so finalization chunks carry real values
+            let mut last_stream_id = String::new();
+            let mut last_stream_model = String::new();
+            let mut last_stream_created: u32 = 0;
+
+            // Pin the stream for iteration (stack pinning is more efficient)
+            tokio::pin!(stream);
+
+
+            // Process each item in the stream
+            while let Some(response) = stream.next().await {
+                if let Some(chat_response) = response.data.as_ref() {
+                    last_stream_id.clone_from(&chat_response.id);
+                    last_stream_model.clone_from(&chat_response.model);
+                    last_stream_created = chat_response.created;
+
+                    let mut all_emissions = Vec::new();
+
+                    if chat_response.choices.is_empty() {
+                        // No choices processed (e.g., usage-only chunk)
+                        // Pass through as-is to preserve usage and other metadata
+                        yield response;
+                        continue;
+                    }
+
+                    // Process each choice independently using the new architecture
+                    for choice in &chat_response.choices {
+                        if let Some(ref content) = choice.delta.content {
+                            // Jailing only applies to text content
+                            let text_content = match content {
+                                dynamo_protocols::types::ChatCompletionMessageContent::Text(text) => Some(text.as_str()),
+                                dynamo_protocols::types::ChatCompletionMessageContent::Parts(_) => None,
+                            };
+
+                            if let Some(text) = text_content {
+                                let choice_state = choice_states
+                                    .get_or_create_state(choice.index, self.is_immediate());
+
+                                if let Some(reasoning_content) = &choice.delta.reasoning_content {
+                                    let pending = choice_state
+                                        .pending_reasoning_content
+                                        .get_or_insert_with(String::new);
+                                    pending.push_str(reasoning_content);
+                                }
+
+                                // Store metadata when any choice becomes jailed (first time only)
+                                if !choice_state.is_jailed && self.should_start_jail(text)
+                                    && last_annotated_id.is_none() {
+                                        last_annotated_id = response.id.clone();
+                                        last_annotated_event = response.event.clone();
+                                        last_annotated_comment = response.comment.clone();
+                                    }
+
+                                // Track actual stream finish reason in the choice state
+                                choice_state.stream_finish_reason = choice.finish_reason;
+
+                                // Process this choice and get emissions
+                                let mut emissions = choice_state.process_content(choice, text, &self).await;
+                                if !emissions.is_empty()
+                                    && let Some(reasoning) = choice_state.pending_reasoning_content.take()
+                                    && let Some(first) = emissions.first_mut()
+                                {
+                                    first.choice_mut().delta.reasoning_content = Some(reasoning);
+                                }
+                                all_emissions.extend(emissions);
+                            }
+                            // For multimodal content, pass through unchanged (no jailing)
+                        } else {
+                            // Handle choices without content (final chunks with finish_reason,
+                            // role-only chunks, or chunks where the upstream reasoning parser
+                            // stripped all content into `reasoning_content`).
+                            //
+                            // `starts_jailed` must reflect the configured jail_mode: if Immediate
+                            // mode is initialized via this branch (e.g., a reasoning-only first
+                            // chunk), hardcoding `false` here silently disables it for the rest
+                            // of the stream — `get_or_create_state` ignores the argument on
+                            // subsequent calls.
+                            let choice_state = choice_states
+                                .get_or_create_state(choice.index, self.is_immediate());
+                            // Also track stream finish reason from content-less final chunks
+                            // (e.g. finish_reason=Stop arriving in a chunk with content=None) so
+                            // the Immediate-mode finalize path can emit the correct finish_reason.
+                            if choice.finish_reason.is_some() {
+                                choice_state.stream_finish_reason = choice.finish_reason;
+                            }
+                            let has_pending_buffered_output =
+                                !choice_state.partial_match_buffer.is_empty();
+                            let was_ever_jailed = !choice_state.accumulated_content.is_empty()
+                                || choice_state.is_jailed
+                                || has_pending_buffered_output;
+
+                            // Reasoning-only chunks must pass through even when jailed; only
+                            // `content` is subject to accumulation.
+                            let should_emit = choice.delta.role.is_some()
+                                || choice.delta.tool_calls.is_some()
+                                || choice.delta.reasoning_content.is_some()
+                                || !was_ever_jailed;
+
+                            if should_emit {
+                                let pass_through_choice = ChatChoiceStream {
+                                    index: choice.index,
+                                    delta: choice.delta.clone(),
+                                    finish_reason: choice.finish_reason,
+                                    logprobs: choice.logprobs.clone(),
+                                };
+                                all_emissions.push(ChoiceEmission::PassThrough(pass_through_choice));
+                            }
+                        }
+                    }
+
+                    // Emit all results based on emission mode
+                    if !all_emissions.is_empty() {
+                        // Group emissions by type for proper ordering and separation
+                        let mut tool_content_emissions = Vec::new();
+                        let mut trailing_emissions = Vec::new();
+                        let mut passthrough_emissions = Vec::new();
+
+                        for emission in all_emissions {
+                            match emission {
+                                ChoiceEmission::PassThrough(_) => passthrough_emissions.push(emission),
+                                ChoiceEmission::ToolCall(_) | ChoiceEmission::Content(_) => {
+                                    tool_content_emissions.push(emission);
+                                }
+                                ChoiceEmission::Trailing(_) => {
+                                    trailing_emissions.push(emission);
+                                }
+                            }
+                        }
+
+                        // Emit tool calls and content with preserved metadata
+                        if !tool_content_emissions.is_empty() {
+                            let preserved_metadata = (
+                                last_annotated_id.clone(),
+                                last_annotated_event.clone(),
+                                last_annotated_comment.clone(),
+                            );
+                            let responses = self.emit_choice_emissions(tool_content_emissions, chat_response, preserved_metadata);
+                            for emitted_response in responses {
+                                yield emitted_response;
+                            }
+                        }
+
+                        // Emit trailing content separately (always as individual chunks)
+                        if !trailing_emissions.is_empty() {
+                            let preserved_metadata = (
+                                last_annotated_id.clone(),
+                                last_annotated_event.clone(),
+                                last_annotated_comment.clone(),
+                            );
+                            let responses = self.emit_choice_emissions(trailing_emissions, chat_response, preserved_metadata);
+                            for emitted_response in responses {
+                                yield emitted_response;
+                            }
+                        }
+
+                        // Emit pass-through content with current metadata
+                        if !passthrough_emissions.is_empty() {
+                            let current_metadata = (response.id.clone(), response.event.clone(), response.comment.clone());
+                            let responses = self.emit_choice_emissions(passthrough_emissions, chat_response, current_metadata);
+                            for emitted_response in responses {
+                                yield emitted_response;
+                            }
+                        }
+                    }
+                } else {
+                    // No response data, pass through as-is
+                    yield response;
+                }
+            }
+
+            // Stream ended - finalize any remaining jailed choices
+            let mut final_emissions = Vec::new();
+            for state in choice_states.states.iter_mut() {
+                if let Some(emission) = state.finalize(&self).await {
+                    final_emissions.push(emission);
+                }
+            }
+
+            if !final_emissions.is_empty() {
+                tracing::debug!("Stream ended while jailed, releasing accumulated content");
+                // Create a finalization response carrying forward real stream metadata
+                let dummy_response = CreateChatCompletionStreamResponse {
+                    id: last_stream_id,
+                    object: "chat.completion.chunk".to_string(),
+                    created: last_stream_created,
+                    model: last_stream_model,
+                    choices: Vec::new(),
+                    usage: None,
+                    service_tier: None,
+                    system_fingerprint: None,
+                };
+
+                let final_metadata = (last_annotated_id, last_annotated_event, last_annotated_comment);
+                let responses = self.emit_choice_emissions(final_emissions, &dummy_response, final_metadata);
+                for emitted_response in responses {
+                    yield emitted_response;
+                }
+            }
+        }
+    }
+
+    /// Emit choice emissions based on the configured emission mode
+    fn emit_choice_emissions(
+        &self,
+        emissions: Vec<ChoiceEmission>,
+        base_response: &CreateChatCompletionStreamResponse,
+        annotated_metadata: (Option<String>, Option<String>, Option<Vec<String>>),
+    ) -> Vec<Annotated<CreateChatCompletionStreamResponse>> {
+        if emissions.is_empty() {
+            return Vec::new();
+        }
+
+        let (id, event, comment) = annotated_metadata;
+
+        match self.emission_mode {
+            EmissionMode::Packed => {
+                // Pack all choices into a single response
+                let mut response = base_response.clone();
+                response.choices = emissions.into_iter().map(|e| e.into_choice()).collect();
+
+                vec![Annotated {
+                    data: Some(response),
+                    id,
+                    event,
+                    comment,
+                    error: None,
+                }]
+            }
+            EmissionMode::SingleChoicePerChunk => {
+                // Emit each choice in a separate response
+                emissions
+                    .into_iter()
+                    .map(|emission| {
+                        let mut response = base_response.clone();
+                        response.choices = vec![emission.into_choice()];
+
+                        Annotated {
+                            data: Some(response),
+                            id: id.clone(),
+                            event: event.clone(),
+                            comment: comment.clone(),
+                            error: None,
+                        }
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    /// Check if content matches any jail start patterns
+    fn split_partial_tool_call_start<'a>(&self, content: &'a str) -> Option<(&'a str, &'a str)> {
+        if self.tool_call_parser.as_deref() == Some("gemma4") {
+            return split_partial_call_prefix_gemma4(content);
+        }
+        None
+    }
+
+    /// Whether this parser must never surface tool-call markup to the user, so
+    /// finalize strips residual markers rather than releasing the raw buffer.
+    ///
+    /// The real source of truth is `dynamo-parsers`'
+    /// `JsonParserConfig::discard_unparseable_wrapper`, set by that crate's
+    /// `hermes()` / `qwen25()` / `jamba()` configs (ai-dynamo/frontend-crates,
+    /// `parsers/src/tool_calling/config.rs`) and already honored by the batch
+    /// parser. We allowlist by name here only because the pinned `dynamo-parsers`
+    /// version predates that exported field, so it can't be read yet; extend the
+    /// list when a new family opts into the never-leak contract.
+    // TODO: read `discard_unparseable_wrapper` from the parser config and drop
+    // this name allowlist (hermes/qwen25/jamba) once the `dynamo-parsers`
+    // dependency is bumped to a version that exports the field.
+    fn suppresses_tool_call_markup(&self) -> bool {
+        matches!(
+            self.tool_call_parser.as_deref(),
+            Some("hermes") | Some("qwen25") | Some("jamba")
+        )
+    }
+
+    fn should_start_jail(&self, content: &str) -> bool {
+        // Path 1: Check configured start sequences
+        let sequence_match = !self.jail_start_sequences.is_empty()
+            && self
+                .jail_start_sequences
+                .iter()
+                .any(|seq| content.contains(seq));
+
+        // Path 2: Check for tool call start pattern
+        let tool_call_match = self.tool_call_parser.is_some()
+            && detect_tool_call_start(content, self.tool_call_parser.as_deref()).unwrap_or(false);
+
+        sequence_match || tool_call_match
+    }
+
+    fn prefix_before_first_tool_call_marker<'a>(&self, content: &'a str) -> Option<&'a str> {
+        let mut first_marker: Option<usize> = None;
+
+        for marker in &self.jail_start_sequences {
+            if marker.is_empty() {
+                continue;
+            }
+            if let Some(pos) = content.find(marker) {
+                first_marker = Some(first_marker.map_or(pos, |current| current.min(pos)));
+            }
+        }
+
+        first_marker.map(|pos| &content[..pos])
+    }
+
+    /// Check if accumulated content should end jail
+    async fn should_end_jail(&self, accumulated_content: &str) -> (bool, usize) {
+        match &self.jail_mode {
+            JailMode::MarkerBased => {
+                // Path 1: End sequence detected via naive string search.
+                let end_marker_info = if !self.jail_end_sequences.is_empty() {
+                    self.jail_end_sequences.iter().find_map(|seq| {
+                        accumulated_content
+                            .find(seq)
+                            .map(|pos| (pos + seq.len(), seq.clone()))
+                    })
+                } else {
+                    None
+                };
+
+                // Path 2: Complete tool call(s) can be parsed (early exit)
+                let early_exit = self.should_exit_jail_early(accumulated_content).await;
+
+                // When a tool_call_parser is active, prefer Path 2 over Path 1 so
+                // that `find_tool_call_end_position` advances past all consecutive
+                // parallel tool calls instead of splitting at the first end tag.
+                // Fall back to Path 1 when parsing fails (e.g. malformed content).
+                if early_exit {
+                    // For early exit, find where the complete tool call ends.
+                    // `find_tool_call_end_position` returns `None` when the
+                    // section wrapper isn't closed (e.g. kimi_k2 without
+                    // section_end). In that case, don't early-exit — more
+                    // parallel calls may follow. The calls will be recovered
+                    // by `finalize()` at stream end.
+                    if let Some(parser) = &self.tool_call_parser {
+                        let tools_slice = self.tool_definitions.as_deref();
+                        if let Ok((_, _)) = try_tool_call_parse_aggregate(
+                            accumulated_content,
+                            Some(parser),
+                            tools_slice,
+                        )
+                        .await
+                        {
+                            if let Some(split_pos) =
+                                find_tool_call_end_position(accumulated_content, Some(parser))
+                            {
+                                (true, split_pos)
+                            } else {
+                                (false, accumulated_content.len())
+                            }
+                        } else {
+                            (false, accumulated_content.len())
+                        }
+                    } else {
+                        (false, accumulated_content.len())
+                    }
+                } else if let Some((end_pos, _)) = end_marker_info {
+                    (true, end_pos)
+                } else {
+                    (false, accumulated_content.len())
+                }
+            }
+            JailMode::Immediate { format } => {
+                // For tool_choice, check if we have valid complete JSON
+                match format {
+                    ToolChoiceFormat::SingleObject { .. } => {
+                        // Expect single object: {"location": "Paris", "unit": "celsius"}
+                        if let Ok(value) =
+                            serde_json::from_str::<serde_json::Value>(accumulated_content)
+                            && value.is_object()
+                        {
+                            return (true, accumulated_content.len());
+                        }
+                        (false, accumulated_content.len())
+                    }
+                    ToolChoiceFormat::ArrayOfTools => {
+                        // Expect array: [{"name":"search","parameters":{...}}, ...]
+                        if let Ok(value) =
+                            serde_json::from_str::<serde_json::Value>(accumulated_content)
+                            && let Some(arr) = value.as_array()
+                            && !arr.is_empty()
+                        {
+                            return (true, accumulated_content.len());
+                        }
+                        (false, accumulated_content.len())
+                    }
+                }
+            }
+        }
+    }
+
+    /// Parse tool calls from accumulated content and create choice.
+    ///
+    /// `is_finalize` selects the recovery-enabled aggregator (missing
+    /// outer end-token / truncated JSON). Streaming early-exit callers pass
+    /// `false`; the stream-end finalize path passes `true`.
+    async fn create_tool_call_choice(
+        &self,
+        choice_index: u32,
+        accumulated_content: &str,
+        base_choice: &ChatChoiceStream,
+        tool_call_offset: usize,
+        is_finalize: bool,
+    ) -> ChatChoiceStream {
+        match &self.jail_mode {
+            JailMode::MarkerBased => {
+                // Traditional marker-based tool call parsing
+                let tools_slice = self.tool_definitions.as_deref();
+                let parse_result = if is_finalize {
+                    try_tool_call_parse_aggregate_finalize(
+                        accumulated_content,
+                        self.tool_call_parser.as_deref(),
+                        tools_slice,
+                    )
+                    .await
+                } else {
+                    try_tool_call_parse_aggregate(
+                        accumulated_content,
+                        self.tool_call_parser.as_deref(),
+                        tools_slice,
+                    )
+                    .await
+                };
+                match parse_result {
+                    Ok((tool_calls, normal_text)) if !tool_calls.is_empty() => {
+                        // If a named tool filter is set (tool_choice=named + parser path), reject
+                        // tool calls that don't match the required tool name.
+                        let tool_calls = if let Some(ref required_name) = self.named_tool_name {
+                            let filtered: Vec<_> = tool_calls
+                                .into_iter()
+                                .filter(|tc| tc.function.name == *required_name)
+                                .collect();
+                            if filtered.is_empty() {
+                                tracing::warn!(
+                                    required = %required_name,
+                                    "tool_choice=named: parser emitted no matching tool calls; dropping jail output"
+                                );
+                            }
+                            filtered
+                        } else {
+                            tool_calls
+                        };
+
+                        if tool_calls.is_empty() {
+                            // All parsed calls were filtered out — emit the parser's stripped
+                            // normal_text, not accumulated_content (which still contains the
+                            // raw tool-call markers).
+                            return create_choice_stream(
+                                choice_index,
+                                Some(Role::Assistant),
+                                normal_text.as_deref().unwrap_or(""),
+                                None,
+                                base_choice.finish_reason,
+                                base_choice.logprobs.clone(),
+                            );
+                        }
+
+                        // Convert to streaming format
+                        let tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> = tool_calls
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, tool_call)| ChatCompletionMessageToolCallChunk {
+                                index: (tool_call_offset + idx) as u32,
+                                id: Some(tool_call.id),
+                                r#type: Some(FunctionType::Function),
+                                function: Some(FunctionCallStream {
+                                    name: Some(tool_call.function.name),
+                                    arguments: Some(tool_call.function.arguments),
+                                }),
+                            })
+                            .collect();
+                        create_choice_stream(
+                            choice_index,
+                            Some(Role::Assistant),
+                            normal_text.as_deref().unwrap_or(""),
+                            Some(tool_call_chunks),
+                            base_choice.finish_reason,
+                            base_choice.logprobs.clone(),
+                        )
+                    }
+                    Ok((_, normal_text)) => {
+                        // Parser succeeded but extracted no structured tool calls. Most parsers
+                        // signal which sub-case via normal_text:
+                        //   - Some(""):  parser detected markers but couldn't form a complete
+                        //                call (e.g. kimi truncated mid-arg, or start token with
+                        //                no valid JSON). Drop the buffer — accumulated_content
+                        //                still has the raw markers and would leak.
+                        //   - otherwise: parser saw no markers (false positive entry, e.g.
+                        //                mistral on a stray `{` in prose, or default `<tool_call>`
+                        //                token when manual sequences are configured). Pass
+                        //                accumulated_content through verbatim — it's regular text
+                        //                and may carry leading/trailing whitespace the parser
+                        //                would have trimmed.
+                        //
+                        // Harmony is different because its tool parser is also responsible for
+                        // stripping Harmony envelopes when no reasoning parser is configured.
+                        // In zero-call Harmony marker cases, emit the stripped normal_text rather
+                        // than accumulated_content, which still contains raw protocol markers.
+                        let content: String = if is_finalize
+                            && self.tool_call_parser.as_deref() == Some("minimax_m2")
+                            && self
+                                .prefix_before_first_tool_call_marker(accumulated_content)
+                                .is_some()
+                        {
+                            // MiniMax's reference parser is strict: missing paired fences means
+                            // zero recovered calls. The raw `<minimax:tool_call>` envelope is
+                            // still protocol markup, so keep only pre-call prose at stream end.
+                            self.prefix_before_first_tool_call_marker(accumulated_content)
+                                .unwrap_or("")
+                                .to_string()
+                        } else if normal_text.as_deref() == Some("") {
+                            String::new()
+                        } else if is_harmony_parser(self.tool_call_parser.as_deref())
+                            && contains_harmony_protocol(accumulated_content)
+                        {
+                            normal_text.as_deref().unwrap_or("").to_string()
+                        } else if self.suppresses_tool_call_markup() {
+                            // No call parsed out of a jailed buffer: strip the markers rather
+                            // than leak the raw text. Handled in the jail so it holds regardless
+                            // of the installed parser version.
+                            if let Some(prefix) =
+                                self.prefix_before_first_tool_call_marker(accumulated_content)
+                            {
+                                // Truncated / unparseable wrapper: keep the prose before the
+                                // opening marker, drop the rest.
+                                prefix.trim_end().to_string()
+                            } else if self.jail_end_sequences.iter().any(|seq| {
+                                !seq.is_empty() && accumulated_content.contains(seq.as_str())
+                            }) {
+                                // Orphan close marker(s) with no opener: remove every occurrence
+                                // (not just trailing) so a mid-buffer marker can't leak.
+                                let mut cleaned = accumulated_content.to_string();
+                                for seq in self.jail_end_sequences.iter().filter(|s| !s.is_empty())
+                                {
+                                    cleaned = cleaned.replace(seq.as_str(), "");
+                                }
+                                cleaned.trim().to_string()
+                            } else {
+                                // No markers: false-positive jail entry on prose, pass through.
+                                accumulated_content.to_string()
+                            }
+                        } else {
+                            // Other parsers / generic jails: release the buffer verbatim.
+                            accumulated_content.to_string()
+                        };
+                        create_choice_stream(
+                            choice_index,
+                            Some(Role::Assistant),
+                            &content,
+                            None,
+                            base_choice.finish_reason,
+                            base_choice.logprobs.clone(),
+                        )
+                    }
+                    Err(e) => {
+                        // Parser errored — emit empty content rather than the raw buffer.
+                        // accumulated_content may still contain tool-call markers, and
+                        // surfacing those to the user is the leak we're guarding against.
+                        // The warn! gives operators visibility into the failure.
+                        tracing::warn!(
+                            error = %e,
+                            "tool-call parser errored; dropping buffered content to avoid marker leak"
+                        );
+                        create_choice_stream(
+                            choice_index,
+                            Some(Role::Assistant),
+                            "",
+                            None,
+                            base_choice.finish_reason,
+                            base_choice.logprobs.clone(),
+                        )
+                    }
+                }
+            }
+            JailMode::Immediate { format } => {
+                // tool_choice=required/named path (SGLang/vLLM-style).
+                //
+                // Primary parser is try_tool_call_parse_basic_json (the
+                // base_json_parser) since guided decoding constrains output
+                // to a bare JSON shape. Fallbacks cover two edge cases:
+                //
+                //   * Named tool_choice when the schema produces just the
+                //     parameters object (no {name, parameters} wrapper) —
+                //     handled by parse_tool_choice_json, which knows the
+                //     target tool_name from ToolChoiceFormat::SingleObject.
+                //
+                //   * Backends that do not honor guided decoding and emit
+                //     the model's native format instead (e.g. qwen3_coder
+                //     XML). In that case try_tool_call_parse_aggregate with
+                //     the configured tool_call_parser recovers the call.
+                let mut tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> = Vec::new();
+
+                // 1. Primary: bare-JSON extraction — handles
+                //    `[{name,parameters}, ...]`, `{name,parameters}`,
+                //    `{name,arguments}`, and arrays of either.
+                let basic_json_cfg = JsonParserConfig {
+                    bare_json_mode: true,
+                    ..Default::default()
+                };
+                // Per-path indices are placeholders — final indices are assigned
+                // below after the named filter so dropped entries don't leave
+                // gaps and multi-emission streams don't collide.
+                if let Ok((parsed, _)) = try_tool_call_parse_basic_json(
+                    accumulated_content,
+                    &basic_json_cfg,
+                    self.tool_definitions.as_deref(),
+                ) && !parsed.is_empty()
+                {
+                    tool_call_chunks.extend(parsed.into_iter().map(|tc| {
+                        ChatCompletionMessageToolCallChunk {
+                            index: 0,
+                            id: Some(tc.id),
+                            r#type: Some(FunctionType::Function),
+                            function: Some(FunctionCallStream {
+                                name: Some(tc.function.name),
+                                arguments: Some(tc.function.arguments),
+                            }),
+                        }
+                    }));
+                }
+
+                // 2. Named-only fallback: output is just the parameters object
+                //    (tool_name is supplied by SingleObject format).
+                if tool_call_chunks.is_empty()
+                    && let Ok(chunks) = self.parse_tool_choice_json(accumulated_content, format)
+                {
+                    tool_call_chunks = chunks;
+                }
+
+                // 3. Marker-based fallback for backends that did not enforce
+                //    guided decoding and emitted the model's native format.
+                if tool_call_chunks.is_empty()
+                    && self.tool_call_parser.is_some()
+                    && let Ok((tool_calls, _)) = try_tool_call_parse_aggregate(
+                        accumulated_content,
+                        self.tool_call_parser.as_deref(),
+                        self.tool_definitions.as_deref(),
+                    )
+                    .await
+                {
+                    tool_call_chunks.extend(tool_calls.into_iter().map(|tc| {
+                        ChatCompletionMessageToolCallChunk {
+                            index: 0,
+                            id: Some(tc.id),
+                            r#type: Some(FunctionType::Function),
+                            function: Some(FunctionCallStream {
+                                name: Some(tc.function.name),
+                                arguments: Some(tc.function.arguments),
+                            }),
+                        }
+                    }));
+                }
+
+                // Named filter: drop any parsed calls whose name doesn't match.
+                // Track whether the filter drained a non-empty list so we can
+                // suppress the content fallback below — otherwise the raw
+                // wrong-tool JSON would leak to the client as assistant text.
+                let mut filter_dropped_all = false;
+                if let Some(ref required_name) = self.named_tool_name {
+                    let pre_filter_len = tool_call_chunks.len();
+                    tool_call_chunks.retain(|tc| {
+                        tc.function.as_ref().and_then(|f| f.name.as_deref())
+                            == Some(required_name.as_str())
+                    });
+                    if pre_filter_len > 0 && tool_call_chunks.is_empty() {
+                        filter_dropped_all = true;
+                        tracing::warn!(
+                            required = %required_name,
+                            "tool_choice=named: parsers emitted no matching tool calls; dropping jail output"
+                        );
+                    }
+                }
+
+                // Assign final indices: renumber survivors 0..n (no gaps from
+                // the filter) then add the cumulative offset for consistency
+                // with the MarkerBased branch across multi-emission streams.
+                for (new_idx, chunk) in tool_call_chunks.iter_mut().enumerate() {
+                    chunk.index = (tool_call_offset + new_idx) as u32;
+                }
+
+                if !tool_call_chunks.is_empty() {
+                    create_choice_stream(
+                        choice_index,
+                        Some(Role::Assistant),
+                        "",
+                        Some(tool_call_chunks),
+                        base_choice.finish_reason,
+                        base_choice.logprobs.clone(),
+                    )
+                } else if filter_dropped_all {
+                    // Named filter rejected every parsed call — do not leak
+                    // the wrong-tool JSON back as content.
+                    create_choice_stream(
+                        choice_index,
+                        Some(Role::Assistant),
+                        "",
+                        None,
+                        base_choice.finish_reason,
+                        base_choice.logprobs.clone(),
+                    )
+                } else {
+                    // All parsing paths failed — return accumulated content as text.
+                    create_choice_stream(
+                        choice_index,
+                        Some(Role::Assistant),
+                        accumulated_content,
+                        None,
+                        base_choice.finish_reason,
+                        base_choice.logprobs.clone(),
+                    )
+                }
+            }
+        }
+    }
+
+    /// Helper to create a ChatCompletionMessageToolCallChunk
+    fn create_tool_call_chunk(
+        index: u32,
+        name: String,
+        arguments: String,
+    ) -> ChatCompletionMessageToolCallChunk {
+        ChatCompletionMessageToolCallChunk {
+            index,
+            id: Some(format!("call-{}", Uuid::new_v4())),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: Some(name),
+                arguments: Some(arguments),
+            }),
+        }
+    }
+
+    /// Parse tool_choice JSON output into tool call chunks
+    fn parse_tool_choice_json(
+        &self,
+        json_content: &str,
+        format: &ToolChoiceFormat,
+    ) -> anyhow::Result<Vec<ChatCompletionMessageToolCallChunk>> {
+        let parsed = serde_json::from_str::<serde_json::Value>(json_content)?;
+
+        match format {
+            ToolChoiceFormat::SingleObject { tool_name } => {
+                // For named tool choice: JSON is the parameters object
+                if parsed.is_object() {
+                    Ok(vec![Self::create_tool_call_chunk(
+                        0,
+                        tool_name.clone(),
+                        json_content.to_string(),
+                    )])
+                } else {
+                    Ok(vec![])
+                }
+            }
+            ToolChoiceFormat::ArrayOfTools => {
+                // For required tool choice: JSON is array of {name, parameters}
+                if let Some(array) = parsed.as_array() {
+                    let chunks: Vec<ChatCompletionMessageToolCallChunk> = array
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(idx, entry)| {
+                            let name = entry.get("name")?.as_str()?.to_string();
+                            let parameters = entry.get("parameters")?;
+                            let args = serde_json::to_string(parameters).ok()?;
+                            Some(Self::create_tool_call_chunk(idx as u32, name, args))
+                        })
+                        .collect();
+                    Ok(chunks)
+                } else {
+                    Ok(vec![])
+                }
+            }
+        }
+    }
+
+    /// Check if accumulated content contains complete tool calls that can be parsed
+    /// Returns true if we should exit the jail early
+    async fn should_exit_jail_early(&self, accumulated: &str) -> bool {
+        if let Some(ref parser) = self.tool_call_parser {
+            // Try to parse - if successful and we have complete tool calls, exit early
+            let tools_slice = self.tool_definitions.as_deref();
+            match try_tool_call_parse_aggregate(accumulated, Some(parser), tools_slice).await {
+                Ok((tool_calls, _normal_text)) => {
+                    let result = !tool_calls.is_empty();
+                    return result;
+                }
+                Err(_e) => {}
+            }
+        }
+        false
+    }
+
+    /// Post-processor that sets finish_reason to ToolCalls when tool calls were emitted
+    /// This should be called after apply() to fix the finish_reason for tool call chunks
+    fn fix_finish_reason<S>(
+        input_stream: S,
+        jail_mode: JailMode,
+        named_tool_active: bool,
+    ) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+    where
+        S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        stream! {
+            tokio::pin!(input_stream);
+            let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
+
+            while let Some(mut response) = input_stream.next().await {
+                // Track if any choice emitted tool calls
+                if let Some(ref data) = response.data {
+                    for choice in &data.choices {
+                        if choice.delta.tool_calls.is_some() {
+                            has_tool_calls_per_choice.insert(choice.index, true);
+                        }
+                    }
+                }
+
+                // Fix finish_reason based on jail mode and whether tool calls were emitted
+                if let Some(ref mut data) = response.data {
+                    for choice in &mut data.choices {
+                        if let Some(finish) = choice.finish_reason {
+                            // Only modify Stop finish reason, preserve Length/ContentFilter
+                            if finish == FinishReason::Stop {
+                                let has_tool_calls = has_tool_calls_per_choice.get(&choice.index).copied().unwrap_or(false);
+
+                                // OpenAI spec: whenever tool_calls were emitted on this
+                                // choice, finish_reason MUST be "tool_calls" — regardless of
+                                // whether tool_choice was "auto", "required", or a named
+                                // function.
+                                let _ = named_tool_active;
+                                match &jail_mode {
+                                    JailMode::MarkerBased => {
+                                        if has_tool_calls {
+                                            choice.finish_reason = Some(FinishReason::ToolCalls);
+                                        }
+                                    }
+                                    JailMode::Immediate { format: _ } => {
+                                        if has_tool_calls {
+                                            choice.finish_reason = Some(FinishReason::ToolCalls);
+                                        }
+                                    }
+                                }
+                            }
+                            // Length and ContentFilter are preserved as-is
+                        }
+                    }
+                }
+
+                yield response;
+            }
+        }
+    }
+}
+
+/// Builder for configuring a JailedStream
+pub struct JailedStreamBuilder {
+    jail_start_sequences: Vec<String>,
+    jail_end_sequences: Vec<String>,
+    tool_call_parser: Option<String>,
+    /// When set, only tool calls with this name are emitted (enforces tool_choice=named
+    /// when a tool_call_parser is active and the parser-aware MarkerBased path is used).
+    named_tool_name: Option<String>,
+    tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
+    emission_mode: EmissionMode,
+    jail_mode: JailMode,
+}
+
+impl JailedStreamBuilder {
+    /// Create a new builder with default settings
+    pub fn new() -> Self {
+        Self {
+            jail_start_sequences: Vec::new(),
+            jail_end_sequences: Vec::new(),
+            tool_call_parser: None,
+            named_tool_name: None,
+            tool_definitions: None,
+            emission_mode: EmissionMode::default(),
+            jail_mode: JailMode::MarkerBased,
+        }
+    }
+
+    /// Add a sequence that triggers jailing when detected
+    pub fn jail_start_sequence(mut self, sequence: impl Into<String>) -> Self {
+        self.jail_start_sequences.push(sequence.into());
+        self
+    }
+
+    /// Add multiple sequences that trigger jailing when detected
+    pub fn jail_start_sequences(
+        mut self,
+        sequences: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.jail_start_sequences
+            .extend(sequences.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a sequence that ends jailing when detected
+    pub fn jail_end_sequence(mut self, sequence: impl Into<String>) -> Self {
+        self.jail_end_sequences.push(sequence.into());
+        self
+    }
+
+    /// Add multiple sequences that end jailing when detected
+    pub fn jail_end_sequences(
+        mut self,
+        sequences: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.jail_end_sequences
+            .extend(sequences.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the tool call parser to use for detection and parsing
+    pub fn tool_call_parser(mut self, parser: impl Into<String>) -> Self {
+        self.tool_call_parser = Some(parser.into());
+        self
+    }
+
+    /// Constrain parsed output to a single named tool (for tool_choice=named + parser path).
+    /// When set, tool calls emitted by the parser that don't match `tool_name` are silently
+    /// filtered out, enforcing the named-tool contract even when the model emits the wrong tool.
+    pub fn named_tool_filter(mut self, tool_name: impl Into<String>) -> Self {
+        self.named_tool_name = Some(tool_name.into());
+        self
+    }
+
+    /// Set the tool definitions for runtime validation and parsing
+    pub fn tool_definitions(mut self, tools: Vec<crate::tool_calling::ToolDefinition>) -> Self {
+        self.tool_definitions = Some(tools);
+        self
+    }
+
+    /// Set the emission mode for handling multiple choices
+    pub fn emission_mode(mut self, mode: EmissionMode) -> Self {
+        self.emission_mode = mode;
+        self
+    }
+
+    /// Enable single choice per chunk emission for OpenAI compatibility
+    pub fn single_choice_per_chunk(mut self) -> Self {
+        self.emission_mode = EmissionMode::SingleChoicePerChunk;
+        self
+    }
+
+    /// Enable packed emission mode (multiple choices per chunk)
+    pub fn packed_emission(mut self) -> Self {
+        self.emission_mode = EmissionMode::Packed;
+        self
+    }
+
+    /// Enable immediate jail mode for tool_choice=named
+    pub fn tool_choice_named(mut self, tool_name: String) -> Self {
+        self.jail_mode = JailMode::Immediate {
+            format: ToolChoiceFormat::SingleObject { tool_name },
+        };
+        self
+    }
+
+    /// Enable immediate jail mode for tool_choice=required
+    pub fn tool_choice_required(mut self) -> Self {
+        self.jail_mode = JailMode::Immediate {
+            format: ToolChoiceFormat::ArrayOfTools,
+        };
+        self
+    }
+
+    /// Build the configured JailedStream
+    pub fn build(mut self) -> JailedStream {
+        // Auto-populate jail sequences from parser config if not manually configured
+        if let Some(ref parser_name) = self.tool_call_parser {
+            let parser_map = get_tool_parser_map();
+            if let Some(config) = parser_map.get(parser_name.as_str()) {
+                // Auto-populate start sequences if none configured
+                if self.jail_start_sequences.is_empty() {
+                    self.jail_start_sequences = config.parser_config.tool_call_start_tokens();
+                }
+
+                // Auto-populate end sequences if none configured
+                if self.jail_end_sequences.is_empty() {
+                    self.jail_end_sequences = config
+                        .parser_config
+                        .tool_call_end_tokens()
+                        .iter()
+                        .filter(|&s| !s.is_empty())
+                        .cloned()
+                        .collect();
+                }
+            }
+        }
+
+        // Collect all possible marker patterns for the MarkerMatcher
+        let mut all_patterns = Vec::new();
+
+        // Add configured start sequences (now auto-populated if needed)
+        all_patterns.extend(self.jail_start_sequences.clone());
+
+        // Add patterns from tool call parser if configured (for redundancy)
+        if let Some(ref parser_name) = self.tool_call_parser {
+            let parser_map = get_tool_parser_map();
+            if let Some(config) = parser_map.get(parser_name.as_str()) {
+                // Add start tokens from the parser config
+                all_patterns.extend(config.parser_config.tool_call_start_tokens());
+                if let ParserConfig::Glm47(glm_config) = &config.parser_config
+                    && let Some(tools) = self.tool_definitions.as_ref()
+                {
+                    for tool in tools {
+                        if !tool.name.is_empty() {
+                            all_patterns.push(format!("{}{}", tool.name, glm_config.arg_key_start));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add common tool call markers to ensure we detect all formats
+        // Only include these when a specific parser is NOT configured,
+        // to avoid unexpected false positives for explicit formats
+        if self.tool_call_parser.is_none() {
+            let common_markers = vec![
+                "<TOOLCALL>".to_string(),     // nemotron_deci format
+                "<tool_call>".to_string(),    // hermes format
+                "[TOOL_CALLS]".to_string(),   // mistral format
+                "<|python_tag|>".to_string(), // llama3_json format
+                "functools[".to_string(),     // phi4 format
+                // Add JSON start patterns for Mistral-style tool calls
+                "[{".to_string(),
+                "{".to_string(),
+                // Note: Harmony parser uses JSON patterns, covered by "{" above
+            ];
+            for marker in common_markers {
+                if !all_patterns.contains(&marker) {
+                    all_patterns.push(marker);
+                }
+            }
+        }
+
+        // Create the marker matcher (fallback to empty patterns if none configured)
+        let marker_matcher = if all_patterns.is_empty() {
+            // If no patterns, create a dummy matcher that never matches
+            MarkerMatcher::new(vec!["__NEVER_MATCH__".to_string()])
+                .expect("Failed to create dummy MarkerMatcher")
+        } else {
+            tracing::debug!("Creating MarkerMatcher with patterns: {:?}", all_patterns);
+            MarkerMatcher::new(all_patterns)
+                .expect("Failed to create MarkerMatcher with configured patterns")
+        };
+
+        JailedStream {
+            jail_start_sequences: self.jail_start_sequences,
+            jail_end_sequences: self.jail_end_sequences,
+            tool_call_parser: self.tool_call_parser,
+            named_tool_name: self.named_tool_name,
+            tool_definitions: self.tool_definitions,
+            emission_mode: self.emission_mode,
+            marker_matcher,
+            jail_mode: self.jail_mode,
+        }
+    }
+}
+
+impl Default for JailedStreamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build and apply a [`JailedStream`] from an OpenAI `tool_choice` option.
+///
+/// This is the single mapping from `(parser, tool_choice, tools)` to a
+/// configured jail, shared by the frontend preprocessor and the conformance
+/// harness so both drive the jail identically. It moved here with the jail
+/// (previously `OpenAIPreprocessor::apply_tool_calling_jail` in dynamo
+/// `lib/llm`) so there is one definition, not a copy per caller.
+pub fn apply_tool_calling_jail<S>(
+    tool_call_parser: Option<String>,
+    tool_choice: Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
+    tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
+    uses_tool_call_structural_tag: bool,
+    stream: S,
+) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    use dynamo_protocols::types::ChatCompletionToolChoiceOption;
+
+    let mut builder = JailedStream::builder();
+
+    // Set tool definitions if provided
+    if let Some(tool_definitions) = tool_definitions
+        && !tool_definitions.is_empty()
+    {
+        builder = builder.tool_definitions(tool_definitions);
+    }
+
+    // When structural_tag is active, the model output is already constrained by
+    // guided decoding into a model-specific format. Always use the marker-based
+    // parser to extract tool calls from that format.
+    if uses_tool_call_structural_tag {
+        if let Some(parser) = tool_call_parser {
+            builder = builder.tool_call_parser(parser);
+        }
+    } else {
+        // Configure jail based on tool_choice
+        //
+        // For tool_choice=required or named we mirror SGLang / vLLM: assume the
+        // backend applied guided decoding and emit a bare JSON shape, so parse
+        // via the JSON array parser (base_json_parser) rather than the model's
+        // native-format parser. If a parser is also configured we still carry
+        // it so the Immediate branch can fall back to marker-based parsing for
+        // backends that do not honor guided decoding (e.g. XML-native models
+        // like qwen3_coder).
+        match tool_choice {
+            Some(ChatCompletionToolChoiceOption::Named(named)) => {
+                builder = builder
+                    .tool_choice_named(named.function.name.clone())
+                    .named_tool_filter(named.function.name.clone());
+                if let Some(parser) = tool_call_parser {
+                    builder = builder.tool_call_parser(parser);
+                }
+            }
+            Some(ChatCompletionToolChoiceOption::Required) => {
+                builder = builder.tool_choice_required();
+                if let Some(parser) = tool_call_parser {
+                    builder = builder.tool_call_parser(parser);
+                }
+            }
+            Some(ChatCompletionToolChoiceOption::Auto)
+            | Some(ChatCompletionToolChoiceOption::None)
+            | None => {
+                // Traditional marker-based jail for auto/none/unspecified
+                if let Some(parser) = tool_call_parser {
+                    builder = builder.tool_call_parser(parser);
+                }
+            }
+        }
+    }
+
+    let jail = builder.build();
+    jail.apply_with_finish_reason(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    /// Helper: build a single-choice stream chunk with text content
+    #[allow(deprecated)]
+    fn text_chunk(text: &str) -> Annotated<CreateChatCompletionStreamResponse> {
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: Some(Role::Assistant),
+                content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                    text.to_string(),
+                )),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+
+        Annotated {
+            data: Some(CreateChatCompletionStreamResponse {
+                id: "id-42".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "test-model".to_string(),
+                choices: vec![choice],
+                usage: None,
+                service_tier: None,
+                system_fingerprint: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Collect all emitted tool calls from the jailed stream output
+    fn collect_tool_calls(
+        responses: &[Annotated<CreateChatCompletionStreamResponse>],
+    ) -> Vec<(String, String)> {
+        let mut tool_calls = Vec::new();
+        for resp in responses {
+            if let Some(ref data) = resp.data {
+                for choice in &data.choices {
+                    if let Some(ref tcs) = choice.delta.tool_calls {
+                        for tc in tcs {
+                            if let Some(ref func) = tc.function {
+                                let name = func.name.clone().unwrap_or_default();
+                                let args = func.arguments.clone().unwrap_or_default();
+                                tool_calls.push((name, args));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        tool_calls
+    }
+
+    /// Collect all emitted text content from the jailed stream output
+    fn collect_text_content(responses: &[Annotated<CreateChatCompletionStreamResponse>]) -> String {
+        responses
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.choices.iter())
+            .filter_map(|c| {
+                if let Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(t)) =
+                    &c.delta.content
+                {
+                    Some(t.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Helper: build a single-choice stream chunk with text content and logprobs
+    #[allow(deprecated)]
+    fn text_chunk_with_logprobs(text: &str) -> Annotated<CreateChatCompletionStreamResponse> {
+        let logprobs = ChatChoiceLogprobs {
+            content: Some(
+                text.chars()
+                    .enumerate()
+                    .map(
+                        |(i, c)| dynamo_protocols::types::ChatCompletionTokenLogprob {
+                            token: c.to_string(),
+                            logprob: -(i as f32 + 1.0) * 0.1,
+                            bytes: Some(c.to_string().into_bytes()),
+                            top_logprobs: vec![],
+                        },
+                    )
+                    .collect(),
+            ),
+            refusal: None,
+        };
+
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: Some(Role::Assistant),
+                content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                    text.to_string(),
+                )),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: Some(logprobs),
+        };
+
+        Annotated {
+            data: Some(CreateChatCompletionStreamResponse {
+                id: "id-42".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "test-model".to_string(),
+                choices: vec![choice],
+                usage: None,
+                service_tier: None,
+                system_fingerprint: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Collect all logprobs from jailed stream output choices
+    fn collect_logprobs(
+        responses: &[Annotated<CreateChatCompletionStreamResponse>],
+    ) -> Vec<Option<ChatChoiceLogprobs>> {
+        responses
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.choices.iter())
+            .map(|c| c.logprobs.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_preserves_logprobs_single_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk_with_logprobs(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "Expected 1 tool call, got {:?}",
+            tool_calls
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+
+        // Logprobs must be preserved even though the entire output is a tool call
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for tool call responses, got all None: {:?}",
+            all_logprobs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_preserves_logprobs_multiple_chunks() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![
+            text_chunk_with_logprobs("<tool_call>\n{\"name\": \"get_weather\", \"arguments\""),
+            text_chunk_with_logprobs(": {\"location\": \"SF\"}}\n</tool_call>"),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(!tool_calls.is_empty(), "Expected tool calls, got none");
+
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for tool call responses across chunks, got all None",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_with_text_preserves_logprobs() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk_with_logprobs(
+            "Let me check.\n<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert_eq!(tool_calls.len(), 1);
+
+        let all_logprobs = collect_logprobs(&responses);
+        let has_some_logprobs = all_logprobs.iter().any(|lp| lp.is_some());
+        assert!(
+            has_some_logprobs,
+            "Logprobs should be preserved for mixed text+tool_call responses",
+        );
+
+        // Verify the logprobs content is non-empty
+        let logprob_entries: Vec<_> = all_logprobs
+            .iter()
+            .filter_map(|lp| lp.as_ref())
+            .filter_map(|lp| lp.content.as_ref())
+            .collect();
+        assert!(
+            logprob_entries.iter().any(|entries| !entries.is_empty()),
+            "Logprobs content should have entries",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_tool_call_single_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>\n<tool_call>\n{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"PST\"}}\n</tool_call>",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert!(
+            tool_calls.len() >= 2,
+            "Expected at least 2 tool calls, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+
+        let names: Vec<&str> = tool_calls.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"get_weather"),
+            "Missing get_weather tool call. Got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"get_time"),
+            "Missing get_time tool call. Got: {:?}",
+            names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_tool_call_multiple_chunks() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![
+            text_chunk("<tool_call>\n{\"name\": \"get_weather\", \"arguments\""),
+            text_chunk(
+                ": {\"location\": \"SF\"}}\n</tool_call>\n<tool_call>\n{\"name\": \"get_time\"",
+            ),
+            text_chunk(", \"arguments\": {\"timezone\": \"PST\"}}\n</tool_call>"),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert!(
+            tool_calls.len() >= 2,
+            "Expected at least 2 tool calls, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+
+        let names: Vec<&str> = tool_calls.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"get_weather"),
+            "Missing get_weather tool call. Got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"get_time"),
+            "Missing get_time tool call. Got: {:?}",
+            names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trailing_text_not_re_jailed() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>\nDone!",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "Expected exactly 1 tool call, got {}: {:?}",
+            tool_calls.len(),
+            tool_calls
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+
+        let all_text = collect_text_content(&responses);
+        assert!(
+            all_text.contains("Done!"),
+            "Trailing text 'Done!' should appear in output. Got text: {:?}",
+            all_text
+        );
+    }
+}

--- a/parsers/src/tool_calling/jail/prefix_matcher.rs
+++ b/parsers/src/tool_calling/jail/prefix_matcher.rs
@@ -1,0 +1,566 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Efficient multi-pattern marker detection with partial suffix matching
+//!
+//! This module provides utilities for detecting complete and partial marker patterns
+//! in streaming text, with support for detecting markers split across chunk boundaries.
+
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
+use std::collections::HashMap;
+
+/// Result of processing a chunk with potential marker detection
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchResult {
+    /// Complete marker found
+    Complete {
+        /// Content before the marker (safe to emit)
+        prefix: String,
+        /// The complete marker matched
+        marker: String,
+        /// Start position of the marker in the input
+        marker_start: usize,
+        /// Remaining content after the marker
+        suffix: String,
+    },
+    /// Partial marker at end of chunk
+    Partial {
+        /// Content before the partial (safe to emit)
+        prefix: String,
+        /// The partial match to hold
+        partial: String,
+        /// Which patterns this could match
+        possible_patterns: Vec<String>,
+    },
+    /// No markers detected
+    None {
+        /// All content is safe to emit
+        content: String,
+    },
+}
+
+/// Efficient multi-pattern matcher with partial suffix detection
+pub struct MarkerMatcher {
+    /// All patterns we're looking for
+    patterns: Vec<String>,
+    /// Aho-Corasick matcher for complete patterns
+    complete_matcher: AhoCorasick,
+    /// Trie for partial matching
+    prefix_trie: PrefixTrie,
+    /// Maximum pattern length (for buffer limits). Part of the ported
+    /// `MarkerMatcher` API; retained for parity with dynamo even though the
+    /// jail does not currently read it.
+    #[allow(dead_code)]
+    max_pattern_len: usize,
+}
+
+impl MarkerMatcher {
+    /// Create a new matcher with the given patterns
+    pub fn new(patterns: Vec<String>) -> Result<Self, String> {
+        if patterns.is_empty() {
+            return Err("Cannot create MarkerMatcher with empty patterns".to_string());
+        }
+
+        let complete_matcher = AhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostFirst)
+            .build(&patterns)
+            .map_err(|e| format!("Failed to build Aho-Corasick matcher: {}", e))?;
+
+        let max_pattern_len = patterns.iter().map(|p| p.len()).max().unwrap_or(0);
+        let prefix_trie = PrefixTrie::new(&patterns);
+
+        Ok(Self {
+            patterns,
+            complete_matcher,
+            prefix_trie,
+            max_pattern_len,
+        })
+    }
+
+    /// Get the maximum pattern length
+    #[allow(dead_code)]
+    pub fn max_pattern_len(&self) -> usize {
+        self.max_pattern_len
+    }
+
+    /// Safe UTF-8 slicing that ensures we only slice at character boundaries
+    fn safe_slice(text: &str, start_byte: usize, end_byte: usize) -> String {
+        // Clamp indices to valid boundaries
+        let start = text
+            .char_indices()
+            .find(|(i, _)| *i >= start_byte)
+            .map(|(i, _)| i)
+            .unwrap_or(text.len());
+
+        let end = text
+            .char_indices()
+            .find(|(i, _)| *i >= end_byte)
+            .map(|(i, _)| i)
+            .unwrap_or(text.len());
+
+        text[start..end].to_string()
+    }
+
+    /// Process a chunk with an optional partial buffer from previous chunk
+    pub fn process_chunk(&self, chunk: &str, partial_buffer: &str) -> MatchResult {
+        // Combine buffer with new chunk
+        let combined = if partial_buffer.is_empty() {
+            chunk.to_string()
+        } else {
+            format!("{}{}", partial_buffer, chunk)
+        };
+
+        // First check for complete markers
+        if let Some(mat) = self.complete_matcher.find(&combined) {
+            let marker = &self.patterns[mat.pattern().as_usize()];
+            return MatchResult::Complete {
+                prefix: Self::safe_slice(&combined, 0, mat.start()),
+                marker: marker.clone(),
+                marker_start: mat.start(),
+                suffix: Self::safe_slice(&combined, mat.end(), combined.len()),
+            };
+        }
+
+        // No complete match - check for partial at ANY suffix position
+        // This is the key: check "n<T" → finds "<T" as partial
+        if let Some((partial_start, partial, patterns)) = self.find_partial_suffix(&combined) {
+            return MatchResult::Partial {
+                prefix: Self::safe_slice(&combined, 0, partial_start),
+                partial: partial.to_string(),
+                possible_patterns: patterns,
+            };
+        }
+
+        // No matches at all
+        MatchResult::None { content: combined }
+    }
+
+    /// Find the longest partial match in any suffix of the input
+    ///
+    /// This scans from left to right to find the EARLIEST partial match,
+    /// ensuring we emit as much content as possible while holding only the minimal partial.
+    fn find_partial_suffix<'a>(&self, text: &'a str) -> Option<(usize, &'a str, Vec<String>)> {
+        // Start from the beginning to find the EARLIEST partial match
+        // This ensures we emit as much as possible
+        // Use char_indices to get valid UTF-8 boundaries
+        for (i, _) in text.char_indices() {
+            let suffix = &text[i..];
+            if let Some(patterns) = self.prefix_trie.find_prefix_match(suffix) {
+                // This suffix is a prefix of one or more patterns
+                return Some((i, suffix, patterns));
+            }
+        }
+        None
+    }
+}
+
+/// Trie structure for efficient prefix matching
+struct PrefixTrie {
+    root: TrieNode,
+}
+
+#[derive(Debug)]
+struct TrieNode {
+    children: HashMap<char, TrieNode>,
+    /// Patterns that have this exact prefix
+    matching_patterns: Vec<String>,
+    /// Is this node a complete pattern?
+    is_complete: bool,
+}
+
+impl PrefixTrie {
+    fn new(patterns: &[String]) -> Self {
+        let mut root = TrieNode {
+            children: HashMap::new(),
+            matching_patterns: Vec::new(),
+            is_complete: false,
+        };
+
+        // Build trie
+        for pattern in patterns {
+            let mut current = &mut root;
+            let chars: Vec<char> = pattern.chars().collect();
+
+            for (i, &ch) in chars.iter().enumerate() {
+                current = current.children.entry(ch).or_insert(TrieNode {
+                    children: HashMap::new(),
+                    matching_patterns: Vec::new(),
+                    is_complete: false,
+                });
+
+                // Add this pattern to all prefix nodes
+                if !current.matching_patterns.contains(pattern) {
+                    current.matching_patterns.push(pattern.clone());
+                }
+
+                // Mark complete if we're at the end
+                if i == chars.len() - 1 {
+                    current.is_complete = true;
+                }
+            }
+        }
+
+        PrefixTrie { root }
+    }
+
+    /// Check if text is a prefix of any pattern (but not a complete pattern)
+    fn find_prefix_match(&self, text: &str) -> Option<Vec<String>> {
+        let mut current = &self.root;
+
+        for ch in text.chars() {
+            if let Some(node) = current.children.get(&ch) {
+                current = node;
+            } else {
+                // Not a prefix of any pattern
+                return None;
+            }
+        }
+
+        // If we matched the entire text and it's a prefix of something (but not complete)
+        if !current.matching_patterns.is_empty() && !current.is_complete {
+            Some(current.matching_patterns.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complete_match() {
+        let patterns = vec!["<TOOLCALL>".to_string(), "<tool_call>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        let result = matcher.process_chunk("<TOOLCALL>data", "");
+
+        if let MatchResult::Complete {
+            prefix,
+            marker,
+            suffix,
+            ..
+        } = result
+        {
+            assert_eq!(prefix, "");
+            assert_eq!(marker, "<TOOLCALL>");
+            assert_eq!(suffix, "data");
+        } else {
+            panic!("Expected complete match");
+        }
+    }
+
+    #[test]
+    fn test_partial_match_suffix() {
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test the key case: "n<T" should detect "<T" as partial
+        let result = matcher.process_chunk("n<T", "");
+
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result
+        {
+            assert_eq!(prefix, "n");
+            assert_eq!(partial, "<T");
+            assert_eq!(possible_patterns, vec!["<TOOLCALL>"]);
+        } else {
+            panic!("Expected partial match, got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_no_false_positive() {
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test case: "n < 5" should not trigger partial match
+        let result = matcher.process_chunk("n < 5", "");
+
+        if let MatchResult::None { content } = result {
+            assert_eq!(content, "n < 5");
+        } else {
+            panic!("Expected no match, got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_partial_buffer_combination() {
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // First chunk: partial "<"
+        let result1 = matcher.process_chunk("<", "");
+        let partial = if let MatchResult::Partial { partial, .. } = result1 {
+            partial
+        } else {
+            panic!("Expected partial match");
+        };
+
+        // Second chunk: "TOOLCALL>" completes the pattern
+        let result2 = matcher.process_chunk("TOOLCALL>", &partial);
+
+        if let MatchResult::Complete { marker, .. } = result2 {
+            assert_eq!(marker, "<TOOLCALL>");
+        } else {
+            panic!("Expected complete match, got: {:?}", result2);
+        }
+    }
+
+    #[test]
+    fn test_prefix_with_content() {
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        let result = matcher.process_chunk("text before <TOOLCALL> after", "");
+
+        if let MatchResult::Complete {
+            prefix,
+            marker,
+            suffix,
+            ..
+        } = result
+        {
+            assert_eq!(prefix, "text before ");
+            assert_eq!(marker, "<TOOLCALL>");
+            assert_eq!(suffix, " after");
+        } else {
+            panic!("Expected complete match");
+        }
+    }
+
+    #[test]
+    fn test_empty_patterns() {
+        let result = MarkerMatcher::new(vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiple_patterns() {
+        let patterns = vec![
+            "<TOOLCALL>".to_string(),
+            "[TOOL_CALLS]".to_string(),
+            "<tool_call>".to_string(),
+        ];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test different patterns
+        let result1 = matcher.process_chunk("[TOOL_CALLS]", "");
+        if let MatchResult::Complete { marker, .. } = result1 {
+            assert_eq!(marker, "[TOOL_CALLS]");
+        } else {
+            panic!("Expected complete match for [TOOL_CALLS]");
+        }
+
+        // Test partial for different pattern
+        let result2 = matcher.process_chunk("text<to", "");
+        if let MatchResult::Partial {
+            partial,
+            possible_patterns,
+            ..
+        } = result2
+        {
+            assert_eq!(partial, "<to");
+            assert!(possible_patterns.contains(&"<tool_call>".to_string()));
+        } else {
+            panic!("Expected partial match for <tool_call>");
+        }
+    }
+
+    #[test]
+    fn test_multiple_partial_matches_edge_case() {
+        // Test scenario: Multiple patterns where one looks like a prefix but isn't valid
+        // Patterns: ["FooBar", "<TOOLCALL>"]
+        // Input: "This is FooBaz which is a no, but <TOO"
+        // Key insight: "FooBa" from "FooBaz" is NOT a valid partial because the 'z'
+        // doesn't match the expected 'r' in "FooBar"
+        // Expected: Hold "<TOO" as partial, emit "This is FooBaz which is a no, but "
+        let patterns = vec!["FooBar".to_string(), "<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        let result = matcher.process_chunk("This is FooBaz which is a no, but <TOO", "");
+
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result
+        {
+            // The algorithm correctly skips "FooBaz" (not a valid prefix) and finds "<TOO"
+            assert_eq!(partial, "<TOO");
+            assert_eq!(prefix, "This is FooBaz which is a no, but ");
+            assert!(possible_patterns.contains(&"<TOOLCALL>".to_string()));
+        } else {
+            panic!("Expected partial match for '<TOO>', got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_earliest_valid_partial_match() {
+        // Test that the algorithm finds the earliest VALID partial match
+        // Patterns: ["FooBar", "<TOOLCALL>"]
+        // Input: "Some text FooBa and then <TO"
+        // Analysis: "FooBa and then <TO" is not a valid prefix of "FooBar" because
+        // after "FooBa" we have " " (space) but "FooBar" expects "r"
+        // Expected: Skip invalid "FooBa..." and find valid "<TO" partial
+        let patterns = vec!["FooBar".to_string(), "<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        let result = matcher.process_chunk("Some text FooBa and then <TO", "");
+
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result
+        {
+            // Should find "<TO" as the valid partial match
+            assert_eq!(partial, "<TO");
+            assert_eq!(prefix, "Some text FooBa and then ");
+            assert!(possible_patterns.contains(&"<TOOLCALL>".to_string()));
+        } else {
+            panic!("Expected partial match for '<TO>', got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_partial_at_exact_end() {
+        // Test case where a valid partial is exactly at the end
+        // Patterns: ["FooBar", "<TOOLCALL>"]
+        // Input: "Some text ending with FooBa"
+        // Expected: Hold "FooBa" as partial (valid prefix of "FooBar")
+        let patterns = vec!["FooBar".to_string(), "<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        let result = matcher.process_chunk("Some text ending with FooBa", "");
+
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result
+        {
+            // Should find "FooBa" as a valid partial match at the end
+            assert_eq!(partial, "FooBa");
+            assert_eq!(prefix, "Some text ending with ");
+            assert!(possible_patterns.contains(&"FooBar".to_string()));
+        } else {
+            panic!("Expected partial match for 'FooBa', got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_unicode_complete_match() {
+        // Test complete pattern matching with unicode content
+        // Use patterns with ASCII markers but unicode content
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test with emoji and multi-byte characters
+        let result = matcher.process_chunk("Hello 👋 world <TOOLCALL>data 🚀", "");
+
+        if let MatchResult::Complete {
+            prefix,
+            marker,
+            suffix,
+            ..
+        } = result
+        {
+            assert_eq!(prefix, "Hello 👋 world ");
+            assert_eq!(marker, "<TOOLCALL>");
+            assert_eq!(suffix, "data 🚀");
+        } else {
+            panic!("Expected complete match, got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_unicode_partial_match() {
+        // Test partial matching where the partial might occur after unicode content
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test partial after multi-byte characters
+        let result = matcher.process_chunk("Text with 中文字符 and <TO", "");
+
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result
+        {
+            assert_eq!(prefix, "Text with 中文字符 and ");
+            assert_eq!(partial, "<TO");
+            assert!(possible_patterns.contains(&"<TOOLCALL>".to_string()));
+        } else {
+            panic!("Expected partial match, got: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_unicode_no_false_positive() {
+        // Test that unicode content doesn't create false positives
+        let patterns = vec!["<TOOLCALL>".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test with unicode that might look similar to ASCII patterns
+        let result = matcher.process_chunk("Unicode test ＜ＴＯＯＬＣＡＬＬ＞ full-width", "");
+
+        if let MatchResult::None { content } = result {
+            assert_eq!(content, "Unicode test ＜ＴＯＯＬＣＡＬＬ＞ full-width");
+        } else {
+            panic!(
+                "Expected no match for full-width characters, got: {:?}",
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_unicode_pattern_itself() {
+        // Test patterns that contain unicode characters
+        let patterns = vec!["🔧工具".to_string(), "📞call".to_string()];
+        let matcher = MarkerMatcher::new(patterns).unwrap();
+
+        // Test complete match with unicode pattern
+        let result1 = matcher.process_chunk("Start 🔧工具 end", "");
+        if let MatchResult::Complete {
+            prefix,
+            marker,
+            suffix,
+            ..
+        } = result1
+        {
+            assert_eq!(prefix, "Start ");
+            assert_eq!(marker, "🔧工具");
+            assert_eq!(suffix, " end");
+        } else {
+            panic!(
+                "Expected complete match for unicode pattern, got: {:?}",
+                result1
+            );
+        }
+
+        // Test partial match with unicode pattern
+        let result2 = matcher.process_chunk("Text 🔧工", "");
+        if let MatchResult::Partial {
+            prefix,
+            partial,
+            possible_patterns,
+        } = result2
+        {
+            assert_eq!(prefix, "Text ");
+            assert_eq!(partial, "🔧工");
+            assert!(possible_patterns.contains(&"🔧工具".to_string()));
+        } else {
+            panic!(
+                "Expected partial match for unicode pattern, got: {:?}",
+                result2
+            );
+        }
+    }
+}

--- a/parsers/src/tool_calling/mod.rs
+++ b/parsers/src/tool_calling/mod.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod dsml;
 pub mod gemma4;
 pub mod harmony;
+pub mod jail;
 pub mod json;
 pub mod parsers;
 pub mod pythonic;

--- a/parsers/tests/jail.rs
+++ b/parsers/tests/jail.rs
@@ -1,0 +1,4267 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream, apply_tool_calling_jail};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionStreamResponseDelta, ChatCompletionToolChoiceOption,
+    CompletionUsage, CreateChatCompletionStreamResponse, FinishReason, Role,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use futures::stream;
+
+    // Test utilities module - shared test infrastructure
+    pub(crate) mod test_utils {
+        use super::*;
+        use dynamo_protocols::types::ChatCompletionMessageContent;
+
+        /// Helper to extract text from ChatCompletionMessageContent
+        pub fn extract_text(content: &ChatCompletionMessageContent) -> &str {
+            match content {
+                ChatCompletionMessageContent::Text(text) => text.as_str(),
+                ChatCompletionMessageContent::Parts(_) => "",
+            }
+        }
+
+        /// Helper function to create a mock chat response chunk
+        pub fn create_mock_response_chunk(
+            content: String,
+            index: u32,
+        ) -> Annotated<CreateChatCompletionStreamResponse> {
+            #[allow(deprecated)]
+            let choice = ChatChoiceStream {
+                index,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: Some(Role::Assistant),
+                    content: Some(ChatCompletionMessageContent::Text(content)),
+                    tool_calls: None,
+                    function_call: None,
+                    refusal: None,
+                    reasoning_content: None,
+                },
+                finish_reason: None,
+                logprobs: None,
+            };
+
+            let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test-id".to_string(),
+                choices: vec![choice],
+                created: 1234567890,
+                model: "test-model".to_string(),
+                system_fingerprint: Some("test-fingerprint".to_string()),
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            };
+
+            Annotated {
+                data: Some(response),
+                id: None,
+                event: None,
+                comment: None,
+                error: None,
+            }
+        }
+
+        /// Helper function to create a final response chunk with finish reason
+        pub fn create_final_response_chunk(
+            index: u32,
+        ) -> Annotated<CreateChatCompletionStreamResponse> {
+            #[allow(deprecated)]
+            let choice = ChatChoiceStream {
+                index,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: None,
+                    function_call: None,
+                    refusal: None,
+                    reasoning_content: None,
+                },
+                finish_reason: Some(FinishReason::Stop),
+                logprobs: None,
+            };
+
+            let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test-id".to_string(),
+                choices: vec![choice],
+                created: 1234567890,
+                model: "test-model".to_string(),
+                system_fingerprint: Some("test-fingerprint".to_string()),
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            };
+
+            Annotated {
+                data: Some(response),
+                id: None,
+                event: None,
+                comment: None,
+                error: None,
+            }
+        }
+
+        /// Helper function to create a mock chat response chunk with metadata
+        pub fn create_annotated_chunk(
+            content: String,
+            index: u32,
+            id: Option<String>,
+            event: Option<String>,
+            comment: Option<Vec<String>>,
+        ) -> Annotated<CreateChatCompletionStreamResponse> {
+            #[allow(deprecated)]
+            let choice = ChatChoiceStream {
+                index,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: Some(Role::Assistant),
+                    content: Some(ChatCompletionMessageContent::Text(content)),
+                    tool_calls: None,
+                    function_call: None,
+                    refusal: None,
+                    reasoning_content: None,
+                },
+                finish_reason: None,
+                logprobs: None,
+            };
+
+            let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test-id".to_string(),
+                choices: vec![choice],
+                created: 1234567890,
+                model: "test-model".to_string(),
+                system_fingerprint: Some("test-fingerprint".to_string()),
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            };
+
+            Annotated {
+                data: Some(response),
+                id,
+                event,
+                comment,
+                error: None,
+            }
+        }
+
+        /// Helper function to create a multi-choice chunk
+        pub fn create_multi_choice_chunk(
+            choices_content: Vec<(String, u32)>, // (content, index)
+        ) -> Annotated<CreateChatCompletionStreamResponse> {
+            let choices: Vec<ChatChoiceStream> = choices_content
+                .into_iter()
+                .map(|(content, index)| {
+                    #[allow(deprecated)]
+                    ChatChoiceStream {
+                        index,
+                        delta: ChatCompletionStreamResponseDelta {
+                            role: Some(Role::Assistant),
+                            content: Some(ChatCompletionMessageContent::Text(content)),
+                            tool_calls: None,
+                            function_call: None,
+                            refusal: None,
+                            reasoning_content: None,
+                        },
+                        finish_reason: None,
+                        logprobs: None,
+                    }
+                })
+                .collect();
+
+            let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test-id".to_string(),
+                choices,
+                created: 1234567890,
+                model: "test-model".to_string(),
+                system_fingerprint: Some("test-fingerprint".to_string()),
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            };
+
+            Annotated {
+                data: Some(response),
+                id: None,
+                event: None,
+                comment: None,
+                error: None,
+            }
+        }
+
+        /// Helper function to create a multi-choice finish_reason chunk
+        pub fn create_multi_choice_finish_chunk(
+            choice_indices: Vec<u32>,
+        ) -> Annotated<CreateChatCompletionStreamResponse> {
+            let choices: Vec<ChatChoiceStream> = choice_indices
+                .into_iter()
+                .map(|index| {
+                    #[allow(deprecated)]
+                    ChatChoiceStream {
+                        index,
+                        delta: ChatCompletionStreamResponseDelta {
+                            role: None,
+                            content: None,
+                            tool_calls: None,
+                            function_call: None,
+                            refusal: None,
+                            reasoning_content: None,
+                        },
+                        finish_reason: Some(FinishReason::Stop),
+                        logprobs: None,
+                    }
+                })
+                .collect();
+
+            let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test-id".to_string(),
+                choices,
+                created: 1234567890,
+                model: "test-model".to_string(),
+                system_fingerprint: Some("test-fingerprint".to_string()),
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            };
+
+            Annotated {
+                data: Some(response),
+                id: None,
+                event: None,
+                comment: None,
+                error: None,
+            }
+        }
+
+        /// Helper to assert content in a result
+        pub fn assert_content(
+            result: &Annotated<CreateChatCompletionStreamResponse>,
+            expected: &str,
+        ) {
+            let content = result
+                .data
+                .as_ref()
+                .and_then(|d| d.choices.first())
+                .and_then(|c| c.delta.content.as_ref())
+                .expect("Expected content in result");
+
+            assert_eq!(
+                extract_text(content),
+                expected,
+                "Content mismatch: expected '{}', got '{}'",
+                expected,
+                extract_text(content)
+            );
+        }
+
+        /// Helper to assert a tool call in a result
+        pub fn assert_tool_call(
+            result: &Annotated<CreateChatCompletionStreamResponse>,
+            name: &str,
+            args: serde_json::Value,
+        ) {
+            let tool_calls = result
+                .data
+                .as_ref()
+                .and_then(|d| d.choices.first())
+                .and_then(|c| c.delta.tool_calls.as_ref())
+                .expect("Expected tool calls in result");
+
+            assert!(!tool_calls.is_empty(), "Expected at least one tool call");
+
+            let tool_call = &tool_calls[0];
+            let function = tool_call
+                .function
+                .as_ref()
+                .expect("Expected function in tool call");
+
+            assert_eq!(
+                function.name.as_deref(),
+                Some(name),
+                "Tool call name mismatch: expected '{}', got '{:?}'",
+                name,
+                function.name
+            );
+
+            if let Some(arguments_str) = &function.arguments {
+                let parsed_args: serde_json::Value = serde_json::from_str(arguments_str)
+                    .expect("Tool call arguments should be valid JSON");
+                assert_eq!(
+                    parsed_args, args,
+                    "Tool call arguments mismatch: expected {}, got {}",
+                    args, parsed_args
+                );
+            } else if !args.is_null() {
+                panic!("Expected tool call arguments {} but got None", args);
+            }
+        }
+
+        /// Helper to assert no content or tool calls (for accumulated chunks)
+        #[allow(dead_code)]
+        pub fn assert_empty_emission(result: &Annotated<CreateChatCompletionStreamResponse>) {
+            if let Some(data) = &result.data
+                && let Some(choice) = data.choices.first()
+            {
+                assert!(
+                    choice.delta.content.is_none()
+                        || choice.delta.content.as_ref().is_none_or(|c| match c {
+                            dynamo_protocols::types::ChatCompletionMessageContent::Text(t) =>
+                                t.is_empty(),
+                            _ => false,
+                        }),
+                    "Expected no content but got: {:?}",
+                    choice.delta.content
+                );
+                assert!(
+                    choice.delta.tool_calls.is_none()
+                        || choice.delta.tool_calls.as_ref().unwrap().is_empty(),
+                    "Expected no tool calls but got: {:?}",
+                    choice.delta.tool_calls
+                );
+            }
+        }
+
+        /// Helper to reconstruct all content from results
+        pub fn reconstruct_content(
+            results: &[Annotated<CreateChatCompletionStreamResponse>],
+        ) -> String {
+            results
+                .iter()
+                .filter_map(|r| {
+                    r.data
+                        .as_ref()
+                        .and_then(|d| d.choices.first())
+                        .and_then(|c| c.delta.content.as_ref())
+                })
+                .map(extract_text)
+                .collect::<Vec<_>>()
+                .join("")
+        }
+
+        /// Helper to extract content from a single result (for negative assertions)
+        pub fn extract_content(result: &Annotated<CreateChatCompletionStreamResponse>) -> String {
+            result
+                .data
+                .as_ref()
+                .and_then(|d| d.choices.first())
+                .and_then(|c| c.delta.content.as_ref())
+                .and_then(|content| match content {
+                    ChatCompletionMessageContent::Text(text) => Some(text.clone()),
+                    ChatCompletionMessageContent::Parts(_) => None,
+                })
+                .unwrap_or_default()
+        }
+
+        /// Helper to check if result contains a tool call
+        pub fn has_tool_call(result: &Annotated<CreateChatCompletionStreamResponse>) -> bool {
+            result
+                .data
+                .as_ref()
+                .and_then(|d| d.choices.first())
+                .and_then(|c| c.delta.tool_calls.as_ref())
+                .map(|tc| !tc.is_empty())
+                .unwrap_or(false)
+        }
+
+        /// Helper to check if result contains content
+        #[allow(dead_code)]
+        pub fn has_content(result: &Annotated<CreateChatCompletionStreamResponse>) -> bool {
+            result
+                .data
+                .as_ref()
+                .and_then(|d| d.choices.first())
+                .and_then(|c| c.delta.content.as_ref())
+                .map(|content| !extract_text(content).is_empty())
+                .unwrap_or(false)
+        }
+    }
+
+    use serde_json::json;
+    use test_utils::*;
+
+    #[tokio::test]
+    async fn test_jailed_stream_with_start_end_sequences() {
+        // Create chunks with jail start/end markers
+        let chunks = vec![
+            create_mock_response_chunk("Hello ".to_string(), 0),
+            create_mock_response_chunk("<jail>".to_string(), 0),
+            create_mock_response_chunk("This is jailed ".to_string(), 0),
+            create_mock_response_chunk("content".to_string(), 0),
+            create_mock_response_chunk("</jail>".to_string(), 0),
+            create_mock_response_chunk(" World".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with start/end sequences
+        let jail = JailedStream::builder()
+            .jail_start_sequence("<jail>")
+            .jail_end_sequence("</jail>")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // We should only get 3 chunks now:
+        // 1. "Hello " (before jail)
+        // 2. Accumulated jailed content when jail ends
+        // 3. " World" (after jail)
+        assert_eq!(results.len(), 3);
+
+        // First chunk should pass through
+        assert_eq!(
+            results[0].data.as_ref().unwrap().choices[0]
+                .delta
+                .content
+                .as_ref()
+                .map(extract_text),
+            Some("Hello ")
+        );
+
+        // When jail ends, accumulated content should be released
+        let unjailed_content = &results[1].data.as_ref().unwrap().choices[0].delta.content;
+        assert!(unjailed_content.is_some());
+        assert!(
+            extract_text(unjailed_content.as_ref().unwrap())
+                .contains("<jail>This is jailed content</jail>")
+        );
+
+        // Last chunk should pass through normally
+        assert_eq!(
+            results[2].data.as_ref().unwrap().choices[0]
+                .delta
+                .content
+                .as_ref()
+                .map(extract_text),
+            Some(" World")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_with_tool_calls() {
+        // Create chunks representing a tool call
+        let chunks = vec![
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(
+                "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}]".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("</TOOLCALL>".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with tool call parser
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have jailed the content and parsed tool calls at the end
+        assert!(!results.is_empty());
+
+        // Check if tool calls were parsed
+        if let Some(last_result) = results.last()
+            && let Some(ref response_data) = last_result.data
+            && let Some(ref tool_calls) = response_data.choices[0].delta.tool_calls
+        {
+            assert!(!tool_calls.as_slice().is_empty());
+            assert_eq!(
+                tool_calls[0].function.as_ref().unwrap().name.as_deref(),
+                Some("get_weather")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_dual_entry_paths() {
+        // Test that BOTH sequence AND tool call detection can trigger jail
+        let chunks = vec![
+            create_mock_response_chunk("Normal text ".to_string(), 0),
+            create_mock_response_chunk("<jail><TOOLCALL>".to_string(), 0), // Both triggers
+            create_mock_response_chunk("Jailed content".to_string(), 0),
+            create_mock_response_chunk("</jail>".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Configure with both sequences AND tool call parser
+        let jail = JailedStream::builder()
+            .jail_start_sequence("<jail>")
+            .jail_end_sequence("</jail>")
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // We should get 2 chunks:
+        // 1. "Normal text " (before jail)
+        // 2. Accumulated jailed content when jail ends via </jail>
+        assert_eq!(results.len(), 2);
+
+        // First chunk should pass through
+        assert_eq!(
+            results[0].data.as_ref().unwrap().choices[0]
+                .delta
+                .content
+                .as_ref()
+                .map(extract_text),
+            Some("Normal text ")
+        );
+
+        // Second chunk should contain the accumulated jailed content
+        let jailed = results[1].data.as_ref().unwrap().choices[0]
+            .delta
+            .content
+            .as_ref()
+            .expect("Expected accumulated jailed content");
+        assert!(extract_text(jailed).contains("<jail><TOOLCALL>Jailed content</jail>"));
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_early_exit() {
+        // Tests detection of complete tool call with unjail in same chunk as the end marker
+        // Input: "<TOOLCALL>" + "[{\"name\": \"test\", " + "\"arguments\": {}}]" + "</TOOLCALL>More text"
+        // Expected output: 2 chunks [ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"test\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {}}]".to_string(), 0),
+            create_mock_response_chunk("</TOOLCALL>More text".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 2 chunks: tool call + trailing content
+        assert_eq!(
+            results.len(),
+            2,
+            "Should have tool call and trailing content"
+        );
+
+        // Verify exact output structure: [ToolCall(), Content()]
+        test_utils::assert_tool_call(&results[0], "test", serde_json::json!({}));
+        test_utils::assert_content(&results[1], "More text");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "More text");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_no_jailing() {
+        // Input chunks:
+        // [0] "Hello "
+        // [1] "World"
+        // [2] [final chunk]
+        //
+        // Expected output (pass-through):
+        // [0] Content("Hello ")
+        // [1] Content("World")
+        // [2] [final chunk]
+        let chunks = vec![
+            create_mock_response_chunk("Hello ".to_string(), 0),
+            create_mock_response_chunk("World".to_string(), 0),
+            create_final_response_chunk(0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with sequences that won't match
+        let jail = JailedStream::builder()
+            .jail_start_sequence("<NOTPRESENT>")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            3,
+            "Should pass through all 3 chunks unchanged"
+        );
+
+        // === Verify individual chunks ===
+        assert_content(&results[0], "Hello ");
+        assert_content(&results[1], "World");
+        // results[2] is the final chunk - no content to verify
+
+        // === Verify negative assertions ===
+        for (i, result) in results.iter().take(2).enumerate() {
+            assert!(
+                !has_tool_call(result),
+                "Chunk {} should not contain tool calls when no patterns match",
+                i
+            );
+        }
+
+        // === Verify content reconstruction ===
+        assert_eq!(
+            reconstruct_content(&results),
+            "Hello World",
+            "Content should pass through unchanged when no jailing occurs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_hermes_parser() {
+        // Tests Hermes format tool call parsing with <tool_call> markers
+        // Input: "I'll help you with that. " + "<tool_call>{\"name\": \"search_web\", \"arguments\": {\"query\": \"weather today\"}}</tool_call>" + " Let me search for that."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("I'll help you with that. ".to_string(), 0),
+            create_mock_response_chunk("<tool_call>".to_string(), 0),
+            create_mock_response_chunk("{\"name\": \"search_web\", ".to_string(), 0),
+            create_mock_response_chunk(
+                "\"arguments\": {\"query\": \"weather today\"}}".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("</tool_call>".to_string(), 0),
+            create_mock_response_chunk(" Let me search for that.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Hermes parser
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + content
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "I'll help you with that. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "search_web",
+            serde_json::json!({"query": "weather today"}),
+        );
+        test_utils::assert_content(&results[2], " Let me search for that.");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "I'll help you with that.  Let me search for that."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_mistral_parser() {
+        // Tests Mistral format tool call parsing with [{ pattern
+        // Input: "Sure, I can help. " + "[{\"name\": \"calculate\", \"arguments\": {\"expression\": \"2+2\"}}]" + " The calculation is done."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("Sure, I can help. ".to_string(), 0),
+            create_mock_response_chunk("[{".to_string(), 0),
+            create_mock_response_chunk("\"name\": \"calculate\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"expression\": \"2+2\"}".to_string(), 0),
+            create_mock_response_chunk("}]".to_string(), 0),
+            create_mock_response_chunk(" The calculation is done.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Mistral parser
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + content
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "Sure, I can help. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "calculate",
+            serde_json::json!({"expression": "2+2"}),
+        );
+        test_utils::assert_content(&results[2], " The calculation is done.");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "Sure, I can help.  The calculation is done.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_mistral_parser_with_tool_calls_marker() {
+        // Tests Mistral format tool call parsing with explicit [TOOL_CALLS] marker
+        // Input: "Let me check that for you. " + "[TOOL_CALLS][{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"UTC\"}}]" + " Here's the time."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("Let me check that for you. ".to_string(), 0),
+            create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"get_time\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"timezone\": \"UTC\"}}]".to_string(), 0),
+            create_mock_response_chunk(" Here's the time.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Mistral parser
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + content
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "Let me check that for you. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "get_time",
+            serde_json::json!({"timezone": "UTC"}),
+        );
+        test_utils::assert_content(&results[2], " Here's the time.");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "Let me check that for you.  Here's the time."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_mistral_parser_repeated_close_markers() {
+        // Framed Mistral call immediately followed by consecutive [/TOOL_CALLS]
+        // close markers. The jail must consume through ALL adjacent closers so
+        // none leak into trailing content. Regression for the streaming
+        // end-position only advancing past the first close marker.
+        // Input: "[TOOL_CALLS][{...}][/TOOL_CALLS][/TOOL_CALLS]" + " All set."
+        let chunks = vec![
+            create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"get_time\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"timezone\": \"UTC\"}}]".to_string(), 0),
+            create_mock_response_chunk("[/TOOL_CALLS][/TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk(" All set.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Exactly one tool call; no [/TOOL_CALLS] marker leaks into content.
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert!(
+            !reconstructed.contains("[/TOOL_CALLS]"),
+            "repeated close markers must not leak into normal_text, got: {reconstructed:?}"
+        );
+        assert_eq!(
+            reconstructed.trim(),
+            "All set.",
+            "only the trailing prose should remain as content"
+        );
+        let tool_calls: Vec<_> = results
+            .iter()
+            .filter(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .and_then(|c| c.delta.tool_calls.as_ref())
+                    .is_some_and(|tc| !tc.is_empty())
+            })
+            .collect();
+        assert_eq!(tool_calls.len(), 1, "should emit exactly one tool call");
+        test_utils::assert_tool_call(
+            tool_calls[0],
+            "get_time",
+            serde_json::json!({"timezone": "UTC"}),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_phi4_parser() {
+        // Tests Phi4 format tool call parsing with functools[ pattern
+        // Input: "I'll analyze this data. " + "functools[{\"name\": \"analyze_data\", \"arguments\": {\"dataset\": \"sales_data\"}}]" + " Analysis complete."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("I'll analyze this data. ".to_string(), 0),
+            create_mock_response_chunk("functools[".to_string(), 0),
+            create_mock_response_chunk("{\"name\": \"analyze_data\", ".to_string(), 0),
+            create_mock_response_chunk(
+                "\"arguments\": {\"dataset\": \"sales_data\"}}".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("]".to_string(), 0),
+            create_mock_response_chunk(" Analysis complete.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Phi4 parser
+        let jail = JailedStream::builder().tool_call_parser("phi4").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + content
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "I'll analyze this data. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "analyze_data",
+            serde_json::json!({"dataset": "sales_data"}),
+        );
+        test_utils::assert_content(&results[2], " Analysis complete.");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "I'll analyze this data.  Analysis complete.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_llama3_json_parser() {
+        // Tests Llama3 JSON format tool call parsing with <|python_tag|> pattern
+        // Input: "Let me run some code. " + "<|python_tag|>{\"name\": \"execute_code\", \"arguments\": {\"code\": \"print('Hello')\"}}" + " Done executing."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("Let me run some code. ".to_string(), 0),
+            create_mock_response_chunk("<|python_tag|>".to_string(), 0),
+            create_mock_response_chunk("{\"name\": \"execute_code\", ".to_string(), 0),
+            create_mock_response_chunk(
+                "\"arguments\": {\"code\": \"print('Hello')\"}}".to_string(),
+                0,
+            ),
+            create_mock_response_chunk(" Done executing.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with llama3_json parser
+        let jail = JailedStream::builder()
+            .tool_call_parser("llama3_json")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + content
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "Let me run some code. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "execute_code",
+            serde_json::json!({"code": "print('Hello')"}),
+        );
+        test_utils::assert_content(&results[2], " Done executing.");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "Let me run some code.  Done executing.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_false_positive_json() {
+        // Tests that JSON-like content doesn't trigger false positive tool call detection
+        // Input: "I can explain JSON format. " + "Here's an example: { \"key\": \"value\" }" + " is a simple JSON object. " + "Hope that helps!"
+        // Expected output: 4 chunks [Content(), Content(), Content(), Content()] - no jailing
+        let chunks = vec![
+            create_mock_response_chunk("I can explain JSON format. ".to_string(), 0),
+            create_mock_response_chunk("Here's an example: { \"key\": \"value\" }".to_string(), 0),
+            create_mock_response_chunk(" is a simple JSON object. ".to_string(), 0),
+            create_mock_response_chunk("Hope that helps!".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with mistral parser (which specifically looks for [{ or [TOOL_CALLS] patterns)
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // The "{" pattern triggers jailing, so some chunks get combined
+        assert_eq!(results.len(), 2);
+
+        // Verify exact output structure: content chunks
+        test_utils::assert_content(&results[0], "I can explain JSON format. ");
+        test_utils::assert_content(
+            &results[1],
+            "Here's an example: { \"key\": \"value\" } is a simple JSON object. Hope that helps!",
+        );
+
+        // Verify no tool calls were detected and all content preserved
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "I can explain JSON format. Here's an example: { \"key\": \"value\" } is a simple JSON object. Hope that helps!"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_malformed_tool_call() {
+        // Tests graceful handling of malformed JSON within tool call markers
+        // Input: "Let me call a function. " + "<TOOLCALL>[{\"name\": \"broken_func\", \"arguments\": {\"param\": incomplete</TOOLCALL>" + " Function call attempt finished."
+        // Expected output: 3 chunks [Content(), Content(malformed), Content()] - parser fails gracefully
+        let chunks = vec![
+            create_mock_response_chunk("Let me call a function. ".to_string(), 0),
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"broken_func\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"param\": incomplete".to_string(), 0), // Malformed JSON
+            create_mock_response_chunk("</TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(" Function call attempt finished.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with nemotron_deci parser
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Jailing combines the tool call content into fewer chunks
+        assert_eq!(
+            results.len(),
+            3,
+            "Should handle malformed JSON gracefully and jail appropriately"
+        );
+
+        // Verify exact output structure: [Content(), Content(complete jailed content)]
+        test_utils::assert_content(&results[0], "Let me call a function. ");
+        test_utils::assert_content(
+            &results[1],
+            "<TOOLCALL>[{\"name\": \"broken_func\", \"arguments\": {\"param\": incomplete</TOOLCALL>",
+        );
+
+        // Verify malformed content is preserved as text (including markers when parsing fails)
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "Let me call a function. <TOOLCALL>[{\"name\": \"broken_func\", \"arguments\": {\"param\": incomplete</TOOLCALL> Function call attempt finished."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_partial_tool_call() {
+        // Tests handling of incomplete tool call when stream ends abruptly.
+        // After PR #8888, finalize() runs `try_tool_call_parse_aggregate_finalize`
+        // which enables EOF recovery — the parser balances the unclosed braces
+        // and surfaces the call (with whatever args were captured) instead of
+        // dropping it as plain text. Streaming early-exit still requires the
+        // end-token to actually arrive, so this only fires at stream end.
+        //
+        // Input: "Starting function call. " + "<TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {" (no end marker)
+        // Expected output: 2 chunks [Content(), ToolCall(incomplete_func, {})]
+        let chunks = vec![
+            create_mock_response_chunk("Starting function call. ".to_string(), 0),
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"incomplete_func\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {".to_string(), 0),
+            // Stream ends abruptly without closing the tool call
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with nemotron_deci parser
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert_eq!(
+            results.len(),
+            2,
+            "Should emit prefix content + recovered tool call"
+        );
+
+        test_utils::assert_content(&results[0], "Starting function call. ");
+        test_utils::assert_tool_call(&results[1], "incomplete_func", serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_empty_stream() {
+        // Input chunks: []
+        //
+        // Expected output: []
+        let chunks: Vec<Annotated<CreateChatCompletionStreamResponse>> = vec![];
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .jail_start_sequence("<jail>")
+            .jail_end_sequence("</jail>")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            0,
+            "Empty stream should produce exactly 0 results"
+        );
+
+        // === Verify content reconstruction ===
+        assert_eq!(
+            reconstruct_content(&results),
+            "",
+            "Empty stream should reconstruct to empty string"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_multiple_tool_calls() {
+        // Input chunks: 9 chunks for 2 tool calls with content between
+        //
+        // Expected output:
+        // [0] Content("I'll help with multiple tasks. ")
+        // [1] ToolCall("get_weather", {"city": "NYC"})
+        // [2] Content(" Now let me get the time. ")
+        // [3] ToolCall("get_time", {"timezone": "EST"})
+        // [4] Content(" Both tasks completed!")
+        let chunks = vec![
+            create_mock_response_chunk("I'll help with multiple tasks. ".to_string(), 0),
+            // First tool call
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(
+                "[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"NYC\"}}]".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("</TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(" Now let me get the time. ".to_string(), 0),
+            // Second tool call
+            create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(
+                "[{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"EST\"}}]".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("</TOOLCALL>".to_string(), 0),
+            create_mock_response_chunk(" Both tasks completed!".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            5,
+            "Should emit exactly 5 chunks as documented above"
+        );
+
+        // === Verify individual chunks ===
+        assert_content(&results[0], "I'll help with multiple tasks. ");
+        assert_tool_call(&results[1], "get_weather", json!({"city": "NYC"}));
+        assert_content(&results[2], " Now let me get the time. ");
+        assert_tool_call(&results[3], "get_time", json!({"timezone": "EST"}));
+        assert_content(&results[4], " Both tasks completed!");
+
+        // === Verify content reconstruction ===
+        let expected_content =
+            "I'll help with multiple tasks.  Now let me get the time.  Both tasks completed!";
+        assert_eq!(
+            reconstruct_content(&results),
+            expected_content,
+            "Content reconstruction should exclude tool calls and preserve text flow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_tool_call_across_many_chunks() {
+        // Tests extreme fragmentation: tool call split across 65 individual character chunks
+        // Input: "I'll process your request. " + "<TOOLCALL>[{"name": "process_data", "arguments": {}}]</TOOLCALL>" + " Processing complete!"
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("I'll process your request. ".to_string(), 0),
+            create_mock_response_chunk("<".to_string(), 0),
+            create_mock_response_chunk("T".to_string(), 0),
+            create_mock_response_chunk("O".to_string(), 0),
+            create_mock_response_chunk("O".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk("C".to_string(), 0),
+            create_mock_response_chunk("A".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk(">".to_string(), 0),
+            create_mock_response_chunk("[".to_string(), 0),
+            create_mock_response_chunk("{".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk("n".to_string(), 0),
+            create_mock_response_chunk("a".to_string(), 0),
+            create_mock_response_chunk("m".to_string(), 0),
+            create_mock_response_chunk("e".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk(":".to_string(), 0),
+            create_mock_response_chunk(" ".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk("p".to_string(), 0),
+            create_mock_response_chunk("r".to_string(), 0),
+            create_mock_response_chunk("o".to_string(), 0),
+            create_mock_response_chunk("c".to_string(), 0),
+            create_mock_response_chunk("e".to_string(), 0),
+            create_mock_response_chunk("s".to_string(), 0),
+            create_mock_response_chunk("s".to_string(), 0),
+            create_mock_response_chunk("_".to_string(), 0),
+            create_mock_response_chunk("d".to_string(), 0),
+            create_mock_response_chunk("a".to_string(), 0),
+            create_mock_response_chunk("t".to_string(), 0),
+            create_mock_response_chunk("a".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk(",".to_string(), 0),
+            create_mock_response_chunk(" ".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk("a".to_string(), 0),
+            create_mock_response_chunk("r".to_string(), 0),
+            create_mock_response_chunk("g".to_string(), 0),
+            create_mock_response_chunk("u".to_string(), 0),
+            create_mock_response_chunk("m".to_string(), 0),
+            create_mock_response_chunk("e".to_string(), 0),
+            create_mock_response_chunk("n".to_string(), 0),
+            create_mock_response_chunk("t".to_string(), 0),
+            create_mock_response_chunk("s".to_string(), 0),
+            create_mock_response_chunk("\"".to_string(), 0),
+            create_mock_response_chunk(":".to_string(), 0),
+            create_mock_response_chunk(" ".to_string(), 0),
+            create_mock_response_chunk("{".to_string(), 0),
+            create_mock_response_chunk("}".to_string(), 0),
+            create_mock_response_chunk("}".to_string(), 0),
+            create_mock_response_chunk("]".to_string(), 0),
+            create_mock_response_chunk("<".to_string(), 0),
+            create_mock_response_chunk("/".to_string(), 0),
+            create_mock_response_chunk("T".to_string(), 0),
+            create_mock_response_chunk("O".to_string(), 0),
+            create_mock_response_chunk("O".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk("C".to_string(), 0),
+            create_mock_response_chunk("A".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk("L".to_string(), 0),
+            create_mock_response_chunk(">".to_string(), 0),
+            create_mock_response_chunk(" Processing complete!".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should consolidate extreme fragmentation into 3 clean chunks
+        // Input: "I'll process your request. " + 54-char tool call + " Processing complete!"
+        // Expected output: [Content(), ToolCall(), Content()]
+        assert_eq!(
+            results.len(),
+            3,
+            "Should consolidate fragments into 3 chunks"
+        );
+
+        // Verify exact output structure
+        test_utils::assert_content(&results[0], "I'll process your request. ");
+        test_utils::assert_tool_call(&results[1], "process_data", serde_json::json!({}));
+        test_utils::assert_content(&results[2], " Processing complete!");
+
+        // Verify content reconstruction excludes tool calls
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "I'll process your request.  Processing complete!"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_preserves_metadata() {
+        // Test metadata preservation through jail processing
+        let test_id = Some("correlation-id-123".to_string());
+        let test_event = Some("request-processing".to_string());
+        let test_comment = Some(vec![
+            "upstream-correlation".to_string(),
+            "debug-info".to_string(),
+        ]);
+
+        // Create chunks with specific metadata for the jail trigger
+        let chunks = vec![
+            create_annotated_chunk(
+                "I'll help you with that. ".to_string(),
+                0,
+                None, // No metadata on first chunk
+                None,
+                None,
+            ),
+            create_annotated_chunk(
+                "<tool_call>".to_string(),
+                0,
+                test_id.clone(), // Metadata on jail trigger chunk
+                test_event.clone(),
+                test_comment.clone(),
+            ),
+            create_mock_response_chunk("{\"name\": \"search_web\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"query\": \"test\"}}".to_string(), 0),
+            create_mock_response_chunk("</tool_call>".to_string(), 0),
+            create_mock_response_chunk(" Processing complete.".to_string(), 0),
+            test_utils::create_final_response_chunk(0), // Backend finish_reason chunk
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Hermes parser
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should get 3 chunks: before jail, tool call response, after jail
+        assert!(
+            results.len() >= 3,
+            "Should have at least 3 chunks, got {}",
+            results.len()
+        );
+
+        // Find the tool call chunk (the one with tool_calls, not the finish_reason chunk)
+        let tool_call_chunk = results
+            .iter()
+            .find(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .map(|c| c.delta.tool_calls.is_some())
+                    .unwrap_or(false)
+            })
+            .expect("Should have a tool call response chunk");
+
+        // Verify metadata is preserved
+        assert_eq!(
+            tool_call_chunk.id, test_id,
+            "ID should be preserved from jail trigger chunk"
+        );
+        assert_eq!(
+            tool_call_chunk.event, test_event,
+            "Event should be preserved from jail trigger chunk"
+        );
+        assert_eq!(
+            tool_call_chunk.comment, test_comment,
+            "Comment should be preserved from jail trigger chunk"
+        );
+
+        // Verify tool call was parsed correctly
+        let tool_calls = &tool_call_chunk.data.as_ref().unwrap().choices[0]
+            .delta
+            .tool_calls;
+        assert!(tool_calls.is_some(), "Should have tool calls");
+        let tool_calls = tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1, "Should have exactly one tool call");
+        assert_eq!(
+            tool_calls[0]
+                .function
+                .as_ref()
+                .unwrap()
+                .name
+                .as_ref()
+                .unwrap(),
+            "search_web"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_preserves_metadata_on_stream_end() {
+        // Test metadata preservation when stream ends while jailed
+        let test_id = Some("end-correlation-456".to_string());
+        let test_event = Some("stream-termination".to_string());
+        let test_comment = Some(vec!["incomplete-processing".to_string()]);
+
+        // Create chunks that end while jailed (no explicit end marker)
+        let chunks = vec![
+            create_mock_response_chunk("Starting function call: ".to_string(), 0),
+            create_annotated_chunk(
+                "<tool_call>".to_string(), // This chunk triggers jail and has metadata
+                0,
+                test_id.clone(),
+                test_event.clone(),
+                test_comment.clone(),
+            ),
+            create_mock_response_chunk(
+                "{\"name\": \"incomplete_call\"".to_string(), // No closing brace
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream with Hermes parser
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should get 2 chunks: first chunk passes through, stream end releases accumulated
+        assert_eq!(results.len(), 2, "Should have exactly 2 chunks");
+
+        // The second chunk is the accumulated content released when stream ended
+        let accumulated_chunk = &results[1];
+
+        // Verify metadata is preserved from the jail trigger
+        assert_eq!(
+            accumulated_chunk.id, test_id,
+            "ID should be preserved when stream ends while jailed"
+        );
+        assert_eq!(
+            accumulated_chunk.event, test_event,
+            "Event should be preserved when stream ends while jailed"
+        );
+        assert_eq!(
+            accumulated_chunk.comment, test_comment,
+            "Comment should be preserved when stream ends while jailed"
+        );
+
+        // Verify inner response metadata carries forward real stream values (not placeholders)
+        let inner = accumulated_chunk.data.as_ref().unwrap();
+        assert_eq!(
+            inner.id, "test-id",
+            "Inner response id should carry forward from real stream chunks, not be 'stream-end'"
+        );
+        assert_eq!(
+            inner.model, "test-model",
+            "Inner response model should carry forward from real stream chunks, not be 'unknown'"
+        );
+        assert_eq!(
+            inner.created, 1234567890,
+            "Inner response created should carry forward from real stream chunks, not be 0"
+        );
+
+        // The hermes parser (dynamo-parsers 2.0.1, PR #63) never surfaces tool-call
+        // markup to the client: a call truncated at stream end is recovered as a real
+        // tool call and the raw `<tool_call>` markup is stripped, rather than leaking
+        // the buffer as text. So the released chunk carries the recovered call with
+        // empty content (the metadata-preservation checks above are the test's subject).
+        let content = &inner.choices[0].delta.content;
+        assert_eq!(
+            content.as_ref().map(test_utils::extract_text),
+            Some(""),
+            "Released chunk must not leak raw tool-call markup as content"
+        );
+        let tool_calls = inner.choices[0].delta.tool_calls.as_ref();
+        assert_eq!(
+            tool_calls.map(|tc| tc.len()),
+            Some(1),
+            "Truncated call must be recovered as a tool call, not leaked as text"
+        );
+        assert_eq!(
+            tool_calls.unwrap()[0]
+                .function
+                .as_ref()
+                .and_then(|f| f.name.as_deref()),
+            Some("incomplete_call"),
+            "Recovered tool call should carry the parsed function name"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_metadata_edge_cases() {
+        // Test edge cases: empty metadata, partial metadata, etc.
+        let chunks = vec![
+            create_annotated_chunk(
+                "Text with ".to_string(),
+                0,
+                Some("".to_string()), // Empty string ID
+                None,                 // No event
+                Some(vec![]),         // Empty comment vector
+            ),
+            create_annotated_chunk(
+                "<tool_call>".to_string(),
+                0,
+                None,                                 // No ID
+                Some("partial-metadata".to_string()), // Only event
+                None,                                 // No comment
+            ),
+            create_mock_response_chunk("{\"name\": \"test\", \"arguments\": {}}".to_string(), 0),
+            create_mock_response_chunk("</tool_call>".to_string(), 0),
+            test_utils::create_final_response_chunk(0), // Backend finish_reason chunk
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Find the tool call chunk (the one with tool_calls, not the finish_reason chunk)
+        let tool_call_chunk = results
+            .iter()
+            .find(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .map(|c| c.delta.tool_calls.is_some())
+                    .unwrap_or(false)
+            })
+            .expect("Should have a tool call response chunk");
+
+        // Verify partial metadata is preserved correctly
+        assert_eq!(tool_call_chunk.id, None, "Should preserve None ID");
+        assert_eq!(
+            tool_call_chunk.event,
+            Some("partial-metadata".to_string()),
+            "Should preserve event"
+        );
+        assert_eq!(
+            tool_call_chunk.comment, None,
+            "Should preserve None comment"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_trailing_content_same_chunk() {
+        // Input chunks:
+        // [0] "I'll help you. "
+        // [1] "<tool_call>"
+        // [2] "{\"name\": \"search\", \"arguments\": {}}"
+        // [3] "</tool_call>trailing text that should not be lost"
+        //
+        // Expected output:
+        // [0] Content("I'll help you. ")
+        // [1] ToolCall("search", {})
+        // [2] Content("trailing text that should not be lost")
+        let chunks = vec![
+            create_mock_response_chunk("I'll help you. ".to_string(), 0),
+            create_mock_response_chunk("<tool_call>".to_string(), 0),
+            create_mock_response_chunk("{\"name\": \"search\", \"arguments\": {}}".to_string(), 0),
+            // This chunk contains both the end marker AND trailing content
+            create_mock_response_chunk(
+                "</tool_call>trailing text that should not be lost".to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            3,
+            "Should emit exactly 3 chunks as documented above"
+        );
+
+        // === Verify individual chunks ===
+        assert_content(&results[0], "I'll help you. ");
+        assert_tool_call(&results[1], "search", json!({}));
+        assert_content(&results[2], "trailing text that should not be lost");
+
+        // === Verify content reconstruction ===
+        let expected_content = "I'll help you. trailing text that should not be lost";
+        assert_eq!(
+            reconstruct_content(&results),
+            expected_content,
+            "Content reconstruction should preserve initial and trailing text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_early_exit_with_trailing() {
+        // Tests early exit when complete tool call is detected in chunk that also contains trailing content
+        // Input: "Starting task: " + "<tool_call>{\"name\": \"complete_task\", \"arguments\": {}}" + "</tool_call> Task completed successfully."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("Starting task: ".to_string(), 0),
+            create_mock_response_chunk(
+                "<tool_call>{\"name\": \"complete_task\", \"arguments\": {}}".to_string(),
+                0,
+            ),
+            // Early exit should happen here, but we also have trailing content
+            create_mock_response_chunk("</tool_call> Task completed successfully.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have exactly 3 chunks: content + tool call + trailing
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        test_utils::assert_content(&results[0], "Starting task: ");
+        test_utils::assert_tool_call(&results[1], "complete_task", serde_json::json!({}));
+        test_utils::assert_content(&results[2], " Task completed successfully.");
+
+        // Verify content reconstruction excludes tool calls but preserves trailing
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(
+            reconstructed,
+            "Starting task:  Task completed successfully."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_choices_independent_jailing() {
+        // Test that different choices can jail and unjail independently
+        // This test will FAIL with the current HashMap-based implementation
+        let chunks = vec![
+            // Chunk 1: All choices start normally
+            create_multi_choice_chunk(vec![
+                ("Starting task A. ".to_string(), 0),
+                ("Starting task B. ".to_string(), 1),
+                ("Starting task C. ".to_string(), 2),
+            ]),
+            // Chunk 2: Choice 0 starts tool call (gets jailed), others continue
+            create_multi_choice_chunk(vec![
+                ("<tool_call>".to_string(), 0),    // Choice 0 jailed
+                ("Continuing B. ".to_string(), 1), // Choice 1 continues
+                ("Continuing C. ".to_string(), 2), // Choice 2 continues
+            ]),
+            // Chunk 3: Choice 0 still jailed, Choice 2 starts tool call
+            create_multi_choice_chunk(vec![
+                ("{\"name\": \"tool_a\"".to_string(), 0), // Choice 0 still jailed
+                ("More B content. ".to_string(), 1),      // Choice 1 continues
+                ("<tool_call>".to_string(), 2),           // Choice 2 now jailed
+            ]),
+            // Chunk 4: Choice 0 finishes tool call, Choice 2 continues tool call
+            create_multi_choice_chunk(vec![
+                (", \"arguments\": {}}</tool_call>".to_string(), 0), // Choice 0 unjails
+                ("Final B. ".to_string(), 1),                        // Choice 1 continues
+                ("{\"name\": \"tool_c\", \"arguments\": {}}".to_string(), 2), // Choice 2 still jailed
+            ]),
+            // Chunk 5: Choice 2 finishes tool call
+            create_multi_choice_chunk(vec![
+                ("After tool A. ".to_string(), 0), // Choice 0 continues after unjail
+                ("Done with B. ".to_string(), 1),  // Choice 1 continues
+                ("</tool_call>".to_string(), 2),   // Choice 2 unjails
+            ]),
+            // Chunk 6: Backend finish_reason chunks for all choices
+            test_utils::create_multi_choice_finish_chunk(vec![0, 1, 2]),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // EXPECTED BEHAVIOR (will fail with current implementation):
+        // - Choice 1 should stream continuously (never jailed)
+        // - Choice 0 should jail from chunk 2 until chunk 4
+        // - Choice 2 should jail from chunk 3 until chunk 5
+        // - Each choice should emit independently
+
+        // Verify choice 1 was never interrupted (should have ~5 chunks of content)
+        let choice_1_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| &d.choices)
+            .filter(|c| c.index == 1 && c.delta.content.is_some())
+            .collect();
+
+        assert!(
+            choice_1_chunks.len() >= 4,
+            "Choice 1 should have multiple continuous chunks, got {}",
+            choice_1_chunks.len()
+        );
+
+        // Verify choice 0 has a tool call response
+        let choice_0_tool_calls: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| &d.choices)
+            .filter(|c| c.index == 0 && c.finish_reason == Some(FinishReason::ToolCalls))
+            .collect();
+
+        assert!(
+            !choice_0_tool_calls.is_empty(),
+            "Choice 0 should have tool call response"
+        );
+
+        // Verify choice 2 has a tool call response
+        let choice_2_tool_calls: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| &d.choices)
+            .filter(|c| c.index == 2 && c.finish_reason == Some(FinishReason::ToolCalls))
+            .collect();
+
+        assert!(
+            !choice_2_tool_calls.is_empty(),
+            "Choice 2 should have tool call response"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deterministic_choice_ordering() {
+        // Test that choices are processed in deterministic order (0, 1, 2...)
+        // This test will FAIL with the current HashMap implementation
+        let chunks = vec![
+            // All choices have tool calls that complete at the same time
+            create_multi_choice_chunk(vec![
+                (
+                    "<tool_call>{\"name\": \"tool_0\", \"arguments\": {}}</tool_call>".to_string(),
+                    0,
+                ),
+                (
+                    "<tool_call>{\"name\": \"tool_1\", \"arguments\": {}}</tool_call>".to_string(),
+                    1,
+                ),
+                (
+                    "<tool_call>{\"name\": \"tool_2\", \"arguments\": {}}</tool_call>".to_string(),
+                    2,
+                ),
+            ]),
+            test_utils::create_multi_choice_finish_chunk(vec![0, 1, 2]),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Find all tool call responses
+        let mut tool_call_responses: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| &d.choices)
+            .filter(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+            .collect();
+
+        // Sort by the order they appear in the results
+        // With HashMap, this order will be non-deterministic
+        // With Vec, this should always be [0, 1, 2]
+        tool_call_responses.sort_by_key(|c| c.index);
+
+        assert_eq!(
+            tool_call_responses.len(),
+            3,
+            "Should have 3 tool call responses"
+        );
+
+        // Run this test multiple times to verify determinism
+        for run in 0..5 {
+            let chunks = vec![
+                create_multi_choice_chunk(vec![
+                    (
+                        "<tool_call>{\"name\": \"tool_0\", \"arguments\": {}}</tool_call>"
+                            .to_string(),
+                        0,
+                    ),
+                    (
+                        "<tool_call>{\"name\": \"tool_1\", \"arguments\": {}}</tool_call>"
+                            .to_string(),
+                        1,
+                    ),
+                    (
+                        "<tool_call>{\"name\": \"tool_2\", \"arguments\": {}}</tool_call>"
+                            .to_string(),
+                        2,
+                    ),
+                ]),
+                test_utils::create_multi_choice_finish_chunk(vec![0, 1, 2]),
+            ];
+
+            let input_stream = stream::iter(chunks);
+            let jail = JailedStream::builder().tool_call_parser("hermes").build();
+            let run_results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+            let run_responses: Vec<_> = run_results
+                .iter()
+                .filter_map(|r| r.data.as_ref())
+                .flat_map(|d| &d.choices)
+                .filter(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+                .collect();
+
+            // The order should be consistent across runs
+            // This will fail with HashMap due to non-deterministic iteration
+            let indices: Vec<u32> = run_responses.iter().map(|c| c.index).collect();
+            assert_eq!(
+                indices,
+                vec![0, 1, 2],
+                "Choice processing order should be deterministic on run {}",
+                run
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_usage_chunk_preserved() {
+        // Create one chunk with choices (content) and one chunk with only usage/no choices.
+        let content_chunk = create_mock_response_chunk("Hello, world!".to_string(), 0);
+        let mut usage_chunk = content_chunk.clone();
+
+        // Modify the inner data to be a usage-only chunk
+        if let Some(ref mut data) = usage_chunk.data {
+            data.choices.clear();
+            data.usage = Some(CompletionUsage {
+                prompt_tokens: 11,
+                completion_tokens: 3,
+                total_tokens: 14,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            });
+        }
+
+        let input_chunks = vec![content_chunk, usage_chunk];
+        let input_stream = stream::iter(input_chunks);
+        let jail = JailedStream::builder().build();
+
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        // Validate we have exactly 2 chunks
+        assert_eq!(results.len(), 2, "Should have exactly 2 chunks");
+
+        // First chunk should be content chunk
+        let content = results[0].data.as_ref().unwrap().choices[0]
+            .delta
+            .content
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            extract_text(content),
+            "Hello, world!",
+            "Content chunk should have 'Hello, world!'"
+        );
+
+        // Second chunk should be usage-only chunk
+        assert!(
+            results[1].data.as_ref().unwrap().choices.is_empty(),
+            "Usage chunk should have no choices"
+        );
+        let usage = results[1].data.as_ref().unwrap().usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, 11);
+        assert_eq!(usage.completion_tokens, 3);
+        assert_eq!(usage.total_tokens, 14);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_choices_usage_aggregation() {
+        // Test that usage is correctly aggregated across multiple choices
+        // This test demonstrates how usage should work with n>1
+
+        // For now, this test just documents expected behavior
+        // It will need to be expanded once usage aggregation is implemented
+
+        let chunks = vec![create_multi_choice_chunk(vec![
+            ("Response A with many tokens".to_string(), 0), // ~5 tokens
+            ("Response B".to_string(), 1),                  // ~2 tokens
+            ("Response C has even more tokens than A".to_string(), 2), // ~8 tokens
+        ])];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // TODO: Once usage aggregation is implemented, verify:
+        // - Usage chunk has choices: [] (empty array)
+        // - completion_tokens = sum of all choices (~15 total)
+        // - prompt_tokens counted once
+        // - total_tokens = prompt_tokens + completion_tokens
+
+        // For now, just verify we got some results
+        assert!(!results.is_empty(), "Should have some results");
+    }
+
+    #[tokio::test]
+    async fn test_partial_matching_false_positive_prevention() {
+        // Input chunks:
+        // [0] "n "
+        // [1] "<"
+        // [2] " 5"
+        //
+        // Expected output:
+        // [0] Content("n ")
+        // [1] Content("< 5")  // "<" held as partial, then combined with " 5" when pattern doesn't match
+        let chunks = vec![
+            create_mock_response_chunk("n ".to_string(), 0),
+            create_mock_response_chunk("<".to_string(), 0),
+            create_mock_response_chunk(" 5".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Use nemotron parser which has <TOOLCALL> as a pattern
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            2,
+            "Should emit exactly 2 chunks: 'n ' and '< 5'"
+        );
+
+        // === Verify individual chunks ===
+        assert_content(&results[0], "n ");
+        assert_content(&results[1], "< 5");
+
+        // === Verify negative assertions ===
+        // Verify NO tool calls were detected
+        for (i, result) in results.iter().enumerate() {
+            assert!(
+                !has_tool_call(result),
+                "Chunk {} should not contain tool calls in mathematical expression",
+                i
+            );
+        }
+
+        // === Verify content reconstruction ===
+        assert_eq!(
+            reconstruct_content(&results),
+            "n < 5",
+            "Content reconstruction should preserve the complete mathematical expression"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_matching_suffix_detection() {
+        // Input chunks:
+        // [0] "text<TO"
+        // [1] "OLCALL>[{\"name\": \"test\", \"arguments\": {}}]</TOOLCALL>"
+        //
+        // Expected output:
+        // [0] Content("text")  // "<TO" held as partial
+        // [1] ToolCall("test", {})
+        let chunks = vec![
+            create_mock_response_chunk("text<TO".to_string(), 0),
+            create_mock_response_chunk(
+                "OLCALL>[{\"name\": \"test\", \"arguments\": {}}]</TOOLCALL>".to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .jail_end_sequence("</TOOLCALL>")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // === Verify chunk count ===
+        assert_eq!(
+            results.len(),
+            2,
+            "Should emit exactly 2 chunks: [0] 'text' content, [1] tool call"
+        );
+
+        // === Verify individual chunks ===
+        assert_content(&results[0], "text");
+        assert_tool_call(&results[1], "test", json!({}));
+
+        // === Verify negative assertions ===
+        // Verify '<' was not emitted in first chunk (held as partial)
+        let first_content = extract_content(&results[0]);
+        assert!(
+            !first_content.contains('<'),
+            "First chunk should not contain '<' as it's part of partial match '<TO'"
+        );
+
+        // === Verify content reconstruction ===
+        assert_eq!(
+            reconstruct_content(&results),
+            "text",
+            "Content reconstruction should only include 'text' (tool call parsed separately)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_parser() {
+        // With only the Harmony tool parser configured, analysis is internal
+        // reasoning and must not be exposed as normal content.
+        let chunks = vec![
+            create_mock_response_chunk(
+                "<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|>"
+                    .to_string(),
+                0,
+            ),
+            create_mock_response_chunk("<|start|>".to_string(), 0),
+            create_mock_response_chunk("assistant".to_string(), 0),
+            create_mock_response_chunk("<|channel|>".to_string(), 0),
+            create_mock_response_chunk(
+                "commentary to=functions.get_current_weather <|constrain|>json".to_string(),
+                0,
+            ),
+            create_mock_response_chunk(
+                "<|message|>{\"location\":\"San Francisco\"}<|call|>".to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have at least one output containing the parsed tool call.
+        assert!(!results.is_empty());
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+
+        // Verify a tool call was parsed with expected name and args
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_current_weather",
+            json!({"location": "San Francisco"}),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_bare_commentary_marker_split() {
+        // TOOLCALLING.stream.3: gpt-oss may start a tool call directly at the
+        // commentary channel marker, and the marker can split across chunks.
+        let chunks = vec![
+            create_mock_response_chunk("<|".to_string(), 0),
+            create_mock_response_chunk("cha".to_string(), 0),
+            create_mock_response_chunk("nnel|".to_string(), 0),
+            create_mock_response_chunk(">commentary".to_string(), 0),
+            create_mock_response_chunk(" to=functions.get_w".to_string(), 0),
+            create_mock_response_chunk("ea".to_string(), 0),
+            create_mock_response_chunk("the".to_string(), 0),
+            create_mock_response_chunk("r <|c".to_string(), 0),
+            create_mock_response_chunk("onstrain|>j".to_string(), 0),
+            create_mock_response_chunk("son<|message|>{\"loc".to_string(), 0),
+            create_mock_response_chunk("at".to_string(), 0),
+            create_mock_response_chunk("ion".to_string(), 0),
+            create_mock_response_chunk("\":\"NY".to_string(), 0),
+            create_mock_response_chunk("C\"}<|call|>".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("<|channel|>"));
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_weather",
+            json!({"location": "NYC"}),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_analysis_only_drops_content() {
+        let chunks = vec![create_mock_response_chunk(
+            "<|channel|>analysis<|message|>Need to inspect the request.<|end|>".to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("<|channel|>"));
+        assert!(!results.iter().any(test_utils::has_tool_call));
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_truncated_call_drops_analysis_without_marker_leak() {
+        let chunks = vec![create_mock_response_chunk(
+            r#"<|channel|>analysis<|message|>Need current weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"Hidden City"}"#.to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("<|channel|>"));
+        assert!(!content.contains("Need current weather."));
+        assert!(!content.contains("Hidden City"));
+        assert!(!results.iter().any(test_utils::has_tool_call));
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_drops_directed_non_function_commentary() {
+        let chunks = vec![create_mock_response_chunk(
+            r#"<|start|>assistant<|channel|>commentary to=browser.search <|constrain|>json<|message|>{"query":"secret weather"}<|call|>"#.to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("secret weather"));
+        assert!(!content.contains("<|channel|>"));
+        assert!(!results.iter().any(test_utils::has_tool_call));
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_harmony_drops_recipientless_tool_call_payload() {
+        let chunks = vec![create_mock_response_chunk(
+            r#"<|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"}<|call|>"#.to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("NYC"));
+        assert!(!content.contains("<|channel|>"));
+        assert!(!results.iter().any(test_utils::has_tool_call));
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_v3_1() {
+        // DeepSeek v3.1 format with two tool calls encoded in special tags
+        let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
+
+        let chunks = vec![create_mock_response_chunk(text.to_string(), 0)];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("deepseek_v3_1")
+            .build();
+        let jailed_stream = jail.apply_with_finish_reason(input_stream);
+        let results: Vec<_> = jailed_stream.collect().await;
+
+        // Should have at least one output containing both analysis text and parsed tool call
+        assert!(!results.is_empty());
+
+        // Verify a tool call was parsed with expected name and args
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_current_weather",
+            json!({"location": "Berlin", "units": "metric"}),
+        );
+        for result in results {
+            let Some(data) = result.data else {
+                continue;
+            };
+            for choice in data.choices {
+                if let Some(content) = choice.delta.content {
+                    assert!(
+                        !test_utils::extract_text(&content).contains("<｜tool▁calls▁end｜>"),
+                        "Should not contain deepseek special tokens in content"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_v3_1_chunk() {
+        // DeepSeek v3.1 format with two tool calls encoded in special tags
+        let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
+
+        // Split text into words, treating angle-bracketed tokens as one word
+        let mut words = Vec::new();
+        let mut i = 0;
+        let chars: Vec<char> = text.chars().collect();
+        while i < chars.len() {
+            if chars[i] == '<' {
+                // Find the next '>'
+                if let Some(end) = chars[i..].iter().position(|&c| c == '>') {
+                    let word: String = chars[i..=i + end].iter().collect();
+                    words.push(word);
+                    i += end + 1;
+                } else {
+                    // Malformed, just push the rest
+                    words.push(chars[i..].iter().collect());
+                    break;
+                }
+            } else if chars[i].is_whitespace() {
+                i += 1;
+            } else {
+                // Collect until next whitespace or '<'
+                let start = i;
+                while i < chars.len() && !chars[i].is_whitespace() && chars[i] != '<' {
+                    i += 1;
+                }
+                words.push(chars[start..i].iter().collect());
+            }
+        }
+
+        let chunks = words
+            .into_iter()
+            .map(|word| create_mock_response_chunk(word, 0))
+            .collect::<Vec<_>>();
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("deepseek_v3_1")
+            .build();
+        let jailed_stream = jail.apply_with_finish_reason(input_stream);
+        let results: Vec<_> = jailed_stream.collect().await;
+
+        // Should have at least one output containing both analysis text and parsed tool call
+        assert!(!results.is_empty());
+
+        // Verify a tool call was parsed with expected name and args
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_current_weather",
+            json!({"location": "Berlin", "units": "metric"}),
+        );
+        for result in results {
+            let Some(data) = result.data else {
+                continue;
+            };
+            for choice in data.choices {
+                if let Some(content) = choice.delta.content {
+                    assert!(
+                        !test_utils::extract_text(&content).contains("<｜tool▁calls▁end｜>"),
+                        "Should not contain deepseek special tokens in content"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_qwen3_coder_parser() {
+        // Input:
+        // "I'll call a function. "
+        // + "<tool_call><function=get_weather><parameter=location>San Francisco</parameter><parameter=unit>celsius</parameter></function></tool_call>"
+        // + " Done."
+        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        let chunks = vec![
+            create_mock_response_chunk("I'll call a function. ".to_string(), 0),
+            create_mock_response_chunk("<tool_call>".to_string(), 0),
+            create_mock_response_chunk("<function=get_weather>".to_string(), 0),
+            create_mock_response_chunk(
+                "<parameter=location>San Francisco</parameter>".to_string(),
+                0,
+            ),
+            create_mock_response_chunk("<parameter=unit>celsius</parameter>".to_string(), 0),
+            create_mock_response_chunk("</function>".to_string(), 0),
+            create_mock_response_chunk("</tool_call>".to_string(), 0),
+            create_mock_response_chunk(" Done.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("qwen3_coder")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        // Verify exact output structure: [Content(), ToolCall(), Content()].
+        test_utils::assert_content(&results[0], "I'll call a function. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "get_weather",
+            serde_json::json!({"location": "San Francisco", "unit": "celsius"}),
+        );
+        test_utils::assert_content(&results[2], " Done.");
+
+        // Verify content reconstruction excludes tool calls.
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "I'll call a function.  Done.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_qwen3_coder_multiple_params() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
+        let chunks = vec![
+            create_mock_response_chunk("Let me search for that. ".to_string(), 0),
+            create_mock_response_chunk(
+                "<tool_call><function=web_search><parameter=query>Rust programming</parameter><parameter=max_results>10</parameter><parameter=filter>recent</parameter></function></tool_call>".to_string(),
+                0,
+            ),
+            create_mock_response_chunk(" Searching now.".to_string(), 0),
+        ];
+
+        // Define the web_search tool with its parameters
+        let tool_defs = vec![ToolDefinition {
+            name: "web_search".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                    "filter": {"type": "string"},
+                },
+            })),
+            strict: None,
+        }];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder()
+            .tool_call_parser("qwen3_coder")
+            .tool_definitions(tool_defs)
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert_eq!(results.len(), 3, "Should have 3 chunks");
+
+        test_utils::assert_content(&results[0], "Let me search for that. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "web_search",
+            serde_json::json!({
+                "query": "Rust programming",
+                "max_results": 10,
+                "filter": "recent"
+            }),
+        );
+        test_utils::assert_content(&results[2], " Searching now.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_xml_parser_config_tokens_auto_population() {
+        // Tests that parser config tokens are auto-populated when using `.tool_call_parser()`.
+        // This verifies the jail system reads `tool_call_start_token` and `tool_call_end_token`
+        // from the `qwen3_coder` parser config.
+        let chunks = vec![
+            create_mock_response_chunk("Before tool call. ".to_string(), 0),
+            create_mock_response_chunk("<tool_call>".to_string(), 0), // Default qwen3_coder token
+            create_mock_response_chunk("<function=get_weather>".to_string(), 0),
+            create_mock_response_chunk("<parameter=city>Seattle</parameter>".to_string(), 0),
+            create_mock_response_chunk("</function>".to_string(), 0),
+            create_mock_response_chunk("</tool_call>".to_string(), 0), // Default qwen3_coder token
+            create_mock_response_chunk(" After tool call.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Create JailedStream using ONLY `.tool_call_parser()`.
+        // This should auto-populate jail sequences from the qwen3_coder config
+        let jail = JailedStream::builder()
+            .tool_call_parser("qwen3_coder")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert_eq!(
+            results.len(),
+            3,
+            "Should have content, tool call, and trailing content"
+        );
+
+        test_utils::assert_content(&results[0], "Before tool call. ");
+        test_utils::assert_tool_call(
+            &results[1],
+            "get_weather",
+            serde_json::json!({"city": "Seattle"}),
+        );
+        test_utils::assert_content(&results[2], " After tool call.");
+
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert_eq!(reconstructed, "Before tool call.  After tool call.");
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_xml_manual_sequences_prevent_auto_population() {
+        // Tests that manually setting jail sequences prevents auto-population.
+        // This verifies the builder respects manual configuration over auto-population.
+        //
+        // When custom sequences are set, the default parser tokens (<tool_call>) should
+        // NOT trigger jailing and should pass through as regular content.
+        let chunks = vec![
+            create_mock_response_chunk("Text with ".to_string(), 0),
+            // Default qwen3_coder token - should NOT trigger jailing.
+            create_mock_response_chunk("<tool_call>".to_string(), 0),
+            create_mock_response_chunk("should not jail".to_string(), 0),
+            create_mock_response_chunk("</tool_call>".to_string(), 0),
+            create_mock_response_chunk(" because custom ".to_string(), 0),
+            // Custom marker - this SHOULD trigger jailing since we register it below.
+            create_mock_response_chunk("[[START]]".to_string(), 0),
+            create_mock_response_chunk("jailed content".to_string(), 0),
+            create_mock_response_chunk("[[END]]".to_string(), 0),
+            create_mock_response_chunk(" text.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        // Set custom jail sequences - this should prevent auto-population.
+        // The default <tool_call> tokens should NOT trigger jailing.
+        let jail = JailedStream::builder()
+            .jail_start_sequence("[[START]]")
+            .jail_end_sequence("[[END]]")
+            .tool_call_parser("qwen3_coder")
+            .build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // The exact number of chunks depends on emission mode (packed vs single-choice-per-chunk)
+        // but we can verify the key behaviors:
+        // 1. Default <tool_call> tokens pass through as content (not jailed)
+        // 2. Custom [[START]]/[[END]] markers trigger jailing
+        // 3. No tool calls are extracted (because jailed content isn't valid XML)
+
+        // Find chunk(s) containing the default tokens that passed through.
+        let default_token_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .and_then(|c| c.delta.content.as_ref())
+            })
+            .filter(|content| {
+                test_utils::extract_text(content).contains("<tool_call>")
+                    || test_utils::extract_text(content).contains("should not jail")
+            })
+            .collect();
+
+        assert!(
+            !default_token_chunks.is_empty(),
+            "Default <tool_call> should pass through as content when manual sequences are set"
+        );
+
+        // Find chunk containing the jailed content that was released.
+        let jailed_chunk = results
+            .iter()
+            .filter_map(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .and_then(|c| c.delta.content.as_ref())
+            })
+            .find(|content| {
+                test_utils::extract_text(content).contains("[[START]]")
+                    && test_utils::extract_text(content).contains("jailed content")
+            });
+
+        assert!(
+            jailed_chunk.is_some(),
+            "Custom markers should trigger jailing and accumulated content should be released"
+        );
+
+        // Since the custom markers include non-XML content, the parser should not extract tool calls.
+        // The accumulated content "[[START]]jailed content[[END]]", although compatible with the
+        // way we configured `jail` above, is not consistent with what `qwen_coder` expects, and
+        // there is (at time of writing) no way to pass a parser instance - only a string that
+        // internally gets mapped to default way of instantiating a particular parser.
+        let tool_call_count = results
+            .iter()
+            .filter(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first())
+                    .and_then(|c| c.delta.tool_calls.as_ref())
+                    .map(|tc| !tc.is_empty())
+                    .unwrap_or(false)
+            })
+            .count();
+
+        assert_eq!(
+            tool_call_count, 0,
+            "Should have 0 tool calls because jailed content doesn't match XML format"
+        );
+
+        // Verify content reconstruction - all original content should be preserved.
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert!(
+            reconstructed.contains("<tool_call>") && reconstructed.contains("should not jail"),
+            "Reconstructed content should include default tokens that passed through"
+        );
+        assert!(
+            reconstructed.contains("[[START]]") && reconstructed.contains("jailed content"),
+            "Reconstructed content should include jailed content with custom markers"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jailed_stream_mistral_false_positive_curly() {
+        // Curly brace in normal text should not trigger tool call detection for mistral
+        let chunks = vec![
+            create_mock_response_chunk("Hey How".to_string(), 0),
+            create_mock_response_chunk("are { you? ".to_string(), 0),
+            create_final_response_chunk(0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(results.len() >= 2);
+        assert_content(&results[0], "Hey How");
+        assert!(
+            results.iter().any(|r| extract_content(r) == "are { you? "),
+            "Should preserve the literal text with curly brace"
+        );
+        for (i, r) in results.iter().enumerate() {
+            assert!(
+                !has_tool_call(r),
+                "Result {} should not contain tool calls for false-positive text",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[ignore]
+    // TODO: This needs to be fixed in parser library. P1 priority.
+    async fn test_jailed_stream_mistral_false_positive_then_tool_calls_marker() {
+        // Normal text with curly brace followed by explicit [TOOL_CALLS] marker should parse tool call
+        let chunks = vec![
+            create_mock_response_chunk("Hey How".to_string(), 0),
+            create_mock_response_chunk("are { you? ".to_string(), 0),
+            create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk(
+                "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"San Francisco\", \"unit\": \"fahrenheit\"}}]"
+                    .to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should preserve earlier content and also produce a tool call
+        assert!(results.len() >= 2);
+
+        assert!(
+            results.iter().any(|r| extract_content(r) == "Hey How"),
+            "Should include initial content"
+        );
+        assert!(
+            results.iter().any(|r| extract_content(r) == "{ you? "),
+            "Should include content preceding the marker"
+        );
+
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_weather",
+            json!({"location": "San Francisco", "unit": "fahrenheit"}),
+        );
+    }
+}
+
+// Comprehensive parallel tool calling jail tests
+#[cfg(test)]
+mod parallel_jail_tests {
+    use super::tests::test_utils;
+    use super::*;
+    use dynamo_protocols::types::ChatCompletionMessageContent;
+    use futures::StreamExt;
+    use futures::stream;
+    use serde_json::json;
+
+    /// Helper function to create a mock response chunk with multiple choices
+    fn create_multi_choice_response_chunk(
+        contents: Vec<String>,
+    ) -> Annotated<CreateChatCompletionStreamResponse> {
+        let choices: Vec<ChatChoiceStream> = contents
+            .into_iter()
+            .enumerate()
+            .map(|(i, content)| {
+                #[allow(deprecated)]
+                ChatChoiceStream {
+                    index: i as u32,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: Some(ChatCompletionMessageContent::Text(content)),
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                }
+            })
+            .collect();
+
+        let response = dynamo_protocols::types::CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices,
+            created: 1234567890,
+            model: "test-model".to_string(),
+            system_fingerprint: Some("test-fingerprint".to_string()),
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        };
+
+        Annotated {
+            data: Some(response),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Helper function to validate parallel tool call results in streaming format
+    fn validate_parallel_streaming_tool_calls(
+        results: &[Annotated<CreateChatCompletionStreamResponse>],
+        expected_tool_calls: &[(&str, serde_json::Value)],
+    ) {
+        // Find results with tool calls
+        let tool_call_results: Vec<_> = results
+            .iter()
+            .filter(|r| {
+                r.data
+                    .as_ref()
+                    .is_some_and(|d| d.choices.iter().any(|c| c.delta.tool_calls.is_some()))
+            })
+            .collect();
+
+        assert!(
+            !tool_call_results.is_empty(),
+            "Should have at least one tool call result"
+        );
+
+        // Collect all tool calls from all results
+        let mut all_tool_calls = Vec::new();
+        for result in &tool_call_results {
+            if let Some(ref data) = result.data {
+                for choice in &data.choices {
+                    if let Some(ref tool_calls) = choice.delta.tool_calls {
+                        all_tool_calls.extend(tool_calls.iter());
+                    }
+                }
+            }
+        }
+
+        assert_eq!(
+            all_tool_calls.len(),
+            expected_tool_calls.len(),
+            "Expected {} tool calls, got {}",
+            expected_tool_calls.len(),
+            all_tool_calls.len()
+        );
+
+        // Validate each tool call
+        for (i, (expected_name, expected_args)) in expected_tool_calls.iter().enumerate() {
+            let tool_call = &all_tool_calls[i];
+            assert!(tool_call.id.is_some(), "Tool call {} should have an ID", i);
+
+            assert_eq!(
+                tool_call.index, i as u32,
+                "Tool call {} should have index {}, got {}",
+                i, i, tool_call.index
+            );
+
+            assert_eq!(
+                tool_call.r#type,
+                Some(dynamo_protocols::types::FunctionType::Function),
+                "Tool call {} should be of type 'function'",
+                i
+            );
+
+            if let Some(ref function) = tool_call.function {
+                assert_eq!(
+                    function.name.as_deref(),
+                    Some(*expected_name),
+                    "Tool call {} name should be {}",
+                    i,
+                    expected_name
+                );
+
+                if let Some(ref args_str) = function.arguments {
+                    let parsed_args: serde_json::Value =
+                        serde_json::from_str(args_str).expect("Arguments should be valid JSON");
+                    assert_eq!(
+                        parsed_args, *expected_args,
+                        "Tool call {} arguments should match expected",
+                        i
+                    );
+                }
+            }
+        }
+    }
+
+    // =============================================================================
+    // 1. PARALLEL TOOL CALLS IN SINGLE CHUNK
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_nemotron() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                r#"<TOOLCALL>[
+    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
+]</TOOLCALL>"#.to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should have tool call results
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX", "unit": "fahrenheit"}),
+            ),
+            (
+                "get_current_weather",
+                json!({"city": "Orlando", "state": "FL", "unit": "fahrenheit"}),
+            ),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+    }
+
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_mistral() {
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                r#"[TOOL_CALLS][{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}, {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}][/TOOL_CALLS]"#.to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX", "unit": "fahrenheit"}),
+            ),
+            (
+                "get_current_weather",
+                json!({"city": "Orlando", "state": "FL", "unit": "fahrenheit"}),
+            ),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+    }
+
+    /// Regression test for issue #6822:
+    /// Hermes-style parallel tool calls in a single chunk must produce N tool call
+    /// results, not 1 call + trailing raw XML text.
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_hermes() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        // Two parallel calls arrive in one streaming chunk (hermes uses JSON inside tags).
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            "<tool_call>\n\
+{\"name\": \"get_current_weather\", \"arguments\": {\"city\": \"Dallas\", \"state\": \"TX\"}}\n\
+</tool_call>\n\
+<tool_call>\n\
+{\"name\": \"get_current_weather\", \"arguments\": {\"city\": \"Orlando\", \"state\": \"FL\"}}\n\
+</tool_call>"
+                .to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX"}),
+            ),
+            (
+                "get_current_weather",
+                json!({"city": "Orlando", "state": "FL"}),
+            ),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+
+        // Verify that raw XML does not leak as text content (the original bug).
+        for result in &results {
+            if let Some(ref data) = result.data {
+                for choice in &data.choices {
+                    if let Some(ref content) = choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("<tool_call>"),
+                            "Raw XML must not leak as text content, got: {text:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Regression test for issue #6822:
+    /// Qwen3Coder-style parallel tool calls in a single chunk must produce N tool
+    /// call results (identical format to hermes, different parser name).
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_qwen3_coder() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("qwen3_coder")
+            .build();
+
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            "<tool_call>\n\
+<function=search>\n\
+<parameter=query>Rust async</parameter>\n\
+</function>\n\
+</tool_call>\n\
+<tool_call>\n\
+<function=search>\n\
+<parameter=query>Python async</parameter>\n\
+</function>\n\
+</tool_call>"
+                .to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            ("search", json!({"query": "Rust async"})),
+            ("search", json!({"query": "Python async"})),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+    }
+
+    /// GLM-4.7 parallel tool calls in a single chunk. GLM uses a distinct
+    /// `<tool_call>func<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>`
+    /// wire format with its own `find_tool_call_end_position_glm47`.
+    /// Regression test: the old single-find end-position function exited after the
+    /// first `</tool_call>`, leaking subsequent calls as raw XML into content.
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_glm47() {
+        let jail = JailedStream::builder().tool_call_parser("glm47").build();
+
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            "<tool_call>get_weather\
+<arg_key>location</arg_key><arg_value>Boston</arg_value>\
+</tool_call>\
+<tool_call>get_weather\
+<arg_key>location</arg_key><arg_value>New York</arg_value>\
+</tool_call>"
+                .to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            ("get_weather", json!({"location": "Boston"})),
+            ("get_weather", json!({"location": "New York"})),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+
+        for result in &results {
+            if let Some(ref data) = result.data {
+                for choice in &data.choices {
+                    if let Some(ref content) = choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("<tool_call>"),
+                            "Raw XML must not leak as text content, got: {text:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // =============================================================================
+    // 2. PARALLEL TOOL CALLS ACROSS MULTIPLE CHUNKS (STREAMING)
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_parallel_tool_calls_streaming_chunks() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("<TOOLCALL>[".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                r#"    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},"#.to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                r#"    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}"#.to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk("]</TOOLCALL>".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX", "unit": "fahrenheit"}),
+            ),
+            (
+                "get_current_weather",
+                json!({"city": "Orlando", "state": "FL", "unit": "fahrenheit"}),
+            ),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+    }
+
+    #[tokio::test]
+    async fn test_parallel_tool_calls_with_normal_text_before_and_after() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("I'll check the weather for both cities. ".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                r#"<TOOLCALL>[
+    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
+]</TOOLCALL>"#.to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(" Let me get that information for you.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should have normal text before tool calls
+        let normal_text_before = results.iter().find(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.choices.iter().any(|c| {
+                    c.delta.content.as_ref().is_some_and(|content| {
+                        test_utils::extract_text(content).contains("I'll check the weather")
+                    })
+                })
+            })
+        });
+        assert!(
+            normal_text_before.is_some(),
+            "Should have normal text before tool calls"
+        );
+
+        // Should have tool calls
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX", "unit": "fahrenheit"}),
+            ),
+            (
+                "get_current_weather",
+                json!({"city": "Orlando", "state": "FL", "unit": "fahrenheit"}),
+            ),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+
+        // Should have normal text after tool calls
+        let normal_text_after = results.iter().find(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.choices.iter().any(|c| {
+                    c.delta.content.as_ref().is_some_and(|content| {
+                        test_utils::extract_text(content).contains("Let me get that information")
+                    })
+                })
+            })
+        });
+        assert!(
+            normal_text_after.is_some(),
+            "Should have normal text after tool calls"
+        );
+    }
+
+    // =============================================================================
+    // 3. MULTIPLE CHOICES WITH PARALLEL TOOL CALLS
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_multiple_choices_with_parallel_tool_calls() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .emission_mode(dynamo_parsers::tool_calling::jail::EmissionMode::SingleChoicePerChunk)
+            .build();
+
+        let input_chunks = vec![
+            create_multi_choice_response_chunk(vec![
+                r#"<TOOLCALL>[{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]</TOOLCALL>"#.to_string(),
+                r#"<TOOLCALL>[{"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}]</TOOLCALL>"#.to_string(),
+            ]),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should have tool calls from both choices
+        let tool_call_count = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                        .sum::<usize>()
+                })
+            })
+            .sum::<usize>();
+
+        assert!(
+            tool_call_count >= 2,
+            "Should have at least 2 tool calls from different choices"
+        );
+    }
+
+    // =============================================================================
+    // 4. MIXED TOOL TYPES IN PARALLEL CALLS
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_parallel_mixed_tool_types_streaming() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                r#"<TOOLCALL>[
+    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},
+    {"name": "web_search", "arguments": {"query": "Orlando Florida attractions", "max_results": 5}},
+    {"name": "get_user_location", "arguments": {"ip_address": "192.168.1.1"}}
+]</TOOLCALL>"#.to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            (
+                "get_current_weather",
+                json!({"city": "Dallas", "state": "TX", "unit": "fahrenheit"}),
+            ),
+            (
+                "web_search",
+                json!({"query": "Orlando Florida attractions", "max_results": 5}),
+            ),
+            ("get_user_location", json!({"ip_address": "192.168.1.1"})),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+    }
+
+    // =============================================================================
+    // 5. LARGE SCALE PARALLEL CALLS (5+ TOOLS)
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_large_scale_parallel_tool_calls() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                r#"<TOOLCALL>[
+    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Seattle", "state": "WA", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Denver", "state": "CO", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Miami", "state": "FL", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Phoenix", "state": "AZ", "unit": "fahrenheit"}},
+    {"name": "get_current_weather", "arguments": {"city": "Chicago", "state": "IL", "unit": "fahrenheit"}}
+]</TOOLCALL>"#.to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should have 7 tool calls
+        let tool_call_count = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                        .sum::<usize>()
+                })
+            })
+            .sum::<usize>();
+
+        assert_eq!(tool_call_count, 7, "Should have exactly 7 tool calls");
+    }
+
+    // =============================================================================
+    // 6. COMPLEX NESTED ARGUMENTS IN PARALLEL CALLS
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_parallel_complex_nested_arguments() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            r#"<TOOLCALL>[
+    {
+        "name": "get_weather_forecast",
+        "arguments": {
+            "location": {
+                "city": "Dallas",
+                "state": "TX",
+                "country": "USA",
+                "coordinates": {"lat": 32.7767, "lon": -96.7970}
+            },
+            "options": {
+                "days": 7,
+                "units": "fahrenheit",
+                "include_hourly": true,
+                "include_alerts": true,
+                "metrics": ["temperature", "humidity", "wind_speed", "precipitation"]
+            }
+        }
+    },
+    {
+        "name": "get_air_quality_data",
+        "arguments": {
+            "location": {
+                "coordinates": {"lat": 32.7767, "lon": -96.7970},
+                "radius_km": 25
+            },
+            "pollutants": ["pm2.5", "pm10", "ozone", "no2", "so2", "co"],
+            "time_range": {
+                "start": "2024-01-01T00:00:00Z",
+                "end": "2024-01-07T23:59:59Z"
+            }
+        }
+    }
+]</TOOLCALL>"#
+                .to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should have 2 tool calls with complex nested arguments
+        let tool_call_count = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                        .sum::<usize>()
+                })
+            })
+            .sum::<usize>();
+
+        assert_eq!(tool_call_count, 2, "Should have exactly 2 tool calls");
+
+        // Validate that complex nested structures are preserved
+        let tool_call_results: Vec<_> = results
+            .iter()
+            .filter(|r| {
+                r.data
+                    .as_ref()
+                    .is_some_and(|d| d.choices.iter().any(|c| c.delta.tool_calls.is_some()))
+            })
+            .collect();
+
+        if let Some(result) = tool_call_results.first()
+            && let Some(ref data) = result.data
+        {
+            for choice in &data.choices {
+                if let Some(ref tool_calls) = choice.delta.tool_calls {
+                    for tool_call in tool_calls {
+                        if let Some(ref function) = tool_call.function
+                            && let Some(args_str) = &function.arguments
+                        {
+                            let parsed_args: serde_json::Value = serde_json::from_str(args_str)
+                                .expect("Arguments should be valid JSON");
+
+                            // Verify nested structure is preserved
+                            if function.name.as_deref() == Some("get_weather_forecast") {
+                                assert!(parsed_args["location"]["coordinates"]["lat"].is_number());
+                                assert!(parsed_args["options"]["metrics"].is_array());
+                            } else if function.name.as_deref() == Some("get_air_quality_data") {
+                                assert!(parsed_args["pollutants"].is_array());
+                                assert!(parsed_args["time_range"]["start"].is_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =============================================================================
+    // 7. ERROR HANDLING AND EDGE CASES
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_parallel_partial_malformed_calls() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                r#"<TOOLCALL>[
+    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},
+    {"invalid": "malformed_call"},
+    {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
+]</TOOLCALL>"#.to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should still parse the valid tool calls despite the malformed one
+        let tool_call_count = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                        .sum::<usize>()
+                })
+            })
+            .sum::<usize>();
+
+        // Should have at least the valid tool calls
+        assert!(
+            tool_call_count >= 1,
+            "Should have at least 1 valid tool call"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parallel_streaming_interrupted() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        // Simulate a stream that gets cut off mid-tool-call
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("<TOOLCALL>[".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                r#"    {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}},"#.to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                r#"    {"name": "get_current_weather", "arguments": {"city": "Orlando""#.to_string(),
+                0,
+            ),
+            // Stream ends abruptly without closing the JSON array or TOOLCALL tag
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Should still handle the incomplete stream gracefully
+        assert!(
+            !results.is_empty(),
+            "Should have results even with incomplete stream"
+        );
+
+        // Should try to parse whatever content was accumulated
+        let has_some_content = results.iter().any(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.choices
+                    .iter()
+                    .any(|c| c.delta.content.is_some() || c.delta.tool_calls.is_some())
+            })
+        });
+
+        assert!(
+            has_some_content,
+            "Should have some content despite incomplete stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parallel_empty_tool_calls_array() {
+        let jail = JailedStream::builder()
+            .tool_call_parser("nemotron_deci")
+            .build();
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("I'll help you with that. ".to_string(), 0),
+            test_utils::create_mock_response_chunk("<TOOLCALL>[]</TOOLCALL>".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                " Actually, I don't need any tools for this.".to_string(),
+                0,
+            ),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        // Should have normal text content but no tool calls
+        let has_normal_text = results.iter().any(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.choices.iter().any(|c| {
+                    c.delta.content.as_ref().is_some_and(|content| {
+                        test_utils::extract_text(content).contains("I'll help you")
+                            || test_utils::extract_text(content).contains("don't need any tools")
+                    })
+                })
+            })
+        });
+
+        assert!(has_normal_text, "Should have normal text content");
+
+        let tool_call_count = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                        .sum::<usize>()
+                })
+            })
+            .sum::<usize>();
+
+        assert_eq!(
+            tool_call_count, 0,
+            "Should have no tool calls for empty array"
+        );
+    }
+
+    /// Regression test for #6821: tool_choice=required with qwen3_coder parser.
+    ///
+    /// When tool_choice=required AND a tool_call_parser (e.g. qwen3_coder) is
+    /// configured, the jail must use marker-based mode so the parser handles the
+    /// XML output.  Previously this fell through to Immediate JSON mode which
+    /// could not parse qwen3_coder XML, causing raw XML to leak as content.
+    #[tokio::test]
+    async fn test_tool_choice_required_with_qwen3_coder_parser() {
+        // Simulate qwen3_coder XML output for a single tool call
+        let xml_output = r#"<tool_call>
+<function=get_weather>
+<parameter=city>
+San Francisco
+</parameter>
+<parameter=unit>
+fahrenheit
+</parameter>
+</function>
+</tool_call>"#;
+
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            xml_output.to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("qwen3_coder".to_string()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            None,
+            false,
+            input_stream,
+        )
+        .collect()
+        .await;
+
+        // Should have parsed a tool call, not leaked raw XML as content
+        let tool_call_count: usize = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c: &ChatChoiceStream| {
+                            c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len())
+                        })
+                        .sum::<usize>()
+                })
+            })
+            .sum();
+
+        assert!(
+            tool_call_count >= 1,
+            "tool_choice=required with qwen3_coder should produce at least one tool call, got {}",
+            tool_call_count
+        );
+
+        // Verify the tool call was parsed correctly
+        for r in &results {
+            if let Some(data) = &r.data {
+                for choice in &data.choices {
+                    if let Some(tool_calls) = &choice.delta.tool_calls {
+                        for tc in tool_calls {
+                            assert_eq!(
+                                tc.function.as_ref().unwrap().name.as_deref(),
+                                Some("get_weather"),
+                                "Tool call name should be 'get_weather'"
+                            );
+                        }
+                    }
+                    // Content should be empty, not raw XML
+                    if let Some(content) = &choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("<tool_call>"),
+                            "Raw XML should not leak as content, got: {}",
+                            text
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Test for tool_choice=named with qwen3_coder parser and named_tool_filter.
+    ///
+    /// When tool_choice=named is used with a specific tool_name, the
+    /// preprocessor decision logic should apply the named_tool_filter to ensure
+    /// only the requested tool is parsed, even if the model emits other tools.
+    #[tokio::test]
+    async fn test_tool_choice_named_with_qwen3_coder_parser() {
+        // Simulate qwen3_coder XML output for a single tool call
+        let xml_output = r#"<tool_call>
+<function=get_weather>
+<parameter=city>
+San Francisco
+</parameter>
+<parameter=unit>
+fahrenheit
+</parameter>
+</function>
+</tool_call>"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(xml_output.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let input_stream = stream::iter(input_chunks);
+
+        // Apply tool_choice=named for get_weather
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("qwen3_coder".to_string()),
+            Some(ChatCompletionToolChoiceOption::Named(
+                "get_weather".to_string().into(),
+            )),
+            None,
+            false,
+            input_stream,
+        )
+        .collect()
+        .await;
+
+        // Should have parsed the named tool call
+        let tool_call_count: usize = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c: &ChatChoiceStream| {
+                            c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len())
+                        })
+                        .sum::<usize>()
+                })
+            })
+            .sum();
+
+        assert!(
+            tool_call_count >= 1,
+            "tool_choice=named with qwen3_coder should produce at least one tool call, got {}",
+            tool_call_count
+        );
+
+        // Verify the tool call was parsed correctly and matches the named tool
+        for r in &results {
+            if let Some(data) = &r.data {
+                for choice in &data.choices {
+                    if let Some(tool_calls) = &choice.delta.tool_calls {
+                        for tc in tool_calls {
+                            assert_eq!(
+                                tc.function.as_ref().unwrap().name.as_deref(),
+                                Some("get_weather"),
+                                "Tool call name should match the named tool choice"
+                            );
+                        }
+                    }
+                    // Content should be empty, not raw XML
+                    if let Some(content) = &choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("<tool_call>"),
+                            "Raw XML should not leak as content, got: {}",
+                            text
+                        );
+                    }
+                }
+            }
+        }
+
+        // OpenAI spec: whenever tool_calls are emitted, finish_reason must be
+        // ToolCalls — regardless of whether tool_choice was auto, required, or named.
+        let finish_reasons: Vec<_> = results
+            .iter()
+            .filter_map(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first().and_then(|c| c.finish_reason))
+            })
+            .collect();
+
+        assert!(
+            finish_reasons.contains(&FinishReason::ToolCalls),
+            "tool_choice=named with emitted tool_calls should have ToolCalls finish reason, got {:?}",
+            finish_reasons
+        );
+    }
+
+    /// tool_choice=required + parser configured + backend applied guided
+    /// decoding → model emits a bare JSON array of tool calls.
+    ///
+    /// This is the minimax/SGLang-after-PR-#6620 regression: previously we
+    /// fell through to the marker-based parser (looking for `<minimax:
+    /// tool_call>` etc.) which cannot parse unmarked JSON, so tool_calls
+    /// were empty and the JSON leaked into content/reasoning_content.
+    /// The Immediate branch now routes through base_json_parser first.
+    #[tokio::test]
+    async fn test_tool_choice_required_with_parser_bare_json() {
+        let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("minimax_m2".to_string()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            None,
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let tool_calls: Vec<_> = results
+            .iter()
+            .flat_map(|r| {
+                r.data
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|d| d.choices.iter())
+                    .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            })
+            .cloned()
+            .collect();
+
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "bare JSON array must be parsed by base_json_parser even when parser is set"
+        );
+        assert_eq!(
+            tool_calls[0].function.as_ref().unwrap().name.as_deref(),
+            Some("get_weather")
+        );
+
+        // finish_reason should be rewritten to ToolCalls (required path).
+        let finish_reasons: Vec<_> = results
+            .iter()
+            .filter_map(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first().and_then(|c| c.finish_reason))
+            })
+            .collect();
+        assert!(
+            finish_reasons.contains(&FinishReason::ToolCalls),
+            "tool_choice=required with tool_calls emitted should have ToolCalls finish_reason"
+        );
+
+        // No raw JSON leaked as content.
+        for r in &results {
+            if let Some(data) = &r.data {
+                for choice in &data.choices {
+                    if let Some(content) = &choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("get_weather"),
+                            "tool call JSON should not leak as content, got: {}",
+                            text
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// MiniMax recovers complete inner invokes even when the outer wrapper is
+    /// damaged. Incomplete paired XML fences still do not recover a call, and
+    /// the jail must not surface raw MiniMax protocol markers as content.
+    #[tokio::test]
+    async fn test_minimax_m2_stream_finalize_recovers_complete_inner_invokes() {
+        // These are jail/finalize regression checks for existing parser parity cases:
+        // the first and prefix-preservation rows cover TOOLCALLING.stream.4.a, and
+        // the mid-call body truncation row covers TOOLCALLING.stream.4.b.
+        let cases = [
+            (
+                "complete body without outer close",
+                "<minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NYC</parameter>\n\
+                 </invoke>",
+                "",
+                1,
+            ),
+            (
+                "mid-call body truncation",
+                "<minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NY",
+                "",
+                0,
+            ),
+            (
+                "pre-marker prose before truncated call",
+                "I will check that. <minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NYC</parameter>\n\
+                 </invoke>",
+                "I will check that. ",
+                1,
+            ),
+        ];
+
+        for (label, partial_tool_call, expected_content, expected_tool_call_count) in cases {
+            let input_chunks = vec![
+                test_utils::create_mock_response_chunk(partial_tool_call.to_string(), 0),
+                test_utils::create_final_response_chunk(0),
+            ];
+
+            let results: Vec<_> = apply_tool_calling_jail(
+                Some("minimax_m2".to_string()),
+                None,
+                None,
+                false,
+                stream::iter(input_chunks),
+            )
+            .collect()
+            .await;
+
+            let tool_call_count: usize = results
+                .iter()
+                .map(|r| {
+                    r.data.as_ref().map_or(0, |d| {
+                        d.choices
+                            .iter()
+                            .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                            .sum::<usize>()
+                    })
+                })
+                .sum();
+            assert_eq!(
+                tool_call_count, expected_tool_call_count,
+                "{label}: unexpected recovered MiniMax tool call count"
+            );
+
+            let content = test_utils::reconstruct_content(&results);
+            assert!(
+                !content.contains("<minimax:tool_call>") && !content.contains("<invoke"),
+                "{label}: MiniMax protocol markup leaked into content: {content:?}"
+            );
+            assert_eq!(
+                content, expected_content,
+                "{label}: unexpected residual content"
+            );
+        }
+    }
+
+    fn tool_call_names(results: &[Annotated<CreateChatCompletionStreamResponse>]) -> Vec<String> {
+        results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            .filter_map(|tc| {
+                tc.function
+                    .as_ref()
+                    .and_then(|function| function.name.clone())
+            })
+            .collect()
+    }
+
+    fn assert_content_omits_markers(
+        label: &str,
+        results: &[Annotated<CreateChatCompletionStreamResponse>],
+        markers: &[&str],
+    ) {
+        let content = test_utils::reconstruct_content(results);
+        for marker in markers {
+            assert!(
+                !content.contains(marker),
+                "{label}: marker {marker:?} leaked into content: {content:?}"
+            );
+        }
+    }
+
+    /// Bare-body recovery must also work when the recovery marker itself is
+    /// split across stream chunks. Otherwise the jail emits protocol bytes as
+    /// normal content before the aggregate parser gets a chance to recover.
+    #[tokio::test]
+    async fn test_partial_marker_buffer_flushes_at_stream_end() {
+        for suffix in ["c", "ca", "cal", "call"] {
+            let expected = format!("I will {suffix}");
+            let input_chunks = vec![test_utils::create_mock_response_chunk(expected.clone(), 0)];
+            let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(test_utils::reconstruct_content(&results), expected);
+            assert!(tool_call_names(&results).is_empty());
+        }
+
+        let expected = "I will call";
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(expected.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(test_utils::reconstruct_content(&results), expected);
+        let finish_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|result| result.data.as_ref())
+            .flat_map(|data| data.choices.iter())
+            .filter(|choice| choice.finish_reason.is_some())
+            .collect();
+        assert_eq!(finish_chunks.len(), 1);
+        let content = finish_chunks[0]
+            .delta
+            .content
+            .as_ref()
+            .expect("partial marker buffer should flush with the final finish chunk");
+        assert_eq!(test_utils::extract_text(content), "call");
+
+        let mut terminal_content_chunk =
+            test_utils::create_mock_response_chunk(expected.to_string(), 0);
+        terminal_content_chunk.data.as_mut().unwrap().choices[0].finish_reason =
+            Some(FinishReason::Stop);
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(vec![terminal_content_chunk]))
+            .collect()
+            .await;
+        let content_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|result| result.data.as_ref())
+            .flat_map(|data| data.choices.iter())
+            .filter_map(|choice| {
+                choice
+                    .delta
+                    .content
+                    .as_ref()
+                    .map(|content| (test_utils::extract_text(content), choice.finish_reason))
+            })
+            .collect();
+        assert_eq!(
+            content_chunks,
+            vec![("I will ", None), ("call", Some(FinishReason::Stop))]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gemma4_call_prefix_prose_passes_without_waiting_for_eof() {
+        let expected = "I will call: you tomorrow";
+        let cases = [
+            vec![expected],
+            vec!["I will ca", "ll: you tomorrow"],
+            vec!["I will call:", " you tomorrow"],
+        ];
+
+        for chunks in cases {
+            let input_chunks = chunks
+                .into_iter()
+                .map(|chunk| test_utils::create_mock_response_chunk(chunk.to_string(), 0))
+                .chain(std::iter::once(test_utils::create_final_response_chunk(0)));
+            let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(test_utils::reconstruct_content(&results), expected);
+            let content_before_finish: String = results
+                .iter()
+                .filter_map(|result| result.data.as_ref())
+                .flat_map(|data| data.choices.iter())
+                .filter(|choice| choice.finish_reason.is_none())
+                .filter_map(|choice| choice.delta.content.as_ref())
+                .map(test_utils::extract_text)
+                .collect();
+            assert_eq!(content_before_finish, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gemma4_trailing_partial_after_unjail_is_buffered() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<|tool_call>call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|> ca".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "ll:get_weather{location:<|\"|>Boston<|\"|>}<tool_call|>".to_string(),
+                0,
+            ),
+        ];
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(
+            tool_call_names(&results),
+            vec!["get_weather".to_string(), "get_weather".to_string()]
+        );
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, " ");
+        assert_content_omits_markers(
+            "Gemma 4 trailing partial",
+            &results,
+            &["call:get_weather", "ca", "ll:get_weather", "<tool_call|>"],
+        );
+    }
+
+    #[tokio::test]
+    async fn test_split_bare_recovery_markers_are_jailed() {
+        let cases = [
+            (
+                "minimax_m2",
+                "MiniMax",
+                vec![
+                    "I will check that. <inv",
+                    "oke name=\"get_weather\">\n<parameter name=\"location\">NYC</parameter>\n</invoke>\n</minimax:tool_call>",
+                ],
+                &["<invoke", "</minimax:tool_call>"][..],
+            ),
+            (
+                "minimax_m2",
+                "MiniMax delayed outer close",
+                vec![
+                    "I will check that. <invoke name=\"get_weather\">\n<parameter name=\"location\">NYC</parameter>\n",
+                    "</invoke>",
+                    "\n</minimax:tool_call>",
+                ],
+                &["<invoke", "</minimax:tool_call>"][..],
+            ),
+            (
+                "qwen3_coder",
+                "Qwen3-Coder delayed outer close",
+                vec![
+                    "I will check that. <function=get_weather>\n<parameter=location>NYC</parameter>\n",
+                    "</function>",
+                    "\n</tool_call>",
+                ],
+                &["<function=", "</tool_call>"][..],
+            ),
+            (
+                "deepseek_v4",
+                "DeepSeek V4",
+                vec![
+                    "I will check that. <｜DSML｜inv",
+                    "oke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+                ],
+                &["<｜DSML｜invoke", "</｜DSML｜tool_calls>"][..],
+            ),
+            (
+                "deepseek_v4",
+                "DeepSeek V4 delayed outer close",
+                vec![
+                    "I will check that. <｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n",
+                    "</｜DSML｜invoke>",
+                    "\n</｜DSML｜tool_calls>",
+                ],
+                &["<｜DSML｜invoke", "</｜DSML｜tool_calls>"][..],
+            ),
+            (
+                "kimi_k2",
+                "Kimi K2",
+                vec![
+                    "I will check that. <|tool_call_beg",
+                    "in|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"NYC\"}<|tool_call_end|><|tool_calls_section_end|>",
+                ],
+                &["<|tool_call_begin|>", "<|tool_calls_section_end|>"][..],
+            ),
+            (
+                "gemma4",
+                "Gemma 4",
+                vec![
+                    "I will check that. ca",
+                    "ll:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+                ],
+                &["call:get_weather", "<tool_call|>"][..],
+            ),
+            (
+                "gemma4",
+                "Gemma 4 split after call prefix",
+                vec![
+                    "I will check that. call:",
+                    "get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+                ],
+                &["call:get_weather", "<tool_call|>"][..],
+            ),
+        ];
+
+        for (parser, label, chunks, markers) in cases {
+            let input_chunks = chunks
+                .into_iter()
+                .map(|chunk| test_utils::create_mock_response_chunk(chunk.to_string(), 0));
+            let jail = JailedStream::builder().tool_call_parser(parser).build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(
+                tool_call_names(&results),
+                vec!["get_weather".to_string()],
+                "{label}: expected recovered get_weather call"
+            );
+            assert_eq!(
+                test_utils::reconstruct_content(&results),
+                "I will check that. ",
+                "{label}: expected only prefix prose as content"
+            );
+            assert_content_omits_markers(label, &results, markers);
+        }
+    }
+
+    /// GLM-4.7's bare-call marker starts at `<arg_key>`, after the function
+    /// name. The stream jail therefore needs parser-aware tool-name patterns
+    /// so a split between the function name and `<arg_key>` does not leak the
+    /// function name as user-visible content.
+    #[tokio::test]
+    async fn test_glm47_split_bare_call_jails_function_name_suffix() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
+        let tool_defs = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+            })),
+            strict: None,
+        }];
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("I will check that. get_weat".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "her<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>".to_string(),
+                0,
+            ),
+        ];
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("glm47")
+            .tool_definitions(tool_defs)
+            .build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(tool_call_names(&results), vec!["get_weather".to_string()]);
+        assert_eq!(
+            test_utils::reconstruct_content(&results),
+            "I will check that. "
+        );
+        assert_content_omits_markers(
+            "GLM-4.7",
+            &results,
+            &["get_weather<arg_key>", "<arg_value>", "</tool_call>"],
+        );
+    }
+
+    #[tokio::test]
+    async fn test_glm47_trailing_split_bare_call_stays_jailed() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
+        let tool_defs = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+            })),
+            strict: None,
+        }];
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>get_weat"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "her<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call>"
+                    .to_string(),
+                0,
+            ),
+        ];
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("glm47")
+            .tool_definitions(tool_defs)
+            .build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(
+            tool_call_names(&results),
+            vec!["get_weather".to_string(), "get_weather".to_string()]
+        );
+        assert_eq!(test_utils::reconstruct_content(&results), "");
+        assert_content_omits_markers(
+            "GLM-4.7 trailing split",
+            &results,
+            &["get_weat", "her<arg_key>", "<arg_value>", "</tool_call>"],
+        );
+    }
+
+    /// tool_choice=required with the alternate `arguments` key (SGLang's
+    /// JsonArrayParser and some vLLM paths emit this variant).  The
+    /// base_json_parser accepts either `parameters` or `arguments`.
+    #[tokio::test]
+    async fn test_tool_choice_required_bare_json_with_arguments_key() {
+        let bare_json = r#"[{"name":"get_weather","arguments":{"location":"Paris"}}]"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("hermes".to_string()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            None,
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let tool_calls: Vec<_> = results
+            .iter()
+            .flat_map(|r| {
+                r.data
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|d| d.choices.iter())
+                    .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            })
+            .cloned()
+            .collect();
+
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "base_json_parser must accept the `arguments` key variant"
+        );
+        let args = tool_calls[0]
+            .function
+            .as_ref()
+            .and_then(|f| f.arguments.as_deref())
+            .unwrap_or_default();
+        assert!(
+            args.contains("Paris"),
+            "arguments should carry the parameters payload, got: {}",
+            args
+        );
+    }
+
+    /// tool_choice=named + parser configured + bare JSON array from guided
+    /// decoding.  The call must be parsed (by base_json_parser) and the
+    /// named-tool filter must accept a matching name; finish_reason stays
+    /// Stop per OpenAI spec for named tool_choice.
+    #[tokio::test]
+    async fn test_tool_choice_named_with_parser_bare_json() {
+        let bare_json = r#"[{"name":"get_weather","parameters":{"location":"Tokyo"}}]"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("minimax_m2".to_string()),
+            Some(ChatCompletionToolChoiceOption::Named(
+                "get_weather".to_string().into(),
+            )),
+            None,
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let tool_calls: Vec<_> = results
+            .iter()
+            .flat_map(|r| {
+                r.data
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|d| d.choices.iter())
+                    .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            })
+            .cloned()
+            .collect();
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].function.as_ref().unwrap().name.as_deref(),
+            Some("get_weather")
+        );
+
+        // OpenAI spec: whenever tool_calls are emitted, finish_reason must be
+        // ToolCalls — regardless of whether tool_choice was auto, required, or named.
+        let finish_reasons: Vec<_> = results
+            .iter()
+            .filter_map(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.choices.first().and_then(|c| c.finish_reason))
+            })
+            .collect();
+        assert!(
+            finish_reasons.contains(&FinishReason::ToolCalls),
+            "tool_choice=named with emitted tool_calls should be rewritten to ToolCalls, got {:?}",
+            finish_reasons
+        );
+    }
+
+    /// tool_choice=named + parser + bare JSON where the model emits a
+    /// different tool than requested.  The named_tool_filter must drop
+    /// the mismatched call so nothing is emitted as a tool call.
+    #[tokio::test]
+    async fn test_tool_choice_named_bare_json_wrong_tool_filtered() {
+        let bare_json = r#"[{"name":"search","parameters":{"q":"foo"}}]"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = apply_tool_calling_jail(
+            Some("minimax_m2".to_string()),
+            Some(ChatCompletionToolChoiceOption::Named(
+                "get_weather".to_string().into(),
+            )),
+            None,
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let tool_call_count: usize = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c: &ChatChoiceStream| {
+                            c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len())
+                        })
+                        .sum::<usize>()
+                })
+            })
+            .sum();
+
+        assert_eq!(
+            tool_call_count, 0,
+            "named_tool_filter must drop tool calls whose name doesn't match the requested tool"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_choice_named_no_parser_bare_json_wrong_tool_filtered() {
+        // Regression: with tool_choice=Named and NO parser, the base-JSON
+        // parser (step 1 in create_tool_call_choice) can now parse arbitrary
+        // JSON arrays. The named filter must still apply or a mismatched
+        // tool name would leak to the client.
+        let bare_json = r#"[{"name":"search","parameters":{"q":"foo"}}]"#;
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = apply_tool_calling_jail(
+            None,
+            Some(ChatCompletionToolChoiceOption::Named(
+                "get_weather".to_string().into(),
+            )),
+            None,
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let tool_call_count: usize = results
+            .iter()
+            .map(|r| {
+                r.data.as_ref().map_or(0, |d| {
+                    d.choices
+                        .iter()
+                        .map(|c: &ChatChoiceStream| {
+                            c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len())
+                        })
+                        .sum::<usize>()
+                })
+            })
+            .sum();
+
+        assert_eq!(
+            tool_call_count, 0,
+            "Named + no-parser: wrong-name tool call must be filtered"
+        );
+
+        // The filtered-out tool JSON must not leak as assistant content.
+        let emitted_text: String = results
+            .iter()
+            .flat_map(|r| r.data.as_ref().map(|d| &d.choices).into_iter())
+            .flatten()
+            .filter_map(|c| match c.delta.content.as_ref()? {
+                ChatCompletionMessageContent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !emitted_text.contains("search"),
+            "wrong-tool JSON leaked to content: {emitted_text:?}"
+        );
+    }
+}

--- a/parsers/tests/jail.rs
+++ b/parsers/tests/jail.rs
@@ -298,6 +298,40 @@ mod tests {
             }
         }
 
+        /// Assert that a stream with tool calls but no upstream finish chunk ends
+        /// with the synthesized `ToolCalls` terminal chunk required by strict clients.
+        pub fn assert_synthesized_tool_calls_finish(
+            results: &[Annotated<CreateChatCompletionStreamResponse>],
+            expected_prefix_chunks: usize,
+            index: u32,
+        ) {
+            assert_eq!(
+                results.len(),
+                expected_prefix_chunks + 1,
+                "expected {expected_prefix_chunks} content/tool-call chunks followed by one synthesized terminal chunk"
+            );
+
+            let choice = results
+                .last()
+                .and_then(|result| result.data.as_ref())
+                .and_then(|data| data.choices.first())
+                .expect("expected a synthesized terminal choice");
+            assert_eq!(choice.index, index, "terminal choice index mismatch");
+            assert_eq!(
+                choice.finish_reason,
+                Some(FinishReason::ToolCalls),
+                "missing synthesized ToolCalls finish reason"
+            );
+            assert!(
+                choice.delta.content.is_none(),
+                "synthesized terminal chunk must not contain content"
+            );
+            assert!(
+                choice.delta.tool_calls.is_none(),
+                "synthesized terminal chunk must not repeat tool calls"
+            );
+        }
+
         /// Helper to assert no content or tool calls (for accumulated chunks)
         #[allow(dead_code)]
         pub fn assert_empty_emission(result: &Annotated<CreateChatCompletionStreamResponse>) {
@@ -524,7 +558,7 @@ mod tests {
     async fn test_jailed_stream_early_exit() {
         // Tests detection of complete tool call with unjail in same chunk as the end marker
         // Input: "<TOOLCALL>" + "[{\"name\": \"test\", " + "\"arguments\": {}}]" + "</TOOLCALL>More text"
-        // Expected output: 2 chunks [ToolCall(), Content()]
+        // Expected output: 3 chunks [ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
             create_mock_response_chunk("[{\"name\": \"test\", ".to_string(), 0),
@@ -540,14 +574,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 2 chunks: tool call + trailing content
-        assert_eq!(
-            results.len(),
-            2,
-            "Should have tool call and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
-        // Verify exact output structure: [ToolCall(), Content()]
+        // Verify the non-terminal prefix: [ToolCall(), Content()]
         test_utils::assert_tool_call(&results[0], "test", serde_json::json!({}));
         test_utils::assert_content(&results[1], "More text");
 
@@ -615,7 +644,7 @@ mod tests {
     async fn test_jailed_stream_hermes_parser() {
         // Tests Hermes format tool call parsing with <tool_call> markers
         // Input: "I'll help you with that. " + "<tool_call>{\"name\": \"search_web\", \"arguments\": {\"query\": \"weather today\"}}</tool_call>" + " Let me search for that."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll help you with that. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -635,14 +664,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "I'll help you with that. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -663,7 +687,7 @@ mod tests {
     async fn test_jailed_stream_mistral_parser() {
         // Tests Mistral format tool call parsing with [{ pattern
         // Input: "Sure, I can help. " + "[{\"name\": \"calculate\", \"arguments\": {\"expression\": \"2+2\"}}]" + " The calculation is done."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Sure, I can help. ".to_string(), 0),
             create_mock_response_chunk("[{".to_string(), 0),
@@ -680,14 +704,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Sure, I can help. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -705,7 +724,7 @@ mod tests {
     async fn test_jailed_stream_mistral_parser_with_tool_calls_marker() {
         // Tests Mistral format tool call parsing with explicit [TOOL_CALLS] marker
         // Input: "Let me check that for you. " + "[TOOL_CALLS][{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"UTC\"}}]" + " Here's the time."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Let me check that for you. ".to_string(), 0),
             create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
@@ -721,14 +740,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Let me check that for you. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -799,7 +813,7 @@ mod tests {
     async fn test_jailed_stream_phi4_parser() {
         // Tests Phi4 format tool call parsing with functools[ pattern
         // Input: "I'll analyze this data. " + "functools[{\"name\": \"analyze_data\", \"arguments\": {\"dataset\": \"sales_data\"}}]" + " Analysis complete."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll analyze this data. ".to_string(), 0),
             create_mock_response_chunk("functools[".to_string(), 0),
@@ -819,14 +833,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "I'll analyze this data. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -844,7 +853,7 @@ mod tests {
     async fn test_jailed_stream_llama3_json_parser() {
         // Tests Llama3 JSON format tool call parsing with <|python_tag|> pattern
         // Input: "Let me run some code. " + "<|python_tag|>{\"name\": \"execute_code\", \"arguments\": {\"code\": \"print('Hello')\"}}" + " Done executing."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Let me run some code. ".to_string(), 0),
             create_mock_response_chunk("<|python_tag|>".to_string(), 0),
@@ -865,14 +874,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Let me run some code. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -978,7 +982,8 @@ mod tests {
         // end-token to actually arrive, so this only fires at stream end.
         //
         // Input: "Starting function call. " + "<TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {" (no end marker)
-        // Expected output: 2 chunks [Content(), ToolCall(incomplete_func, {})]
+        // Expected output: 3 chunks
+        // [Content(), ToolCall(incomplete_func, {}), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Starting function call. ".to_string(), 0),
             create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
@@ -996,11 +1001,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            2,
-            "Should emit prefix content + recovered tool call"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         test_utils::assert_content(&results[0], "Starting function call. ");
         test_utils::assert_tool_call(&results[1], "incomplete_func", serde_json::json!({}));
@@ -1048,6 +1049,7 @@ mod tests {
         // [2] Content(" Now let me get the time. ")
         // [3] ToolCall("get_time", {"timezone": "EST"})
         // [4] Content(" Both tasks completed!")
+        // [5] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("I'll help with multiple tasks. ".to_string(), 0),
             // First tool call
@@ -1077,12 +1079,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            5,
-            "Should emit exactly 5 chunks as documented above"
-        );
+        assert_synthesized_tool_calls_finish(&results, 5, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "I'll help with multiple tasks. ");
@@ -1105,7 +1102,7 @@ mod tests {
     async fn test_jailed_stream_tool_call_across_many_chunks() {
         // Tests extreme fragmentation: tool call split across 65 individual character chunks
         // Input: "I'll process your request. " + "<TOOLCALL>[{"name": "process_data", "arguments": {}}]</TOOLCALL>" + " Processing complete!"
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll process your request. ".to_string(), 0),
             create_mock_response_chunk("<".to_string(), 0),
@@ -1186,14 +1183,10 @@ mod tests {
 
         // Should consolidate extreme fragmentation into 3 clean chunks
         // Input: "I'll process your request. " + 54-char tool call + " Processing complete!"
-        // Expected output: [Content(), ToolCall(), Content()]
-        assert_eq!(
-            results.len(),
-            3,
-            "Should consolidate fragments into 3 chunks"
-        );
+        // Expected output: [Content(), ToolCall(), Content(), Finish(ToolCalls)]
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure
+        // Verify the non-terminal prefix.
         test_utils::assert_content(&results[0], "I'll process your request. ");
         test_utils::assert_tool_call(&results[1], "process_data", serde_json::json!({}));
         test_utils::assert_content(&results[2], " Processing complete!");
@@ -1328,8 +1321,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should get 2 chunks: first chunk passes through, stream end releases accumulated
-        assert_eq!(results.len(), 2, "Should have exactly 2 chunks");
+        // The first chunk passes through, stream end releases the accumulated tool
+        // call, and the finish-reason postprocessor adds its terminal chunk.
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         // The second chunk is the accumulated content released when stream ended
         let accumulated_chunk = &results[1];
@@ -1456,6 +1450,7 @@ mod tests {
         // [0] Content("I'll help you. ")
         // [1] ToolCall("search", {})
         // [2] Content("trailing text that should not be lost")
+        // [3] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("I'll help you. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -1473,12 +1468,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            3,
-            "Should emit exactly 3 chunks as documented above"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "I'll help you. ");
@@ -1498,7 +1488,7 @@ mod tests {
     async fn test_jailed_stream_early_exit_with_trailing() {
         // Tests early exit when complete tool call is detected in chunk that also contains trailing content
         // Input: "Starting task: " + "<tool_call>{\"name\": \"complete_task\", \"arguments\": {}}" + "</tool_call> Task completed successfully."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Starting task: ".to_string(), 0),
             create_mock_response_chunk(
@@ -1515,14 +1505,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + trailing
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Starting task: ");
         test_utils::assert_tool_call(&results[1], "complete_task", serde_json::json!({}));
         test_utils::assert_content(&results[2], " Task completed successfully.");
@@ -1864,6 +1849,7 @@ mod tests {
         // Expected output:
         // [0] Content("text")  // "<TO" held as partial
         // [1] ToolCall("test", {})
+        // [2] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("text<TO".to_string(), 0),
             create_mock_response_chunk(
@@ -1881,12 +1867,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            2,
-            "Should emit exactly 2 chunks: [0] 'text' content, [1] tool call"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "text");
@@ -2188,7 +2169,7 @@ mod tests {
         // "I'll call a function. "
         // + "<tool_call><function=get_weather><parameter=location>San Francisco</parameter><parameter=unit>celsius</parameter></function></tool_call>"
         // + " Done."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll call a function. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -2211,13 +2192,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()].
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()].
         test_utils::assert_content(&results[0], "I'll call a function. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -2266,7 +2243,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(results.len(), 3, "Should have 3 chunks");
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         test_utils::assert_content(&results[0], "Let me search for that. ");
         test_utils::assert_tool_call(
@@ -2306,11 +2283,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         test_utils::assert_content(&results[0], "Before tool call. ");
         test_utils::assert_tool_call(


### PR DESCRIPTION
#### Overview:

This PR moves Dynamo's **v1** tool-call jail (the *jail-and-batch* mechanism, being deprecated by the v2 streaming parser) out of dynamo `lib/llm` into `dynamo-parsers`, so the jail and the v1 parsers it wraps are tested together in one repo.

Relates to [DIS-2296](https://linear.app/nvidia/issue/DIS-2296/evaluate-jail-v1-parser-together-and-frontend-crates-move)

#### Details:

- Relocation, not a rewrite: `JailedStream` + builder + `apply_tool_calling_jail` + `MarkerMatcher` + a vendored minimal `Annotated<R>` moved over; the jail now runs on the shared `CreateChatCompletionStreamResponse` instead of dynamo's `Annotated<Nv…>` — all shared `dynamo-*` types, so nothing drifts.
- Also re-syncs the moved jail to dynamo `main`: ports [#11045](https://github.com/ai-dynamo/dynamo/pull/11045) (synthesize `tool_calls` finish_reason when the stream lacks one) — the branch base was ~150 commits behind, so this keeps the moved code current before dynamo drops its copy.
- Lands in sequence: merge this → release-plz publishes `dynamo-parsers 3.1.0` → dynamo [#11112](https://github.com/ai-dynamo/dynamo/pull/11112) repins, deletes the jail, and adapts at its `Nv⇄Create` boundary.

#### Verification:

657 `dynamo-parsers` lib tests + 69 jail integration tests pass; full workspace build / fmt / clippy green; #11112 validated locally against this branch.

#### Where should the reviewer start?

`parsers/src/tool_calling/jail/mod.rs`, then `parsers/tests/jail.rs`

/coderabbit profile chill
