### PR TITLE
fix(tokenizer): support tokenizer options

### DIFF
--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -6,12 +6,16 @@ use std::path::Path;
 use tokenizers::tokenizer::{AddedToken, Tokenizer as HfTokenizer};
 
 use super::{
-    Encoding, Error, Result, TokenIdType,
+    Encoding, Error, Result, TokenIdType, TokenizerOptions,
     traits::{DecodeResult, Decoder, Encoder, Tokenizer},
 };
 
 pub struct HuggingFaceTokenizer {
     tokenizer: HfTokenizer,
+    /// Construction-time options; see [`TokenizerOptions`]. Defaults preserve
+    /// the historical behavior (e.g. `add_special_tokens: false`). Set via
+    /// [`Tokenizer::with_options`].
+    options: TokenizerOptions,
 }
 
 impl HuggingFaceTokenizer {
@@ -27,11 +31,14 @@ impl HuggingFaceTokenizer {
             merge_special_tokens_from_config(&mut tokenizer, parent);
         }
 
-        Ok(HuggingFaceTokenizer { tokenizer })
+        Ok(Self::from_tokenizer(tokenizer))
     }
 
     pub fn from_tokenizer(tokenizer: HfTokenizer) -> Self {
-        HuggingFaceTokenizer { tokenizer }
+        HuggingFaceTokenizer {
+            tokenizer,
+            options: TokenizerOptions::default(),
+        }
     }
 
     /// Wrap an already-loaded `HfTokenizer` and merge in the sibling
@@ -39,7 +46,7 @@ impl HuggingFaceTokenizer {
     pub fn from_tokenizer_with_model_dir(tokenizer: HfTokenizer, model_dir: &Path) -> Self {
         let mut tokenizer = tokenizer;
         merge_special_tokens_from_config(&mut tokenizer, model_dir);
-        HuggingFaceTokenizer { tokenizer }
+        Self::from_tokenizer(tokenizer)
     }
 }
 
@@ -136,7 +143,7 @@ impl Encoder for HuggingFaceTokenizer {
         // This self.tokenizer is the library
         let encoding = self
             .tokenizer
-            .encode(input, false)
+            .encode(input, self.options.add_special_tokens)
             .map_err(|err| Error::msg(format!("Error tokenizing input: {err}")))?;
 
         Ok(Encoding::Hf(Box::new(encoding)))
@@ -145,7 +152,7 @@ impl Encoder for HuggingFaceTokenizer {
     fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
         let hf_encodings = self
             .tokenizer
-            .encode_batch(inputs.to_vec(), false)
+            .encode_batch(inputs.to_vec(), self.options.add_special_tokens)
             .map_err(|err| Error::msg(format!("Error batch tokenizing input: {err}")))?;
 
         let encodings = hf_encodings
@@ -169,11 +176,18 @@ impl Decoder for HuggingFaceTokenizer {
     }
 }
 
-impl Tokenizer for HuggingFaceTokenizer {}
+impl Tokenizer for HuggingFaceTokenizer {
+    /// HF honors [`TokenizerOptions::add_special_tokens`] (BOS/EOS per the
+    /// tokenizer's post-processor template).
+    fn with_options(mut self, options: TokenizerOptions) -> Self {
+        self.options = options;
+        self
+    }
+}
 
 impl From<HfTokenizer> for HuggingFaceTokenizer {
     fn from(tokenizer: HfTokenizer) -> Self {
-        HuggingFaceTokenizer { tokenizer }
+        Self::from_tokenizer(tokenizer)
     }
 }
 
@@ -275,5 +289,85 @@ mod tests {
             decoded_keep.contains("<|special_dropped|>"),
             "non-promoted special:false token must survive skip_special_tokens=true; got {decoded_keep:?}"
         );
+    }
+
+    #[test]
+    fn add_special_tokens_flag_controls_encode() {
+        // WordLevel tokenizer with a TemplateProcessing post-processor that
+        // prepends <bos>. The post-processor only fires when encode is
+        // called with add_special_tokens=true, which is exactly the knob
+        // `TokenizerOptions`/`with_options` exposes.
+        const TOKENIZER_JSON: &str = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {"id": 0, "content": "<unk>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+                {"id": 3, "content": "<bos>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false}
+            ],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": {
+                "type": "TemplateProcessing",
+                "single": [
+                    {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}}
+                ],
+                "pair": [
+                    {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}},
+                    {"Sequence": {"id": "B", "type_id": 0}}
+                ],
+                "special_tokens": {
+                    "<bos>": {"id": "<bos>", "ids": [3], "tokens": ["<bos>"]}
+                }
+            },
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {"<unk>": 0, "hello": 1, "world": 2, "<bos>": 3},
+                "unk_token": "<unk>"
+            }
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("tokenizer.json"), TOKENIZER_JSON).unwrap();
+        let path = dir.path().join("tokenizer.json");
+        let path = path.to_str().unwrap();
+
+        let ids = |enc: &Encoding| match enc {
+            Encoding::Hf(e) => e.get_ids().to_vec(),
+            _ => panic!("expected Hf encoding"),
+        };
+
+        // Default: unchanged historical behavior — no BOS.
+        let plain = HuggingFaceTokenizer::from_file(path).unwrap();
+        assert_eq!(ids(&plain.encode("hello").unwrap()), vec![1]);
+
+        let with_bos = HuggingFaceTokenizer::from_file(path)
+            .unwrap()
+            .with_options(TokenizerOptions {
+                add_special_tokens: true,
+            });
+        assert_eq!(ids(&with_bos.encode("hello").unwrap()), vec![3, 1]);
+        let batch = with_bos.encode_batch(&["hello", "world"]).unwrap();
+        assert_eq!(ids(&batch[0]), vec![3, 1]);
+        assert_eq!(ids(&batch[1]), vec![3, 2]);
+
+        // Same knob through the top-level wrapper: from_file keeps the
+        // historical default, from_file_with_options threads the flag to
+        // construction before the tokenizer goes behind the shared Arc.
+        use crate::Tokenizer as TokenizerWrapper;
+        let wrapper_plain = TokenizerWrapper::from_file(path).unwrap();
+        assert_eq!(ids(&wrapper_plain.encode("hello").unwrap()), vec![1]);
+
+        let wrapper_bos = TokenizerWrapper::from_file_with_options(
+            path,
+            TokenizerOptions {
+                add_special_tokens: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&wrapper_bos.encode("hello").unwrap()), vec![3, 1]);
     }
 }

