### PR TITLE
feat(tokenizers): expose tiktoken special tokens for caching

### DIFF
--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -81,6 +81,21 @@ let stats = cached.cache_stats();
 println!("hits={} misses={} hit_rate={:.2}", stats.hits, stats.misses, stats.hit_rate);
 ```
 
+TikToken models expose the exact special-token strings registered with their BPE, so
+the same cache can be constructed without duplicating model metadata:
+
+```rust
+use dynamo_tokenizers::{CachedTokenizer, TikTokenTokenizer};
+use dynamo_tokenizers::traits::Tokenizer;
+use std::sync::Arc;
+
+let tiktoken = TikTokenTokenizer::from_file_auto("/path/to/tiktoken.model")
+    .expect("load tokenizer");
+let specials = tiktoken.special_tokens().to_vec();
+let inner: Arc<dyn Tokenizer> = Arc::new(tiktoken);
+let cached = CachedTokenizer::new(inner, specials, 256 * 1024 * 1024);
+```
+
 Entries are evicted by approximate LRU once `max_memory_bytes` is exceeded. The
 cache lives as long as the `CachedTokenizer` instance. Use `.with_observer(...)`
 to push request-level hit/miss events into your metrics. Use

--- a/tokenizers/src/tiktoken.rs
+++ b/tokenizers/src/tiktoken.rs
@@ -24,6 +24,14 @@ const KIMI_PATTERN: &str = r#"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p
 pub struct TikTokenTokenizer {
     bpe: CoreBPE,
     special_token_ids: HashSet<u32>,
+    special_tokens: Vec<String>,
+}
+
+fn sorted_special_token_strings(special_tokens: &FxHashMap<String, u32>) -> Vec<String> {
+    let mut strings: Vec<String> = special_tokens.keys().cloned().collect();
+    strings.sort();
+    strings.dedup();
+    strings
 }
 
 impl TikTokenTokenizer {
@@ -40,6 +48,7 @@ impl TikTokenTokenizer {
     ) -> Result<Self> {
         let encoder = parse_tiktoken_file(path)?;
         let special_token_ids: HashSet<u32> = special_tokens.values().copied().collect();
+        let special_token_strings = sorted_special_token_strings(&special_tokens);
 
         let bpe = CoreBPE::new(encoder, special_tokens, pattern)
             .map_err(|err| Error::msg(format!("Error creating tiktoken BPE: {err}")))?;
@@ -47,6 +56,7 @@ impl TikTokenTokenizer {
         Ok(Self {
             bpe,
             special_token_ids,
+            special_tokens: special_token_strings,
         })
     }
 
@@ -66,6 +76,7 @@ impl TikTokenTokenizer {
         let num_base_tokens = encoder.values().max().map_or(0, |&m| m + 1) as usize;
         let special_tokens = load_special_tokens(directory, num_base_tokens)?;
         let special_token_ids: HashSet<u32> = special_tokens.values().copied().collect();
+        let special_token_strings = sorted_special_token_strings(&special_tokens);
 
         let bpe = CoreBPE::new(encoder, special_tokens, pattern)
             .map_err(|err| Error::msg(format!("Error creating tiktoken BPE: {err}")))?;
@@ -73,7 +84,17 @@ impl TikTokenTokenizer {
         Ok(Self {
             bpe,
             special_token_ids,
+            special_tokens: special_token_strings,
         })
+    }
+
+    /// Atomic special-token strings registered with the underlying TikToken BPE.
+    ///
+    /// [`CoreBPE::encode_with_special_tokens`] recognizes these strings outside ordinary
+    /// BPE. For non-overlapping token spellings, splitting immediately after a match
+    /// preserves tokenization.
+    pub fn special_tokens(&self) -> &[String] {
+        &self.special_tokens
     }
 }
 
@@ -355,6 +376,11 @@ mod tests {
 
         let tokenizer = TikTokenTokenizer::from_file(&file_path, pattern, special_tokens).unwrap();
 
+        assert_eq!(
+            tokenizer.special_tokens(),
+            &["[BOS]".to_string(), "[EOS]".to_string()]
+        );
+
         // Test encode
         let encoding = tokenizer.encode("hello world").unwrap();
         let ids = encoding.token_ids();
@@ -374,6 +400,7 @@ mod tests {
         let pattern = r"[\w]+|[^\w\s]+|\s+";
 
         let tokenizer = TikTokenTokenizer::from_file(&file_path, pattern, special_tokens).unwrap();
+        assert!(tokenizer.special_tokens().is_empty());
         let encoding = tokenizer.encode("hello").unwrap();
 
         // Verify it produces the Sp variant
@@ -419,7 +446,13 @@ mod tests {
         create_test_config(dir.path(), "kimi");
         create_test_tokenizer_config(dir.path(), 21);
 
+        let mut expected_specials: Vec<String> = load_special_tokens(dir.path(), 21)
+            .unwrap()
+            .into_keys()
+            .collect();
+        expected_specials.sort();
         let tokenizer = TikTokenTokenizer::from_file_auto(&file_path).unwrap();
+        assert_eq!(tokenizer.special_tokens(), expected_specials);
 
         // Basic encode/decode roundtrip
         let encoding = tokenizer.encode("hello world").unwrap();
@@ -716,6 +749,98 @@ mod tests {
         let file_path = dir.join("tiktoken.model");
         std::fs::write(&file_path, &content).unwrap();
         file_path.to_str().unwrap().to_string()
+    }
+
+    fn has_nontrivial_self_overlap(token: &str) -> bool {
+        let bytes = token.as_bytes();
+        (1..bytes.len()).any(|overlap| bytes[bytes.len() - overlap..] == bytes[..overlap])
+    }
+
+    fn have_ambiguous_overlap(a: &str, b: &str) -> bool {
+        let a = a.as_bytes();
+        let b = b.as_bytes();
+
+        if a.windows(b.len()).any(|window| window == b)
+            || b.windows(a.len()).any(|window| window == a)
+        {
+            return true;
+        }
+
+        let max_overlap = a.len().min(b.len());
+        (1..max_overlap).any(|overlap| {
+            a[a.len() - overlap..] == b[..overlap] || b[b.len() - overlap..] == a[..overlap]
+        })
+    }
+
+    fn assert_special_split_invariant(
+        tokenizer: &TikTokenTokenizer,
+        left: &str,
+        special: &str,
+        right: &str,
+    ) {
+        let whole = tokenizer
+            .encode(&format!("{left}{special}{right}"))
+            .unwrap()
+            .token_ids()
+            .to_vec();
+        let mut split = tokenizer
+            .encode(&format!("{left}{special}"))
+            .unwrap()
+            .token_ids()
+            .to_vec();
+        split.extend_from_slice(tokenizer.encode(right).unwrap().token_ids());
+        assert_eq!(
+            whole, split,
+            "splitting after registered special token {special:?} must preserve tokenization"
+        );
+    }
+
+    #[test]
+    fn test_registered_special_tokens_are_cache_safe_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = create_byte_level_tiktoken_file(dir.path());
+        create_test_config(dir.path(), "kimi");
+        create_test_tokenizer_config(dir.path(), 256);
+
+        let tokenizer = TikTokenTokenizer::from_file_auto(&file_path).unwrap();
+        let specials = tokenizer.special_tokens();
+        assert!(!specials.is_empty());
+
+        for (index, special) in specials.iter().enumerate() {
+            assert!(
+                !has_nontrivial_self_overlap(special),
+                "registered special token has an ambiguous self-overlap: {special:?}"
+            );
+            for other in &specials[index + 1..] {
+                assert!(
+                    !have_ambiguous_overlap(special, other),
+                    "registered special tokens overlap ambiguously: {special:?} and {other:?}"
+                );
+            }
+
+            for (left, right) in [
+                ("ordinary prefix ", " ordinary suffix"),
+                ("line before\n", "\tUnicode after: 北京 😀"),
+                ("", " trailing text"),
+            ] {
+                assert_special_split_invariant(&tokenizer, left, special, right);
+            }
+        }
+
+        let bos = specials
+            .iter()
+            .find(|token| token.as_str() == "[BOS]")
+            .unwrap();
+        let eos = specials
+            .iter()
+            .find(|token| token.as_str() == "[EOS]")
+            .unwrap();
+        assert_special_split_invariant(
+            &tokenizer,
+            "prefix ",
+            bos,
+            &format!("{eos}<|reserved_token_258|>Unicode 尾部"),
+        );
     }
 
     /// Regression test for Kimi K2.5 tokenizer inflation.

--- a/tokenizers/tests/cache_correctness.rs
+++ b/tokenizers/tests/cache_correctness.rs
@@ -6,15 +6,12 @@
 // CHAT_TURNS corpus adapted from sgl-project/llm-tokenizer v1.3.2
 // (`tests/tokenizer_cache_correctness_test.rs`). The ChatML markers `<|im_start|>` /
 // `<|im_end|>` were rewritten to TinyLlama's `<s>` / `</s>` so the test runs offline
-// against in-tree tokenizer fixtures. The same corpus is also rendered into Llama-3.1
-// format and tested against the bundled mock-llama-3.1 fixture, exercising a second
-// special-token family with a different added-token layout (4 boundary tokens instead
-// of 2, distinct surface strings `<|begin_of_text|>` / `<|start_header_id|>` /
-// `<|end_header_id|>` / `<|eot_id|>`).
+// against in-tree tokenizer fixtures. The same corpus is also rendered into Llama-3.1,
+// DeepSeek, and Kimi ChatML formats. The fourth setup uses the bundled mock Kimi
+// TikToken fixture and obtains its boundary strings from `TikTokenTokenizer` itself.
 //
-// All boundary tokens used in both formats are atomic in their respective BPE
-// vocabularies (`special: true, normalized: false`), so the same L1 correctness
-// invariant is exercised for each:
+// All boundary tokens are atomic in their respective tokenizer's special-token set, so
+// the same L1 correctness invariant is exercised for each:
 //
 //   tokenize(prefix) + tokenize(suffix) == tokenize(prefix + suffix)
 
@@ -24,7 +21,7 @@
 use std::sync::Arc;
 
 use dynamo_tokenizers::{
-    CachedTokenizer, HuggingFaceTokenizer,
+    CachedTokenizer, HuggingFaceTokenizer, TikTokenTokenizer,
     traits::{Encoder, Tokenizer},
 };
 
@@ -57,16 +54,71 @@ const DEEPSEEK_PATH: &str = concat!(
     "/../llm/tests/data/sample-models/mock-deepseek-r1/tokenizer.json"
 );
 
+/// In-tree mock Kimi TikToken fixture. Its byte-pair ranks cover ordinary text and its
+/// tokenizer config registers Kimi's ChatML boundaries as CoreBPE special tokens.
+const TIKTOKEN_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../llm/tests/data/sample-models/mock-tiktoken/tiktoken.model"
+);
+
 /// A tokenizer fixture together with the formatter that re-keys the chat corpus into
-/// that family's native special-token markers, plus the list of those markers for the
-/// `CachedTokenizer` constructor.
+/// that family's native special-token markers.
 struct Setup {
     name: &'static str,
-    path: &'static str,
-    specials: &'static [&'static str],
+    build: fn() -> (Arc<dyn Tokenizer>, Vec<String>),
     /// Rewrite a corpus turn from the canonical TinyLlama-format CHAT_TURNS entry
     /// (with `<s>role\n...</s>` markers) into this family's native chat format.
     render: fn(tinyllama_format: &str) -> String,
+}
+
+fn build_hf_setup(
+    path: &'static str,
+    specials: &'static [&'static str],
+) -> (Arc<dyn Tokenizer>, Vec<String>) {
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+        HuggingFaceTokenizer::from_file(path)
+            .unwrap_or_else(|error| panic!("load tokenizer {path}: {error}")),
+    );
+    let specials = specials.iter().map(|token| (*token).to_string()).collect();
+    (tokenizer, specials)
+}
+
+fn build_tinyllama() -> (Arc<dyn Tokenizer>, Vec<String>) {
+    build_hf_setup(TINYLLAMA_PATH, &["<s>", "</s>"])
+}
+
+fn build_llama31() -> (Arc<dyn Tokenizer>, Vec<String>) {
+    build_hf_setup(
+        LLAMA31_PATH,
+        &[
+            "<|begin_of_text|>",
+            "<|start_header_id|>",
+            "<|end_header_id|>",
+            "<|eot_id|>",
+        ],
+    )
+}
+
+fn build_deepseek() -> (Arc<dyn Tokenizer>, Vec<String>) {
+    build_hf_setup(
+        DEEPSEEK_PATH,
+        &[
+            "<｜begin▁of▁sentence｜>",
+            "<｜User｜>",
+            "<｜Assistant｜>",
+            "<｜end▁of▁sentence｜>",
+        ],
+    )
+}
+
+fn build_kimi_tiktoken() -> (Arc<dyn Tokenizer>, Vec<String>) {
+    let tokenizer = Arc::new(
+        TikTokenTokenizer::from_file_auto(TIKTOKEN_PATH)
+            .expect("load in-tree mock Kimi TikToken tokenizer"),
+    );
+    let specials = tokenizer.special_tokens().to_vec();
+    let tokenizer: Arc<dyn Tokenizer> = tokenizer;
+    (tokenizer, specials)
 }
 
 /// Identity: CHAT_TURNS entries are already in TinyLlama format.
@@ -136,43 +188,51 @@ fn render_deepseek(s: &str) -> String {
     out
 }
 
+/// Convert the canonical corpus into a ChatML-style Kimi prompt.
+fn render_kimi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 64);
+    let mut remaining = s;
+    while let Some(rest) = remaining.strip_prefix("<s>") {
+        let end = rest
+            .find("</s>")
+            .expect("CHAT_TURNS turn must end with </s>");
+        let turn = &rest[..end];
+        let (role, content) = turn.split_once('\n').unwrap_or((turn, ""));
+        out.push_str("<|im_start|>");
+        out.push_str(role);
+        out.push('\n');
+        out.push_str(content);
+        out.push_str("<|im_end|>");
+        remaining = &rest[end + "</s>".len()..];
+    }
+    out
+}
+
 const SETUPS: &[Setup] = &[
     Setup {
         name: "tinyllama (Llama-2 family, <s>/</s>)",
-        path: TINYLLAMA_PATH,
-        specials: &["<s>", "</s>"],
+        build: build_tinyllama,
         render: render_llama2,
     },
     Setup {
         name: "mock-llama-3.1 (Llama-3 family, <|begin_of_text|>/<|*_header_id|>/<|eot_id|>)",
-        path: LLAMA31_PATH,
-        specials: &[
-            "<|begin_of_text|>",
-            "<|start_header_id|>",
-            "<|end_header_id|>",
-            "<|eot_id|>",
-        ],
+        build: build_llama31,
         render: render_llama3,
     },
     Setup {
         name: "mock-deepseek-r1 (DeepSeek family, <｜begin▁of▁sentence｜>/<｜User｜>/<｜Assistant｜>/<｜end▁of▁sentence｜>)",
-        path: DEEPSEEK_PATH,
-        specials: &[
-            "<｜begin▁of▁sentence｜>",
-            "<｜User｜>",
-            "<｜Assistant｜>",
-            "<｜end▁of▁sentence｜>",
-        ],
+        build: build_deepseek,
         render: render_deepseek,
+    },
+    Setup {
+        name: "mock-kimi (TikToken, <|im_start|>/<|im_end|>)",
+        build: build_kimi_tiktoken,
+        render: render_kimi,
     },
 ];
 
 fn build_cached_setup(setup: &Setup) -> (Arc<dyn Tokenizer>, CachedTokenizer) {
-    let base = Arc::new(
-        HuggingFaceTokenizer::from_file(setup.path)
-            .unwrap_or_else(|e| panic!("load tokenizer {}: {e}", setup.path)),
-    );
-    let specials: Vec<String> = setup.specials.iter().map(|s| (*s).to_string()).collect();
+    let (base, specials) = (setup.build)();
     let cached = CachedTokenizer::new(base.clone(), specials, 50 * 1024 * 1024);
     (base, cached)
 }
@@ -317,10 +377,7 @@ fn cache_disabled_by_empty_specials_is_transparent() {
     // tokenizer. Output must still equal uncached encode. Tested per tokenizer family
     // because the relevant code path is the wrapper, not the tokenizer.
     for setup in SETUPS {
-        let base = Arc::new(
-            HuggingFaceTokenizer::from_file(setup.path)
-                .unwrap_or_else(|e| panic!("load tokenizer {}: {e}", setup.path)),
-        );
+        let (base, _specials) = (setup.build)();
         let cached = CachedTokenizer::new(base.clone(), Vec::new(), 4096);
         for (i, raw_turn) in CHAT_TURNS.iter().enumerate() {
             let turn = (setup.render)(raw_turn);
@@ -366,11 +423,7 @@ fn extend_on_hit_matches_uncached_across_growing_turns() {
     // (mock-llama-3.1's empty-BPE vocab surfaces any seg_a/seg_b split off-by-one).
     let turns = growing_chat_turns(12);
     for setup in SETUPS {
-        let base = Arc::new(
-            HuggingFaceTokenizer::from_file(setup.path)
-                .unwrap_or_else(|e| panic!("load tokenizer {}: {e}", setup.path)),
-        );
-        let specials: Vec<String> = setup.specials.iter().map(|s| (*s).to_string()).collect();
+        let (base, specials) = (setup.build)();
         let cached =
             CachedTokenizer::new(base.clone(), specials, 50 * 1024 * 1024).with_extend(true);
 
@@ -442,11 +495,7 @@ fn extend_on_partial_hit_adds_exactly_one_entry() {
     // the intermediate boundaries. Holds on every family.
     let turns = growing_chat_turns(6);
     for setup in SETUPS {
-        let base = Arc::new(
-            HuggingFaceTokenizer::from_file(setup.path)
-                .unwrap_or_else(|e| panic!("load tokenizer {}: {e}", setup.path)),
-        );
-        let specials: Vec<String> = setup.specials.iter().map(|s| (*s).to_string()).collect();
+        let (base, specials) = (setup.build)();
         let cached = CachedTokenizer::new(base, specials, 50 * 1024 * 1024).with_extend(true);
 
         // Turn 0: miss path populates the cache at every boundary.
@@ -589,11 +638,7 @@ fn extend_transparent_to_plaintext_tool_markup() {
         let bare = growing_tool_turns(8, false);
 
         let build = || {
-            let base = Arc::new(
-                HuggingFaceTokenizer::from_file(setup.path)
-                    .unwrap_or_else(|e| panic!("load tokenizer {}: {e}", setup.path)),
-            );
-            let specials: Vec<String> = setup.specials.iter().map(|s| (*s).to_string()).collect();
+            let (base, specials) = (setup.build)();
             let cached =
                 CachedTokenizer::new(base.clone(), specials, 50 * 1024 * 1024).with_extend(true);
             (base, cached)


### PR DESCRIPTION
## Summary

- preserve the exact special-token strings registered with `CoreBPE` and expose them through `TikTokenTokenizer::special_tokens()`
- exercise TikToken through the existing multi-turn prefix-cache correctness corpus and focused segmentation invariants
- document constructing `CachedTokenizer` from a TikToken tokenizer without duplicating token metadata

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-tokenizers --lib`
- `cargo test -p dynamo-tokenizers --test cache_correctness`
- `cargo test --workspace --all-targets --locked --exclude dynamo-conformance-fixtures-v2`
- `cargo test --workspace --doc --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo publish --workspace --dry-run --locked --allow-dirty`

The unfiltered all-targets workspace run was also attempted. It reached the conformance fixture setup, then failed before repository tests because the private `ai-dynamo/conformance-fixtures` Hugging Face dataset returned `401 Unauthorized` without an `HF_TOKEN`.
