### PR TITLE
chore: upgrade Rust toolchain to 1.96.1 to match Dynamo

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -32,7 +32,7 @@ conformance/
 
 ## Running the tests
 
-Use the repo's pinned toolchain (Rust 1.93.1 via rustup; a system `cargo` may be too old for the workspace):
+Use the repo's pinned toolchain (Rust 1.96.1 via rustup; a system `cargo` may be too old for the workspace):
 
 ```bash
 # tool-calling batch parity, all families:

--- a/conformance/utils/src/_common.sh
+++ b/conformance/utils/src/_common.sh
@@ -23,7 +23,7 @@ TOOLS="$ROOT/conformance/utils/src"
 # so CI and .gitignore find it where they always have.
 STAGE="${STAGE:-$UTILS/.stage}"
 # Override when the default cargo can't build the workspace (edition 2024 /
-# resolver "3" needs >= 1.85): CARGO='cargo +1.93.1' conformance/utils/check.sh ...
+# resolver "3" needs >= 1.85): CARGO='cargo +1.96.1' conformance/utils/check.sh ...
 CARGO="${CARGO:-cargo}"
 : "${DRY:=0}"
 

--- a/conformance/utils/src/capture_cli.py
+++ b/conformance/utils/src/capture_cli.py
@@ -12,7 +12,7 @@ Subcommands:
   token-ids              stamp token ids into stream fixtures (cargo bin)
 
 `--dry-run` prints the commands instead of running them. `CARGO` env overrides the
-cargo binary (e.g. `CARGO='cargo +1.93.1'`). `--family`/`--fixture` (B4) narrow the
+cargo binary (e.g. `CARGO='cargo +1.96.1'`). `--family`/`--fixture` (B4) narrow the
 peer captures to one family/fixture.
 """
 import argparse

--- a/docs/PARSERS-V2-MIGRATION-PLAN.md
+++ b/docs/PARSERS-V2-MIGRATION-PLAN.md
@@ -96,7 +96,7 @@ conformance/utils/render_table_v2.sh
 | `openai_harmony` (Python, in the engine containers) | recorded as `captured_with` in `conformance/toolcalling/fixtures-stream-v2/harmony*/` | n/a (engine container) | vLLM container `0.0.8`, SGLang container `0.0.4` | The gpt-oss/Harmony parser behavior is defined by the Harmony grammar; a Rust-`0.0.3`-vs-Python-`0.0.8` gap is the most likely source of a Harmony conformance mismatch. Re-check the in-container version after any vLLM/SGLang bump. Consider bumping the Rust crate to match. |
 | `fastokens` (Rust) | root `Cargo.toml` | root `Cargo.toml` | frontend-crates `0.1.0` vs Dynamo `0.2.0` (skew) | Tokenizer backend; low parser conformance impact but the one hard Rust skew. Bump to `0.2.0` to stay honest. |
 | `vllm` / `sglang` (Python engine pins) | `conformance/utils/src/pyproject.stub.toml` | `pyproject.toml` | `vllm==0.22.0`, `sglang==0.5.12.post1` | Matches current `main`. After bumping, re-capture peer streaming data and update `captured_with`. |
-| Shared crate versions + parser deps | `parsers/v1/`, `tokenizers/`, `protocols/`, `renderer/` `Cargo.toml` + root | `lib/*/Cargo.toml` + root | all `1.3.0`; async-openai `0.34`, tokenizers `0.21.4`, tiktoken-rs `0.9`, rustpython-parser `0.4.0`, minijinja `2.20.0`; Rust `1.93.1` | Should always match the Dynamo workspace; verify on sync. |
+| Shared crate versions + parser deps | `parsers/v1/`, `tokenizers/`, `protocols/`, `renderer/` `Cargo.toml` + root | `lib/*/Cargo.toml` + root | all `1.3.0`; async-openai `0.34`, tokenizers `0.21.4`, tiktoken-rs `0.9`, rustpython-parser `0.4.0`, minijinja `2.20.0`; Rust `1.96.1` | Should always match the Dynamo workspace; verify on sync. |
 
 ## Frontend-Crate-Only Files
 

--- a/parsers/v1/src/reasoning/gpt_oss_parser.rs
+++ b/parsers/v1/src/reasoning/gpt_oss_parser.rs
@@ -551,29 +551,25 @@ impl ReasoningParser for GptOssReasoningParser {
                         normal_delta.push_str(&delta);
                         self.emitted_normal_text = true;
                     }
-                    "analysis" => {
-                        // Analysis WITHOUT a recipient is reasoning content.
-                        // Analysis WITH a functions recipient is a (malformed)
-                        // tool call — its payload is handed off via normal_delta
-                        // below; do not also surface it as reasoning_content.
-                        if current_recipient.is_none() {
-                            if self.insert_reasoning_separator {
-                                reasoning_delta.push('\n');
-                                self.insert_reasoning_separator = false;
-                            }
-                            reasoning_delta.push_str(&delta);
-                            self.emitted_reasoning_text = true;
+                    // Analysis WITHOUT a recipient is reasoning content.
+                    // Analysis WITH a functions recipient is a (malformed)
+                    // tool call — its payload is handed off via normal_delta
+                    // below; do not also surface it as reasoning_content.
+                    "analysis" if current_recipient.is_none() => {
+                        if self.insert_reasoning_separator {
+                            reasoning_delta.push('\n');
+                            self.insert_reasoning_separator = false;
                         }
+                        reasoning_delta.push_str(&delta);
+                        self.emitted_reasoning_text = true;
                     }
-                    "commentary" => {
-                        if current_recipient.is_none() {
-                            if self.insert_normal_separator {
-                                normal_delta.push('\n');
-                                self.insert_normal_separator = false;
-                            }
-                            normal_delta.push_str(&delta);
-                            self.emitted_normal_text = true;
+                    "commentary" if current_recipient.is_none() => {
+                        if self.insert_normal_separator {
+                            normal_delta.push('\n');
+                            self.insert_normal_separator = false;
                         }
+                        normal_delta.push_str(&delta);
+                        self.emitted_normal_text = true;
                     }
                     _ => {}
                 }

--- a/parsers/v1/src/tool_calling/xml/glm47_parser.rs
+++ b/parsers/v1/src/tool_calling/xml/glm47_parser.rs
@@ -529,10 +529,8 @@ fn coerce_value(raw: &str, schema_type: Option<&str>) -> ParsedValue {
                 .collect();
             return Value::Array(items).into();
         }
-        Some("null") => {
-            if trimmed == "null" || trimmed == "None" || trimmed.is_empty() {
-                return Value::Null.into();
-            }
+        Some("null") if trimmed == "null" || trimmed == "None" || trimmed.is_empty() => {
+            return Value::Null.into();
         }
         _ => {}
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.96.1"
 profile = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
#### Overview:

Upgrades frontend-crates' pinned Rust toolchain from 1.93.1 to 1.96.1 so it tracks the Dynamo workspace, mirroring [dynamo#11260](https://github.com/ai-dynamo/dynamo/pull/11260). `PARSERS-V2-MIGRATION-PLAN.md` requires the Rust version to match Dynamo.

No Linear ticket — dynamo#11260 (the upstream Rust bump) carried none, and no matching DIS/DYN issue exists; happy to attach one if desired.

#### Details:

- Bumps `rust-toolchain.toml` channel to 1.96.1 (CI installs from this file via `rustup toolchain install`) plus the four doc/comment version references (`docs/PARSERS-V2-MIGRATION-PLAN.md`, `conformance/README.md`, `_common.sh`, `capture_cli.py`).
- Fixes two `clippy::collapsible_match` errors newly enforced by 1.96.1 in `dynamo-parsers` (`gpt_oss_parser.rs`, `glm47_parser.rs`): collapses single-body match-arm `if`s into arm guards. The false branch already fell through to a no-op `_ => {}`, so behavior is unchanged.
- No crate version bumps and no container/Makefile changes — frontend-crates has none, so that part of dynamo#11260 doesn't apply.

#### Verification:

Ran the CI command set locally under 1.96.1: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --locked` all clean (633+ tests pass, doctests pass). `cargo publish --dry-run` has a pre-existing path-dep checksum quirk that also fails on `main` under 1.93.1 (unrelated to this change; a clean CI environment validates it).

#### Where should the reviewer start?

`rust-toolchain.toml`, then `parsers/v1/src/reasoning/gpt_oss_parser.rs` and `parsers/v1/src/tool_calling/xml/glm47_parser.rs`

/coderabbit profile chill