--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -344,11 +344,12 @@ mod tests {
         let plain = HuggingFaceTokenizer::from_file(path).unwrap();
         assert_eq!(ids(&plain.encode("hello").unwrap()), vec![1]);
 
-        let with_bos = HuggingFaceTokenizer::from_file(path)
-            .unwrap()
-            .with_options(TokenizerOptions {
-                add_special_tokens: true,
-            });
+        let with_bos =
+            HuggingFaceTokenizer::from_file(path)
+                .unwrap()
+                .with_options(TokenizerOptions {
+                    add_special_tokens: true,
+                });
         assert_eq!(ids(&with_bos.encode("hello").unwrap()), vec![3, 1]);
         let batch = with_bos.encode_batch(&["hello", "world"]).unwrap();
         assert_eq!(ids(&batch[0]), vec![3, 1]);

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -247,11 +247,13 @@ pub struct Tokenizer(Arc<dyn traits::Tokenizer>);
 
 impl Tokenizer {
     pub fn from_file(file_path: &str) -> Result<Tokenizer> {
-        Self::from_file_with_options(file_path, TokenizerOptions::default())
+        Ok(Tokenizer(create_tokenizer_from_file(file_path)?))
     }
 
     pub fn from_file_with_options(file_path: &str, options: TokenizerOptions) -> Result<Tokenizer> {
-        Ok(Tokenizer(create_tokenizer_from_file(file_path, options)?))
+        Ok(Tokenizer(create_tokenizer_from_file_with_options(
+            file_path, options,
+        )?))
     }
 
     /// Create a stateful sequence object for decoding token_ids into text
@@ -293,7 +295,17 @@ where
 /// - json: HuggingFace tokenizer
 /// - model, tiktoken: tiktoken BPE tokenizer (requires `config.json` with a supported
 ///   `model_type` in the same directory; currently: kimi, kimi_k2, kimi_k25)
-pub fn create_tokenizer_from_file(
+pub fn create_tokenizer_from_file(file_path: &str) -> Result<Arc<dyn traits::Tokenizer>> {
+    create_tokenizer_from_file_with_options(file_path, Default::default())
+}
+
+/// Create a tokenizer from a file path to a tokenizer file with additional tokenizer option.
+/// The file extension is used to determine the tokenizer type.
+/// Supported file types are:
+/// - json: HuggingFace tokenizer
+/// - model, tiktoken: tiktoken BPE tokenizer (requires `config.json` with a supported
+///   `model_type` in the same directory; currently: kimi, kimi_k2, kimi_k25)
+pub fn create_tokenizer_from_file_with_options(
     file_path: &str,
     options: TokenizerOptions,
 ) -> Result<Arc<dyn traits::Tokenizer>> {

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -130,6 +130,17 @@ pub mod traits {
     }
 
     pub trait Tokenizer: Encoder + Decoder {
+        /// Apply construction-time [`TokenizerOptions`].
+        ///
+        /// The default implementation ignores the options — correct for
+        /// tokenizers with no applicable option.
+        fn with_options(self, options: TokenizerOptions) -> Self
+        where
+            Self: Sized,
+        {
+            let _ = options;
+            self
+        }
         // fn get_vocab_size(&self) -> usize;
         // fn make_unique_clone(&self) -> Box<dyn Tokenizer>;
     }
@@ -217,13 +228,30 @@ impl Encoding {
     }
 }
 
+/// Construction options for [`Tokenizer::from_file_with_options`] /
+/// [`create_tokenizer_from_file`], applied to concrete tokenizers via
+/// [`traits::Tokenizer::with_options`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokenizerOptions {
+    /// Ask the tokenizer to add its declared special tokens (e.g. BOS/EOS via
+    /// the HuggingFace post-processor) during `encode`/`encode_batch`.
+    /// Defaults to `false`, the historical behavior.
+    ///
+    /// Only applicable to HuggingFace tokenizers.
+    pub add_special_tokens: bool,
+}
+
 /// Main tokenizer wrapper that provides a unified interface for different tokenizer implementations
 #[derive(Clone)]
 pub struct Tokenizer(Arc<dyn traits::Tokenizer>);
 
 impl Tokenizer {
     pub fn from_file(file_path: &str) -> Result<Tokenizer> {
-        Ok(Tokenizer(create_tokenizer_from_file(file_path)?))
+        Self::from_file_with_options(file_path, TokenizerOptions::default())
+    }
+
+    pub fn from_file_with_options(file_path: &str, options: TokenizerOptions) -> Result<Tokenizer> {
+        Ok(Tokenizer(create_tokenizer_from_file(file_path, options)?))
     }
 
     /// Create a stateful sequence object for decoding token_ids into text
@@ -265,7 +293,12 @@ where
 /// - json: HuggingFace tokenizer
 /// - model, tiktoken: tiktoken BPE tokenizer (requires `config.json` with a supported
 ///   `model_type` in the same directory; currently: kimi, kimi_k2, kimi_k25)
-pub fn create_tokenizer_from_file(file_path: &str) -> Result<Arc<dyn traits::Tokenizer>> {
+pub fn create_tokenizer_from_file(
+    file_path: &str,
+    options: TokenizerOptions,
+) -> Result<Arc<dyn traits::Tokenizer>> {
+    use traits::Tokenizer as _;
+
     let path = Path::new(file_path);
     let extension = path
         .extension()
@@ -274,11 +307,11 @@ pub fn create_tokenizer_from_file(file_path: &str) -> Result<Arc<dyn traits::Tok
 
     match extension {
         "json" => {
-            let tokenizer = HuggingFaceTokenizer::from_file(file_path)?;
+            let tokenizer = HuggingFaceTokenizer::from_file(file_path)?.with_options(options);
             Ok(Arc::new(tokenizer))
         }
         "model" | "tiktoken" => {
-            let tokenizer = TikTokenTokenizer::from_file_auto(file_path)?;
+            let tokenizer = TikTokenTokenizer::from_file_auto(file_path)?.with_options(options);
             Ok(Arc::new(tokenizer))
         }
         _ => Err(Error::msg(format!(


### PR DESCRIPTION
# Overview

Support tokenizer options. This change is mandatory for Sglang rust server since the add_special_tokens is enabled by default during encode. Without this, some model gsm8k return low value.

Refer: https://github.com/huggingface/transformers/blob/1f8daee0c80cd53a44b1094b79309dd8675d6392/src/transformers/tokenization_utils_base.py#L2258
