### PR TITLE
ci(conformance): run chart-invariant guards in the conformance-table job (DIS-2310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python3 -m venv /tmp/pvenv
-          /tmp/pvenv/bin/pip install --quiet pyyaml jinja2 huggingface_hub
+          /tmp/pvenv/bin/pip install --quiet pyyaml jinja2 huggingface_hub pytest
           PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_table_v1.sh
           PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_table_v2.sh
           OUT=conformance/PARITY_v1.html
@@ -95,6 +95,18 @@ jobs:
           test -s conformance/CONFORMANCE_v2.html
           echo "conformance matrix rendered: $(wc -c < "$OUT") bytes"
           cp "$OUT" conformance/utils/CONFORMITY.html
+
+      # Structural regression guard on the rendered charts: parser selectors present,
+      # every candidate versioned from fixture provenance (not the live Cargo.toml),
+      # all peer versions present, no "not yet implemented", coloring intact. Reuses the
+      # HTML rendered above. See conformance/utils/tests/test_chart_invariants.py.
+      - name: Chart invariants
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          PATH="/tmp/pvenv/bin:$PATH" python3 -m pytest \
+            conformance/utils/tests/test_chart_invariants.py \
+            conformance/utils/tests/test_stream_on_batch.py -q
 
       - name: Upload conformance matrix
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
#### Overview:

Wires the conformance chart regression guards into CI. Adds a **Chart invariants** step to the `conformance-table` job that runs the guard tests on the charts already rendered in that same job. Split out of #98 ([DIS-2310](https://linear.app/nvidia/issue/DIS-2310)) so it can review/land separately; **stacked on #98**, which adds the guard tests themselves (so this must merge after it).

#### Details:

- Installs `pytest` in the job venv and adds a `Chart invariants` step running `test_chart_invariants.py` + `test_stream_on_batch.py` against the freshly rendered `PARITY_v1.html` / `CONFORMANCE_v2.html`.
- Guards against silent structural regressions — empty parser selector, version-less candidate, missing peer versions, broken coloring, "not yet implemented" leak — that exit-0 render smoke and `cargo test` don't catch.

#### Verification:

Guards pass locally (`python3 -m pytest test_chart_invariants.py test_stream_on_batch.py` — 59 passed); this PR's CI runs them.

#### Where should the reviewer start?

`.github/workflows/ci.yml`

/coderabbit profile chill
