### PR TITLE
chore(GUI): update conformance compare-bar labels, tab labels, and legend

### DIFF
--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -87,6 +87,9 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .cmprow.cmphd { padding-bottom: 3px; margin-bottom: 3px; border-bottom: 1px solid #e3e8ee; }
 .cmphd-ref, .cmphd-cmp { font-size: 9px; font-weight: 700; text-transform: uppercase;
   letter-spacing: 0.03em; color: #8a95a3; text-align: center; }
+/* "COMPARE WITH" is too wide for the 26px checkbox column, so let the header span
+   into the (empty) label column and left-align it over the checkboxes. */
+.cmphd-cmp { grid-column: 2 / 4; text-align: left; white-space: nowrap; padding-left: 3px; }
 .cmprow-ref, .cmprow-cmp { position: relative; display: flex; justify-content: center;
   align-items: center; margin: 0; cursor: pointer; }
 .cmprow input.cmp-on { margin: 0; cursor: pointer; }
@@ -102,9 +105,19 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
   text-overflow: ellipsis; padding-left: 4px; }
 .cmprow.is-ref { background: #eef4fc; }
 .cmprow.is-ref .cmprow-label { font-weight: 700; color: #174a86; }
+/* Mode word coding in candidate labels: (batch) maroon, (stream) NVIDIA green. */
+.cmprow-label .cand-batch { color: #800000; }
+.cmprow-label .cand-stream { color: #15803d; }
 /* The Reference's Compare box is checked + locked (can't be unchecked) — keep it
  * clearly visible (pressed), just slightly muted to read as locked. */
 .cmprow input.cmp-on:disabled { opacity: 0.55; }
+/* Overview (non-Detailed) cells show only leak color, which depends solely on the
+ * Reference — the Compare-with count is a Details-only marker. So hide the CMP
+ * column entirely in Overview and keep just the Reference picker (REF), collapsing
+ * the row to two tracks. Compare selections are preserved and reappear in Details. */
+body.view-overview .cmpctl .cmphd-cmp,
+body.view-overview .cmpctl .cmprow-cmp { display: none; }
+body.view-overview .cmpctl .cmprow { grid-template-columns: 26px 1fr; }
 /* Cells: compare coloring wins over the dormant parser-status rules (!important).
  * Numbers are not bold. */
 .cmp-marker { position: absolute; inset: 0; display: none; align-items: center;
@@ -151,8 +164,6 @@ body.view-details td.cell.cmp-donly .cmp-marker { color: #9aa1a9; }
 .view-overview .parity-option { display: none; }
 .view-overview .details-only { display: none; }
 .view-details .summary-only { display: none; }
-.parity-explainer { display: none; }
-.view-details.parity-mode .parity-explainer { display: block; }
 .summary-key { display: inline-block; width: 12px; height: 12px; border: 1px solid rgba(0,0,0,0.22); margin: 0 4px 0 10px; vertical-align: -2px; }
 .summary-key:first-of-type { margin-left: 0; }
 .summary-key.ok { background: #76b884; }
@@ -197,7 +208,7 @@ body.view-details td.cell.cmp-donly .cmp-marker { color: #9aa1a9; }
 /* Smaller-font parenthetical in tab labels, with "batch"/"stream" color-coded so the
    data axis and parser axis read at a glance. */
 .tab-button .tab-sub { font-size: 0.82em; font-weight: 400; }
-.tab-button .w-batch { color: #7c3aed; }
+.tab-button .w-batch { color: #800000; }
 .tab-button .w-stream { color: #15803d; }
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -166,7 +166,9 @@
       // green too. The marker count is the number of selected Compares that diverge;
       // with no comparable peer there is simply nothing to count (blank), not gray.
       const donly = avail.length === 0;
-      const txt = donly ? '' : (diffs === 0 ? '=' : String(diffs));
+      // Δ suffix marks the number as a count of diverging Compare-with parsers,
+      // e.g. "2Δ"; "=" (all agree) and a lone leak "↯" carry no count.
+      const txt = donly ? '' : (diffs === 0 ? '=' : String(diffs) + 'Δ');
       if (marker) { marker.textContent = (leak ? '↯' : '') + txt; }
       // Color = leak only: red = Reference leaks markup, green = clean.
       cell.classList.add(leak ? 'cmp-leak' : 'cmp-eq');

--- a/conformance/utils/src/conformance_table.html.j2
+++ b/conformance/utils/src/conformance_table.html.j2
@@ -99,16 +99,6 @@
   <p class="versions">{{ panel.captured_note|e }}</p>
 {% endif %}
 </div>
-<p class="legend details-only parity-explainer">
-{% if panel.parity_explainer_html is defined and panel.parity_explainer_html %}
-  {{ panel.parity_explainer_html|safe }}
-{% else %}
-  <strong>Conformance:</strong>
-  <span style="color:#0a7d2c">=</span> all available outputs match ·
-  <span style="color:#555">D<sub>RB</sub></span> (Dynamo Rust batch parser) / <span style="color:#555">V<sub>PB</sub></span> (vLLM Python batch parser) / <span style="color:#555">S<sub>RB</sub></span> (SGLang batch parser) names output that differs from the selected parser ·
-  multiple markers mean multiple peer outputs differ from the selected parser.
-{% endif %}
-</p>
 <p class="stats details-only">
   Stats: {{ panel.stats.families }} families × {{ panel.stats.sub_cases }} sub-cases
   = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -625,11 +625,11 @@ def _common_legend_html(
     return (
         "<p><strong>Legend:</strong></p>"
         '<ul class="marker-defs">'
-        '<li><span style="color:#0a7d2c"><strong>green</strong></span> = the selected <strong>Reference</strong> parser output is clean — no tool-call markup leaked into <code>normal_text</code>. A clean Reference is green whether or not any Compare parser is selected.</li>'
-        '<li><span style="color:#b00"><strong>red</strong> (↯)</span> = the Reference parser leaks tool-call markup into <code>normal_text</code>.</li>'
+        '<li><span style="color:#0a7d2c"><strong>green</strong></span> = the selected <strong>Reference</strong> parser output is clean — no structured markup (tool-call or reasoning) leaked into the visible <code>normal_text</code>. A clean Reference is green whether or not any Compare parser is selected.</li>'
+        '<li><span style="color:#b00"><strong>red</strong> (↯)</span> = the Reference parser leaks structured markup (tool-call or reasoning) into the visible <code>normal_text</code>.</li>'
         '<li><span style="color:#aaa"><strong>n/a</strong></span> = the selected Reference is not applicable for this case (for example the Dynamo v2 stream parser is not implemented for this family).</li>'
         '<li><span style="color:#8a6d3b">—</span> missing fixture coverage.</li>'
-        '<li>In the <strong>Detailed</strong> view the number on a cell = how many selected <strong>Compare</strong> parsers diverge from the Reference (<span style="color:#0a7d2c">=</span> means every selected Compare matches). A divergence with no <code>explanation:</code> yet is flagged <span style="color:#b00">?</span> (research needed); <span style="color:#b00">!</span> marks an engine that errors by design; <span style="color:#b00">✗</span> means the parser ran but failed to parse.</li>'
+        '<li>In the <strong>Detailed</strong> view the number on a cell (with a <span style="color:#8a6d3b">Δ</span> suffix, e.g. <span style="color:#8a6d3b">2Δ</span>) = how many selected <strong>Compare</strong> parsers diverge from the Reference (<span style="color:#0a7d2c">=</span> means every selected Compare matches). A divergence with no <code>explanation:</code> yet is flagged <span style="color:#b00">?</span> (research needed); <span style="color:#b00">!</span> marks an engine that errors by design; <span style="color:#b00">✗</span> means the parser ran but failed to parse.</li>'
         '<li><strong>v1</strong> = the stable batch parser crate (<code>parsers/v1/src/...</code>, <code>dynamo-parsers</code>); <strong>v2</strong> = the WIP streaming parser crate (<code>parsers/v2/src/...</code>, <code>dynamo-parsers-v2</code>).</li>'
         '<li><span class="parser-suffix">†</span> no vLLM Python peer parser for this family. &nbsp; <span class="parser-suffix">§</span> no SGLang peer parser for this family. &nbsp; <span class="parser-suffix">‡</span> Nemotron V3 (Ultra) reuses the qwen3_coder parser.</li>'
         "</ul>"
@@ -1898,6 +1898,21 @@ def _full_label(impl: str, version: object, mode: str) -> str:
     return f"{base}{ver} ({mode})"
 
 
+def _candidate_label_html(label: str) -> str:
+    """Escape a compare candidate label and color the trailing mode parenthetical:
+    `batch` maroon, `stream` NVIDIA green (matches the tab-label word coding). The
+    plain `label` stays around for tooltips; only the compare bar uses this HTML."""
+    esc = html_lib.escape(label)
+    m = re.search(r"\(([^)]*)\)\s*$", esc)
+    if not m:
+        return esc
+    s, e = m.span(1)
+    inner = m.group(1)
+    inner = inner.replace("batch", '<span class="cand-batch">batch</span>')
+    inner = inner.replace("stream", '<span class="cand-stream">stream</span>')
+    return esc[:s] + inner + esc[e:]
+
+
 def _dynamo_v2_version() -> str | None:
     """Version label for the Dynamo v2 stream parser, taken from the PUBLISHED fixture
     provenance (the v2-major `dynamo_rust-<ver>` dir, e.g. 0.1.11), NOT the live
@@ -2472,7 +2487,6 @@ def render_html_panel(
     }
     if comparison == "stream_vs_batch":
         panel["details_note_html"] = f"<p>{_stream_parity_explainer_html(parser_stream_context)}</p>"
-        panel["parity_explainer_html"] = ""
     return panel
 
 
@@ -2856,25 +2870,36 @@ def _rewrite_panel_paths(
 
 
 def _tab_label(
-    prefix: str, data: str, parser: str | None, v2: bool, data_word: bool = True
+    prefix: str,
+    data: str,
+    parser: str | None,
+    v2: bool,
+    data_word: bool = True,
+    on_parser: bool = True,
 ) -> tuple[str, str]:
     """Build a tab label as `<prefix> vN (<data> data on <parser>-parser)`.
     Returns (plain, html); the html form wraps the parenthetical in a smaller-font
     span (`tab-sub`) and color-codes the words "batch"/"stream" (`w-batch`/`w-stream`)
     so the two axes are distinguishable. `data` is "batch" or "stream". `parser` is
     "batch"/"stream", or None for a bare "parser" (reasoning has a single parser, not
-    a batch/stream split). `data_word=False` drops the literal " data" word, e.g.
-    reasoning renders `(batch on parser)`."""
+    a batch/stream split). `data_word=False` drops the literal " data" word.
+    `on_parser=False` drops the `on <parser>-parser` clause entirely, so reasoning
+    renders `(batch data)` — the parser axis is meaningless there (one parser)."""
     version = "v2" if v2 else "v1"
     dword = " data" if data_word else ""
 
     def _w(word: str) -> str:
         return f'<span class="w-{word}">{word}</span>'
 
-    parser_plain = f"{parser}-parser" if parser else "parser"
-    parser_html = f"{_w(parser)}-parser" if parser else "parser"
-    plain = f"{prefix} {version} ({data}{dword} on {parser_plain})"
-    sub_html = f"({_w(data)}{dword} on {parser_html})"
+    if on_parser:
+        parser_plain = f"{parser}-parser" if parser else "parser"
+        parser_html = f"{_w(parser)}-parser" if parser else "parser"
+        on_plain = f" on {parser_plain}"
+        on_html = f" on {parser_html}"
+    else:
+        on_plain = on_html = ""
+    plain = f"{prefix} {version} ({data}{dword}{on_plain})"
+    sub_html = f"({_w(data)}{dword}{on_html})"
     return plain, f'{prefix} {version} <span class="tab-sub">{sub_html}</span>'
 
 
@@ -2900,33 +2925,15 @@ def _tab_button(panel: dict[str, Any]) -> str:
     )
 
 
-def _compare_legend_html() -> str:
-    return (
-        "<p><strong>Legend — compare mode:</strong> pick one <strong>Base</strong> and any number of "
-        "<strong>Compare</strong> candidates (parser + version); each cell counts how many selected "
-        "candidates produce different output than Base.</p>"
-        '<ul class="marker-defs">'
-        '<li><span style="color:#0a7d2c">=</span> every selected candidate matches Base.</li>'
-        '<li><span style="color:#8a6d3b">N</span> N selected candidates differ from Base.</li>'
-        '<li><span style="color:#8b949e">·</span> nothing available to compare (Base-only / peers not captured).</li>'
-        '<li><span style="color:#b00">↯</span> Base leaks tool call markup into <code>normal_text</code>.</li>'
-        '<li><span style="color:#aaa">n/a</span> Base has no captured output for this case.</li>'
-        "<li>Unavailable candidates never count toward the number but still appear in the hover tooltip, "
-        "which shows Base plus each selected candidate's output.</li>"
-        "</ul>"
-    )
-
-
 def _apply_common_legend(panels: list[dict[str, Any]], hrefs: dict[str, str]) -> None:
     legend_html = _common_legend_html(
         _peer_version_items(_peer_versions()),
         hrefs["pyproject_stub"],
     )
-    compare_legend = _compare_legend_html()
+    # One legend for every tab: the compare model (Reference vs Compare) is identical
+    # across tabs, so they all get the same rich legend.
     for panel in panels:
-        panel["legend_html"] = (
-            compare_legend if panel.get("id") == "tab-toolcalling-batch" else legend_html
-        )
+        panel["legend_html"] = legend_html
 
 
 def _combined_toolcalling_panels(hrefs: dict[str, str]) -> list[dict[str, Any]]:
@@ -3032,8 +3039,9 @@ def _combined_reasoning_panels(hrefs: dict[str, str]) -> list[dict[str, Any]]:
         )
         # Reasoning has a single parser (not a batch/stream split), so the parser
         # axis renders as a bare "parser"; only the data axis varies.
-        _r_label, _r_label_html = _tab_label("Reasoning", mode, None, False, data_word=False)
-        mode_word = "stream" if mode == "stream" else "batch"
+        _r_label, _r_label_html = _tab_label(
+            "Reasoning", mode, None, False, on_parser=False
+        )
         panel.update(
             {
                 "id": f"tab-reasoning-{mode}",
@@ -3051,15 +3059,6 @@ def _combined_reasoning_panels(hrefs: dict[str, str]) -> list[dict[str, Any]]:
                 "case_docs_label": "lib/parsers/REASONING_CASES.md",
                 "case_prefix": "REASONING.",
                 "case_section_id": f"reasoning-{mode}",
-                "parity_explainer_html": (
-                    "<strong>Conformance:</strong> "
-                    '<span style="color:#0a7d2c">=</span> all available reasoning outputs match · '
-                    f'<span style="color:#555">D</span> (Dynamo Rust {mode_word} parser) / '
-                    f'<span style="color:#555">V</span> (vLLM Python {mode_word} parser) / '
-                    f'<span style="color:#555">S</span> (SGLang {mode_word} parser) names output '
-                    "that differs from the selected parser · multiple markers mean multiple peer "
-                    "outputs differ from the selected parser."
-                ),
                 "parser_options": ("dynamo_rust", "vllm_python", "sglang_python"),
             }
         )
@@ -3084,6 +3083,10 @@ def render_combined_html(
         *_combined_reasoning_panels(hrefs),
     ]
     panels[0]["active"] = True
+    # Color the trailing (batch)/(stream) mode word in every compare candidate label.
+    for panel in panels:
+        for cand in panel.get("candidates", []):
+            cand["label_html"] = _candidate_label_html(cand["label"])
 
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")

--- a/conformance/utils/tests/parity/_compare_bar.html.j2
+++ b/conformance/utils/tests/parity/_compare_bar.html.j2
@@ -6,12 +6,12 @@
 <div class="cmpctl" role="group" aria-label="Pick one Reference parser (radio) and any number of Compare-with parsers (checkbox)">
   {% for grp, prefix in [('Dynamo', 'dynamo'), ('vLLM', 'vllm'), ('SGLang', 'sglang')] %}
   <div class="cmpcol" data-engine="{{ grp }}">
-    <div class="cmprow cmphd"><span class="cmphd-ref" title="Reference (pick one)">ref</span><span class="cmphd-cmp" title="Compare-with">cmp</span><span></span></div>
+    <div class="cmprow cmphd"><span class="cmphd-ref" title="Reference (pick one)">ref</span><span class="cmphd-cmp" title="Compare-with">compare with</span></div>
     {% for c in panel.candidates %}{% if c.key.startswith(prefix) %}
     <div class="cmprow{% if c.default_bucket == 'A' %} is-ref{% endif %}">
       <label class="cmprow-ref" title="Set as the Reference parser"><input type="radio" class="cmp-ref" name="ref_{{ panel.id }}" value="{{ c.key }}"{% if c.default_bucket == 'A' %} checked{% endif %}><span class="star" aria-hidden="true">★</span></label>
       <label class="cmprow-cmp" title="Include in Compare-with"><input type="checkbox" class="cmp-on" value="{{ c.key }}"{% if c.default_bucket in ['A', 'B'] %} checked{% endif %}{% if c.default_bucket == 'A' %} disabled{% endif %}></label>
-      <span class="cmprow-label" data-cand="{{ c.key }}">{{ c.label|e }}</span>
+      <span class="cmprow-label" data-cand="{{ c.key }}">{% if c.label_html is defined and c.label_html %}{{ c.label_html|safe }}{% else %}{{ c.label|e }}{% endif %}</span>
     </div>
     {% endif %}{% endfor %}
   </div>

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -140,3 +140,43 @@ def test_compare_shows_one_marker_per_cell(driver):
         f"{result['overlap']} cell(s) still show a legacy marker alongside the compare marker"
     )
     assert result["cmpShown"] > 0, "no compare marker is visible in Details view"
+
+
+def test_overview_hides_compare_column(driver):
+    """In Overview (Detailed off) the compare bar shows only the Reference picker;
+    the CMP checkboxes + header are hidden, because an overview cell's color is
+    leak-only (depends on the Reference, not the Compares). Turning Detailed on
+    reveals the CMP column again — the selections themselves are preserved."""
+    driver.execute_script(
+        "document.querySelector('.tab-button[data-tab-target=\"tab-toolcalling-batch\"]').click();"
+    )
+    time.sleep(0.2)
+
+    def set_detailed(on):
+        driver.execute_script(
+            "const v=document.querySelector('[data-view-detailed]');"
+            "if(v && v.checked!==arguments[0]){v.checked=arguments[0]; v.dispatchEvent(new Event('change'));}",
+            on,
+        )
+        time.sleep(0.2)
+
+    def cmp_box_visible():
+        # offsetParent is null when the element (or an ancestor) is display:none.
+        return driver.execute_script(
+            "const p=document.querySelector('.tab-panel.active .cmpctl');"
+            "const box=p && p.querySelector('.cmprow:not(.cmphd) .cmprow-cmp');"
+            "return box ? (box.offsetParent !== null) : null;"
+        )
+
+    def ref_box_visible():
+        return driver.execute_script(
+            "const p=document.querySelector('.tab-panel.active .cmpctl');"
+            "const r=p && p.querySelector('.cmprow:not(.cmphd) .cmprow-ref');"
+            "return r ? (r.offsetParent !== null) : null;"
+        )
+
+    set_detailed(False)
+    assert cmp_box_visible() is False, "CMP column should be hidden in Overview"
+    assert ref_box_visible() is True, "REF picker must still show in Overview"
+    set_detailed(True)
+    assert cmp_box_visible() is True, "CMP column should reappear in Details"

--- a/conformance/utils/tests/test_chart_invariants.py
+++ b/conformance/utils/tests/test_chart_invariants.py
@@ -86,8 +86,13 @@ def _panel(html: str, panel_id: str, all_ids: tuple[str, ...]) -> str:
 
 
 def _candidates(segment: str) -> list[str]:
-    """Compare-bar candidate labels (chips) within a panel segment."""
-    return re.findall(r'data-cand="[^"]*"[^>]*>([^<]+)</', segment)
+    """Compare-bar candidate labels (chips) within a panel segment. A label may carry
+    one level of inline markup (the colored (batch)/(stream) mode word), so capture the
+    whole label span — allowing a nested <span> — and strip tags for the visible text."""
+    raw = re.findall(
+        r'data-cand="[^"]*"[^>]*>((?:[^<]|<span[^>]*>[^<]*</span>)*)</span>', segment
+    )
+    return [re.sub(r"<[^>]+>", "", r).strip() for r in raw]
 
 
 # A candidate label is "<Engine> <Runtime> <version> (<mode>)". The version token

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -701,6 +701,7 @@ def test_template_has_compare_picker_and_reasoning_candidates() -> None:
     assert 'data-engine="Dynamo"' in partial or "'Dynamo'" in partial
     assert 'class="cmp-ref"' in partial  # Reference radio
     assert 'class="cmp-on"' in partial  # Compare-with checkbox
+    assert ">compare with<" in partial.lower()
     assert "data-cmp-base" not in partial  # old radio-based control is gone
     # The compare JS drives cells from each cell's data-cmp payload.
     js = (SRC / "assets" / "conformance.js").read_text()
@@ -720,8 +721,8 @@ def test_template_has_compare_picker_and_reasoning_candidates() -> None:
     }
     panels = g._combined_reasoning_panels(hrefs)
     assert {panel["id"] for panel in panels} == {"tab-reasoning-batch", "tab-reasoning-stream"}
+    # No vLLM Rust for reasoning (parser_options already excludes it).
     assert all(panel["parser_options"] == ("dynamo_rust", "vllm_python", "sglang_python") for panel in panels)
-    assert all("vLLM Rust" not in panel["parity_explainer_html"] for panel in panels)
 
 
 def test_template_overview_cells_do_not_expand_from_hidden_marker_text() -> None:
@@ -772,9 +773,14 @@ def test_tab_labels_put_version_after_family() -> None:
     assert html.startswith('TC v2 <span class="tab-sub">')
     assert "(v2)" not in plain
 
-    plain, html = g._tab_label("Reasoning", "batch", None, False, data_word=False)
-    assert plain == "Reasoning v1 (batch on parser)"
+    # Reasoning has a single parser, so its tab drops the "on <parser>-parser" clause
+    # and shows the data word only: "(batch data)" / "(stream data)".
+    plain, html = g._tab_label("Reasoning", "batch", None, False, on_parser=False)
+    assert plain == "Reasoning v1 (batch data)"
     assert html.startswith('Reasoning v1 <span class="tab-sub">')
+    assert "on parser" not in plain and "on parser" not in html
+    stream_plain, _ = g._tab_label("Reasoning", "stream", None, False, on_parser=False)
+    assert stream_plain == "Reasoning v1 (stream data)"
 
 
 def test_common_legend_defines_v1_v2() -> None:
@@ -935,3 +941,60 @@ def test_impl_spec_is_single_identity_source() -> None:
     # vLLM Rust is stream-only: no `V_rb` batch parser option exists anywhere.
     assert "vllm_rust" not in g.BATCH_IMPL_KEYS
     assert "vllm_rust" in g.STREAM_IMPL_KEYS
+
+
+def test_candidate_label_html_colors_mode_word() -> None:
+    """Compare candidate labels color the trailing mode word: (batch) maroon,
+    (stream) NVIDIA green — via cand-batch / cand-stream spans, still HTML-escaped."""
+    assert (
+        g._candidate_label_html("Dynamo v1 Rust 3.0.0 (batch)")
+        == 'Dynamo v1 Rust 3.0.0 (<span class="cand-batch">batch</span>)'
+    )
+    assert (
+        g._candidate_label_html("vLLM Rust 0.23.0 (stream)")
+        == 'vLLM Rust 0.23.0 (<span class="cand-stream">stream</span>)'
+    )
+    # Only the trailing mode parenthetical is recolored; escaping still applies.
+    assert g._candidate_label_html("A & B (batch)").startswith("A &amp; B (")
+    # No mode parenthetical -> unchanged (but escaped).
+    assert g._candidate_label_html("plain label") == "plain label"
+
+
+def test_compare_legend_documents_delta_and_drops_stale_parity_explainer() -> None:
+    """The single compare-model legend documents the Δ divergence count and no longer
+    describes the removed per-parser "names output that differs" markers; and no panel
+    carries the stale parity_explainer_html field."""
+    legend = g._common_legend_html()
+    assert "Δ" in legend, "legend should document the Δ divergence count"
+    assert "names output that differs" not in legend, "stale per-parser marker text gone"
+    hrefs = {
+        k: "#"
+        for k in (
+            "reasoning_fixtures", "reasoning_cases", "reasoning_src", "toolcalling_src",
+            "streaming_harmony_src", "streaming_src", "toolcalling_streaming_cases",
+            "toolcalling_cases", "pyproject_stub",
+        )
+    }
+    # _apply_common_legend gives every panel the same rich legend.
+    panels = [{"id": "tab-a"}, {"id": "tab-b"}, {"id": "tab-toolcalling-batch"}]
+    g._apply_common_legend(panels, hrefs)
+    assert len({p["legend_html"] for p in panels}) == 1, "all tabs share one legend"
+    # Reasoning panels no longer carry the stale per-parser parity-explainer.
+    assert not any(
+        "parity_explainer_html" in p for p in g._combined_reasoning_panels(hrefs)
+    )
+
+
+def test_compare_bar_renders_when_candidate_lacks_label_html() -> None:
+    """The compare bar is shared with the v1 parity page, whose candidates carry no
+    label_html. Under StrictUndefined the template must guard the optional field and
+    fall back to the plain label instead of raising (regression: PR #105)."""
+    bar = (UTILS / "tests" / "parity" / "_compare_bar.html.j2").read_text(encoding="utf-8")
+    env = g.Environment(undefined=g.StrictUndefined, autoescape=True)
+    html = env.from_string(bar).render(
+        panel={
+            "id": "p",
+            "candidates": [{"key": "dynamo_x", "label": "X (batch)", "default_bucket": "A"}],
+        }
+    )
+    assert "cmprow-label" in html and "X (batch)" in html


### PR DESCRIPTION
#### Overview:

GUI polish for the v2 conformance table's compare bar, cell markers, tabs, and legend — all presentation-only, no data changes.

#### Details:

- **Overview shows only REF**: in Overview a cell's color is leak-only (depends solely on the Reference), so hide the Compare-with checkboxes and keep just the Reference picker. Selections are preserved and reappear in Detailed.
- **`cmp` → `COMPARE WITH`**: the compare-bar header now spells it out.
- **Consistent mode-word colors**: `batch` = maroon, `stream` = the tab's dark green — identical in the tabs and the compare bar.
- **Δ divergence count**: cells show the diff count with a `Δ` suffix (`2Δ`).
- **Reasoning tabs**: `(batch on parser)` → `(batch data)`, `(stream on parser)` → `(stream data)`.
- **Legend**: every tab now shares one compare-model legend (which documents the `Δ` count); removed the stale per-parser "parity-explainer" block (it described `D_RB`/`V_PB` markers for a Conformance mode that no longer exists in the UI), plus its dead CSS and panel fields.

#### Verification:

`python3 -m pytest conformance/utils/tests/` — Overview REF-only + one-marker browser tests and the tab-label / candidate-label / legend unit tests pass; a rendered `CONFORMANCE_v2` confirms all of the above.

#### Related Issues:

[DIS-2310](https://linear.app/nvidia/issue/DIS-2310)

#### Where should the reviewer start?

`conformance/utils/src/generate_conformance_table.py`, then `conformance/utils/src/assets/conformance.css`

/coderabbit profile chill
