### PR TITLE
fix(GUI): conformance popup candidate chart + compare fixes (UI only)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -11,6 +11,12 @@ Parser conformance fixtures, fixture-based Rust tests, and HTML renderers for fr
 
 Parser v1/v2 terminology, migration steps, fixture ownership, and temporary sync rules are documented in [`../docs/PARSERS-V2-MIGRATION-PLAN.md`](../docs/PARSERS-V2-MIGRATION-PLAN.md). New streaming parser authors should also read [`../parsers/v2/README.md`](../parsers/v2/README.md); it explains the vLLM-shaped Rust parser contract, the v2 fixture schema, and the exact `conformance/toolcalling/*` files to add. This README covers conformance layout, render outputs, and test commands.
 
+## Parser paths and modes (universal convention)
+
+- **Dynamo v1** = the batch parser, used two ways: **batch** (the complete text parsed in one call) and **jail+batch** (streaming input is buffered — "jailed" — until a call completes, then batch-parsed and emitted all at once). The jail never streams a call's name/arguments incrementally; only text outside the jail passes through as it arrives.
+- **Dynamo v2** = the **streaming** parser (primary mode): emits text and tool-call deltas per chunk, as input arrives. It can also take batch input (the whole text fed as one chunk) — the `batch-on-stream` rows.
+- In the rendered tables, the TC (stream) tab's **default Reference is Dynamo v1 (jail+batch)** — the one stream path with coverage on every family — so every row shows data by default. Star **Dynamo v2** as the Reference to see v2's streaming coverage; families v2 doesn't implement yet gray out as "not implemented".
+
 ## Layout
 
 ```
@@ -20,7 +26,7 @@ conformance/
 └── utils/                                         # render, check, and record helpers
 ```
 
