### PR TITLE
perf: Make tool-call jail completion incremental

### DIFF
--- a/parsers/v1/src/tool_calling/jail/mod.rs
+++ b/parsers/v1/src/tool_calling/jail/mod.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use crate::tool_calling::config::{JsonParserConfig, ParserConfig};
 use crate::tool_calling::gemma4::split_partial_call_prefix_gemma4;
-use crate::tool_calling::json::try_tool_call_parse_basic_json;
+use crate::tool_calling::json::{JsonParserType, try_tool_call_parse_basic_json};
 use crate::tool_calling::parsers::get_tool_parser_map;
 use crate::tool_calling::{
     ToolCallResponse, detect_tool_call_start, find_tool_call_end_position,
@@ -158,26 +158,31 @@ struct ChoiceJailState {
 #[derive(Debug, Clone, Default)]
 struct JailCompletionProgress {
     next_end_search_start: usize,
+    pending_end_marker: Option<usize>,
+    pending_parse: Option<ParsedToolCalls>,
     json: JsonCompletionProgress,
 }
 
 impl JailCompletionProgress {
     fn reset(&mut self) {
         self.next_end_search_start = 0;
+        self.pending_end_marker = None;
+        self.pending_parse = None;
         self.json.reset();
     }
 }
 
 #[derive(Debug, Clone, Default)]
 struct JsonCompletionProgress {
-    base_offset: usize,
     scanned_len: usize,
+    next_start_search_start: usize,
+    last_start_end: Option<usize>,
     started: bool,
     depth: usize,
     in_string: bool,
     escape: bool,
     last_complete_end: Option<usize>,
-    last_validation_len: usize,
+    last_reported_end: Option<usize>,
 }
 
 impl JsonCompletionProgress {
@@ -185,18 +190,59 @@ impl JsonCompletionProgress {
         *self = Self::default();
     }
 
-    /// Scan only newly appended bytes and return the last completed top-level
-    /// JSON boundary when new input makes validation useful. The boundary is
-    /// lexical state, not parser acceptance: every appended suffix can trigger
-    /// fresh validation, so a malformed first candidate never pins the jail.
-    fn new_complete_end_from(&mut self, content: &str, base_offset: usize) -> Option<usize> {
-        if self.base_offset != base_offset
-            || self.scanned_len > content.len()
-            || self.scanned_len < base_offset
-        {
+    fn reset_lexer_at(&mut self, offset: usize) {
+        self.scanned_len = offset;
+        self.started = false;
+        self.depth = 0;
+        self.in_string = false;
+        self.escape = false;
+        self.last_complete_end = None;
+        self.last_reported_end = None;
+    }
+
+    fn find_new_start(&mut self, content: &str, start_tokens: &[String]) -> Option<usize> {
+        let max_token_len = start_tokens
+            .iter()
+            .filter(|token| !token.is_empty())
+            .map(String::len)
+            .max()?;
+        let mut search_start = self
+            .next_start_search_start
+            .min(content.len())
+            .saturating_sub(max_token_len.saturating_sub(1));
+        while search_start > 0 && !content.is_char_boundary(search_start) {
+            search_start -= 1;
+        }
+
+        let newest = start_tokens
+            .iter()
+            .filter(|token| !token.is_empty())
+            .filter_map(|token| {
+                content[search_start..]
+                    .match_indices(token)
+                    .map(|(offset, _)| search_start + offset + token.len())
+                    .filter(|end| self.last_start_end.is_none_or(|previous| *end > previous))
+                    .last()
+            })
+            .max();
+
+        self.next_start_search_start = content.len();
+        if let Some(end) = newest {
+            self.last_start_end = Some(end);
+        }
+        newest
+    }
+
+    /// Scan only newly appended bytes and report each completed top-level JSON
+    /// boundary once. A new configured start marker resets lexical state to
+    /// mirror parsers that resynchronize with `split(start_token)`.
+    fn new_complete_end(&mut self, content: &str, start_tokens: &[String]) -> Option<usize> {
+        if self.scanned_len > content.len() || self.next_start_search_start > content.len() {
             self.reset();
-            self.base_offset = base_offset;
-            self.scanned_len = base_offset;
+        }
+
+        if let Some(start_end) = self.find_new_start(content, start_tokens) {
+            self.reset_lexer_at(start_end);
         }
 
         for (offset, ch) in content[self.scanned_len..].char_indices() {
@@ -239,16 +285,29 @@ impl JsonCompletionProgress {
         }
 
         self.scanned_len = content.len();
-        if self.last_complete_end.is_some() && self.last_validation_len < content.len() {
-            self.last_validation_len = content.len();
-            self.last_complete_end
-        } else {
-            None
+        if self.last_complete_end != self.last_reported_end {
+            self.last_reported_end = self.last_complete_end;
+            return self.last_complete_end;
         }
+        None
     }
 }
 
-type MarkerParseResult = anyhow::Result<(Vec<ToolCallResponse>, Option<String>)>;
+type ParsedToolCalls = (Vec<ToolCallResponse>, Option<String>);
+type MarkerParseResult = anyhow::Result<ParsedToolCalls>;
+
+#[derive(Debug, Clone)]
+enum CompletionStrategy {
+    EndMarker,
+    JsonBoundary { start_tokens: Vec<String> },
+    ParserDriven,
+}
+
+enum ParsedCompletion {
+    Complete(CompletedJail),
+    Pending(ParsedToolCalls),
+    Invalid,
+}
 
 struct CompletedJail {
     split_pos: usize,
@@ -751,6 +810,7 @@ pub enum EmissionMode {
 pub struct JailedStream {
     jail_start_sequences: Vec<String>,
     jail_end_sequences: Vec<String>,
+    completion_strategy: CompletionStrategy,
     tool_call_parser: Option<String>,
     /// When set, only tool calls with this name are emitted (enforces tool_choice=named
     /// when a tool_call_parser is active and the parser-aware MarkerBased path is used).
@@ -1116,6 +1176,10 @@ impl JailedStream {
         accumulated_content: &str,
         progress: &mut JailCompletionProgress,
     ) -> Option<usize> {
+        if let Some(end_pos) = progress.pending_end_marker {
+            return Some(end_pos);
+        }
+
         let max_marker_len = self
             .jail_end_sequences
             .iter()
@@ -1132,53 +1196,23 @@ impl JailedStream {
             search_start -= 1;
         }
 
+        // Preserve the pre-incremental contract: configured sequence order has
+        // priority over text position when more than one marker is present.
         let found = self
             .jail_end_sequences
             .iter()
             .filter(|seq| !seq.is_empty())
-            .filter_map(|seq| {
-                accumulated_content[search_start..].find(seq).map(|pos| {
-                    let start = search_start + pos;
-                    (start, start + seq.len())
-                })
+            .find_map(|seq| {
+                accumulated_content[search_start..]
+                    .find(seq)
+                    .map(|pos| search_start + pos + seq.len())
             })
-            .min_by(|(start_a, end_a), (start_b, end_b)| {
-                start_a.cmp(start_b).then(end_b.cmp(end_a))
-            })
-            .map(|(_, end)| end);
+            .inspect(|end_pos| progress.pending_end_marker = Some(*end_pos));
 
-        progress.next_end_search_start = accumulated_content.len();
-        found
-    }
-
-    /// Return the JSON payload start for parser configurations whose empty end
-    /// token makes a structurally complete JSON value a valid completion
-    /// candidate. This is capability-based and contains no parser-name policy.
-    fn json_completion_base(&self, accumulated_content: &str) -> Option<usize> {
-        let parser_name = self.tool_call_parser.as_deref()?;
-        let parser_map = get_tool_parser_map();
-        let Some(ParserConfig::Json(config)) = parser_map
-            .get(parser_name)
-            .map(|config| &config.parser_config)
-        else {
-            return None;
-        };
-
-        if !config.tool_call_end_tokens.iter().any(String::is_empty) {
-            return None;
+        if found.is_none() {
+            progress.next_end_search_start = accumulated_content.len();
         }
-
-        config
-            .tool_call_start_tokens
-            .iter()
-            .filter(|token| !token.is_empty())
-            .filter_map(|token| {
-                accumulated_content
-                    .find(token.as_str())
-                    .map(|pos| pos + token.len())
-            })
-            .min()
-            .or_else(|| accumulated_content.find(['{', '[']))
+        found
     }
 
     async fn parse_marker_tool_calls(&self, accumulated_content: &str) -> MarkerParseResult {
@@ -1190,32 +1224,29 @@ impl JailedStream {
         .await
     }
 
-    fn marker_parse_has_tool_calls(parse_result: &MarkerParseResult) -> bool {
-        matches!(parse_result, Ok((tool_calls, _)) if !tool_calls.is_empty())
-    }
-
-    async fn completed_from_valid_marker_parse(
+    async fn completion_from_parsed_tool_calls(
         &self,
         accumulated_content: &str,
-        parse_result: MarkerParseResult,
-    ) -> Option<CompletedJail> {
-        if !Self::marker_parse_has_tool_calls(&parse_result) {
-            return None;
-        }
-        let parser = self.tool_call_parser.as_deref()?;
-        let split_pos = find_tool_call_end_position(accumulated_content, Some(parser))?;
-        let marker_parse_result = if split_pos < accumulated_content.len() {
-            let reparsed = self
-                .parse_marker_tool_calls(&accumulated_content[..split_pos])
-                .await;
-            if !Self::marker_parse_has_tool_calls(&reparsed) {
-                return None;
-            }
-            Some(reparsed)
-        } else {
-            Some(parse_result)
+        parsed: ParsedToolCalls,
+    ) -> ParsedCompletion {
+        let Some(parser) = self.tool_call_parser.as_deref() else {
+            return ParsedCompletion::Invalid;
         };
-        Some(CompletedJail {
+        let Some(split_pos) = find_tool_call_end_position(accumulated_content, Some(parser)) else {
+            return ParsedCompletion::Pending(parsed);
+        };
+        let marker_parse_result = if split_pos < accumulated_content.len() {
+            match self
+                .parse_marker_tool_calls(&accumulated_content[..split_pos])
+                .await
+            {
+                Ok(reparsed) if !reparsed.0.is_empty() => Some(Ok(reparsed)),
+                _ => return ParsedCompletion::Invalid,
+            }
+        } else {
+            Some(Ok(parsed))
+        };
+        ParsedCompletion::Complete(CompletedJail {
             split_pos,
             marker_parse_result,
         })
@@ -1231,60 +1262,89 @@ impl JailedStream {
     ) -> JailCompletion {
         match &self.jail_mode {
             JailMode::MarkerBased => {
+                if let Some(parsed) = progress.pending_parse.take() {
+                    match self
+                        .completion_from_parsed_tool_calls(accumulated_content, parsed)
+                        .await
+                    {
+                        ParsedCompletion::Complete(completed) => {
+                            return JailCompletion::Complete(completed);
+                        }
+                        ParsedCompletion::Pending(parsed) => {
+                            progress.pending_parse = Some(parsed);
+                        }
+                        ParsedCompletion::Invalid => {}
+                    }
+                }
+
                 if let Some(end_pos) =
                     self.find_incremental_end_marker(accumulated_content, progress)
                 {
-                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
-                    if Self::marker_parse_has_tool_calls(&parse_result) {
-                        if let Some(completed) = self
-                            .completed_from_valid_marker_parse(accumulated_content, parse_result)
-                            .await
-                        {
+                    if self.tool_call_parser.is_none() {
+                        return JailCompletion::Complete(CompletedJail {
+                            split_pos: end_pos,
+                            marker_parse_result: None,
+                        });
+                    }
+
+                    match self.parse_marker_tool_calls(accumulated_content).await {
+                        Ok(parsed) if !parsed.0.is_empty() => {
+                            match self
+                                .completion_from_parsed_tool_calls(accumulated_content, parsed)
+                                .await
+                            {
+                                ParsedCompletion::Complete(completed) => {
+                                    return JailCompletion::Complete(completed);
+                                }
+                                ParsedCompletion::Pending(parsed) => {
+                                    progress.pending_parse = Some(parsed);
+                                    progress.pending_end_marker = None;
+                                    progress.next_end_search_start = accumulated_content.len();
+                                }
+                                ParsedCompletion::Invalid => {}
+                            }
+                            return JailCompletion::Incomplete;
+                        }
+                        _ => {
+                            return JailCompletion::Complete(CompletedJail {
+                                split_pos: end_pos,
+                                marker_parse_result: None,
+                            });
+                        }
+                    }
+                }
+
+                let should_parse = match &self.completion_strategy {
+                    CompletionStrategy::EndMarker => false,
+                    CompletionStrategy::JsonBoundary { start_tokens } => progress
+                        .json
+                        .new_complete_end(accumulated_content, start_tokens)
+                        .is_some(),
+                    CompletionStrategy::ParserDriven => progress.pending_parse.is_none(),
+                };
+
+                if should_parse
+                    && let Ok(parsed) = self.parse_marker_tool_calls(accumulated_content).await
+                    && !parsed.0.is_empty()
+                {
+                    match self
+                        .completion_from_parsed_tool_calls(accumulated_content, parsed)
+                        .await
+                    {
+                        ParsedCompletion::Complete(completed) => {
                             return JailCompletion::Complete(completed);
                         }
-                        return JailCompletion::Incomplete;
-                    }
-
-                    return JailCompletion::Complete(CompletedJail {
-                        split_pos: end_pos,
-                        marker_parse_result: None,
-                    });
-                }
-
-                if let Some(json_base) = self.json_completion_base(accumulated_content)
-                    && progress
-                        .json
-                        .new_complete_end_from(accumulated_content, json_base)
-                        .is_some()
-                {
-                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
-                    if let Some(completed) = self
-                        .completed_from_valid_marker_parse(accumulated_content, parse_result)
-                        .await
-                    {
-                        return JailCompletion::Complete(completed);
-                    }
-                }
-
-                // Parsers without markers or JSON framing have no generic
-                // lexical completion signal. Preserve their existing streaming
-                // behavior by validating appended input as before.
-                if self.jail_end_sequences.is_empty()
-                    && self.json_completion_base(accumulated_content).is_none()
-                {
-                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
-                    if let Some(completed) = self
-                        .completed_from_valid_marker_parse(accumulated_content, parse_result)
-                        .await
-                    {
-                        return JailCompletion::Complete(completed);
+                        ParsedCompletion::Pending(parsed) => {
+                            progress.pending_parse = Some(parsed);
+                        }
+                        ParsedCompletion::Invalid => {}
                     }
                 }
 
                 JailCompletion::Incomplete
             }
             JailMode::Immediate { format } => {
-                let Some(split_pos) = progress.json.new_complete_end_from(accumulated_content, 0)
+                let Some(split_pos) = progress.json.new_complete_end(accumulated_content, &[])
                 else {
                     return JailCompletion::Incomplete;
                 };
@@ -1835,6 +1895,7 @@ impl JailedStream {
 pub struct JailedStreamBuilder {
     jail_start_sequences: Vec<String>,
     jail_end_sequences: Vec<String>,
+    has_custom_end_sequences: bool,
     tool_call_parser: Option<String>,
     /// When set, only tool calls with this name are emitted (enforces tool_choice=named
     /// when a tool_call_parser is active and the parser-aware MarkerBased path is used).
@@ -1850,6 +1911,7 @@ impl JailedStreamBuilder {
         Self {
             jail_start_sequences: Vec::new(),
             jail_end_sequences: Vec::new(),
+            has_custom_end_sequences: false,
             tool_call_parser: None,
             named_tool_name: None,
             tool_definitions: None,
@@ -1876,6 +1938,7 @@ impl JailedStreamBuilder {
 
     /// Add a sequence that ends jailing when detected
     pub fn jail_end_sequence(mut self, sequence: impl Into<String>) -> Self {
+        self.has_custom_end_sequences = true;
         self.jail_end_sequences.push(sequence.into());
         self
     }
@@ -1885,6 +1948,7 @@ impl JailedStreamBuilder {
         mut self,
         sequences: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
+        self.has_custom_end_sequences = true;
         self.jail_end_sequences
             .extend(sequences.into_iter().map(Into::into));
         self
@@ -1946,10 +2010,13 @@ impl JailedStreamBuilder {
 
     /// Build the configured JailedStream
     pub fn build(mut self) -> JailedStream {
+        let mut parser_config = None;
+
         // Auto-populate jail sequences from parser config if not manually configured
         if let Some(ref parser_name) = self.tool_call_parser {
             let parser_map = get_tool_parser_map();
             if let Some(config) = parser_map.get(parser_name.as_str()) {
+                parser_config = Some(&config.parser_config);
                 // Auto-populate start sequences if none configured
                 if self.jail_start_sequences.is_empty() {
                     self.jail_start_sequences = config.parser_config.tool_call_start_tokens();
@@ -1967,6 +2034,28 @@ impl JailedStreamBuilder {
                 }
             }
         }
+
+        let completion_strategy = if self.has_custom_end_sequences {
+            CompletionStrategy::EndMarker
+        } else {
+            match parser_config {
+                Some(ParserConfig::Json(config)) => match &config.parser_type {
+                    JsonParserType::Basic => CompletionStrategy::JsonBoundary {
+                        start_tokens: config.tool_call_start_tokens.clone(),
+                    },
+                    JsonParserType::DeepseekV3 | JsonParserType::DeepseekV31 => {
+                        CompletionStrategy::ParserDriven
+                    }
+                },
+                Some(ParserConfig::Pythonic | ParserConfig::Typescript) => {
+                    CompletionStrategy::ParserDriven
+                }
+                Some(ParserConfig::Xml(config)) if config.backoff_when_no_wrapper => {
+                    CompletionStrategy::ParserDriven
+                }
+                _ => CompletionStrategy::EndMarker,
+            }
+        };
 
         // Collect all possible marker patterns for the MarkerMatcher
         let mut all_patterns = Vec::new();
@@ -2028,6 +2117,7 @@ impl JailedStreamBuilder {
         JailedStream {
             jail_start_sequences: self.jail_start_sequences,
             jail_end_sequences: self.jail_end_sequences,
+            completion_strategy,
             tool_call_parser: self.tool_call_parser,
             named_tool_name: self.named_tool_name,
             tool_definitions: self.tool_definitions,

--- a/parsers/v1/src/tool_calling/jail/mod.rs
+++ b/parsers/v1/src/tool_calling/jail/mod.rs
@@ -43,8 +43,8 @@ use crate::tool_calling::gemma4::split_partial_call_prefix_gemma4;
 use crate::tool_calling::json::try_tool_call_parse_basic_json;
 use crate::tool_calling::parsers::get_tool_parser_map;
 use crate::tool_calling::{
-    detect_tool_call_start, find_tool_call_end_position, try_tool_call_parse_aggregate,
-    try_tool_call_parse_aggregate_finalize,
+    ToolCallResponse, detect_tool_call_start, find_tool_call_end_position,
+    try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
 };
 
 pub use self::annotated::Annotated;
@@ -150,6 +150,114 @@ struct ChoiceJailState {
     emitted_tool_calls_count: usize,
     /// Reasoning content collected while waiting for a suitable emission.
     pending_reasoning_content: Option<String>,
+    /// Incremental lexical progress used to decide when parser validation is
+    /// worthwhile. Parser acceptance is never cached here.
+    completion_progress: JailCompletionProgress,
+}
+
+#[derive(Debug, Clone, Default)]
+struct JailCompletionProgress {
+    next_end_search_start: usize,
+    json: JsonCompletionProgress,
+}
+
+impl JailCompletionProgress {
+    fn reset(&mut self) {
+        self.next_end_search_start = 0;
+        self.json.reset();
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct JsonCompletionProgress {
+    base_offset: usize,
+    scanned_len: usize,
+    started: bool,
+    depth: usize,
+    in_string: bool,
+    escape: bool,
+    last_complete_end: Option<usize>,
+    last_validation_len: usize,
+}
+
+impl JsonCompletionProgress {
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Scan only newly appended bytes and return the last completed top-level
+    /// JSON boundary when new input makes validation useful. The boundary is
+    /// lexical state, not parser acceptance: every appended suffix can trigger
+    /// fresh validation, so a malformed first candidate never pins the jail.
+    fn new_complete_end_from(&mut self, content: &str, base_offset: usize) -> Option<usize> {
+        if self.base_offset != base_offset
+            || self.scanned_len > content.len()
+            || self.scanned_len < base_offset
+        {
+            self.reset();
+            self.base_offset = base_offset;
+            self.scanned_len = base_offset;
+        }
+
+        for (offset, ch) in content[self.scanned_len..].char_indices() {
+            let pos = self.scanned_len + offset;
+
+            if !self.started {
+                if ch == '{' || ch == '[' {
+                    self.started = true;
+                    self.depth = 1;
+                }
+                continue;
+            }
+
+            if self.escape {
+                self.escape = false;
+                continue;
+            }
+
+            if self.in_string {
+                match ch {
+                    '\\' => self.escape = true,
+                    '"' => self.in_string = false,
+                    _ => {}
+                }
+                continue;
+            }
+
+            match ch {
+                '"' => self.in_string = true,
+                '{' | '[' => self.depth += 1,
+                '}' | ']' => {
+                    self.depth = self.depth.saturating_sub(1);
+                    if self.depth == 0 {
+                        self.last_complete_end = Some(pos + ch.len_utf8());
+                        self.started = false;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        self.scanned_len = content.len();
+        if self.last_complete_end.is_some() && self.last_validation_len < content.len() {
+            self.last_validation_len = content.len();
+            self.last_complete_end
+        } else {
+            None
+        }
+    }
+}
+
+type MarkerParseResult = anyhow::Result<(Vec<ToolCallResponse>, Option<String>)>;
+
+struct CompletedJail {
+    split_pos: usize,
+    marker_parse_result: Option<MarkerParseResult>,
+}
+
+enum JailCompletion {
+    Incomplete,
+    Complete(CompletedJail),
 }
 
 fn create_choice_stream(
@@ -229,7 +337,15 @@ impl ChoiceJailState {
             stream_finish_reason: None,
             emitted_tool_calls_count: 0,
             pending_reasoning_content: None,
+            completion_progress: JailCompletionProgress::default(),
         }
+    }
+
+    fn begin_jail(&mut self, content: String, logprobs: Option<ChatChoiceLogprobs>) {
+        self.is_jailed = true;
+        self.accumulated_content = content;
+        self.accumulated_logprobs = logprobs;
+        self.completion_progress.reset();
     }
 
     /// Add content and logprobs to this choice's accumulation
@@ -267,6 +383,7 @@ impl ChoiceJailState {
     fn end_jail(&mut self) -> String {
         self.is_jailed = false;
         self.accumulated_logprobs = None;
+        self.completion_progress.reset();
         std::mem::take(&mut self.accumulated_content)
     }
 
@@ -316,9 +433,7 @@ impl ChoiceJailState {
             }
             self.partial_match_buffer = partial.to_string();
         } else if jail_stream.should_start_jail(content) {
-            self.is_jailed = true;
-            self.accumulated_content = content.to_string();
-            self.accumulated_logprobs = None;
+            self.begin_jail(content.to_string(), None);
         } else {
             #[allow(deprecated)]
             let trailing_choice = create_choice_stream(
@@ -331,6 +446,42 @@ impl ChoiceJailState {
             );
             emissions.push(ChoiceEmission::Trailing(trailing_choice));
         }
+    }
+
+    async fn emit_completed_jail(
+        &mut self,
+        completed: CompletedJail,
+        choice: &ChatChoiceStream,
+        jail_stream: &JailedStream,
+        emissions: &mut Vec<ChoiceEmission>,
+    ) {
+        let split_pos = completed.split_pos.min(self.accumulated_content.len());
+        let (jailed_part, trailing_part) = self.accumulated_content.split_at(split_pos);
+        let jailed_owned = jailed_part.to_string();
+        let trailing_owned = trailing_part.to_string();
+        let jail_logprobs = self.take_accumulated_logprobs();
+
+        let mut unjailed_choice = jail_stream
+            .create_tool_call_choice(
+                choice.index,
+                &jailed_owned,
+                choice,
+                self.emitted_tool_calls_count,
+                false,
+                completed.marker_parse_result,
+            )
+            .await;
+        unjailed_choice.logprobs = jail_logprobs;
+
+        if let Some(ref tool_calls) = unjailed_choice.delta.tool_calls {
+            self.emitted_tool_calls_count += tool_calls.len();
+            emissions.push(ChoiceEmission::ToolCall(unjailed_choice));
+        } else {
+            emissions.push(ChoiceEmission::Content(unjailed_choice));
+        }
+
+        self.end_jail();
+        self.handle_trailing_content(&trailing_owned, choice, jail_stream, emissions);
     }
 
     /// Process incoming content and return what should be emitted (if anything)
@@ -379,47 +530,18 @@ impl ChoiceJailState {
                         format!("{}{}", marker, suffix)
                     };
 
-                    // Check if this already contains the end marker
-                    let (should_end, split_pos) = jail_stream.should_end_jail(&full_content).await;
+                    self.begin_jail(full_content, choice.logprobs.clone());
+                    let completion = jail_stream
+                        .check_jail_completion(
+                            &self.accumulated_content,
+                            &mut self.completion_progress,
+                        )
+                        .await;
                     self.partial_match_buffer.clear();
 
-                    if should_end {
-                        // Complete tool call found in this chunk
-                        let (jailed_part, trailing_part) = full_content.split_at(split_pos);
-
-                        // Create the tool call choice
-                        let tool_choice = jail_stream
-                            .create_tool_call_choice(
-                                choice.index,
-                                jailed_part,
-                                choice,
-                                self.emitted_tool_calls_count,
-                                false, // streaming early-exit, no EOF recovery
-                            )
+                    if let JailCompletion::Complete(completed) = completion {
+                        self.emit_completed_jail(completed, choice, jail_stream, &mut emissions)
                             .await;
-
-                        if tool_choice.delta.tool_calls.is_some() {
-                            if let Some(ref tool_calls) = tool_choice.delta.tool_calls {
-                                self.emitted_tool_calls_count += tool_calls.len();
-                            }
-                            emissions.push(ChoiceEmission::ToolCall(tool_choice));
-                        } else {
-                            emissions.push(ChoiceEmission::Content(tool_choice));
-                        }
-
-                        // Handle trailing content if any
-                        self.handle_trailing_content(
-                            trailing_part,
-                            choice,
-                            jail_stream,
-                            &mut emissions,
-                        );
-                    } else {
-                        // Start jailing with the marker and suffix
-                        self.is_jailed = true;
-                        self.accumulated_content = full_content;
-                        // Seed accumulated logprobs with this chunk's logprobs
-                        self.accumulated_logprobs = choice.logprobs.clone();
                     }
                 }
 
@@ -431,9 +553,7 @@ impl ChoiceJailState {
                     if is_harmony_parser(jail_stream.tool_call_parser.as_deref())
                         && contains_harmony_protocol(&prefix)
                     {
-                        self.is_jailed = true;
-                        self.accumulated_content = format!("{}{}", prefix, partial);
-                        self.accumulated_logprobs = choice.logprobs.clone();
+                        self.begin_jail(format!("{}{}", prefix, partial), choice.logprobs.clone());
                         self.partial_match_buffer.clear();
                         return emissions;
                     }
@@ -481,11 +601,7 @@ impl ChoiceJailState {
                         }
                         self.partial_match_buffer = partial.to_string();
                     } else if jail_stream.should_start_jail(&content) {
-                        // Start jailing with the combined content
-                        self.is_jailed = true;
-                        self.accumulated_content = content;
-                        // Seed accumulated logprobs with this chunk's logprobs
-                        self.accumulated_logprobs = choice.logprobs.clone();
+                        self.begin_jail(content, choice.logprobs.clone());
                         self.partial_match_buffer.clear();
                     } else {
                         // No markers - emit everything
@@ -509,45 +625,13 @@ impl ChoiceJailState {
             // Already jailed - accumulate content AND logprobs, then check for unjail
             self.accumulate(content, choice.logprobs.as_ref());
 
-            let (should_end, split_pos) =
-                jail_stream.should_end_jail(&self.accumulated_content).await;
+            let completion = jail_stream
+                .check_jail_completion(&self.accumulated_content, &mut self.completion_progress)
+                .await;
 
-            if should_end {
-                // Take accumulated logprobs before borrowing accumulated_content
-                let jail_logprobs = self.take_accumulated_logprobs();
-
-                // Split the content
-                let (jailed_part, trailing_part) = self.accumulated_content.split_at(split_pos);
-                let trailing_owned = trailing_part.to_string();
-                let jailed_owned = jailed_part.to_string();
-
-                // Create the unjailed choice, using accumulated logprobs
-                let mut unjailed_choice = jail_stream
-                    .create_tool_call_choice(
-                        choice.index,
-                        &jailed_owned,
-                        choice,
-                        self.emitted_tool_calls_count,
-                        false, // streaming unjail, no EOF recovery
-                    )
+            if let JailCompletion::Complete(completed) = completion {
+                self.emit_completed_jail(completed, choice, jail_stream, &mut emissions)
                     .await;
-                unjailed_choice.logprobs = jail_logprobs;
-
-                // Determine emission type based on whether tool calls were parsed
-                if unjailed_choice.delta.tool_calls.is_some() {
-                    if let Some(ref tool_calls) = unjailed_choice.delta.tool_calls {
-                        self.emitted_tool_calls_count += tool_calls.len();
-                    }
-                    emissions.push(ChoiceEmission::ToolCall(unjailed_choice));
-                } else {
-                    emissions.push(ChoiceEmission::Content(unjailed_choice));
-                }
-
-                // End jailing before processing trailing content
-                self.end_jail();
-
-                // Handle trailing content if any
-                self.handle_trailing_content(&trailing_owned, choice, jail_stream, &mut emissions);
             }
             // If not unjailing, don't emit anything (still accumulating)
         }
@@ -575,6 +659,7 @@ impl ChoiceJailState {
                     &dummy_choice,
                     self.emitted_tool_calls_count,
                     true, // finalize: enable EOF recovery for missing-end-token / truncated-JSON
+                    None,
                 )
                 .await;
             // Attach the full accumulated logprobs to the final choice
@@ -1026,87 +1111,203 @@ impl JailedStream {
         first_marker.map(|pos| &content[..pos])
     }
 
-    /// Check if accumulated content should end jail
-    async fn should_end_jail(&self, accumulated_content: &str) -> (bool, usize) {
+    fn find_incremental_end_marker(
+        &self,
+        accumulated_content: &str,
+        progress: &mut JailCompletionProgress,
+    ) -> Option<usize> {
+        let max_marker_len = self
+            .jail_end_sequences
+            .iter()
+            .filter(|seq| !seq.is_empty())
+            .map(String::len)
+            .max()?;
+        let overlap = max_marker_len.saturating_sub(1);
+        let mut search_start = progress
+            .next_end_search_start
+            .min(accumulated_content.len())
+            .saturating_sub(overlap);
+
+        while search_start > 0 && !accumulated_content.is_char_boundary(search_start) {
+            search_start -= 1;
+        }
+
+        let found = self
+            .jail_end_sequences
+            .iter()
+            .filter(|seq| !seq.is_empty())
+            .filter_map(|seq| {
+                accumulated_content[search_start..].find(seq).map(|pos| {
+                    let start = search_start + pos;
+                    (start, start + seq.len())
+                })
+            })
+            .min_by(|(start_a, end_a), (start_b, end_b)| {
+                start_a.cmp(start_b).then(end_b.cmp(end_a))
+            })
+            .map(|(_, end)| end);
+
+        progress.next_end_search_start = accumulated_content.len();
+        found
+    }
+
+    /// Return the JSON payload start for parser configurations whose empty end
+    /// token makes a structurally complete JSON value a valid completion
+    /// candidate. This is capability-based and contains no parser-name policy.
+    fn json_completion_base(&self, accumulated_content: &str) -> Option<usize> {
+        let parser_name = self.tool_call_parser.as_deref()?;
+        let parser_map = get_tool_parser_map();
+        let Some(ParserConfig::Json(config)) = parser_map
+            .get(parser_name)
+            .map(|config| &config.parser_config)
+        else {
+            return None;
+        };
+
+        if !config.tool_call_end_tokens.iter().any(String::is_empty) {
+            return None;
+        }
+
+        config
+            .tool_call_start_tokens
+            .iter()
+            .filter(|token| !token.is_empty())
+            .filter_map(|token| {
+                accumulated_content
+                    .find(token.as_str())
+                    .map(|pos| pos + token.len())
+            })
+            .min()
+            .or_else(|| accumulated_content.find(['{', '[']))
+    }
+
+    async fn parse_marker_tool_calls(&self, accumulated_content: &str) -> MarkerParseResult {
+        try_tool_call_parse_aggregate(
+            accumulated_content,
+            self.tool_call_parser.as_deref(),
+            self.tool_definitions.as_deref(),
+        )
+        .await
+    }
+
+    fn marker_parse_has_tool_calls(parse_result: &MarkerParseResult) -> bool {
+        matches!(parse_result, Ok((tool_calls, _)) if !tool_calls.is_empty())
+    }
+
+    async fn completed_from_valid_marker_parse(
+        &self,
+        accumulated_content: &str,
+        parse_result: MarkerParseResult,
+    ) -> Option<CompletedJail> {
+        if !Self::marker_parse_has_tool_calls(&parse_result) {
+            return None;
+        }
+        let parser = self.tool_call_parser.as_deref()?;
+        let split_pos = find_tool_call_end_position(accumulated_content, Some(parser))?;
+        let marker_parse_result = if split_pos < accumulated_content.len() {
+            let reparsed = self
+                .parse_marker_tool_calls(&accumulated_content[..split_pos])
+                .await;
+            if !Self::marker_parse_has_tool_calls(&reparsed) {
+                return None;
+            }
+            Some(reparsed)
+        } else {
+            Some(parse_result)
+        };
+        Some(CompletedJail {
+            split_pos,
+            marker_parse_result,
+        })
+    }
+
+    /// Check completion only when incremental lexical state discovers a new
+    /// marker or balanced JSON boundary. Parser results are cached only after
+    /// successful validation and reused by the emission path.
+    async fn check_jail_completion(
+        &self,
+        accumulated_content: &str,
+        progress: &mut JailCompletionProgress,
+    ) -> JailCompletion {
         match &self.jail_mode {
             JailMode::MarkerBased => {
-                // Path 1: End sequence detected via naive string search.
-                let end_marker_info = if !self.jail_end_sequences.is_empty() {
-                    self.jail_end_sequences.iter().find_map(|seq| {
-                        accumulated_content
-                            .find(seq)
-                            .map(|pos| (pos + seq.len(), seq.clone()))
-                    })
-                } else {
-                    None
-                };
-
-                // Path 2: Complete tool call(s) can be parsed (early exit)
-                let early_exit = self.should_exit_jail_early(accumulated_content).await;
-
-                // When a tool_call_parser is active, prefer Path 2 over Path 1 so
-                // that `find_tool_call_end_position` advances past all consecutive
-                // parallel tool calls instead of splitting at the first end tag.
-                // Fall back to Path 1 when parsing fails (e.g. malformed content).
-                if early_exit {
-                    // For early exit, find where the complete tool call ends.
-                    // `find_tool_call_end_position` returns `None` when the
-                    // section wrapper isn't closed (e.g. kimi_k2 without
-                    // section_end). In that case, don't early-exit — more
-                    // parallel calls may follow. The calls will be recovered
-                    // by `finalize()` at stream end.
-                    if let Some(parser) = &self.tool_call_parser {
-                        let tools_slice = self.tool_definitions.as_deref();
-                        if let Ok((_, _)) = try_tool_call_parse_aggregate(
-                            accumulated_content,
-                            Some(parser),
-                            tools_slice,
-                        )
-                        .await
+                if let Some(end_pos) =
+                    self.find_incremental_end_marker(accumulated_content, progress)
+                {
+                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
+                    if Self::marker_parse_has_tool_calls(&parse_result) {
+                        if let Some(completed) = self
+                            .completed_from_valid_marker_parse(accumulated_content, parse_result)
+                            .await
                         {
-                            if let Some(split_pos) =
-                                find_tool_call_end_position(accumulated_content, Some(parser))
-                            {
-                                (true, split_pos)
-                            } else {
-                                (false, accumulated_content.len())
-                            }
-                        } else {
-                            (false, accumulated_content.len())
+                            return JailCompletion::Complete(completed);
                         }
-                    } else {
-                        (false, accumulated_content.len())
+                        return JailCompletion::Incomplete;
                     }
-                } else if let Some((end_pos, _)) = end_marker_info {
-                    (true, end_pos)
-                } else {
-                    (false, accumulated_content.len())
+
+                    return JailCompletion::Complete(CompletedJail {
+                        split_pos: end_pos,
+                        marker_parse_result: None,
+                    });
                 }
+
+                if let Some(json_base) = self.json_completion_base(accumulated_content)
+                    && progress
+                        .json
+                        .new_complete_end_from(accumulated_content, json_base)
+                        .is_some()
+                {
+                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
+                    if let Some(completed) = self
+                        .completed_from_valid_marker_parse(accumulated_content, parse_result)
+                        .await
+                    {
+                        return JailCompletion::Complete(completed);
+                    }
+                }
+
+                // Parsers without markers or JSON framing have no generic
+                // lexical completion signal. Preserve their existing streaming
+                // behavior by validating appended input as before.
+                if self.jail_end_sequences.is_empty()
+                    && self.json_completion_base(accumulated_content).is_none()
+                {
+                    let parse_result = self.parse_marker_tool_calls(accumulated_content).await;
+                    if let Some(completed) = self
+                        .completed_from_valid_marker_parse(accumulated_content, parse_result)
+                        .await
+                    {
+                        return JailCompletion::Complete(completed);
+                    }
+                }
+
+                JailCompletion::Incomplete
             }
             JailMode::Immediate { format } => {
-                // For tool_choice, check if we have valid complete JSON
-                match format {
-                    ToolChoiceFormat::SingleObject { .. } => {
-                        // Expect single object: {"location": "Paris", "unit": "celsius"}
-                        if let Ok(value) =
-                            serde_json::from_str::<serde_json::Value>(accumulated_content)
-                            && value.is_object()
-                        {
-                            return (true, accumulated_content.len());
-                        }
-                        (false, accumulated_content.len())
-                    }
+                let Some(split_pos) = progress.json.new_complete_end_from(accumulated_content, 0)
+                else {
+                    return JailCompletion::Incomplete;
+                };
+                let Ok(value) =
+                    serde_json::from_str::<serde_json::Value>(&accumulated_content[..split_pos])
+                else {
+                    return JailCompletion::Incomplete;
+                };
+
+                let is_complete = match format {
+                    ToolChoiceFormat::SingleObject { .. } => value.is_object(),
                     ToolChoiceFormat::ArrayOfTools => {
-                        // Expect array: [{"name":"search","parameters":{...}}, ...]
-                        if let Ok(value) =
-                            serde_json::from_str::<serde_json::Value>(accumulated_content)
-                            && let Some(arr) = value.as_array()
-                            && !arr.is_empty()
-                        {
-                            return (true, accumulated_content.len());
-                        }
-                        (false, accumulated_content.len())
+                        value.as_array().is_some_and(|array| !array.is_empty())
                     }
+                };
+
+                if is_complete {
+                    JailCompletion::Complete(CompletedJail {
+                        split_pos,
+                        marker_parse_result: None,
+                    })
+                } else {
+                    JailCompletion::Incomplete
                 }
             }
         }
@@ -1124,25 +1325,22 @@ impl JailedStream {
         base_choice: &ChatChoiceStream,
         tool_call_offset: usize,
         is_finalize: bool,
+        marker_parse_result: Option<MarkerParseResult>,
     ) -> ChatChoiceStream {
         match &self.jail_mode {
             JailMode::MarkerBased => {
                 // Traditional marker-based tool call parsing
-                let tools_slice = self.tool_definitions.as_deref();
-                let parse_result = if is_finalize {
+                let parse_result = if let Some(parse_result) = marker_parse_result {
+                    parse_result
+                } else if is_finalize {
                     try_tool_call_parse_aggregate_finalize(
                         accumulated_content,
                         self.tool_call_parser.as_deref(),
-                        tools_slice,
+                        self.tool_definitions.as_deref(),
                     )
                     .await
                 } else {
-                    try_tool_call_parse_aggregate(
-                        accumulated_content,
-                        self.tool_call_parser.as_deref(),
-                        tools_slice,
-                    )
-                    .await
+                    self.parse_marker_tool_calls(accumulated_content).await
                 };
                 match parse_result {
                     Ok((tool_calls, normal_text)) if !tool_calls.is_empty() => {
@@ -1493,23 +1691,6 @@ impl JailedStream {
                 }
             }
         }
-    }
-
-    /// Check if accumulated content contains complete tool calls that can be parsed
-    /// Returns true if we should exit the jail early
-    async fn should_exit_jail_early(&self, accumulated: &str) -> bool {
-        if let Some(ref parser) = self.tool_call_parser {
-            // Try to parse - if successful and we have complete tool calls, exit early
-            let tools_slice = self.tool_definitions.as_deref();
-            match try_tool_call_parse_aggregate(accumulated, Some(parser), tools_slice).await {
-                Ok((tool_calls, _normal_text)) => {
-                    let result = !tool_calls.is_empty();
-                    return result;
-                }
-                Err(_e) => {}
-            }
-        }
-        false
     }
 
     /// Post-processor that sets finish_reason to ToolCalls when tool calls were emitted

--- a/parsers/v1/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/v1/src/tool_calling/json/base_json_parser.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
+
 use serde_json::value::RawValue;
 use uuid::Uuid;
 
@@ -8,7 +10,9 @@ use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
-// Same as CalledFunction with named parameters.
+/// Public compatibility shape for callers that deserialize a tool call using
+/// the legacy `parameters` key. The parser itself uses an internal union so it
+/// can accept both argument-key variants in a single pass.
 //
 // `parameters` / `arguments` are deserialized as `Box<RawValue>` so the
 // original byte span — including key order, whitespace, and number
@@ -24,35 +28,20 @@ pub struct CalledFunctionParameters {
     pub parameters: Box<RawValue>,
 }
 
+/// Public compatibility shape for callers that deserialize a tool call using
+/// the `arguments` key. The parser itself uses an internal union.
 #[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionArguments {
     pub name: String,
     pub arguments: Box<RawValue>,
 }
 
-// A tool call may omit both `arguments` and `parameters` when the function
-// takes no inputs (e.g. `{"name": "get_time"}`). vLLM's and SGLang's Hermes
-// detectors treat that as an empty-argument call; this name-only shape is
-// tried as a last resort (after the `parameters` / `arguments` shapes) so the
-// call is recovered with `{}` args rather than dropped and its wrapper leaked.
+/// Public compatibility shape for a call containing only a function name.
+/// Parsers whose configuration permits name-only calls convert it to `{}`
+/// arguments through the internal union representation.
 #[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionNameOnly {
     pub name: String,
-}
-
-#[derive(Debug)]
-enum JsonPayload<'a> {
-    Borrowed(&'a str),
-    Owned(String),
-}
-
-impl JsonPayload<'_> {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Borrowed(value) => value,
-            Self::Owned(value) => value,
-        }
-    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -77,7 +66,7 @@ fn extract_tool_call_content<'a>(
     input: &'a str,
     start_token: &str,
     end_token: &str,
-) -> Option<JsonPayload<'a>> {
+) -> Option<Cow<'a, str>> {
     if start_token.is_empty() || end_token.is_empty() {
         return None;
     }
@@ -100,8 +89,8 @@ fn extract_tool_call_content<'a>(
 
     match matches.len() {
         0 => None,
-        1 => Some(JsonPayload::Borrowed(matches[0])),
-        _ => Some(JsonPayload::Owned(format!("[{}]", matches.join(",")))),
+        1 => Some(Cow::Borrowed(matches[0])),
+        _ => Some(Cow::Owned(format!("[{}]", matches.join(",")))),
     }
 }
 
@@ -112,11 +101,11 @@ fn extract_tool_call_content<'a>(
 fn extract_tool_call_content_eof_recovery<'a>(
     input: &'a str,
     start_token: &str,
-) -> Option<JsonPayload<'a>> {
+) -> Option<Cow<'a, str>> {
     let start_pos = input.find(start_token)?;
     let tail = input[start_pos + start_token.len()..].trim();
     if tail.starts_with('{') || tail.starts_with('[') {
-        Some(JsonPayload::Borrowed(tail))
+        Some(Cow::Borrowed(tail))
     } else {
         None
     }
@@ -353,10 +342,9 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
 /// let result = try_tool_call_parse_json(input)?;
 /// assert!(result.is_some());
 /// ```
-/// Parse `payload` into tool calls, trying the three canonical JSON shapes in
-/// order: an array of calls, a single `{name, arguments}`, then a single
-/// `{name, parameters}`. Within an array, each element is tried as
-/// `arguments` then `parameters`.
+/// Parse `payload` into tool calls through one internal representation that
+/// accepts both `arguments` and `parameters`. Arrays retain arguments-first
+/// precedence; single calls retain parameters-first precedence.
 ///
 /// Returns:
 /// - `Ok(Some(calls))` when `payload` matched one of the shapes. The vec may be
@@ -455,7 +443,7 @@ pub fn try_tool_call_parse_basic_json(
 
     // Iterate over all start and end tokens and try to extract the content between them
     // Assumption : One message will not contain different tags for tool calls. Iteration over tags is to support different tags by default for multiple models
-    let mut json = JsonPayload::Borrowed(trimmed);
+    let mut json = Cow::Borrowed(trimmed);
     let mut normal_text = trimmed.to_string();
     let mut found_start_token_with_no_valid_json = false;
 
@@ -473,7 +461,7 @@ pub fn try_tool_call_parse_basic_json(
             let extracted_json = trimmed[idx..].trim();
             if !extracted_json.is_empty() {
                 normal_text = extracted_normal;
-                json = JsonPayload::Borrowed(extracted_json);
+                json = Cow::Borrowed(extracted_json);
             }
         }
     } else {
@@ -487,7 +475,7 @@ pub fn try_tool_call_parse_basic_json(
                 match (start_token.is_empty(), end_token.is_empty()) {
                     (false, true) => {
                         // Single token case
-                        let result = handle_single_token_tool_calls(json.as_str(), start_token);
+                        let result = handle_single_token_tool_calls(json.as_ref(), start_token);
                         if let Some(content) = result {
                             // handle_single_token_tool_calls returns either:
                             //   Some("[{...}, ...]") — one or more extracted calls
@@ -500,7 +488,7 @@ pub fn try_tool_call_parse_basic_json(
                                 found_start_token_with_no_valid_json = true;
                             }
 
-                            json = JsonPayload::Owned(content);
+                            json = Cow::Owned(content);
                             // For single token case, use the normal text we extracted earlier
                             normal_text = new_normal_text;
 
@@ -523,7 +511,7 @@ pub fn try_tool_call_parse_basic_json(
                         if let Some(content) = result {
                             // Check if we found a start token but got empty JSON back
                             // This indicates the token was found but no valid JSON followed
-                            if content.as_str().is_empty() {
+                            if content.as_ref().is_empty() {
                                 found_start_token_with_no_valid_json = true;
                             }
 
@@ -540,7 +528,7 @@ pub fn try_tool_call_parse_basic_json(
             }
         }
     }
-    let json = json.as_str();
+    let json = json.as_ref();
     // Anonymous function to attempt deserialization into a known representation.
     //
     // Try the three canonical JSON shapes (single object with `parameters` or

--- a/parsers/v1/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/v1/src/tool_calling/json/base_json_parser.rs
@@ -10,40 +10,6 @@ use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
-/// Public compatibility shape for callers that deserialize a tool call using
-/// the legacy `parameters` key. The parser itself uses an internal union so it
-/// can accept both argument-key variants in a single pass.
-//
-// `parameters` / `arguments` are deserialized as `Box<RawValue>` so the
-// original byte span — including key order, whitespace, and number
-// formatting — is preserved verbatim. Going through `HashMap<String, Value>`
-// here would normalize via `serde_json::to_string`, which strips spaces and
-// reorders keys based on HashMap iteration. That broke append-only KV-cache
-// prefix matching: when the model's emitted `arguments` were re-rendered
-// through this parser and round-tripped back into the next turn's prompt,
-// the bytes diverged from what the model originally emitted.
-#[derive(Debug, serde::Deserialize)]
-pub struct CalledFunctionParameters {
-    pub name: String,
-    pub parameters: Box<RawValue>,
-}
-
-/// Public compatibility shape for callers that deserialize a tool call using
-/// the `arguments` key. The parser itself uses an internal union.
-#[derive(Debug, serde::Deserialize)]
-pub struct CalledFunctionArguments {
-    pub name: String,
-    pub arguments: Box<RawValue>,
-}
-
-/// Public compatibility shape for a call containing only a function name.
-/// Parsers whose configuration permits name-only calls convert it to `{}`
-/// arguments through the internal union representation.
-#[derive(Debug, serde::Deserialize)]
-pub struct CalledFunctionNameOnly {
-    pub name: String,
-}
-
 #[derive(Debug, serde::Deserialize)]
 struct CalledFunctionRaw {
     name: String,
@@ -301,50 +267,13 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
     String::new()
 }
 
-/// Attempts to parse a tool call from a raw LLM message string into a unified [`ToolCallResponse`] format.
+/// Parse a JSON `payload` into tool calls through one internal representation.
 ///
-/// This is a flexible helper that handles a variety of potential formats emitted by LLMs for function/tool calls,
-/// including wrapped payloads (`<TOOLCALL>[...]</TOOLCALL>`, `<|python_tag|>...`) and JSON representations
-/// with either `parameters` or `arguments` fields.
-///
-/// # Supported Formats
-///
-/// The input `message` may be one of:
-///
-/// - `<TOOLCALL>[{ "name": ..., "parameters": { ... } }]</TOOLCALL>`
-/// - `<|python_tag|>{ "name": ..., "arguments": { ... } }`
-/// - Raw JSON of:
-///     - `CalledFunctionParameters`: `{ "name": ..., "parameters": { ... } }`
-///     - `CalledFunctionArguments`: `{ "name": ..., "arguments": { ... } }`
-///     - Or a list of either of those types: `[ { "name": ..., "arguments": { ... } }, ... ]`
-///
-/// # Return
-///
-/// - `Ok(Some(ToolCallResponse))` if parsing succeeds
-/// - `Ok(None)` if input format is unrecognized or invalid JSON
-/// - `Err(...)` if JSON is valid but deserialization or argument re-serialization fails
-///
-/// # Note on List Handling
-///
-/// When the input contains a list of tool calls (either with `parameters` or `arguments`),
-/// only the **last item** in the list is returned. This design choice assumes that the
-/// most recent tool call in a list is the one to execute.
-///
-/// # Errors
-///
-/// Returns a `Result::Err` only if an inner `serde_json::to_string(...)` fails
-/// (e.g., if the arguments are not serializable).
-///
-/// # Examples
-///
-/// ```ignore
-/// let input = r#"<TOOLCALL>[{ "name": "search", "parameters": { "query": "rust" } }]</TOOLCALL>"#;
-/// let result = try_tool_call_parse_json(input)?;
-/// assert!(result.is_some());
-/// ```
-/// Parse `payload` into tool calls through one internal representation that
-/// accepts both `arguments` and `parameters`. Arrays retain arguments-first
-/// precedence; single calls retain parameters-first precedence.
+/// Accepted payloads are a single object or an array of objects containing a
+/// `name` plus either `arguments` or `parameters`. When `allow_name_only` is
+/// enabled, an object containing only `name` is accepted with `{}` arguments.
+/// Array entries retain arguments-first precedence when both keys are present;
+/// single calls retain parameters-first precedence.
 ///
 /// Returns:
 /// - `Ok(Some(calls))` when `payload` matched one of the shapes. The vec may be

--- a/parsers/v1/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/v1/src/tool_calling/json/base_json_parser.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use regex::RegexBuilder;
 use serde_json::value::RawValue;
 use uuid::Uuid;
 
@@ -41,37 +40,68 @@ pub struct CalledFunctionNameOnly {
     pub name: String,
 }
 
-// Extract the contents between start and end tokens using regex parsing.
-// Returns a JSON array string if there are multiple matches, otherwise returns the last match directly.
-fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) -> Option<String> {
-    let escaped_start = regex::escape(start_token);
-    let escaped_end = regex::escape(end_token);
-    let pattern = format!(r"{}(.*?){}", escaped_start, escaped_end);
+#[derive(Debug)]
+enum JsonPayload<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
 
-    match RegexBuilder::new(&pattern)
-        .dot_matches_new_line(true)
-        .build()
-    {
-        Ok(regex) => {
-            // Get all matches and take the last one for now. TODO: Handle multiple tool calls
-            let matches: Vec<_> = regex
-                .captures_iter(input)
-                .filter_map(|captures| captures.get(1))
-                .map(|m| m.as_str().trim().to_string())
-                .collect();
-            if !matches.is_empty() {
-                // If only one match, return it directly, otherwise return as a JSON array string
-                if matches.len() == 1 {
-                    // Return the last match directly
-                    return Some(matches.last().unwrap().clone());
-                } else {
-                    // Join the matches into a JSON array string
-                    return Some(format!("[{}]", matches.join(",")));
-                }
-            }
-            None
+impl JsonPayload<'_> {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(value) => value,
+            Self::Owned(value) => value,
         }
-        Err(_) => None,
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CalledFunctionRaw {
+    name: String,
+    #[serde(default, deserialize_with = "deserialize_present_raw")]
+    parameters: Option<Box<RawValue>>,
+    #[serde(default, deserialize_with = "deserialize_present_raw")]
+    arguments: Option<Box<RawValue>>,
+}
+
+fn deserialize_present_raw<'de, D>(deserializer: D) -> Result<Option<Box<RawValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    <Box<RawValue> as serde::Deserialize>::deserialize(deserializer).map(Some)
+}
+
+// Extract the contents between start and end tokens using slice search.
+// Returns a JSON array string if there are multiple matches, otherwise returns the last match directly.
+fn extract_tool_call_content<'a>(
+    input: &'a str,
+    start_token: &str,
+    end_token: &str,
+) -> Option<JsonPayload<'a>> {
+    if start_token.is_empty() || end_token.is_empty() {
+        return None;
+    }
+
+    let mut search_from = 0;
+    let mut matches = Vec::new();
+    while search_from < input.len() {
+        let Some(start_rel) = input[search_from..].find(start_token) else {
+            break;
+        };
+        let start_pos = search_from + start_rel;
+        let content_start = start_pos + start_token.len();
+        let Some(end_rel) = input[content_start..].find(end_token) else {
+            break;
+        };
+        let content_end = content_start + end_rel;
+        matches.push(input[content_start..content_end].trim());
+        search_from = content_end + end_token.len();
+    }
+
+    match matches.len() {
+        0 => None,
+        1 => Some(JsonPayload::Borrowed(matches[0])),
+        _ => Some(JsonPayload::Owned(format!("[{}]", matches.join(",")))),
     }
 }
 
@@ -79,11 +109,14 @@ fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) ->
 /// tail after `start_token` when the outer end-token never arrived. Gated on
 /// `JsonParserConfig::allow_eof_recovery` so streaming early-exit doesn't
 /// fire mid-stream before the end-token has shown up.
-fn extract_tool_call_content_eof_recovery(input: &str, start_token: &str) -> Option<String> {
+fn extract_tool_call_content_eof_recovery<'a>(
+    input: &'a str,
+    start_token: &str,
+) -> Option<JsonPayload<'a>> {
     let start_pos = input.find(start_token)?;
     let tail = input[start_pos + start_token.len()..].trim();
     if tail.starts_with('{') || tail.starts_with('[') {
-        Some(tail.to_string())
+        Some(JsonPayload::Borrowed(tail))
     } else {
         None
     }
@@ -340,48 +373,59 @@ fn parse_calls(
     payload: &str,
     allow_name_only: bool,
 ) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
-    let mk = |name: String, args: &RawValue| ToolCallResponse {
-        id: format!("call-{}", Uuid::new_v4()),
-        tp: ToolCallType::Function,
-        function: CalledFunction {
+    fn make_tool_call(name: String, args: &RawValue) -> ToolCallResponse {
+        ToolCallResponse {
+            id: format!("call-{}", Uuid::new_v4()),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name,
+                arguments: args.get().to_string(),
+            },
+        }
+    }
+
+    fn convert_raw(
+        raw: CalledFunctionRaw,
+        prefer_arguments: bool,
+        allow_name_only: bool,
+    ) -> anyhow::Result<Option<ToolCallResponse>> {
+        let CalledFunctionRaw {
             name,
-            arguments: args.get().to_string(),
-        },
-    };
+            parameters,
+            arguments,
+        } = raw;
+        let args = if prefer_arguments {
+            arguments.or(parameters)
+        } else {
+            parameters.or(arguments)
+        };
+
+        if let Some(args) = args {
+            return Ok(Some(make_tool_call(name, args.as_ref())));
+        }
+        if allow_name_only {
+            let empty = RawValue::from_string("{}".to_string())?;
+            return Ok(Some(make_tool_call(name, empty.as_ref())));
+        }
+        Ok(None)
+    }
 
     if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(payload) {
         let mut calls = Vec::new();
         for item in array {
-            let item_str = item.get();
-            if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
-                calls.push(mk(func_args.name, &func_args.arguments));
-            } else if let Ok(func_params) =
-                serde_json::from_str::<CalledFunctionParameters>(item_str)
+            if let Ok(raw) = serde_json::from_str::<CalledFunctionRaw>(item.get())
+                && let Some(call) = convert_raw(raw, true, allow_name_only)?
             {
-                calls.push(mk(func_params.name, &func_params.parameters));
-            } else if allow_name_only
-                && let Ok(name_only) = serde_json::from_str::<CalledFunctionNameOnly>(item_str)
-            {
-                // No `arguments`/`parameters` key — treat as an empty-arg call.
-                let empty = RawValue::from_string("{}".to_string())?;
-                calls.push(mk(name_only.name, &empty));
+                calls.push(call);
             }
             // Skip malformed entries silently.
         }
         return Ok(Some(calls));
     }
-    if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(payload) {
-        return Ok(Some(vec![mk(single.name, &single.parameters)]));
-    }
-    if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
-        return Ok(Some(vec![mk(single.name, &single.arguments)]));
-    }
-    if allow_name_only
-        && let Ok(name_only) = serde_json::from_str::<CalledFunctionNameOnly>(payload)
+    if let Ok(single) = serde_json::from_str::<CalledFunctionRaw>(payload)
+        && let Some(call) = convert_raw(single, false, allow_name_only)?
     {
-        // No `arguments`/`parameters` key — treat as an empty-arg call.
-        let empty = RawValue::from_string("{}".to_string())?;
-        return Ok(Some(vec![mk(name_only.name, &empty)]));
+        return Ok(Some(vec![call]));
     }
     Ok(None)
 }
@@ -411,7 +455,7 @@ pub fn try_tool_call_parse_basic_json(
 
     // Iterate over all start and end tokens and try to extract the content between them
     // Assumption : One message will not contain different tags for tool calls. Iteration over tags is to support different tags by default for multiple models
-    let mut json = trimmed.to_string();
+    let mut json = JsonPayload::Borrowed(trimmed);
     let mut normal_text = trimmed.to_string();
     let mut found_start_token_with_no_valid_json = false;
 
@@ -426,14 +470,14 @@ pub fn try_tool_call_parse_basic_json(
         // No start tokens found, try to extract JSON directly. Everything that starts with { or [ is considered a potential JSON.
         if let Some(idx) = normal_text.find(['{', '[']) {
             let extracted_normal = normal_text[..idx].trim().to_string();
-            let extracted_json = normal_text[idx..].trim().to_string();
+            let extracted_json = trimmed[idx..].trim();
             if !extracted_json.is_empty() {
                 normal_text = extracted_normal;
-                json = extracted_json;
+                json = JsonPayload::Borrowed(extracted_json);
             }
         }
     } else {
-        // Start tokens exist, use regex-based parsing
+        // Start tokens exist, extract payloads between or after the markers.
         // Try all combinations of start and end tokens
         'outer: for start_token in tool_call_start_tokens.iter() {
             for end_token in tool_call_end_tokens.iter() {
@@ -443,7 +487,7 @@ pub fn try_tool_call_parse_basic_json(
                 match (start_token.is_empty(), end_token.is_empty()) {
                     (false, true) => {
                         // Single token case
-                        let result = handle_single_token_tool_calls(&json, start_token);
+                        let result = handle_single_token_tool_calls(json.as_str(), start_token);
                         if let Some(content) = result {
                             // handle_single_token_tool_calls returns either:
                             //   Some("[{...}, ...]") — one or more extracted calls
@@ -456,7 +500,7 @@ pub fn try_tool_call_parse_basic_json(
                                 found_start_token_with_no_valid_json = true;
                             }
 
-                            json = content;
+                            json = JsonPayload::Owned(content);
                             // For single token case, use the normal text we extracted earlier
                             normal_text = new_normal_text;
 
@@ -465,21 +509,21 @@ pub fn try_tool_call_parse_basic_json(
                     }
                     (false, false) => {
                         // Start and end token case
-                        let mut result = extract_tool_call_content(&json, start_token, end_token);
+                        let mut result = extract_tool_call_content(trimmed, start_token, end_token);
                         // EOF recovery: only when explicitly opted in (finalize
                         // path). Streaming jails leave `allow_eof_recovery=false`
                         // so the parser doesn't claim a complete call before
                         // the end-token has actually arrived.
                         if result.is_none()
                             && config.allow_eof_recovery
-                            && json.contains(start_token.as_str())
+                            && trimmed.contains(start_token.as_str())
                         {
-                            result = extract_tool_call_content_eof_recovery(&json, start_token);
+                            result = extract_tool_call_content_eof_recovery(trimmed, start_token);
                         }
                         if let Some(content) = result {
                             // Check if we found a start token but got empty JSON back
                             // This indicates the token was found but no valid JSON followed
-                            if content.is_empty() {
+                            if content.as_str().is_empty() {
                                 found_start_token_with_no_valid_json = true;
                             }
 
@@ -496,7 +540,6 @@ pub fn try_tool_call_parse_basic_json(
             }
         }
     }
-    // Convert json (String) to &str
     let json = json.as_str();
     // Anonymous function to attempt deserialization into a known representation.
     //

--- a/parsers/v1/tests/jail_incremental.rs
+++ b/parsers/v1/tests/jail_incremental.rs
@@ -87,6 +87,37 @@ fn content(responses: &[Annotated<CreateChatCompletionStreamResponse>]) -> Strin
         .collect()
 }
 
+fn content_chunks(responses: &[Annotated<CreateChatCompletionStreamResponse>]) -> Vec<String> {
+    responses
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|response| response.choices.iter())
+        .filter_map(|choice| choice.delta.content.as_ref())
+        .filter_map(|content| match content {
+            ChatCompletionMessageContent::Text(text) => Some(text.clone()),
+            ChatCompletionMessageContent::Parts(_) => None,
+        })
+        .filter(|text| !text.is_empty())
+        .collect()
+}
+
+#[tokio::test]
+async fn marker_only_jail_completes_even_when_default_parser_accepts_body() {
+    let responses: Vec<_> = JailedStream::builder()
+        .jail_start_sequence("<jail>")
+        .jail_end_sequence("</jail>")
+        .build()
+        .apply_with_finish_reason(stream::iter([
+            chunk(r#"<jail><TOOLCALL>[{"name":"get_time","arguments":{}}]</TOOLCALL></jail>"#),
+            chunk(" trailing prose"),
+        ]))
+        .collect()
+        .await;
+
+    assert_eq!(tool_calls(&responses).len(), 1);
+    assert!(content(&responses).ends_with(" trailing prose"));
+}
+
 #[tokio::test]
 async fn invalid_balanced_candidate_does_not_pin_later_valid_call() {
     let responses = run(
@@ -101,6 +132,55 @@ async fn invalid_balanced_candidate_does_not_pin_later_valid_call() {
     let calls = tool_calls(&responses);
     assert_eq!(calls.len(), 1, "later valid JSON must trigger revalidation");
     assert_eq!(calls[0].0, "get_time");
+}
+
+#[tokio::test]
+async fn unbalanced_candidate_resynchronizes_at_later_start_marker() {
+    for poisoned in [r#"<|python_tag|>{""#, r#"<|python_tag|>{{{"#] {
+        let responses = run(
+            "llama3_json",
+            [
+                poisoned,
+                r#"<|python_tag|>{"name":"get_time","arguments":{}}"#,
+                " all done!",
+            ],
+        )
+        .await;
+
+        let calls = tool_calls(&responses);
+        assert_eq!(calls.len(), 1, "poisoned prefix: {poisoned:?}");
+        assert_eq!(calls[0].0, "get_time");
+        assert_eq!(content(&responses), " all done!");
+    }
+}
+
+#[tokio::test]
+async fn deepseek_bare_calls_complete_before_trailing_prose() {
+    let cases = [
+        (
+            "deepseek_v3",
+            concat!(
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n",
+                "```json\n{\"location\":\"Paris\"}\n```\n",
+                "<｜tool▁call▁end｜>"
+            ),
+        ),
+        (
+            "deepseek_v3_1",
+            concat!(
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>",
+                "{\"location\":\"Paris\"}<｜tool▁call▁end｜>"
+            ),
+        ),
+    ];
+
+    for (parser, call) in cases {
+        let responses = run(parser, [call, " And here is some trailing prose."]).await;
+        let calls = tool_calls(&responses);
+        assert_eq!(calls.len(), 1, "bare call was dropped for {parser}");
+        assert_eq!(calls[0].0, "get_weather");
+        assert_eq!(content(&responses), " And here is some trailing prose.");
+    }
 }
 
 #[tokio::test]
@@ -137,10 +217,25 @@ async fn split_mistral_close_marker_never_leaks() {
 }
 
 #[tokio::test]
+async fn validated_mistral_candidate_retries_authoritative_boundary() {
+    let responses = run(
+        "mistral",
+        [
+            r#"[TOOL_CALLS][{"name":"get_time","arguments":{}}]"#,
+            " trailing prose",
+        ],
+    )
+    .await;
+
+    assert_eq!(tool_calls(&responses).len(), 1);
+    assert_eq!(content(&responses), " trailing prose");
+}
+
+#[tokio::test]
 async fn overlapping_end_markers_choose_longest_boundary() {
     let responses: Vec<_> = JailedStream::builder()
         .tool_call_parser("hermes")
-        .jail_end_sequences(["</tool", "</tool_call>"])
+        .jail_end_sequences(["</tool_call>", "</tool"])
         .build()
         .apply_with_finish_reason(stream::iter([chunk(
             "<tool_call>not-json</tool_call>visible",
@@ -149,6 +244,42 @@ async fn overlapping_end_markers_choose_longest_boundary() {
         .await;
 
     assert_eq!(content(&responses), "visible");
+}
+
+#[tokio::test]
+async fn configured_end_marker_order_has_priority_over_text_position() {
+    let responses: Vec<_> = JailedStream::builder()
+        .jail_start_sequence("<jail>")
+        .jail_end_sequences(["<late>", "</jail>"])
+        .build()
+        .apply_with_finish_reason(stream::iter([chunk(
+            "<jail>inside</jail>outside<late>tail",
+        )]))
+        .collect()
+        .await;
+
+    let chunks = content_chunks(&responses);
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(chunks[0], "<jail>inside</jail>outside<late>");
+    assert_eq!(chunks[1], "tail");
+}
+
+#[tokio::test]
+async fn manual_end_marker_override_disables_json_boundary_exit() {
+    let responses: Vec<_> = JailedStream::builder()
+        .tool_call_parser("llama3_json")
+        .jail_end_sequence("[[END]]")
+        .build()
+        .apply_with_finish_reason(stream::iter([
+            chunk(r#"<|python_tag|>{"name":"get_time","arguments":{}}"#),
+            chunk("[[END]]"),
+            chunk(" after"),
+        ]))
+        .collect()
+        .await;
+
+    assert_eq!(tool_calls(&responses).len(), 1);
+    assert_eq!(content(&responses), " after");
 }
 
 #[tokio::test]

--- a/parsers/v1/tests/jail_incremental.rs
+++ b/parsers/v1/tests/jail_incremental.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream};
+use dynamo_parsers::tool_calling::{config::ToolCallConfig, json::try_tool_call_parse_basic_json};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, Role,
+};
+use futures::{StreamExt, stream};
+
+fn chunk(content: impl Into<String>) -> Annotated<CreateChatCompletionStreamResponse> {
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            role: Some(Role::Assistant),
+            content: Some(ChatCompletionMessageContent::Text(content.into())),
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        logprobs: None,
+    };
+    Annotated {
+        data: Some(CreateChatCompletionStreamResponse {
+            id: "incremental-jail-test".to_string(),
+            choices: vec![choice],
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        }),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+async fn run(
+    parser: &str,
+    chunks: impl IntoIterator<Item = &'static str>,
+) -> Vec<Annotated<CreateChatCompletionStreamResponse>> {
+    let chunks: Vec<_> = chunks.into_iter().map(chunk).collect();
+    JailedStream::builder()
+        .tool_call_parser(parser)
+        .build()
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await
+}
+
+fn tool_calls(
+    responses: &[Annotated<CreateChatCompletionStreamResponse>],
+) -> Vec<(String, String)> {
+    responses
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|response| response.choices.iter())
+        .filter_map(|choice| choice.delta.tool_calls.as_ref())
+        .flatten()
+        .filter_map(|call| call.function.as_ref())
+        .filter_map(|function| {
+            Some((
+                function.name.clone()?,
+                function.arguments.clone().unwrap_or_default(),
+            ))
+        })
+        .collect()
+}
+
+fn content(responses: &[Annotated<CreateChatCompletionStreamResponse>]) -> String {
+    responses
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|response| response.choices.iter())
+        .filter_map(|choice| choice.delta.content.as_ref())
+        .filter_map(|content| match content {
+            ChatCompletionMessageContent::Text(text) => Some(text.as_str()),
+            ChatCompletionMessageContent::Parts(_) => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn invalid_balanced_candidate_does_not_pin_later_valid_call() {
+    let responses = run(
+        "llama3_json",
+        [
+            r#"<|python_tag|>{"name": }"#,
+            r#"<|python_tag|>{"name":"get_time","arguments":{}}"#,
+        ],
+    )
+    .await;
+
+    let calls = tool_calls(&responses);
+    assert_eq!(calls.len(), 1, "later valid JSON must trigger revalidation");
+    assert_eq!(calls[0].0, "get_time");
+}
+
+#[tokio::test]
+async fn argumentless_wrapped_calls_keep_existing_behavior() {
+    for parser in ["hermes", "qwen25"] {
+        let responses = run(parser, [r#"<tool_call>{"name":"get_time"}</tool_call>"#]).await;
+        let calls = tool_calls(&responses);
+        assert_eq!(calls.len(), 1, "{parser} argument-less call was dropped");
+        assert_eq!(calls[0].0, "get_time");
+        assert_eq!(calls[0].1, "{}");
+    }
+}
+
+#[tokio::test]
+async fn split_mistral_close_marker_never_leaks() {
+    let responses = run(
+        "mistral",
+        [
+            r#"[TOOL_CALLS][{"name":"get_time","arguments":{}}]"#,
+            "[/TOOL_CA",
+            "LLS]",
+            " terminé 🧪",
+        ],
+    )
+    .await;
+
+    assert_eq!(tool_calls(&responses).len(), 1);
+    let text = content(&responses);
+    assert!(
+        !text.contains("[/TOOL_CALLS]"),
+        "close marker leaked: {text:?}"
+    );
+    assert_eq!(text, " terminé 🧪");
+}
+
+#[tokio::test]
+async fn overlapping_end_markers_choose_longest_boundary() {
+    let responses: Vec<_> = JailedStream::builder()
+        .tool_call_parser("hermes")
+        .jail_end_sequences(["</tool", "</tool_call>"])
+        .build()
+        .apply_with_finish_reason(stream::iter([chunk(
+            "<tool_call>not-json</tool_call>visible",
+        )]))
+        .collect()
+        .await;
+
+    assert_eq!(content(&responses), "visible");
+}
+
+#[tokio::test]
+async fn markerless_followup_calls_rejail_from_parser_capabilities() {
+    let cases = [
+        (
+            "llama3_json",
+            r#"<|python_tag|>{"name":"first","arguments":{}}"#,
+            r#"{"name":"second","arguments":{}}"#,
+        ),
+        (
+            "phi4",
+            r#"functools[{"name":"first","arguments":{}}]"#,
+            r#"[{"name":"second","arguments":{}}]"#,
+        ),
+    ];
+
+    for (parser, first, second) in cases {
+        let responses = run(parser, [first, second]).await;
+        let names: Vec<_> = tool_calls(&responses)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(names, ["first", "second"], "{parser} markerless followup");
+    }
+}
+
+#[tokio::test]
+async fn kimi_missing_section_end_still_recovers_at_eof() {
+    let responses = run(
+        "kimi_k2",
+        [
+            "<|tool_calls_section_begin|>",
+            r#"<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Paris"}<|tool_call_end|>"#,
+        ],
+    )
+    .await;
+
+    let calls = tool_calls(&responses);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "get_weather");
+    assert!(!content(&responses).contains("<|tool_call"));
+}
+
+#[test]
+fn raw_null_arguments_remain_present() {
+    let ToolCallConfig { parser_config, .. } = ToolCallConfig::hermes();
+    let dynamo_parsers::tool_calling::config::ParserConfig::Json(config) = parser_config else {
+        unreachable!();
+    };
+    let (calls, _) = try_tool_call_parse_basic_json(
+        r#"<tool_call>{"name":"nullable","arguments":null}</tool_call>"#,
+        &config,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.arguments, "null");
+}


### PR DESCRIPTION
## Summary

- track tool-call jail completion incrementally instead of rescanning the full accumulated buffer for every streamed delta
- validate parsers only at lexical completion candidates, cache only successful results, and keep `find_tool_call_end_position` authoritative for emitted boundaries
- replace per-call wrapped-JSON regex construction with slice scanning while preserving parser output, recovery behavior, and public interfaces
- add focused regressions without modifying existing tests or parity fixtures

This ports the optimization from ai-dynamo/dynamo#10570 to the crate that now owns the jail after ai-dynamo/dynamo#11112. The previous path repeatedly scanned and parsed a growing buffer, producing quadratic behavior for large streamed tool arguments.

Markerless JSON completion is derived from parser configuration rather than parser-name allowlists. Invalid balanced candidates remain eligible for later revalidation, and parser results are reused only after successful validation.

## Validation

All of the following passed locally:

```text
cargo fmt --all -- --check
cargo check --workspace --all-targets --locked
cargo test --workspace --all-targets --locked
cargo test --workspace --doc --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

cargo test --locked -p dynamo-parsers
cargo test --locked -p dynamo-conformance-fixtures-v2 --test parity_toolcalling
cargo test --locked -p dynamo-conformance-fixtures-v2 --test parity_toolcalling_batch_via_stream
cargo test --locked -p dynamo-conformance-fixtures-v2 --test parity_toolcalling_stream
```

The downstream Dynamo integration suite also passed against this local crate candidate: 127 tests passed across the six jail/tool-call targets, with one pre-existing ignored test. Dynamo formatting and all-targets clippy passed as well.

The new regression target covers invalid first balanced JSON, argument-less Hermes/Qwen calls, split Mistral close markers, markerless Llama/Phi calls, Kimi finalize recovery, overlapping markers, explicit null arguments, and UTF-8 boundaries.

## Benchmark

Hermes tool calls streamed in 16-byte chunks, median time:

| Payload | `dynamo-parsers` 3.1.0 | Candidate | Speedup |
| ---: | ---: | ---: | ---: |
| 128 B | 380 us | 7 us | 54.3x |
| 1 KiB | 1,707 us | 22 us | 77.6x |
| 8 KiB | 14,113 us | 135 us | 104.5x |
| 64 KiB | 227,887 us | 1,084 us | 210.2x |
