### PR TITLE
fix: Add minimax m2 reasoning parser

### DIFF
--- a/parsers/v1/src/reasoning/base_parser.rs
+++ b/parsers/v1/src/reasoning/base_parser.rs
@@ -53,6 +53,22 @@ fn overlap(s: &str, delim: &str) -> usize {
     0
 }
 
+fn earliest_marker_offset(s: &str, markers: &[String]) -> Option<usize> {
+    markers
+        .iter()
+        .filter(|marker| !marker.is_empty())
+        .filter_map(|marker| s.find(marker))
+        .min()
+}
+
+fn max_marker_overlap(s: &str, markers: &[String]) -> usize {
+    markers
+        .iter()
+        .map(|marker| overlap(s, marker))
+        .max()
+        .unwrap_or(0)
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct BasicReasoningParser {
     think_start_token: String,
@@ -70,10 +86,10 @@ pub struct BasicReasoningParser {
     /// ends for every delimiter pair already; this flag only gates the
     /// streaming path so existing `<think>` stray-close stripping is preserved.
     recover_dangling_end: bool,
-    /// Optional marker that force-exits reasoning mode when encountered inside a
+    /// Optional markers that force-exit reasoning mode when encountered inside a
     /// reasoning block (e.g. Kimi-K2/K2.5 models sometimes emit
     /// `<|tool_calls_section_begin|>` without first closing `</think>`).
-    tool_start_token: Option<String>,
+    tool_start_tokens: Vec<String>,
 }
 
 impl BasicReasoningParser {
@@ -91,14 +107,17 @@ impl BasicReasoningParser {
             _buffer: String::new(),
             stripped_think_start: false,
             recover_dangling_end: false,
-            tool_start_token: None,
+            tool_start_tokens: Vec::new(),
         }
     }
 
     /// Enables force-exit from reasoning when `token` appears inside an open reasoning
     /// block.
     pub fn with_tool_start_token(mut self, token: impl Into<String>) -> Self {
-        self.tool_start_token = Some(token.into());
+        let token = token.into();
+        if !token.is_empty() {
+            self.tool_start_tokens.push(token);
+        }
         self
     }
 
@@ -148,10 +167,7 @@ impl ReasoningParser for BasicReasoningParser {
 
         // If force_reasoning and no start tag, no end tag, and no tool-start marker,
         // treat entire text as reasoning.
-        let has_tool_start = self
-            .tool_start_token
-            .as_deref()
-            .is_some_and(|tok| text.contains(tok));
+        let has_tool_start = earliest_marker_offset(text, &self.tool_start_tokens).is_some();
         if self._in_reasoning
             && !has_think_tag
             && !text.contains(&self.think_end_token)
@@ -188,10 +204,7 @@ impl ReasoningParser for BasicReasoningParser {
                 // Look for the earliest reasoning exit point: either </think> or the
                 // optional tool_start_token (force-exit case).
                 let end_offset = text[cursor..].find(&self.think_end_token);
-                let tool_offset = self
-                    .tool_start_token
-                    .as_deref()
-                    .and_then(|tok| text[cursor..].find(tok));
+                let tool_offset = earliest_marker_offset(&text[cursor..], &self.tool_start_tokens);
 
                 match (end_offset, tool_offset) {
                     (Some(e), Some(t)) if t < e => {
@@ -316,10 +329,7 @@ impl ReasoningParser for BasicReasoningParser {
 
             if self._in_reasoning {
                 let end_idx = current_text.find(self.think_end_token.as_str());
-                let tool_idx = self
-                    .tool_start_token
-                    .as_deref()
-                    .and_then(|tok| current_text.find(tok));
+                let tool_idx = earliest_marker_offset(&current_text, &self.tool_start_tokens);
 
                 // Prefer whichever marker appears first. If only one is present, use it.
                 let force_exit_idx = match (end_idx, tool_idx) {
@@ -352,11 +362,7 @@ impl ReasoningParser for BasicReasoningParser {
                     // force-exit marker isn't split into reasoning text.
                     if self.stream_reasoning {
                         let ol_end = overlap(&current_text, &self.think_end_token);
-                        let ol_tool = self
-                            .tool_start_token
-                            .as_deref()
-                            .map(|tok| overlap(&current_text, tok))
-                            .unwrap_or(0);
+                        let ol_tool = max_marker_overlap(&current_text, &self.tool_start_tokens);
                         let ol = ol_end.max(ol_tool);
                         if ol >= 2 {
                             let safe_end = current_text.len() - ol;

--- a/parsers/v1/src/reasoning/mod.rs
+++ b/parsers/v1/src/reasoning/mod.rs
@@ -69,6 +69,7 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
             "minimax_append_think",
             ReasoningParserType::MiniMaxAppendThink,
         );
+        map.insert("minimax_m2", ReasoningParserType::MiniMaxM2);
         // MiniMax M3 thinking blocks use `<mm:think>...</mm:think>`. The chat
         // template pre-fills the opener, so the completion typically emits only
         // the closing marker; dangling-end recovery handles that.
@@ -172,6 +173,9 @@ pub enum ReasoningParserType {
     Mistral,
     Granite,
     MiniMaxAppendThink,
+    /// MiniMax M2 emits reasoning from token one and may transition directly
+    /// into its XML tool-call envelope without a closing reasoning marker.
+    MiniMaxM2,
     /// MiniMax M3 thinking models. `<mm:think>...</mm:think>` delimiters with
     /// streaming dangling-end recovery (the chat template pre-fills the opener).
     MiniMaxM3,
@@ -282,6 +286,12 @@ impl ReasoningParserType {
             ReasoningParserType::MiniMaxAppendThink => ReasoningParserWrapper {
                 parser: Box::new(MiniMaxAppendThinkParser::new()),
             },
+            ReasoningParserType::MiniMaxM2 => ReasoningParserWrapper {
+                parser: Box::new(
+                    BasicReasoningParser::new("<think>".into(), "</think>".into(), true, true)
+                        .with_tool_start_token("<minimax:tool_call>"),
+                ),
+            },
             ReasoningParserType::MiniMaxM3 => ReasoningParserWrapper {
                 parser: Box::new(
                     BasicReasoningParser::new(
@@ -349,6 +359,7 @@ mod tests {
             "nemotron_v3",
             "glm45",
             "minimax_append_think",
+            "minimax_m2",
             "minimax_m3",
             "minimax-m3",
             "gemma4",
@@ -357,6 +368,32 @@ mod tests {
         for parser in available_parsers {
             assert!(parsers.contains(&parser));
         }
+    }
+
+    #[test] // MiniMax M2
+    fn test_minimax_m2_force_reasoning_and_tool_transition() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m2");
+        let result = parser.detect_and_parse_reasoning(
+            "I should call weather.</think><minimax:tool_call><invoke name=\"get_weather\"></invoke></minimax:tool_call>",
+            &[],
+        );
+
+        assert_eq!(result.reasoning_text, "I should call weather.");
+        assert_eq!(
+            result.normal_text,
+            "<minimax:tool_call><invoke name=\"get_weather\"></invoke></minimax:tool_call>"
+        );
+    }
+
+    #[test] // MiniMax M2
+    fn test_minimax_m2_tool_start_exits_force_reasoning() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m2");
+        let tool_call =
+            "<minimax:tool_call><invoke name=\"get_weather\"></invoke></minimax:tool_call>";
+        let result = parser.detect_and_parse_reasoning(tool_call, &[]);
+
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, tool_call);
     }
 
     #[test] // MiniMax M3

--- a/parsers/v1/src/reasoning/mod.rs
+++ b/parsers/v1/src/reasoning/mod.rs
@@ -289,7 +289,8 @@ impl ReasoningParserType {
             ReasoningParserType::MiniMaxM2 => ReasoningParserWrapper {
                 parser: Box::new(
                     BasicReasoningParser::new("<think>".into(), "</think>".into(), true, true)
-                        .with_tool_start_token("<minimax:tool_call>"),
+                        .with_tool_start_token("<minimax:tool_call>")
+                        .with_tool_start_token("<invoke name="),
                 ),
             },
             ReasoningParserType::MiniMaxM3 => ReasoningParserWrapper {
@@ -394,6 +395,39 @@ mod tests {
 
         assert_eq!(result.reasoning_text, "");
         assert_eq!(result.normal_text, tool_call);
+    }
+
+    #[test] // MiniMax M2
+    fn test_minimax_m2_bare_invoke_exits_force_reasoning() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m2");
+        let tool_call =
+            "<invoke name=\"get_weather\"><parameter name=\"city\">NYC</parameter></invoke>";
+        let result =
+            parser.detect_and_parse_reasoning(&format!("I should call weather.{tool_call}"), &[]);
+
+        assert_eq!(result.reasoning_text, "I should call weather.");
+        assert_eq!(result.normal_text, tool_call);
+    }
+
+    #[test] // MiniMax M2
+    fn test_minimax_m2_bare_invoke_streaming_exits_force_reasoning() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("minimax_m2");
+
+        let r1 = parser.parse_reasoning_streaming_incremental("I should call ", &[]);
+        assert_eq!(r1.reasoning_text, "I should call ");
+        assert_eq!(r1.normal_text, "");
+
+        let r2 = parser.parse_reasoning_streaming_incremental("weather.<invoke na", &[]);
+        assert_eq!(r2.reasoning_text, "weather.");
+        assert_eq!(r2.normal_text, "");
+
+        let tail = "me=\"get_weather\"><parameter name=\"city\">NYC</parameter></invoke>";
+        let r3 = parser.parse_reasoning_streaming_incremental(tail, &[]);
+        assert_eq!(r3.reasoning_text, "");
+        assert_eq!(
+            r3.normal_text,
+            "<invoke name=\"get_weather\"><parameter name=\"city\">NYC</parameter></invoke>"
+        );
     }
 
     #[test] // MiniMax M3


### PR DESCRIPTION
## Summary

Adds `minimax_m2` as a named reasoning parser in `dynamo-parsers`.

## Why

MiniMax M2 can begin a response in reasoning mode and then transition directly
into its XML tool-call envelope. The existing legacy parser,
`minimax_append_think`, assumes implicit reasoning but does not treat
`<minimax:tool_call>` as a tool boundary.

That is not sufficient for forced or named tool-call flows: the reasoning
parser must stop consuming text as soon as the MiniMax tool envelope begins so
the existing `minimax_m2` tool-call parser can extract the structured call.
This PR adds the missing named reasoning parser configuration without adding a
new parser implementation.

This is a small registry/config change, not a new parser implementation. MiniMax
M2 reasoning fits the existing `BasicReasoningParser`:

```text
start marker: <think>
end marker:   </think>
force mode:   true
tool escape:  <minimax:tool_call>
```

The tool escape matters because MiniMax M2 can begin in reasoning mode and then
transition directly into its XML tool-call envelope. When the tool envelope
starts, the reasoning parser must stop consuming text so the existing
`minimax_m2` tool-call parser can extract the structured call.

Why not `minimax_append_think`:

`minimax_append_think` is the legacy MiniMax M2 pass-through parser. It assumes
reasoning starts implicitly, but it does not model the MiniMax XML tool-call
boundary as a reasoning exit. In forced/named tool-call flows, the parser can
keep consuming the generated tool-call payload as reasoning instead of handing
it to the tool-call parser.

`minimax_m2` fixes this by using the force-reasoning `BasicReasoningParser`
configuration and adding `<minimax:tool_call>` as the tool-start escape marker.

## Changes

- Registers `minimax_m2` in `parsers/v1/src/reasoning/mod.rs`.
- Adds `ReasoningParserType::MiniMaxM2`.
- Configures it with `BasicReasoningParser` plus
  `<minimax:tool_call>` as the tool-start escape marker.
- Adds two focused tests:
  - reasoning followed by `</think>` and a MiniMax XML tool call
  - direct MiniMax XML tool call with no reasoning text

No new parser file is needed because the grammar is covered by the existing
basic reasoning parser configuration.

## Validation

```bash
cargo fmt --all
cargo test -p dynamo-parsers reasoning::tests::test_minimax_m2 -- --nocapture
```

Result:

```text
2 passed
```