-Fixture YAMLs are NOT in the repo. They live on HuggingFace (`ai-dynamo/conformance-fixtures`, public) and are downloaded automatically on first use. HF snapshot layout:
+Fixture YAMLs are NOT in the repo. They live on HuggingFace (`ai-dynamo/conformance-fixtures`, private — set a read-capable `HF_TOKEN`) and are downloaded automatically on first use. HF snapshot layout:
 
 ```
 toolcalling/fixtures-batch-v1/<family>/           # v1 tool-calling batch cases

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -15,6 +15,7 @@ Parser v1/v2 terminology, migration steps, fixture ownership, and temporary sync
 
 - **Dynamo v1** = the batch parser, used two ways: **batch** (the complete text parsed in one call) and **jail+batch** (streaming input is buffered — "jailed" — until a call completes, then batch-parsed and emitted all at once). The jail never streams a call's name/arguments incrementally; only text outside the jail passes through as it arrives.
 - **Dynamo v2** = the **streaming** parser (primary mode): emits text and tool-call deltas per chunk, as input arrives. It can also take batch input (the whole text fed as one chunk) — the `batch-on-stream` rows.
+- **Per-chunk cells show WHEN output reaches the consumer.** Streaming parsers emit whenever something is parseable, so their cells carry deltas at real chunk positions. The v1 jail bursts at end-of-call — its captures record emission order, not per-chunk timing — so its per-chunk cells stay `—` with a "(bursts at end of call; per-chunk timing not recorded)" header note, and its output appears only in the `assembled` row.
 - In the rendered tables, the TC (stream) tab's **default Reference is Dynamo v1 (jail+batch)** — the one stream path with coverage on every family — so every row shows data by default. Star **Dynamo v2** as the Reference to see v2's streaming coverage; families v2 doesn't implement yet gray out as "not implemented".
 
 ## Layout

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -76,9 +76,11 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
  * Reference star (acts as a radio, one across all columns) + a Compare checkbox
  * (any number) + the label; the ref/cmp header labels sit directly over the two
  * control columns. */
-.cmpctl { display: flex; align-items: stretch; margin: 16px 0 10px;
+.cmpctl { display: inline-flex; align-items: stretch; margin: 16px 0 10px; max-width: 100%;
   border: 1px solid #d0d7de; background: #f8fafc; border-radius: 6px; padding: 5px 0; }
-.cmpcol { flex: 1 1 0; min-width: 0; padding: 0 12px; }
+/* Each engine column shrink-wraps to its longest label — no full-width stretch and
+ * no dead space trailing the checkbox+label rows. */
+.cmpcol { flex: 0 0 auto; min-width: 0; padding: 0 12px; }
 .cmpcol + .cmpcol { border-left: 1px solid #dde3ea; }
 /* header + data rows share the same grid so ref/cmp headers align over the star
  * and checkbox columns. */
@@ -395,3 +397,14 @@ body.view-details .transpose-table td.cell > a { position: absolute; inset: 0; }
 /* Column-header note for candidates whose capture has no per-chunk timing (e.g. the
  * v1 jail bursts at end-of-call); their per-chunk cells stay em-dashes. */
 .ttip .ttip-note { color: #9aa4b2; font-weight: 400; font-size: 11px; white-space: normal; }
+
+/* Fresh-load state: the server-rendered pinned colors are NOT the compare model the
+ * page settles on — showing them first reads as a false green that then flips.
+ * Until the first applyCtl pass, cells render neutral and a loading note shows;
+ * conformance.js removes body.cmp-loading when the compare model has been applied. */
+body.cmp-loading td.cell { background: #eef0f3 !important; }
+body.cmp-loading td.cell .cmp-marker, body.cmp-loading td.cell .cell-marker { visibility: hidden; }
+.cmp-loading-note { display: none; }
+body.cmp-loading .cmp-loading-note { display: block; position: fixed; top: 8px; right: 12px;
+  background: #fff7e0; border: 1px solid #e5c765; color: #7a5d00; padding: 4px 10px;
+  border-radius: 4px; font: 12px ui-monospace, monospace; z-index: 99; }

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -148,8 +148,17 @@ body.view-details td.cell.cmp-donly .cmp-marker { color: #9aa1a9; }
 .cmp-why { font-weight: 600; color: #8a4b0b; background: #fdf2e2; border: 1px solid #f0d9b5;
   border-radius: 4px; padding: 4px 6px; margin-bottom: 6px; font-size: 12px; line-height: 1.35;
   white-space: normal; }
-/* Base reference's section is flagged with a marker (same color as the others). */
-.ttip .cand.cand-base .ttip-section::after { content: ' ← base reference'; font-weight: 700; }
+/* The Reference section (and the per-chunk Reference column) is flagged with a
+ * gold ★ (matching the compare-bar Reference star) before the name and `← REF` after. */
+.ttip .cand.cand-base .ttip-section::before { content: '★ '; color: #f5a623; font-weight: 700; }
+.ttip .cand.cand-base .ttip-section::after { content: ' ← REF'; font-weight: 700; }
+.ttip .ttip-ref { font-weight: 700; white-space: nowrap; }
+.ttip .ttip-ref-star { color: #f5a623; font-weight: 700; }
+/* Per-chunk grid column hidden when it isn't in the Reference/Compare-with set. */
+.ttip .ttip-chunks .col-hidden { display: none; }
+/* The Reference candidate column: gold ★ before + `← REF` after its header label. */
+.ttip .ttip-chunks th.col-ref::before { content: '★ '; color: #f5a623; font-weight: 700; }
+.ttip .ttip-chunks th.col-ref::after { content: ' ← REF'; font-weight: 700; white-space: nowrap; }
 .radio-option { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer; }
 /* The parser-radio JS hides options the active tab doesn't support via `hidden`;
    the explicit display above would otherwise override the default [hidden] rule

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -392,3 +392,6 @@ body.view-details .transpose-table td.cell > a { position: absolute; inset: 0; }
 /* Case-group banner rows reuse the original tr.section band, but centered: in the
    transposed layout they span the full model width, so left-aligned reads lost. */
 .transpose-table tr.section td { background: #eef; font-weight: bold; text-align: center; padding-left: 0.5ch; padding-right: 0.5ch; }
+/* Column-header note for candidates whose capture has no per-chunk timing (e.g. the
+ * v1 jail bursts at end-of-call); their per-chunk cells stay em-dashes. */
+.ttip .ttip-note { color: #9aa4b2; font-weight: 400; font-size: 11px; white-space: normal; }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -275,6 +275,8 @@
     document.querySelectorAll('.tab-panel').forEach(function (panel) {
       if (panelCtl(panel)) { applyCtl(panel); }
     });
+    // Compare model applied — reveal the real colors (see body.cmp-loading CSS).
+    document.body.classList.remove('cmp-loading');
   }
 
   function readDetailed() {

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -61,15 +61,54 @@
       if (row) { row.classList.toggle('is-ref', isRef); }
     });
   }
+  // Compare keys are `<impl>-s-<version>` / `<impl>-b-<version>` (or `<impl>-s`); the
+  // per-chunk grid columns are keyed by bare impl. Strip the mode+version suffix.
+  function implOf(key) { return key ? key.replace(/-[sb](-.*)?$/, '') : key; }
   function toggleCands(cell, active, base) {
+    let baseSec = null;
     cell.querySelectorAll('.ttip .cand').forEach(function (sec) {
       const cls = Array.from(sec.classList).find(function (c) { return c.indexOf('cand-') === 0; });
       const key = cls ? cls.slice(5) : null;
       sec.classList.toggle('cand-on', key !== null && active.has(key));
       // Mark the Base reference's section so the tooltip flags which output the
       // others are being compared against.
-      sec.classList.toggle('cand-base', key !== null && key === base);
+      const isBase = key !== null && key === base;
+      sec.classList.toggle('cand-base', isBase);
+      if (isBase) { baseSec = sec; }
     });
+    // The Reference reads FIRST: move its section ahead of its sibling candidates.
+    if (baseSec) {
+      const first = baseSec.parentNode.querySelector('.cand');
+      if (first && first !== baseSec) { baseSec.parentNode.insertBefore(baseSec, first); }
+    }
+    // Per-chunk grid: show only the columns in the Reference + Compare-with selection.
+    const grid = cell.querySelector('.ttip-chunks');
+    if (grid) {
+      const cands = grid.querySelectorAll('[data-cand]');
+      if (cands.length) {
+        // Candidate-column grid: columns ARE the (impl, version) candidates. Show the
+        // Reference + each checked compare-with, flag the Reference column, and move
+        // it first (right after the input column) in every row.
+        cands.forEach(function (el) {
+          const key = el.getAttribute('data-cand');
+          el.classList.toggle('col-hidden', !active.has(key));
+          el.classList.toggle('col-ref', key === base);
+        });
+        if (base) {
+          grid.querySelectorAll('tr').forEach(function (tr) {
+            const el = tr.querySelector('[data-cand="' + base + '"]');
+            const first = tr.querySelector('[data-cand]');
+            if (el && first && first !== el) { tr.insertBefore(el, first); }
+          });
+        }
+      } else {
+        // Legacy impl-column grid: show columns whose engine is active.
+        const activeImpls = new Set(Array.from(active).map(implOf));
+        grid.querySelectorAll('[data-col-impl]').forEach(function (el) {
+          el.classList.toggle('col-hidden', !activeImpls.has(el.getAttribute('data-col-impl')));
+        });
+      }
+    }
   }
   // Parsers with limited family coverage (Dynamo v2): key -> {label, families}. Drives
   // the reference-aware "not implemented" reason. Empty on pages without such a parser.

--- a/conformance/utils/src/conformance_table.html.j2
+++ b/conformance/utils/src/conformance_table.html.j2
@@ -8,7 +8,8 @@
 {{ impl_status_css|safe }}
 </style>
 </head>
-<body class="view-overview parser-dynamo_rust">
+<body class="view-overview parser-dynamo_rust cmp-loading">
+<div class="cmp-loading-note">loading&hellip; applying the compare model (colors are not final)</div>
 <h1>{% if title_html is defined and title_html %}{{ title_html|safe }}{% else %}{{ title|e }}{% endif %}</h1>
 <p class="generated">
   Auto-generated on {{ stamp|e }}{% if sha %} on commit <a href="https://github.com/ai-dynamo/frontend-crates/commit/{{ sha|e }}"><code>{{ short_sha|e }}</code></a>{% endif %}:

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -962,10 +962,22 @@ def _version_candidate_chart_html(case: dict, ver_status: dict) -> tuple[str, st
             )
     if not candidates:
         return None
-    header = "".join(
-        f'<th data-cand="{html_lib.escape(key, quote=True)}">{html_lib.escape(label)}</th>'
-        for key, label, _info in candidates
-    )
+    def _col_header(key: str, label: str, info: dict) -> str:
+        note = ""
+        if not info.get("aligned", True):
+            # The capture is emission-packed (fewer rows than input chunks): row
+            # positions are NOT consumer-visible timing, so per-chunk cells stay
+            # empty and the output shows only in the assembled row.
+            note = (
+                ' <span class="ttip-note">(bursts at end of call;'
+                " per-chunk timing not recorded)</span>"
+            )
+        return (
+            f'<th data-cand="{html_lib.escape(key, quote=True)}">'
+            f"{html_lib.escape(label)}{note}</th>"
+        )
+
+    header = "".join(_col_header(key, label, info) for key, label, info in candidates)
     rows = []
     for i, chunk in enumerate(input_chunks):
         inp = chunk_html[i]
@@ -979,7 +991,9 @@ def _version_candidate_chart_html(case: dict, ver_status: dict) -> tuple[str, st
         for key, _label, info in candidates:
             chs = info.get("chunks")
             body = ""
-            if isinstance(chs, list) and i < len(chs):
+            if not info.get("aligned", True):
+                body = "—"  # timing not recorded; output appears in `assembled` only
+            elif isinstance(chs, list) and i < len(chs):
                 body = _render_chunk_deltas(
                     chs[i].get("deltas") or [], chs[i].get("normal_text") or ""
                 )
@@ -2295,8 +2309,27 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
     saved_captured = _CAPTURED_WITH_BY_MODE.get("streamv2")
     result: dict[tuple[str, str], dict[str, dict[str, dict]]] = {}
 
+    def _raw_chunk_counts(impl, version):
+        """{(family, case_id): n_chunks} straight from the <impl>-<version> dir docs.
+        The resolver pads a folded case to the input chunk count, so alignment
+        (did this capture record per-input-chunk timing?) is only visible here."""
+        counts: dict[tuple[str, str], int] = {}
+        vdir = _STREAM_SRC / f"{impl}-{version}"
+        if vdir.is_dir():
+            for fp in vdir.glob("*/*.yaml"):
+                try:
+                    doc = yaml.safe_load(fp.read_text()) or {}
+                except Exception:
+                    continue
+                fam = doc.get("family") or fp.parent.name
+                for cid, vc in (doc.get("cases") or {}).items():
+                    if isinstance(vc, dict) and isinstance(vc.get("chunks"), list):
+                        counts[(fam, cid)] = len(vc["chunks"])
+        return counts
+
     def _record(cases, impl, version):
         slug = toolcalling_table._version_slug(version)
+        raw_counts = _raw_chunk_counts(impl, version)
         # The Dynamo parser is version-split into two DIFFERENT parsers: v2
         # (dynamo_rust-0.1.11) implements only a handful of families, while the v1
         # jail (dynamo_rust-3.0.0) covers all. The stream assembly defaults an absent
@@ -2324,11 +2357,18 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
                     })
             if covered is not None and case.get("__family") not in covered:
                 block, status, vchunks = None, "na", None
+            # Aligned = the raw capture recorded one row per INPUT chunk, so a row
+            # index is real consumer-visible timing. The v1 jail captures are
+            # emission-packed (fewer rows than inputs) — timing NOT recorded.
+            raw_n = raw_counts.get((key[0], case.get("__case_id") or ""))
+            n_input = len(raw) if isinstance(raw, list) else 0
+            aligned = raw_n is None or raw_n == n_input
             result.setdefault(key, {}).setdefault(impl, {})[slug] = {
                 "status": status,
                 "block": block,
                 "version": version,
                 "chunks": vchunks,
+                "aligned": aligned,
             }
 
     def _resolve_and_load(select):

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -963,19 +963,15 @@ def _version_candidate_chart_html(case: dict, ver_status: dict) -> tuple[str, st
     if not candidates:
         return None
     def _col_header(key: str, label: str, info: dict) -> str:
-        note = ""
-        if not info.get("aligned", True):
-            # The capture is emission-packed (fewer rows than input chunks): row
-            # positions are NOT consumer-visible timing, so per-chunk cells stay
-            # empty and the output shows only in the assembled row.
-            note = (
-                ' <span class="ttip-note">(bursts at end of call;'
-                " per-chunk timing not recorded)</span>"
-            )
-        return (
-            f'<th data-cand="{html_lib.escape(key, quote=True)}">'
-            f"{html_lib.escape(label)}{note}</th>"
+        # The capture is emission-packed (fewer rows than input chunks): row
+        # positions are NOT consumer-visible timing, so per-chunk cells stay
+        # empty and the output shows only in the assembled row.
+        note = (
+            common.timing_note("bursts at end of call; per-chunk timing not recorded")
+            if not info.get("aligned", True)
+            else ""
         )
+        return common.cand_th(key, html_lib.escape(label) + note)
 
     header = "".join(_col_header(key, label, info) for key, label, info in candidates)
     rows = []
@@ -997,24 +993,19 @@ def _version_candidate_chart_html(case: dict, ver_status: dict) -> tuple[str, st
                 body = _render_chunk_deltas(
                     chs[i].get("deltas") or [], chs[i].get("normal_text") or ""
                 )
-            cells += f'<td data-cand="{html_lib.escape(key, quote=True)}">{body}</td>'
+            cells += common.cand_td(key, body)
         rows.append(f'<tr><td class="cin">{inp}</td>{cells}</tr>')
     # `_cand_section_body` (not the bare block formatter) so each candidate's
     # `explanation:` note rides in its column — the chart REPLACES the per-candidate
     # list sections, so nothing the list carried may be lost.
     final_cells = "".join(
-        f'<td data-cand="{html_lib.escape(key, quote=True)}">'
-        f'{_cand_section_body(info.get("block"), family).replace(chr(10), "<br>")}</td>'
+        common.cand_td(
+            key, _cand_section_body(info.get("block"), family).replace(chr(10), "<br>")
+        )
         for key, _label, info in candidates
     )
     rows.append(f'<tr class="ttip-final"><td class="cin">assembled</td>{final_cells}</tr>')
-    table = (
-        '<table class="ttip-chunks"><thead><tr><th>input</th>'
-        + header
-        + "</tr></thead><tbody>"
-        + "".join(rows)
-        + "</tbody></table>"
-    )
+    table = common.candidate_chart_table(header, rows)
     return ("Per-chunk emit (recorded from parser = expected)", table)
 
 
@@ -1029,22 +1020,18 @@ def _merged_candidate_chart_html(case: dict, cmp_items: list) -> tuple[str, str]
         return None
     family = case.get("__family")
     header = "".join(
-        f'<th data-cand="{html_lib.escape(item["key"], quote=True)}">{html_lib.escape(item["label"])}</th>'
-        for item in cmp_items
+        common.cand_th(item["key"], html_lib.escape(item["label"])) for item in cmp_items
     )
     cells = "".join(
-        f'<td data-cand="{html_lib.escape(item["key"], quote=True)}">'
-        f'{_cand_section_body(item.get("block"), family).replace(chr(10), "<br>")}</td>'
+        common.cand_td(
+            item["key"],
+            _cand_section_body(item.get("block"), family).replace(chr(10), "<br>"),
+        )
         for item in cmp_items
     )
     input_html = f"input_text='{colorize_markup(model_text, family)}'"
-    table = (
-        '<table class="ttip-chunks"><thead><tr><th>input</th>'
-        + header
-        + f'</tr></thead><tbody><tr class="ttip-final"><td class="cin">{input_html}</td>'
-        + cells
-        + "</tr></tbody></table>"
-    )
+    final_row = f'<tr class="ttip-final"><td class="cin">{input_html}</td>{cells}</tr>'
+    table = common.candidate_chart_table(header, [final_row])
     return ("Output (recorded from parser = expected)", table)
 
 
@@ -1115,7 +1102,7 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
             )
         else:
             inner = name
-        return f'<th data-col-impl="{impl}">{inner}</th>'
+        return common.cand_th(impl, inner, attr="data-col-impl")
 
     header = base_header + "".join(_col_h(i) for i in impls)
     rows = []
@@ -1138,7 +1125,13 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
         exp = _normalize_impl_mapping(chunk.get("expected") or {})
         nt = _normalize_impl_mapping(chunk.get("normal_text") or {})
         cells = "".join(
-            f'<td data-col-impl="{i2}">{_render_chunk_deltas(_impl_get(exp, i2, []) or [], _impl_get(nt, i2, "") or "")}</td>'
+            common.cand_td(
+                i2,
+                _render_chunk_deltas(
+                    _impl_get(exp, i2, []) or [], _impl_get(nt, i2, "") or ""
+                ),
+                attr="data-col-impl",
+            )
             for i2 in impls
         )
         # The baseline cell (rowspan) is emitted once, on the first body row.
@@ -1149,19 +1142,19 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
     # baseline column on the left (assembled X_s vs Dynamo batch).
     derived = _expected(case)
     final_cells = "".join(
-        f'<td data-col-impl="{i2}">{_format_output_block_html(_impl_get(derived, i2), family).replace(chr(10), "<br>")}</td>'
+        common.cand_td(
+            i2,
+            _format_output_block_html(_impl_get(derived, i2), family).replace(
+                chr(10), "<br>"
+            ),
+            attr="data-col-impl",
+        )
         for i2 in impls
     )
     rows.append(
         f'<tr class="ttip-final"><td class="cin">assembled</td>{baseline_td}{final_cells}</tr>'
     )
-    table = (
-        '<table class="ttip-chunks"><thead><tr><th>input</th>'
-        + header
-        + "</tr></thead><tbody>"
-        + "".join(rows)
-        + "</tbody></table>"
-    )
+    table = common.candidate_chart_table(header, rows)
     if unavailable:
         note = "; ".join(
             f"{_IMPL_DISPLAY[i]}: {_short_unavailable(unavailable[i])}"

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -729,6 +729,27 @@ def _dynamo_note_sections(case: dict) -> list[tuple[str, str]]:
     return [("Dynamo recovery contract", linkify_text_html(str(note)))]
 
 
+
+# Candidate labels look like "vLLM Python 0.23.0 (stream)". Sort sections by engine
+# (label prefix) ascending, then version DESCENDING within the engine — matching the
+# compare bar's latest-first ordering. Two stable passes: version-desc, then prefix.
+_CAND_LABEL_VER_RE = re.compile(r"^(.*?)(\d[\w.\-]*)(\s*\(.*\))?\s*$")
+
+
+def _sort_candidate_sections(sections: list) -> None:
+    def parts(label: str):
+        m = _CAND_LABEL_VER_RE.match(label)
+        if not m:
+            return (label, "0", "")
+        return (m.group(1), m.group(2) or "0", m.group(3) or "")
+
+    sections.sort(
+        key=lambda sec: toolcalling_table._version_sort_key(parts(sec[0])[1]),
+        reverse=True,
+    )
+    sections.sort(key=lambda sec: (parts(sec[0])[0], parts(sec[0])[2]))
+
+
 def _build_tooltip_html(case: dict, dyn, output_kind: str = "batch") -> str:
     """Rich HTML hover tooltip: head, input (colorized), per-engine output,
     divergence reasons. Returns the full `<div class="ttip">...</div>`.
@@ -837,13 +858,19 @@ def _build_tooltip_html(case: dict, dyn, output_kind: str = "batch") -> str:
                 )
             )
 
-    # Show the compare candidates in the same lexical order as the bucket chips.
+    # Engine ascending, version DESCENDING within the engine (latest first),
+    # matching the compare-bar ordering.
     if cmp_items or ver_status:
-        output_sections.sort(key=lambda s: s[0])
+        _sort_candidate_sections(output_sections)
 
     reasons = _tooltip_for(case, dyn, impl_keys) if isinstance(dyn, dict) else ""
 
     chart = _per_chunk_chart_html(case, output_kind)
+    # A CANDIDATE chart (columns = compare candidates, `data-cand`-keyed) already
+    # carries every candidate's output + explanation in its assembled/output row,
+    # so the per-candidate list sections above it would repeat the same info —
+    # drop them. Legacy impl-column charts keep the sections for versioned cells.
+    cand_chart = chart is not None and "data-cand" in chart[1]
 
     dyn_leak = _dynamo_tool_call_leak(dyn) if isinstance(dyn, dict) else None
     return _build_conformance_tooltip_html(
@@ -854,12 +881,16 @@ def _build_tooltip_html(case: dict, dyn, output_kind: str = "batch") -> str:
         # When the chart is shown it carries a final "assembled" row per impl, so
         # the separate per-engine output blocks would be redundant — drop them.
         # Exception: versioned candidates (__ver_status) keep their per-candidate
-        # `cand cand-<impl>-<slug>` sections so the compare selection can toggle each
-        # version's assembled output alongside the chart.
+        # `cand cand-<impl>-<slug>` sections ONLY while the chart is impl-keyed;
+        # a candidate chart replaces them entirely.
         output_sections=(
-            output_sections
-            if (ver_status or cmp_items)
-            else (None if chart else output_sections)
+            None
+            if cand_chart
+            else (
+                output_sections
+                if (ver_status or cmp_items)
+                else (None if chart else output_sections)
+            )
         ),
         # In the compare model each candidate's reason lives in its own section
         # (via _cand_section_body), so suppress the global cross-engine blob that
@@ -905,12 +936,123 @@ def _render_chunk_deltas(deltas: list, normal_text: str) -> str:
     return "   ".join(parts) if parts else "—"
 
 
+def _version_candidate_chart_html(case: dict, ver_status: dict) -> tuple[str, str] | None:
+    """Per-chunk grid whose columns are the per-version CANDIDATES from `__ver_status`
+    (one per `(impl, version)`, key `{impl}-{slug}` matching the compare-bar). Each
+    column shows that version's per-chunk deltas (captured in `_stream_version_status_map`)
+    and, in the final `assembled` row, its assembled output. The JS shows only the
+    Reference + checked compare-with columns and marks the Reference. First column is the
+    shared input (delta_text)."""
+    input_chunks = [c for c in (case.get("chunks") or []) if isinstance(c, dict)]
+    if not input_chunks:
+        return None
+    family = case.get("__family")
+    chunk_html = colorize_stream_deltas(input_chunks, family)
+    candidates = []  # (key, label, info)
+    for impl in ("dynamo_rust", "vllm_rust", "vllm_python", "sglang_python"):
+        # Engine columns in canonical order; within an engine, LATEST version first.
+        entries = sorted(
+            (ver_status.get(impl) or {}).items(),
+            key=lambda kv: toolcalling_table._version_sort_key(str(kv[1].get("version") or "0")),
+            reverse=True,
+        )
+        for slug, info in entries:
+            candidates.append(
+                (f"{impl}-{slug}", _full_label(impl, info.get("version"), "stream"), info)
+            )
+    if not candidates:
+        return None
+    header = "".join(
+        f'<th data-cand="{html_lib.escape(key, quote=True)}">{html_lib.escape(label)}</th>'
+        for key, label, _info in candidates
+    )
+    rows = []
+    for i, chunk in enumerate(input_chunks):
+        inp = chunk_html[i]
+        if chunk.get("finish_reason"):
+            inp += (
+                ' <span class="fr">finish='
+                + html_lib.escape(str(chunk["finish_reason"]))
+                + "</span>"
+            )
+        cells = ""
+        for key, _label, info in candidates:
+            chs = info.get("chunks")
+            body = ""
+            if isinstance(chs, list) and i < len(chs):
+                body = _render_chunk_deltas(
+                    chs[i].get("deltas") or [], chs[i].get("normal_text") or ""
+                )
+            cells += f'<td data-cand="{html_lib.escape(key, quote=True)}">{body}</td>'
+        rows.append(f'<tr><td class="cin">{inp}</td>{cells}</tr>')
+    # `_cand_section_body` (not the bare block formatter) so each candidate's
+    # `explanation:` note rides in its column — the chart REPLACES the per-candidate
+    # list sections, so nothing the list carried may be lost.
+    final_cells = "".join(
+        f'<td data-cand="{html_lib.escape(key, quote=True)}">'
+        f'{_cand_section_body(info.get("block"), family).replace(chr(10), "<br>")}</td>'
+        for key, _label, info in candidates
+    )
+    rows.append(f'<tr class="ttip-final"><td class="cin">assembled</td>{final_cells}</tr>')
+    table = (
+        '<table class="ttip-chunks"><thead><tr><th>input</th>'
+        + header
+        + "</tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+    return ("Per-chunk emit (recorded from parser = expected)", table)
+
+
+def _merged_candidate_chart_html(case: dict, cmp_items: list) -> tuple[str, str] | None:
+    """Candidate chart for the merged batch tab: same left-to-right layout as the
+    stream chart, but batch input is a single text (one "chunk"), so there is one
+    `output` row — each candidate's full result side by side. Columns are the
+    `__cmp` candidates (`data-cand` keys match the compare bar), toggled/REF-marked
+    by the same JS as the stream chart."""
+    model_text = case.get("model_text")
+    if not isinstance(model_text, str) or not model_text or not cmp_items:
+        return None
+    family = case.get("__family")
+    header = "".join(
+        f'<th data-cand="{html_lib.escape(item["key"], quote=True)}">{html_lib.escape(item["label"])}</th>'
+        for item in cmp_items
+    )
+    cells = "".join(
+        f'<td data-cand="{html_lib.escape(item["key"], quote=True)}">'
+        f'{_cand_section_body(item.get("block"), family).replace(chr(10), "<br>")}</td>'
+        for item in cmp_items
+    )
+    input_html = f"input_text='{colorize_markup(model_text, family)}'"
+    table = (
+        '<table class="ttip-chunks"><thead><tr><th>input</th>'
+        + header
+        + f'</tr></thead><tbody><tr class="ttip-final"><td class="cin">{input_html}</td>'
+        + cells
+        + "</tr></tbody></table>"
+    )
+    return ("Output (recorded from parser = expected)", table)
+
+
 def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str, str] | None:
     """Per-chunk breakdown as a compact table: one row per chunk, first column the
     input delta_text, then one column per available impl (Dynamo Rust, vLLM Rust,
     vLLM Python, SGLang)
     showing what it emitted at that chunk. Returns (label, table_html), or None for
     non per-chunk stream cases. No inter-tag whitespace (keeps the markup tight)."""
+    # Stream tab: columns are the per-version CANDIDATES (from __ver_status), so the
+    # popup shows the Reference + each checked compare-with (e.g. Dynamo v1 vs v2).
+    ver_status = case.get("__ver_status")
+    if ver_status and case.get("chunks"):
+        cand = _version_candidate_chart_html(case, ver_status)
+        if cand is not None:
+            return cand
+    # Merged batch tab: same chart, single-output row (batch input is "one chunk").
+    cmp_items = case.get("__cmp")
+    if cmp_items and not case.get("chunks"):
+        cand = _merged_candidate_chart_html(case, cmp_items)
+        if cand is not None:
+            return cand
     chunks = case.get("chunks")
     if not (isinstance(chunks, list) and chunks):
         return None
@@ -938,7 +1080,7 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
     baseline_td = ""
     base_header = ""
     if show_baseline:
-        base_header = f'<th class="cbase-h">baseline<br>{_impl_mode_label_html(BASELINE_IMPL, _BATCH_MODE_MARKER)}</th>'
+        base_header = f'<th class="cbase-h">baseline<br>{html_lib.escape(_IMPL_DISPLAY[BASELINE_IMPL])} batch parser</th>'
         baseline_body = _format_output_block_html(dyn_batch, family).replace(
             chr(10), "<br>"
         )
@@ -946,9 +1088,22 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
             f'<td class="cbase" rowspan="{n_body_rows}">{baseline_body}</td>'
         )
     mode_marker = _STREAM_MODE_MARKER if output_kind == "stream" else _BATCH_MODE_MARKER
-    header = base_header + "".join(
-        f"<th>{_impl_mode_label_html(i, mode_marker)}</th>" for i in impls
-    )
+    parse_mode = "stream" if mode_marker == _STREAM_MODE_MARKER else "batch"
+
+    # Full parser names (no cryptic D_RS/V_RS/… tags); the Dynamo column is the
+    # Reference the peer columns are compared against, so flag it `← REF`.
+    def _col_h(impl: str) -> str:
+        name = html_lib.escape(f"{_IMPL_DISPLAY[impl]} {parse_mode} parser")
+        if impl == BASELINE_IMPL:
+            inner = (
+                '<span class="ttip-ref-star">★</span> '
+                f'{name} <span class="ttip-ref">← REF</span>'
+            )
+        else:
+            inner = name
+        return f'<th data-col-impl="{impl}">{inner}</th>'
+
+    header = base_header + "".join(_col_h(i) for i in impls)
     rows = []
     for i, chunk in enumerate(chunks):
         if not isinstance(chunk, dict):
@@ -969,7 +1124,7 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
         exp = _normalize_impl_mapping(chunk.get("expected") or {})
         nt = _normalize_impl_mapping(chunk.get("normal_text") or {})
         cells = "".join(
-            f"<td>{_render_chunk_deltas(_impl_get(exp, i2, []) or [], _impl_get(nt, i2, '') or '')}</td>"
+            f'<td data-col-impl="{i2}">{_render_chunk_deltas(_impl_get(exp, i2, []) or [], _impl_get(nt, i2, "") or "")}</td>'
             for i2 in impls
         )
         # The baseline cell (rowspan) is emitted once, on the first body row.
@@ -980,7 +1135,7 @@ def _per_chunk_chart_html(case: dict, output_kind: str = "stream") -> tuple[str,
     # baseline column on the left (assembled X_s vs Dynamo batch).
     derived = _expected(case)
     final_cells = "".join(
-        f"<td>{_format_output_block_html(_impl_get(derived, i2), family).replace(chr(10), '<br>')}</td>"
+        f'<td data-col-impl="{i2}">{_format_output_block_html(_impl_get(derived, i2), family).replace(chr(10), "<br>")}</td>'
         for i2 in impls
     )
     rows.append(
@@ -1313,6 +1468,15 @@ def _parser_label_markdown(
     return f"{family}{suff}"
 
 
+# Dynamo parser v2 stream parsers with a standard `push`/`finish` text path:
+# family -> (backend label, source file under parsers/v2/src/tool_calling/, format marker).
+# Families with bespoke paths (harmony token-id/text, deepseek_v4 DSML note) keep their
+# dedicated branches below; new standard families belong here, not in new if-branches.
+_V2_STREAM_PARSER_CELLS: dict[str, tuple[str, str, str]] = {
+    "qwen3_coder": ("Qwen3CoderToolStreamParser text path", "qwen3_coder.rs", "Qwen XML"),
+}
+
+
 def _parser_cell_html(
     family: str,
     refs: dict[str, tuple[str, int]],
@@ -1370,6 +1534,18 @@ def _parser_cell_html(
             "push",
             fixtures,
             note,
+        )
+    v2_cell = _V2_STREAM_PARSER_CELLS.get(family)
+    if v2_cell and stream_context in ("streamv2", "batch_on_stream"):
+        backend, source_file, marker = v2_cell
+        fixtures = "v2 stream fixtures" if stream_context == "streamv2" else "v1 batch fixtures"
+        note = (
+            f"TC stream row. It consumes {marker} text chunks and emits per-chunk tool-call deltas."
+            if stream_context == "streamv2"
+            else f"TC batch-on-stream row. It feeds each v1 batch fixture's full text through the v2 {marker} streaming parser."
+        )
+        return _v2_parser_cell_html(
+            row_label, family, backend, source_file, "push", fixtures, note
         )
     if stream_context in ("streamv2", "batch_on_stream"):
         # No Dynamo parser v2 stream parser for this family yet. Inventory-only
@@ -1974,18 +2150,19 @@ def _impl_candidate_items(
 
 
 def _candidate_items() -> list[dict[str, str]]:
-    """Ordered comparison candidates for the batch tab: Dynamo, then vLLM/SGLang
-    versions ascending. Each: {key, impl, version, slug, label, short, default_bucket}.
+    """Ordered comparison candidates for the batch tab: Dynamo, then vLLM/SGLang —
+    within each engine versions run LATEST-FIRST (0.24.0 before 0.23.0). Each:
+    {key, impl, version, slug, label, short, default_bucket}.
 
-    Default layout: A (reference) = the first candidate (Dynamo); B (compare with) =
-    the latest version of each peer impl; C (others) = the remaining older versions."""
+    Default layout: A (reference) = the first candidate (Dynamo's latest); B (compare
+    with) = the latest version of each peer impl; C (others) = the older versions."""
     impl_versions = _batch_impl_versions()
     latest = {lg: (vers[-1] if vers else None) for lg, vers in impl_versions.items()}
     out: list[dict[str, str]] = []
     first = True
     for legacy in ("dynamo", "vllm", "sglang"):
         canon = _VERSION_LEGACY_TO_CANON.get(legacy)
-        for v in impl_versions.get(legacy, []):
+        for v in reversed(impl_versions.get(legacy, [])):
             slug = toolcalling_table._version_slug(v)
             if first:
                 bucket = "A"
@@ -2048,7 +2225,8 @@ def _stream_candidate_items() -> list[dict[str, str]]:
     latest = {i: (vs[-1] if vs else None) for i, vs in impl_versions.items()}
     out: list[dict[str, str]] = []
     for impl in ("dynamo_rust", "vllm_rust", "vllm_python", "sglang_python"):
-        for v in impl_versions.get(impl, []):
+        # Within an engine, versions run LATEST-FIRST (0.24.0 before 0.23.0).
+        for v in reversed(impl_versions.get(impl, [])):
             slug = toolcalling_table._version_slug(v)
             if impl == BASELINE_IMPL:
                 # Dynamo v1 (jail+batch) is the default reference; v2 goes to compare.
@@ -2129,12 +2307,28 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
         for key, case in cases.items():
             block = _impl_get(case.get("expected") or {}, impl)
             status = _overview_status(case, impl)
+            # Capture this impl's per-chunk deltas at THIS version so the tooltip's
+            # per-chunk grid can show a column per (impl, version) candidate.
+            vchunks = None
+            raw = case.get("chunks")
+            if isinstance(raw, list):
+                vchunks = []
+                for ch in raw:
+                    if not isinstance(ch, dict):
+                        continue
+                    exp = _normalize_impl_mapping(ch.get("expected") or {})
+                    nt = _normalize_impl_mapping(ch.get("normal_text") or {})
+                    vchunks.append({
+                        "deltas": _impl_get(exp, impl, []) or [],
+                        "normal_text": _impl_get(nt, impl, "") or "",
+                    })
             if covered is not None and case.get("__family") not in covered:
-                block, status = None, "na"
+                block, status, vchunks = None, "na", None
             result.setdefault(key, {}).setdefault(impl, {})[slug] = {
                 "status": status,
                 "block": block,
                 "version": version,
+                "chunks": vchunks,
             }
 
     def _resolve_and_load(select):
@@ -2288,7 +2482,13 @@ def _attach_merged_cmp(cases: dict) -> None:
         items: list[dict] = []
         ver_status = case.get("__ver_status") or {}
         for impl in ("dynamo_rust", "vllm_python", "sglang_python"):
-            for slug, info in (ver_status.get(impl) or {}).items():
+            # Within an engine, LATEST version first (matches the compare bar).
+            entries = sorted(
+                (ver_status.get(impl) or {}).items(),
+                key=lambda kv: toolcalling_table._version_sort_key(str(kv[1].get("version") or "0")),
+                reverse=True,
+            )
+            for slug, info in entries:
                 items.append({
                     "key": f"{impl}-b-{slug}",
                     "label": _full_label(impl, info['version'], "batch"),
@@ -2517,13 +2717,18 @@ def _build_sob_tooltip(case: dict, marker_context: str | None = None) -> str:
     # `chunks:`. When it's present it already shows both X_s and X_b, so the
     # separate per-engine blocks below would be redundant — skip them.
     chart = _per_chunk_chart_html(case, "stream")
+    # A CANDIDATE chart (data-cand columns = the compare candidates) already carries
+    # each candidate's per-chunk emit + assembled output (with explanation) in its
+    # own toggleable/REF-ordered column — the per-candidate list sections would
+    # repeat it one by one, so they are dropped when that chart rendered.
+    cand_chart = chart is not None and "data-cand" in chart[1]
     sections: list[tuple] = []
     ver_status = case.get("__ver_status") or {}
-    if ver_status:
+    if ver_status and not cand_chart:
         # Versioned candidates (impl×engine-version, e.g. vLLM 0.23.0 vs 0.24.0):
         # one toggleable section each showing that version's assembled stream output.
-        # Kept alongside the chart so the Base/Compare selection reveals each
-        # candidate — the stream analogue of the batch tab's per-version blocks.
+        # Kept alongside a legacy impl-keyed chart so the Base/Compare selection
+        # reveals each candidate — the stream analogue of the batch per-version blocks.
         for impl in ("dynamo_rust", "vllm_rust", "vllm_python", "sglang_python"):
             for slug, info in (ver_status.get(impl) or {}).items():
                 blk = info["block"]
@@ -2547,8 +2752,8 @@ def _build_sob_tooltip(case: dict, marker_context: str | None = None) -> str:
                     (f"{lbl} (batch)", _format_output_block_html(bblk, family), f"cand cand-{impl}",
                      isinstance(bblk, dict) and _block_tool_call_leaks(bblk))
                 )
-    # Show the compare candidates in the same lexical order as the bucket chips.
-    sections.sort(key=lambda s: s[0])
+    # Engine ascending, version DESCENDING within the engine (latest first).
+    _sort_candidate_sections(sections)
     return _build_conformance_tooltip_html(
         head=head,
         description=desc,

--- a/conformance/utils/src/resolve_stream_fixtures.py
+++ b/conformance/utils/src/resolve_stream_fixtures.py
@@ -88,6 +88,17 @@ def _merge_impl(base_doc, vdoc, impl):
         if isinstance(bc.get("unavailable"), dict):
             bc["unavailable"].pop(impl, None)
         bchunks = bc.get("chunks") or []
+        # Clear the impl from EVERY base chunk before applying this version's chunks.
+        # A version doc may carry FEWER chunks than the base (the v1 jail records 2
+        # chunks against a 6-chunk input while the v2 anchor emits in chunk 3); the
+        # per-index overwrite below never reaches the tail chunks, so without this
+        # clear the lower version's deltas survive there and assembly concatenates
+        # both versions (the `get_weatherget_weather` doubling).
+        for ch in bchunks:
+            if isinstance(ch, dict):
+                (ch.get("expected") or {}).pop(impl, None)
+                if isinstance(ch.get("normal_text"), dict):
+                    ch["normal_text"].pop(impl, None)
         for i, ve in enumerate(vc.get("chunks") or []):
             if i >= len(bchunks) or not isinstance(bchunks[i], dict):
                 continue

--- a/conformance/utils/tests/conftest.py
+++ b/conformance/utils/tests/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures: one real render per test session, reused by the output-invariant
+and browser tests (rendering takes ~1-2 min; per-module renders would multiply that)."""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+UTILS = Path(__file__).resolve().parents[1]
+REPO = UTILS.parents[1]
+
+
+@pytest.fixture(scope="session")
+def rendered_page(tmp_path_factory) -> Path:
+    out = tmp_path_factory.mktemp("render") / "CONFORMANCE_v2.html"
+    subprocess.run(
+        [str(UTILS / "render_table_v2.sh"), "--output", str(out)],
+        check=True, cwd=REPO, capture_output=True, text=True,
+    )
+    return out

--- a/conformance/utils/tests/parity/common.py
+++ b/conformance/utils/tests/parity/common.py
@@ -320,6 +320,45 @@ def ref_text(value: Any) -> str:
     return str(value)
 
 
+# --- Shared candidate-chart scaffold -----------------------------------------
+# Every popup chart (stream per-version, merged batch, reasoning, and the legacy
+# per-impl grid) is the same <table class="ttip-chunks"> with a fixed `input`
+# column plus per-candidate columns; only the columns/rows differ. These helpers
+# own that scaffold so the four builders don't each re-template it (and so the
+# `data-cand` / `data-col-impl` attribute the compare JS keys on can't drift).
+
+
+def cand_th(key: str, inner: str, *, attr: str = "data-cand") -> str:
+    """A candidate-chart column header. `key` becomes the `attr` value the compare
+    JS toggles/reorders; `inner` is already-rendered (escaped) HTML."""
+    return f'<th {attr}="{html_lib.escape(key, quote=True)}">{inner}</th>'
+
+
+def cand_td(key: str, inner: str, *, attr: str = "data-cand") -> str:
+    """A candidate-chart body cell (see cand_th). `inner` is already-rendered HTML."""
+    return f'<td {attr}="{html_lib.escape(key, quote=True)}">{inner}</td>'
+
+
+def timing_note(reason: str) -> str:
+    """The muted `(… per-chunk timing not recorded)` header note the stream charts
+    add to a column whose capture is not per-input-chunk aligned. `reason` is the
+    parenthetical text (e.g. `bursts at end of call; per-chunk timing not recorded`)."""
+    return f' <span class="ttip-note">({html_lib.escape(reason)})</span>'
+
+
+def candidate_chart_table(header_cells: str, body_rows: list[str]) -> str:
+    """Assemble the shared chart <table>: fixed `input` column + per-candidate
+    columns (header_cells), then body_rows. Callers build the columns/rows;
+    the scaffold lives here once."""
+    return (
+        '<table class="ttip-chunks"><thead><tr><th>input</th>'
+        + header_cells
+        + "</tr></thead><tbody>"
+        + "".join(body_rows)
+        + "</tbody></table>"
+    )
+
+
 def build_parity_tooltip_html(
     *,
     head: str,

--- a/conformance/utils/tests/parity/common.py
+++ b/conformance/utils/tests/parity/common.py
@@ -331,6 +331,7 @@ def build_parity_tooltip_html(
     leak_label: str | None = None,
     leak_text: str | None = None,
     extra_sections: list[tuple[str, str]] | None = None,
+    chart: tuple[str, str] | None = None,
     refs: list[tuple[str, Any]] | None = None,
 ) -> str:
     """Build the hover popup used by parser and reasoning parity tables.
@@ -366,6 +367,15 @@ def build_parity_tooltip_html(
 
     for section in output_sections or []:
         add_section(*section)
+
+    # Candidate chart (left-to-right per-candidate output table). Raw table HTML —
+    # not a <pre> section — toggled/REF-ordered by the shared compare JS.
+    if chart:
+        chart_label, chart_html = chart
+        parts.append(
+            f'<div class="ttip-section">{html_lib.escape(chart_label)}:</div>'
+        )
+        parts.append(chart_html)
 
     if divergent_reasons:
         add_section("Divergent reasons", linkify_text_html(divergent_reasons))

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -1738,6 +1738,7 @@ def _reasoning_candidate_chart_html(
     if not isinstance(expected, dict):
         return None
     mode = "stream" if ".stream." in case_id else "batch"
+    has_chunks = isinstance(case.get("chunks"), list) and bool(case.get("chunks"))
     header = ""
     cells = ""
     for impl in ("dynamo", "vllm", "sglang"):
@@ -1748,7 +1749,13 @@ def _reasoning_candidate_chart_html(
             if isinstance(blk, dict) and _block_leak_reason(blk, family) is not None
             else ""
         )
-        header += f'<th data-cand="{impl}">{label}{leak}</th>'
+        note = (
+            ' <span class="ttip-note">(final output only;'
+            " per-chunk timing not recorded)</span>"
+            if has_chunks
+            else ""
+        )
+        header += f'<th data-cand="{impl}">{label}{leak}{note}</th>'
         body = _format_output_block_html(blk, family, display_family=display_family)
         note = _explanation(blk)
         if note:

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -1750,23 +1750,22 @@ def _reasoning_candidate_chart_html(
             else ""
         )
         note = (
-            ' <span class="ttip-note">(final output only;'
-            " per-chunk timing not recorded)</span>"
+            common.timing_note("final output only; per-chunk timing not recorded")
             if has_chunks
             else ""
         )
-        header += f'<th data-cand="{impl}">{label}{leak}{note}</th>'
+        header += common.cand_th(impl, f"{label}{leak}{note}")
         body = _format_output_block_html(blk, family, display_family=display_family)
         note = _explanation(blk)
         if note:
             body += "\nexplanation: " + html_lib.escape(str(note))
-        cells += f'<td data-cand="{impl}">{body.replace(chr(10), "<br>")}</td>'
+        cells += common.cand_td(impl, body.replace(chr(10), "<br>"))
     rows = []
     chunks = case.get("chunks")
     if isinstance(chunks, list) and chunks:
         chunk_html = _colorize_stream_chunks(chunks, family)
         empty = "".join(
-            f'<td data-cand="{impl}">—</td>' for impl in ("dynamo", "vllm", "sglang")
+            common.cand_td(impl, "—") for impl in ("dynamo", "vllm", "sglang")
         )
         for i in range(len(chunks)):
             rows.append(f'<tr><td class="cin">{chunk_html[i]}</td>{empty}</tr>')
@@ -1775,13 +1774,7 @@ def _reasoning_candidate_chart_html(
         rows.append(
             f'<tr class="ttip-final"><td class="cin">{_input_text_html(case, family)}</td>{cells}</tr>'
         )
-    table = (
-        '<table class="ttip-chunks"><thead><tr><th>input</th>'
-        + header
-        + "</tr></thead><tbody>"
-        + "".join(rows)
-        + "</tbody></table>"
-    )
+    table = common.candidate_chart_table(header, rows)
     return ("Output (recorded from parser = expected)", table)
 
 

--- a/conformance/utils/tests/parity/reasoning/table.py
+++ b/conformance/utils/tests/parity/reasoning/table.py
@@ -1719,6 +1719,65 @@ def _explanations_for(
     return "\n".join(parts)
 
 
+def _reasoning_candidate_chart_html(
+    case_id: str,
+    family: str,
+    case: dict[str, Any],
+    *,
+    display_family: str | None = None,
+) -> tuple[str, str] | None:
+    """Left-to-right candidate chart (same layout/JS contract as the toolcalling
+    charts): one column per compare candidate (`data-cand` = the compare-bar keys
+    `dynamo`/`vllm`/`sglang`), REF column ordered first + `★ … ← REF`-marked by the
+    shared JS. Batch input is a single text, so there is one `output` row; stream
+    cases additionally list their input chunks (one row each) — the reasoning corpus
+    records final output only, so per-chunk candidate cells stay `—`. A leaking
+    candidate keeps its red `↯` on the column header (the list sections this chart
+    replaces carried it)."""
+    expected = case.get("expected")
+    if not isinstance(expected, dict):
+        return None
+    mode = "stream" if ".stream." in case_id else "batch"
+    header = ""
+    cells = ""
+    for impl in ("dynamo", "vllm", "sglang"):
+        blk = expected.get(impl)
+        label = html_lib.escape(_reasoning_cand_label(impl, mode))
+        leak = (
+            ' <span class="ttip-leak">↯</span>'
+            if isinstance(blk, dict) and _block_leak_reason(blk, family) is not None
+            else ""
+        )
+        header += f'<th data-cand="{impl}">{label}{leak}</th>'
+        body = _format_output_block_html(blk, family, display_family=display_family)
+        note = _explanation(blk)
+        if note:
+            body += "\nexplanation: " + html_lib.escape(str(note))
+        cells += f'<td data-cand="{impl}">{body.replace(chr(10), "<br>")}</td>'
+    rows = []
+    chunks = case.get("chunks")
+    if isinstance(chunks, list) and chunks:
+        chunk_html = _colorize_stream_chunks(chunks, family)
+        empty = "".join(
+            f'<td data-cand="{impl}">—</td>' for impl in ("dynamo", "vllm", "sglang")
+        )
+        for i in range(len(chunks)):
+            rows.append(f'<tr><td class="cin">{chunk_html[i]}</td>{empty}</tr>')
+        rows.append(f'<tr class="ttip-final"><td class="cin">output</td>{cells}</tr>')
+    else:
+        rows.append(
+            f'<tr class="ttip-final"><td class="cin">{_input_text_html(case, family)}</td>{cells}</tr>'
+        )
+    table = (
+        '<table class="ttip-chunks"><thead><tr><th>input</th>'
+        + header
+        + "</tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+    return ("Output (recorded from parser = expected)", table)
+
+
 def _tooltip_html(
     case_id: str,
     family: str,
@@ -1776,28 +1835,13 @@ def _tooltip_html(
             ),
         )
     )
-    # Always emit one wrapped section per impl so the shared compare-candidates JS
-    # can toggle the per-impl output block (mirrors generate_conformance_table's
-    # per-candidate `cand cand-<key>` wrapping). The optional 3rd tuple element is
-    # the wrap class, consumed by common.build_parity_tooltip_html's add_section.
-    mode = "stream" if ".stream." in case_id else "batch"
-    output_sections: list[tuple] = []
-    for impl in ("dynamo", "vllm", "sglang"):
-        blk = expected.get(impl)
-        body = _format_output_block_html(blk, family, display_family=display_family)
-        note = _explanation(blk)
-        if note:
-            body += "\nexplanation: " + html_lib.escape(str(note))
-        output_sections.append(
-            (
-                _reasoning_cand_label(impl, mode),
-                body,
-                f"cand cand-{impl}",
-                isinstance(blk, dict) and _block_leak_reason(blk, family) is not None,
-            )
-        )
-    # Show the compare candidates in the same lexical order as the bucket chips.
-    output_sections.sort(key=lambda s: s[0])
+    # The candidate chart (one column per compare candidate, left-to-right) replaces
+    # the old per-impl list sections — its output row carries each candidate's block
+    # + explanation, and its headers keep the per-candidate `↯`. The input lives in
+    # the chart's first column, so the separate Input section is dropped too.
+    chart = _reasoning_candidate_chart_html(
+        case_id, family, case, display_family=display_family
+    )
 
     dynamo_leak = (
         _dynamo_leak_reason(expected, family)
@@ -1807,14 +1851,15 @@ def _tooltip_html(
     return build_parity_tooltip_html(
         head=head,
         description=str(description) if description else None,
-        input_label="Input chunks" if "chunks" in case else "Input",
-        input_html=_input_text_html(case, family),
-        output_sections=output_sections,
+        input_label=None if chart else ("Input chunks" if "chunks" in case else "Input"),
+        input_html=None if chart else _input_text_html(case, family),
+        output_sections=None,
         divergent_reasons=None,
         leak_label="↯ Dynamo leaks",
         leak_text=dynamo_leak
         or ("unresolved" if _has_dynamo_leak(case, family) else None),
         extra_sections=extra_sections,
+        chart=chart,
         refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
     )
 

--- a/conformance/utils/tests/test_browser_popup_compare.py
+++ b/conformance/utils/tests/test_browser_popup_compare.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Browser test for the per-chunk popup's candidate columns (real clicks, real DOM).
+
+The popup's grid columns are the compare-bar candidates: selecting REF = Dynamo v2 and
+Compare-with = Dynamo v1 must show exactly `input | v2 (REF-marked) | v1` — no vLLM /
+SGLang columns unless checked — and unchecking v1 must hide its column live. The JS was
+previously shipped without ever being executed; this test exists so that can't recur.
+
+Skips when Selenium or headless Chrome aren't available (same policy as
+test_browser_smoke.py).
+"""
+from __future__ import annotations
+
+import shutil
+import time
+
+import pytest
+
+selenium = pytest.importorskip("selenium")
+from selenium import webdriver  # noqa: E402
+from selenium.webdriver.chrome.options import Options  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not any(
+        shutil.which(b)
+        for b in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser")
+    ),
+    reason="no headless Chrome available",
+)
+
+V2_KEY = "dynamo_rust-0-1-11"
+V1_KEY = "dynamo_rust-3-0-0"
+
+
+@pytest.fixture(scope="module")
+def driver(rendered_page):
+    opts = Options()
+    for a in ("--headless=new", "--no-sandbox", "--disable-gpu",
+              "--disable-dev-shm-usage", "--window-size=1600,1200"):
+        opts.add_argument(a)
+    try:
+        d = webdriver.Chrome(options=opts)
+    except Exception as exc:  # noqa: BLE001 — environment without a usable driver
+        pytest.skip(f"could not start Chrome webdriver: {exc}")
+    d.get(f"file://{rendered_page}")
+    d.implicitly_wait(2)
+    yield d
+    d.quit()
+
+
+def _open_stream_tab(driver):
+    ok = driver.execute_script(
+        """
+        for (const b of document.querySelectorAll('.tab-button')) {
+          const t = b.getAttribute('data-tab-target') || '';
+          if (t.includes('stream') && t.includes('toolcalling')) { b.click(); return t; }
+        }
+        return null;
+        """
+    )
+    assert ok, "no Tool Calling stream tab button found"
+    time.sleep(0.3)
+
+
+def _select(driver, ref_key, cmp_keys):
+    """Set the active panel's Reference radio + Compare-with checkboxes, fire change.
+    Reference radios are made exclusive explicitly (the star inputs are per-column,
+    so a stale checked radio elsewhere must be cleared)."""
+    driver.execute_script(
+        """
+        const [refKey, cmpKeys] = arguments;
+        const ctl = document.querySelector('.tab-panel.active .cmpctl');
+        if (!ctl) { return false; }
+        for (const r of ctl.querySelectorAll('input.cmp-ref')) {
+          const want = r.value === refKey;
+          if (r.checked !== want) { r.checked = want; }
+          if (want) { r.dispatchEvent(new Event('change', {bubbles: true})); }
+        }
+        for (const cb of ctl.querySelectorAll('input.cmp-on')) {
+          const want = cmpKeys.includes(cb.value) || cb.value === refKey;
+          if (!cb.disabled && cb.checked !== want) {
+            cb.checked = want; cb.dispatchEvent(new Event('change', {bubbles: true}));
+          }
+        }
+        return true;
+        """,
+        ref_key, list(cmp_keys),
+    )
+    time.sleep(0.3)
+
+
+def _grid_column_order(driver):
+    """Visible [data-cand] header keys of the first candidate grid, in DOM order."""
+    return driver.execute_script(
+        """
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const grid of tab.querySelectorAll('.ttip-chunks')) {
+          const ths = Array.from(grid.querySelectorAll('th[data-cand]'));
+          if (!ths.length) { continue; }
+          return ths.filter(t => !t.classList.contains('col-hidden'))
+                    .map(t => t.getAttribute('data-cand'));
+        }
+        return null;
+        """
+    )
+
+
+def _chart_tooltip_has_cand_list(driver):
+    """True if any tooltip in the active panel contains BOTH a candidate grid and
+    the legacy per-candidate list sections (they must be mutually exclusive)."""
+    return driver.execute_script(
+        """
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const tip of tab.querySelectorAll('.ttip')) {
+          if (tip.querySelector('.ttip-chunks [data-cand]') && tip.querySelector('.cand')) {
+            return true;
+          }
+        }
+        return false;
+        """
+    )
+
+
+def _grid_state(driver):
+    """{key: {hidden, ref}} for the first candidate grid in the active panel."""
+    return driver.execute_script(
+        """
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const grid of tab.querySelectorAll('.ttip-chunks')) {
+          const ths = grid.querySelectorAll('th[data-cand]');
+          if (!ths.length) { continue; }
+          const out = {};
+          ths.forEach(th => {
+            out[th.getAttribute('data-cand')] = {
+              hidden: th.classList.contains('col-hidden'),
+              ref: th.classList.contains('col-ref'),
+            };
+          });
+          return out;
+        }
+        return null;
+        """
+    )
+
+
+def _assembled_text(driver, key):
+    return driver.execute_script(
+        """
+        const key = arguments[0];
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const row of tab.querySelectorAll('.ttip-chunks tr.ttip-final')) {
+          const td = row.querySelector(`td[data-cand="${key}"]`);
+          if (td) { return td.textContent; }
+        }
+        return null;
+        """,
+        key,
+    )
+
+
+def test_popup_columns_follow_ref_and_compare(driver):
+    _open_stream_tab(driver)
+    _select(driver, V2_KEY, [V1_KEY])
+
+    state = _grid_state(driver)
+    assert state, "no candidate-column grid found in the stream tab"
+    assert V2_KEY in state and V1_KEY in state, f"expected both Dynamo columns, got {state}"
+
+    visible = sorted(k for k, s in state.items() if not s["hidden"])
+    assert visible == sorted([V2_KEY, V1_KEY]), (
+        f"popup must show exactly REF + compare-with columns, got visible={visible}"
+    )
+    assert state[V2_KEY]["ref"] and not state[V1_KEY]["ref"], (
+        f"REF marking wrong: {state}"
+    )
+
+
+def test_v1_assembled_is_not_doubled(driver):
+    _open_stream_tab(driver)
+    _select(driver, V2_KEY, [V1_KEY])
+    text = _assembled_text(driver, V1_KEY)
+    assert text is not None, "no assembled cell for the Dynamo v1 candidate"
+    assert "get_weatherget_weather" not in text, f"doubled v1 output on the page: {text!r}"
+
+
+def test_unchecking_compare_hides_its_column(driver):
+    _open_stream_tab(driver)
+    _select(driver, V2_KEY, [V1_KEY])
+    assert not _grid_state(driver)[V1_KEY]["hidden"]
+    _select(driver, V2_KEY, [])
+    state = _grid_state(driver)
+    assert state[V1_KEY]["hidden"], f"unchecked v1 column still visible: {state}"
+    assert not state[V2_KEY]["hidden"], "REF column must stay visible"
+
+
+def test_ref_column_is_first_and_follows_restar(driver):
+    """The REF candidate reads FIRST (leftmost after input), and re-starring another
+    candidate moves that one to the front."""
+    _open_stream_tab(driver)
+    _select(driver, V2_KEY, [V1_KEY])
+    order = _grid_column_order(driver)
+    assert order and order[0] == V2_KEY, f"REF (v2) must be the first column, got {order}"
+    _select(driver, V1_KEY, [V2_KEY])
+    order = _grid_column_order(driver)
+    assert order and order[0] == V1_KEY, f"after re-star, v1 must lead, got {order}"
+    # restore the default-ish selection for subsequent tests
+    _select(driver, V2_KEY, [V1_KEY])
+
+
+def test_chart_tooltips_have_no_candidate_list(driver):
+    """Wherever the candidate chart renders, the per-candidate list sections are gone
+    (the chart's output row carries the same info)."""
+    _open_stream_tab(driver)
+    assert not _chart_tooltip_has_cand_list(driver), (
+        "stream tab: tooltip shows BOTH the candidate chart and the legacy list"
+    )
+
+
+def _open_tab(driver, target_substr):
+    ok = driver.execute_script(
+        """
+        const want = arguments[0];
+        for (const b of document.querySelectorAll('.tab-button')) {
+          const t = b.getAttribute('data-tab-target') || '';
+          if (t.includes(want)) { b.click(); return t; }
+        }
+        return null;
+        """,
+        target_substr,
+    )
+    assert ok, f"no tab button matching {target_substr!r}"
+    time.sleep(0.3)
+
+
+def test_batch_tab_uses_candidate_chart(driver):
+    """The merged TC (batch data) tab renders the same candidate chart (single
+    output row), REF first, no duplicate list."""
+    _open_tab(driver, "toolcalling-batch")
+    order = _grid_column_order(driver)
+    assert order, "batch tab: no candidate chart found"
+    base = driver.execute_script(
+        "const c=document.querySelector('.tab-panel.active .cmpctl input.cmp-ref:checked');"
+        "return c?c.value:null;"
+    )
+    assert base and order[0] == base, f"batch REF {base!r} must lead, got {order}"
+    assert not _chart_tooltip_has_cand_list(driver), (
+        "batch tab: tooltip shows BOTH chart and legacy list"
+    )
+
+
+def test_reasoning_tabs_use_candidate_chart(driver):
+    """Both Reasoning tabs render the candidate chart with the dynamo/vllm/sglang
+    columns (stream additionally lists its input chunks as rows)."""
+    for target in ("reasoning-batch", "reasoning-stream"):
+        _open_tab(driver, target)
+        order = _grid_column_order(driver)
+        assert order, f"{target}: no candidate chart found"
+        assert set(order) <= {"dynamo", "vllm", "sglang"}, (
+            f"{target}: unexpected candidate keys {order}"
+        )
+        assert not _chart_tooltip_has_cand_list(driver), (
+            f"{target}: tooltip shows BOTH chart and legacy list"
+        )

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -88,12 +88,14 @@ def test_hover_shows_tooltip(driver):
 
 
 def test_compare_candidates_are_per_tab(driver):
-    """Each tab's compare control carries its own candidate chips: the merged Tool
-    Calling (batch data) tab offers a vLLM Rust stream candidate; Reasoning does not."""
+    """Each tab's compare control carries its own candidate rows: the merged Tool
+    Calling (batch data) tab offers a vLLM Rust stream candidate; Reasoning does not.
+    (The candidates were `.chip` elements before the compare-bar rework (#98/#105)
+    replaced them with `.cmprow-label[data-cand]` rows.)"""
     def cand_keys():
         return driver.execute_script(
             "const p=document.querySelector('.tab-panel.active .cmpctl');"
-            "return p?Array.from(p.querySelectorAll('.chip')).map(c=>c.dataset.cand):[];"
+            "return p?Array.from(p.querySelectorAll('.cmprow-label[data-cand]')).map(c=>c.dataset.cand):[];"
         )
 
     def click_tab(panel_id):

--- a/conformance/utils/tests/test_render_invariants.py
+++ b/conformance/utils/tests/test_render_invariants.py
@@ -207,3 +207,37 @@ def test_implemented_v2_families_not_marked_inventory_only(rendered_page):
     assert not mislabeled, (
         f"families with a real v2 parser labeled 'inventory only': {sorted(set(mislabeled))}"
     )
+
+
+# --- I8: unaligned captures must not fake per-chunk timing -------------------------
+def test_unaligned_candidates_show_no_per_chunk_timing(rendered_page):
+    """A candidate column whose header carries the 'timing not recorded' note must
+    have NO per-chunk deltas rendered (all cells em-dash outside the assembled row) —
+    the v1 jail's emission-packed captures previously displayed at wrong positions."""
+    html = rendered_page.read_text()
+    noted = 0
+    for seg in html.split('<table class="ttip-chunks">')[1:]:
+        table = seg.split("</table>")[0]
+        m = re.search(
+            r'<th data-cand="([^"]+)">(?:(?!</th>).)*?timing not recorded', table, re.S
+        )
+        if not m:
+            continue
+        noted += 1
+        key = m.group(1)
+        for row in table.split("<tr")[1:]:
+            if 'class="ttip-final"' in row:
+                continue
+            cm = re.search(rf'<td data-cand="{re.escape(key)}">(.*?)</td>', row, re.S)
+            if cm:
+                assert cm.group(1).strip() in ("—", ""), (
+                    f"noted column {key} renders per-chunk data: {cm.group(1)[:80]!r}"
+                )
+    assert noted > 0, "expected at least one 'timing not recorded' column (v1 jail)"
+    # The reasoning tab's final-output-only notes alone must NOT satisfy this guard:
+    # the TC stream tab's v1 jail column (emission-packed capture) must be noted too.
+    html2 = rendered_page.read_text()
+    assert re.search(
+        r'<th data-cand="dynamo_rust-3-0-0">(?:(?!</th>).)*?timing not recorded',
+        html2, re.S,
+    ), "the v1 jail (dynamo_rust-3-0-0) stream column lacks the timing note"

--- a/conformance/utils/tests/test_render_invariants.py
+++ b/conformance/utils/tests/test_render_invariants.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Semantic invariants on the FINAL rendered page (not greps of the source code).
+
+Born from a real escape: the resolver fold doubled Dynamo v1 output into
+`calls=[get_weatherget_weather(...)]` and it shipped to the rendered page unnoticed
+because verification stopped at "the data exists", never "the output is right".
+
+Scoping learned the hard way while writing these:
+- Doubled names are only OUR bug in Dynamo-attributed content. Captured peer blocks
+  legitimately record imperfect engine behavior (e.g. SGLang really emits
+  `get_weatherget_weather` on gemma4's two-call case) — the legend says so.
+- Row-slicing the HTML with `<tr>...</tr>` regexes is wrong: tooltips embed nested
+  tables. Cells carry `data-family`; panels have ids — use those.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from resolve_stream_fixtures import resolve, version_key  # noqa: E402
+
+FIXTURES_ROOT = Path(
+    os.environ.get(
+        "CONFORMANCE_FIXTURES_ROOT",
+        os.path.expanduser("~/.cache/dynamo/conformance-fixtures"),
+    )
+)
+STREAM_SRC = FIXTURES_ROOT / "toolcalling" / "fixtures-stream-v2"
+
+pytestmark = pytest.mark.skipif(
+    not STREAM_SRC.is_dir(), reason="conformance fixtures not downloaded"
+)
+
+DOUBLED = re.compile(r"calls=\[(\w+?)\1\(")
+
+
+def _dynamo_version_dirs() -> list[tuple[str, Path]]:
+    out = []
+    for d in STREAM_SRC.iterdir():
+        if d.is_dir() and d.name.startswith("dynamo_rust-"):
+            out.append((d.name.split("-", 1)[1], d))
+    out.sort(key=lambda t: version_key(t[0]))
+    return out
+
+
+def _panel(html: str, panel_id: str) -> str:
+    i = html.find(f'id="{panel_id}"')
+    assert i != -1, f"panel {panel_id!r} not found in render"
+    j = html.find('id="tab-', i + len(panel_id) + 6)
+    return html[i : j if j != -1 else len(html)]
+
+
+# --- I1: no doubled call name in DYNAMO-attributed output --------------------------
+def test_no_doubled_call_names_in_dynamo_output(rendered_page):
+    html = rendered_page.read_text()
+    bad: set[str] = set()
+    # Tooltip candidate sections for any Dynamo candidate (top blocks).
+    for m in re.finditer(
+        r'class="cand cand-dynamo[^"]*">(.*?)</span>', html, re.S
+    ):
+        bad.update(DOUBLED.findall(m.group(1)))
+    # Per-chunk grid assembled cells for Dynamo candidates.
+    for m in re.finditer(r'<td data-cand="dynamo[^"]*">(.*?)</td>', html, re.S):
+        bad.update(DOUBLED.findall(m.group(1)))
+    assert not bad, f"doubled call names in Dynamo output: {sorted(bad)}"
+
+
+# --- I2: per-chunk grid columns must be selectable in the compare bar --------------
+def test_grid_candidate_keys_match_compare_bar(rendered_page):
+    html = rendered_page.read_text()
+    grid_keys = set(re.findall(r'<th data-cand="([^"]+)">', html))
+    bar_keys = set(re.findall(r'class="cmp-(?:on|ref)"[^>]*value="([^"]+)"', html))
+    orphans = grid_keys - bar_keys
+    assert not orphans, (
+        f"grid columns not toggleable from the compare bar (key mismatch): {sorted(orphans)}"
+    )
+
+
+# --- I3: folding a higher dynamo version reproduces that version's docs exactly ----
+def test_fold_reproduces_each_dynamo_version_exactly():
+    versions = _dynamo_version_dirs()
+    if len(versions) < 2:
+        pytest.skip("needs at least two dynamo_rust version dirs")
+    top_ver, top_dir = versions[-1]
+    with tempfile.TemporaryDirectory() as tmp:
+        resolve(STREAM_SRC, tmp, select=[f"dynamo_rust-{top_ver}"])
+        for vfp in top_dir.glob("*/*.yaml"):
+            folded_fp = Path(tmp) / vfp.parent.name / vfp.name
+            if not folded_fp.exists():
+                continue
+            want_doc = yaml.safe_load(vfp.read_text()) or {}
+            got_doc = yaml.safe_load(folded_fp.read_text()) or {}
+            for cid, want_case in (want_doc.get("cases") or {}).items():
+                got_case = (got_doc.get("cases") or {}).get(cid)
+                if got_case is None or "unavailable" in want_case:
+                    continue
+                got = [
+                    (i, d)
+                    for i, ch in enumerate(got_case.get("chunks") or [])
+                    for d in ((ch.get("expected") or {}).get("dynamo_rust") or [])
+                ]
+                want = [
+                    (i, d)
+                    for i, ch in enumerate(want_case.get("chunks") or [])
+                    for d in (ch.get("expected") or [])
+                ]
+                assert got == want, (
+                    f"{vfp.parent.name}/{vfp.name} {cid}: folded dynamo_rust deltas "
+                    f"differ from the {top_ver} doc (lower-version residue?)\n"
+                    f"  got:  {got}\n  want: {want}"
+                )
+
+
+# --- I4: every family the default REF covers renders populated stream cells --------
+def test_ref_covered_families_have_populated_stream_cells(rendered_page):
+    versions = _dynamo_version_dirs()
+    if not versions:
+        pytest.skip("no dynamo_rust version dirs")
+    _ver, anchor_dir = versions[0]  # lowest version = the default REF
+    covered = {p.name for p in anchor_dir.iterdir() if p.is_dir()}
+    panel = _panel(rendered_page.read_text(), "tab-toolcalling-streamv2")
+    for family in sorted(covered):
+        classes = re.findall(
+            rf'<td class="cell ([a-z]+)[^"]*"[^>]*data-family="{re.escape(family)}"',
+            panel,
+        )
+        populated = sum(1 for c in classes if c in ("ok", "research", "documented"))
+        assert populated > 0, (
+            f"family {family!r} is covered by the default REF but renders no populated "
+            f"stream cells (cells found: {len(classes)})"
+        )
+
+
+# --- I6: candidate chart and per-candidate list are mutually exclusive -------------
+def test_no_tooltip_has_both_chart_and_candidate_list(rendered_page):
+    """A tooltip that renders the candidate chart must NOT also render the legacy
+    per-candidate list sections — the chart's output row replaces them."""
+    html = rendered_page.read_text()
+    both = 0
+    # Splitting on tooltip openings yields one segment per tooltip (charts and cand
+    # sections only exist inside tooltips, so trailing inter-tooltip markup is inert).
+    for seg in html.split('<div class="ttip">')[1:]:
+        if (
+            '<table class="ttip-chunks">' in seg
+            and 'data-cand="' in seg
+            and 'class="cand cand-' in seg
+        ):
+            both += 1
+    assert both == 0, f"{both} tooltips render BOTH the candidate chart and the list"
+
+
+# --- I7: within an engine, compare-bar versions run latest-first -------------------
+def test_compare_bar_versions_latest_first(rendered_page):
+    """Within one engine (e.g. vLLM Python), versions must list DESCENDING
+    (0.24.0 before 0.23.0) in the compare bar; engines keep their canonical order."""
+    html = rendered_page.read_text()
+    for pid in ("tab-toolcalling-batch", "tab-toolcalling-streamv2"):
+        panel = _panel(html, pid)
+        keys = re.findall(r'class="cmprow-label" data-cand="([^"]+)"', panel)
+        groups: dict[str, list[str]] = {}
+        for k in keys:
+            m = re.match(r"^([a-z_]+(?:-[sb])?)-(\d[\w-]*)$", k)
+            if m:
+                groups.setdefault(m.group(1), []).append(m.group(2))
+        for impl, slugs in groups.items():
+            parsed = [version_key(s.replace("-", ".")) for s in slugs]
+            assert parsed == sorted(parsed, reverse=True), (
+                f"{pid}: {impl} versions not latest-first: {slugs}"
+            )
+
+
+# --- I5: no v2-implemented family renders as "inventory only" ----------------------
+def test_implemented_v2_families_not_marked_inventory_only(rendered_page):
+    """A family whose parser exists in parsers/v2 must not carry the
+    'not implemented / inventory only' parser tooltip (the copy-paste chain gap that
+    left gemma4/glm47/kimi_k2/minimax_m2/qwen3_coder mislabeled)."""
+    registered = set(
+        re.findall(
+            r'^\s*"(\w+)"\s*(?:\|\s*"\w+"\s*)*=>',
+            (UTILS.parents[1] / "parsers/v2/src/tool_calling/mod.rs").read_text(),
+            re.M,
+        )
+    )
+    registered.discard("other")
+    panel = _panel(rendered_page.read_text(), "tab-toolcalling-streamv2")
+    mislabeled = []
+    for m in re.finditer(
+        r'<td class="parser"[^>]*>(\w+)(?:<span[^>]*>[^<]*</span>)?'
+        r"<div class=\"ttip\">.{0,400}?not implemented for this family yet",
+        panel,
+        re.S,
+    ):
+        if m.group(1) in registered:
+            mislabeled.append(m.group(1))
+    assert not mislabeled, (
+        f"families with a real v2 parser labeled 'inventory only': {sorted(set(mislabeled))}"
+    )

--- a/conformance/utils/tests/test_resolve_stream_fixtures.py
+++ b/conformance/utils/tests/test_resolve_stream_fixtures.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fold semantics of resolve_stream_fixtures.py.
+
+Regression for the doubled-call bug: `_merge_impl`'s docstring promises that when a
+version doc lists a case it "replaces the impl's prior state entirely", but the code
+only overwrote chunk indices `0..len(overlay.chunks)`. A higher-version doc with FEWER
+chunks than the base (Dynamo v1 3.0.0 records 2 chunks against a 6-chunk input, while
+the v2 0.1.11 anchor emits in chunk 3) left the lower version's deltas in the tail
+chunks, so assembly concatenated both versions:
+`get_weatherget_weather("{"location":"NYC"}{"location":"NYC"}")`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from resolve_stream_fixtures import resolve  # noqa: E402
+
+FAMILY = "famx"
+CASE = "TOOLCALLING.streamv2.1"
+NAME = "TOOLCALLING.streamv2.1.yaml"
+
+
+def _write(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+
+
+def _make_tree(root: Path) -> None:
+    # Shared inputs: 6 chunks (the real deepseek streamv2.1 shape).
+    _write(root / "inputs" / FAMILY / NAME, {
+        "family": FAMILY,
+        "mode": "streamv2",
+        "cases": {CASE: {"chunks": [
+            {"delta_text": "<tc> <invoke"},
+            {"delta_text": ' name="get_weather">'},
+            {"delta_text": ' <param name="location">'},
+            {"delta_text": "NYC</param> </invoke>"},
+            {"delta_text": " </tc>"},
+            {"delta_text": "", "finish_reason": "tool_calls"},
+        ]}},
+    })
+    # v2 anchor (lowest version): emits name then args in chunk 3.
+    _write(root / "dynamo_rust-0.1.11" / FAMILY / NAME, {
+        "family": FAMILY,
+        "mode": "streamv2",
+        "captured_with": {"dynamo_rust": "0.1.11"},
+        "cases": {CASE: {"chunks": [
+            {"expected": []},
+            {"expected": []},
+            {"expected": []},
+            {"expected": [
+                {"index": 0, "name": "get_weather", "arguments": ""},
+                {"index": 0, "arguments": '{"location":"NYC"}'},
+            ]},
+            {"expected": []},
+            {"expected": []},
+        ]}},
+    })
+    # v1 overlay (higher version): a DIFFERENT parser, and its doc carries FEWER
+    # chunks than the base — the shape that triggered the bug.
+    _write(root / "dynamo_rust-3.0.0" / FAMILY / NAME, {
+        "family": FAMILY,
+        "mode": "streamv2",
+        "captured_with": {"dynamo_rust": "3.0.0"},
+        "cases": {CASE: {"chunks": [
+            {"expected": [
+                {"index": 0, "id": True, "name": "get_weather",
+                 "arguments": '{"location":"NYC"}'},
+            ]},
+            {"expected": []},
+        ]}},
+    })
+
+
+def _dynamo_deltas(folded_case: dict) -> list[tuple[int, dict]]:
+    """(chunk_index, delta) for every dynamo_rust delta in the folded case."""
+    out = []
+    for i, ch in enumerate(folded_case.get("chunks") or []):
+        for delta in ((ch.get("expected") or {}).get("dynamo_rust") or []):
+            out.append((i, delta))
+    return out
+
+
+def test_higher_version_with_fewer_chunks_fully_replaces_lower(tmp_path):
+    root = tmp_path / "sv2"
+    out = tmp_path / "out"
+    _make_tree(root)
+
+    resolve(root, out, select=["dynamo_rust-3.0.0"])
+
+    folded = yaml.safe_load((out / FAMILY / NAME).read_text())
+    case = folded["cases"][CASE]
+    deltas = _dynamo_deltas(case)
+
+    # Exactly the 3.0.0 doc's content: ONE delta, in chunk 0 — no v2 residue anywhere.
+    assert [i for i, _ in deltas] == [0], (
+        f"v2 anchor deltas leaked into tail chunks: indices {[i for i, _ in deltas]}"
+    )
+    # Assembly must be a single, un-doubled call.
+    name = "".join(d.get("name") or "" for _, d in deltas)
+    args = "".join(d.get("arguments") or "" for _, d in deltas)
+    assert name == "get_weather", f"doubled/mangled name: {name!r}"
+    assert args == '{"location":"NYC"}', f"doubled/mangled arguments: {args!r}"
+
+
+def test_lower_target_keeps_anchor_untouched(tmp_path):
+    # Selecting the anchor version itself must reproduce the anchor exactly.
+    root = tmp_path / "sv2"
+    out = tmp_path / "out"
+    _make_tree(root)
+
+    resolve(root, out, select=["dynamo_rust-0.1.11"])
+
+    folded = yaml.safe_load((out / FAMILY / NAME).read_text())
+    deltas = _dynamo_deltas(folded["cases"][CASE])
+    assert [i for i, _ in deltas] == [3, 3]
+    assert "".join(d.get("name") or "" for _, d in deltas) == "get_weather"

--- a/parsers/v2/README.md
+++ b/parsers/v2/README.md
@@ -4,7 +4,7 @@ Rust crate for Dynamo-owned token-incremental tool-call parsers. This is the v2 
 
 This README is the canonical parser documentation for the workspace. The goals, family taxonomy, and how-to-add-a-parser guidance below cover both the v1 batch crate (`../parsers/`) and this v2 streaming crate, and `../parsers/README.md` defers here.
 
-**Two parser paths exist today.** v1 (`../parsers/`) is the **jail-and-buffer** path still in use: it buffers the entire model output, then parses it. v2 (this crate) is the **pure-streaming** path — token-incremental, and still under development. The two are kept in agreement (goal 8 below). v1 is not being merged into v2; when v2 is done it will fully replace v1, and all v1 code and docs will be removed outright. Put new parser work and documentation here, not in v1.
+**Two parser paths exist today (universal convention).** v1 (`../parsers/`) is the **batch** parser, used two ways: plain **batch** (complete text parsed in one call) and **jail+batch** (streaming input is buffered — "jailed" — until a call completes, then batch-parsed and emitted all at once; a call is never streamed incrementally). v2 (this crate) is the **streaming** parser — its primary mode emits deltas per chunk as input arrives, and it can also take batch input (the whole text as one chunk, the batch-on-stream path). v2 is still under development. The two are kept in agreement (goal 8 below). v1 is not being merged into v2; when v2 is done it will fully replace v1, and all v1 code and docs will be removed outright. Put new parser work and documentation here, not in v1.
 
 ## Parser goals (read first)
 


### PR DESCRIPTION
#### Overview:

**UI change only — no parser code is touched** (zero `.rs` files; only the HTML generator, JS/CSS, render tooling, tests, and docs). Very harmless: nothing in the parsing pipeline changes behavior.

This PR makes every conformance popup show one left-to-right chart whose columns are exactly the selected Reference + Compare-with parsers (REF first, gold-starred), replacing the repeated per-candidate list — and fixes the stream fixture version-fold that doubled Dynamo v1 output in the DISPLAY data. It also adds a loading state (no false-green flash before the compare model applies), shrink-wraps the compare bar, marks jail columns whose captures carry no per-chunk timing, and orders versions latest-first within each engine.

Linear: [DIS-2380](https://linear.app/nvidia/issue/DIS-2380/conformance-popup-unified-candidate-chart-ref-first-across-tabs-fix)

#### Example (before → after):

Input: `deepseek_v4` `TOOLCALLING.streamv2.1` (single `get_weather` call), REF = Dynamo v2, Compare-with = Dynamo v1

```
before:  v1 column: calls=[get_weatherget_weather("{\"location\":\"NYC\"}{\"location\":\"NYC\"}")]   <- fold merged two versions' deltas
after:   v1 column: calls=[get_weather({"location": "NYC"})]   in a grid: input | * v2 <- REF | v1
```

#### Details:

- `resolve_stream_fixtures._merge_impl` now clears an impl from every base chunk before applying a version overlay — a higher version with fewer chunks previously left the lower version's deltas in the tail chunks, and assembly concatenated both.
- One chart everywhere: TC stream (per-chunk), TC batch + Reasoning (single output row; reasoning stream lists its input chunks), candidate columns toggled/REF-first-ordered by the compare bar; the per-candidate list sections are dropped and each candidate's `explanation:` rides in its column.
- Version ordering: within one engine the compare bar + chart columns list versions LATEST-FIRST (0.24.0 before 0.23.0); engines keep canonical order. The batch tab's default Reference becomes Dynamo's latest.
- New guards: fold unit tests, rendered-page invariants (no doubled Dynamo names, grid keys match the compare bar, fold reproduces each version doc exactly, chart/list mutual exclusion, no implemented family labeled inventory-only), and Selenium browser tests driving real clicks, sharing one render via a session fixture.

#### Verification:

`python3 -m pytest conformance/utils/tests/` → 87 passed, 0 failed, 0 skipped (includes the headless-Chrome Selenium tests driving real REF/compare clicks); CONFORMANCE_v2 rendered from the same state.

#### Where should the reviewer start?

`conformance/utils/src/resolve_stream_fixtures.py`, then `conformance/utils/src/generate_conformance_table.py`, `conformance/utils/src/assets/conformance.js`

/coderabbit profile chill

