### PR TITLE
docs(conformance): add HF dataset card and publish it from package_and_publish.py

### DIFF
--- a/conformance/utils/dataset_card.md
+++ b/conformance/utils/dataset_card.md
@@ -35,10 +35,10 @@ This dataset is ready for commercial or non-commercial uses.
 NVIDIA Corporation
 
 ## Dataset Creation Date:
-July 2026 (snapshot `20260708_190827`)
+{{CREATED_PT}} (snapshot `{{STAMP}}`)
 
 ## Version:
-`20260708_190827` — peers: vLLM 0.24.0, SGLang 0.5.14; Dynamo parser crates dynamo-parsers 4.1.x / dynamo-parsers-v2 0.1.x. <br>
+`{{STAMP}}` — peers: {{PEERS}}; Dynamo parser crates {{CRATES}}. <br>
 
 Previous Version(s): earlier dated snapshots were used internally; no prior public versions are published.
 

--- a/conformance/utils/dataset_card.md
+++ b/conformance/utils/dataset_card.md
@@ -53,15 +53,17 @@ For NVIDIA Dynamo developers and contributors to run **parser conformance and re
 * Hybrid: Manually Collected, Synthetic, Automated <br>
 Hand-authored cases; fuzzer/randomizer-generated cases (a chunking-invariance harness); and expected outputs captured automatically by running the parser implementations. Some cases are adapted from the open-source vLLM and SGLang test suites (attributed per fixture). No data is scraped from users; no real user conversations are included.
 
-** Labeling Method<br>
+** Labeling Method (here: expected-output authoring)<br>
 * Hybrid: Manually-Labelled, Automated <br>
-The "label" for each case is its expected parser output, produced either by hand-authoring the intended result or by capturing the actual parser output at pinned engine versions.
+The "label" for each case is its expected parser output — the structured result a parser implementation must produce for a given input. Labels are produced either by hand-authoring the intended result or by capturing the actual parser output at pinned engine versions.
 
 ## Dataset Format
 Text. YAML (`.yaml`) test-fixture files, distributed as gzip tarballs (`.tar.gz`) pinned by an in-repo SHA-256 manifest.
 
 ## Dataset Quantification
 ~504 authored fixture files / ~1,967 test cases, plus per-engine-version expected-output overlays. Distributed as versioned `.tar.gz` shards plus a single monolith snapshot. A few megabytes total (well under 100 MB).
+
+Feature Count: N/A — test fixtures, not an ML dataset.
 
 ## Reference(s):
 * NVIDIA Dynamo — https://github.com/ai-dynamo/dynamo (the `conformance/` fixtures and `parsers/` crates)

--- a/conformance/utils/dataset_card.md
+++ b/conformance/utils/dataset_card.md
@@ -1,0 +1,76 @@
+---
+license: apache-2.0
+pretty_name: Dynamo Parser Conformance Fixtures
+task_categories:
+  - other
+tags:
+  - tool-calling
+  - parser-conformance
+  - reasoning-parsing
+  - nvidia-dynamo
+  - test-fixtures
+language:
+  - en
+size_categories:
+  - n<1K
+configs: []
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo Parser Conformance Fixtures
+
+## Dataset Description:
+
+Deterministic input / expected-output **test fixtures** for the [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) tool-calling and reasoning text parsers. Each fixture is a small YAML test case that pairs a piece of model-output text (or a sequence of streaming chunks) with the structured output that each parser implementation is expected to produce, so CI can catch parser regressions and cross-engine divergences (leaked delimiters, dropped/duplicated calls, truncated arguments).
+
+Despite HuggingFace's "dataset" namespace, this is a **software test-fixture corpus, NOT a training dataset**: it contains no machine learning content — no model training, no fine-tuning, no model evaluation — and nothing here is, or is used to produce, model weights. It is unit-test material that happens to be hosted on the Hub.
+
+This dataset is ready for commercial or non-commercial uses.
+
+## Dataset Owner(s):
+NVIDIA Corporation
+
+## Dataset Creation Date:
+July 2026 (snapshot `20260708_190827`)
+
+## Version:
+`20260708_190827` — peers: vLLM 0.24.0, SGLang 0.5.14; Dynamo parser crates dynamo-parsers 4.1.x / dynamo-parsers-v2 0.1.x. <br>
+
+Previous Version(s): earlier dated snapshots were used internally; no prior public versions are published.
+
+## License/Terms of Use:
+Apache-2.0 (`SPDX-License-Identifier: Apache-2.0`), matching the NVIDIA Dynamo project. Some cases are adapted from the vLLM and SGLang test suites (both Apache-2.0) and redistributed under Apache-2.0 with modifications; see [Reference(s)](#references).
+
+## Intended Usage:
+For NVIDIA Dynamo developers and contributors to run **parser conformance and regression tests** in CI, and to track cross-engine (Dynamo / vLLM / SGLang) parser divergences. Not intended for training or fine-tuning models, for measuring model quality, or as a general tool-calling benchmark.
+
+## Dataset Characterization
+** Data Collection Method<br>
+* Hybrid: Manually Collected, Synthetic, Automated <br>
+Hand-authored cases; fuzzer/randomizer-generated cases (a chunking-invariance harness); and expected outputs captured automatically by running the parser implementations. Some cases are adapted from the open-source vLLM and SGLang test suites (attributed per fixture). No data is scraped from users; no real user conversations are included.
+
+** Labeling Method<br>
+* Hybrid: Manually-Labelled, Automated <br>
+The "label" for each case is its expected parser output, produced either by hand-authoring the intended result or by capturing the actual parser output at pinned engine versions.
+
+## Dataset Format
+Text. YAML (`.yaml`) test-fixture files, distributed as gzip tarballs (`.tar.gz`) pinned by an in-repo SHA-256 manifest.
+
+## Dataset Quantification
+~504 authored fixture files / ~1,967 test cases, plus per-engine-version expected-output overlays. Distributed as versioned `.tar.gz` shards plus a single monolith snapshot. A few megabytes total (well under 100 MB).
+
+## Reference(s):
+* NVIDIA Dynamo — https://github.com/ai-dynamo/dynamo (the `conformance/` fixtures and `parsers/` crates)
+* vLLM (Apache-2.0) — https://github.com/vllm-project/vllm
+* SGLang (Apache-2.0) — https://github.com/sgl-project/sglang
+
+Upstream-adapted cases carry a per-fixture `ref`/`upstream` pointer to their source file.
+
+## Ethical Considerations:
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. Developers should work with their internal developer teams to ensure this dataset meets requirements for the relevant industry and use case and addresses unforeseen product misuse.
+
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/).

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -39,6 +39,10 @@ from pathlib import Path
 # conformance/utils/src/ -> repo root: 4 .parent calls (strip filename, then 3 dirs)
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MANIFEST_REL = Path("conformance") / "fixtures-manifest.json"
+# Source of truth for the HF dataset card. Published as the dataset's README.md
+# so the rendered card stays in sync with the repo instead of being hand-edited
+# on the Hub.
+DATASET_CARD_REL = Path("conformance") / "utils" / "dataset_card.md"
 DEFAULT_REPO = "ai-dynamo/conformance-fixtures"
 
 # Fixture trees that get one shard tarball per immediate subdir
@@ -216,6 +220,31 @@ def upload_blobs(token, repo_id, blobs_dir, commit_msg, dry_run):
     print(f"  Upload complete.")
 
 
+def upload_readme(token, repo_id, dry_run):
+    """Publish the in-repo dataset card as the HF dataset README (the rendered card).
+
+    `cleanup_old_loose` deliberately keeps README.md on the Hub; this keeps it
+    authoritative from the repo instead, so the card never drifts from source.
+    """
+    card = ROOT / DATASET_CARD_REL
+    if not card.is_file():
+        sys.exit(f"dataset card not found: {card}")
+    if dry_run:
+        print(f"  [dry-run] would upload {DATASET_CARD_REL} -> README.md")
+        return
+    from huggingface_hub import HfApi
+
+    api = HfApi(token=token)
+    api.upload_file(
+        path_or_fileobj=str(card),
+        path_in_repo="README.md",
+        repo_id=repo_id,
+        repo_type="dataset",
+        commit_message="docs: sync dataset card from repo",
+    )
+    print(f"  README.md <- {DATASET_CARD_REL}")
+
+
 def cleanup_old_loose(token, repo_id, dry_run):
     """Delete non-tarball files from the HF repo (clears the old loose YAML mirror)."""
     try:
@@ -330,6 +359,9 @@ def main():
 
         print(f"\nUploading to {args.repo}…")
         upload_blobs(token, args.repo, blobs_dir, f"fixtures: snapshot {stamp}", args.dry_run)
+
+        print("\nUploading dataset card…")
+        upload_readme(token, args.repo, args.dry_run)
 
         if args.cleanup_old:
             print(f"\nCleaning up old loose files in {args.repo}…")

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -220,8 +220,11 @@ def upload_blobs(token, repo_id, blobs_dir, commit_msg, dry_run):
     print(f"  Upload complete.")
 
 
-def upload_readme(token, repo_id, dry_run):
+def upload_readme(token, repo_id, stamp, created_pt, crates, peers, dry_run):
     """Publish the in-repo dataset card as the HF dataset README (the rendered card).
+
+    Renders {{STAMP}}, {{CREATED_PT}}, {{CRATES}}, {{PEERS}} placeholders so the
+    live card always reflects the current snapshot's version metadata.
 
     `cleanup_old_loose` deliberately keeps README.md on the Hub; this keeps it
     authoritative from the repo instead, so the card never drifts from source.
@@ -229,20 +232,32 @@ def upload_readme(token, repo_id, dry_run):
     card = ROOT / DATASET_CARD_REL
     if not card.is_file():
         sys.exit(f"dataset card not found: {card}")
+
+    peers_str = ", ".join(f"{k} {v}" for k, v in sorted(peers.items()))
+    crates_str = ", ".join(f"{k} {v}" for k, v in sorted(crates.items()))
+    rendered = (
+        card.read_text()
+        .replace("{{STAMP}}", stamp)
+        .replace("{{CREATED_PT}}", created_pt)
+        .replace("{{PEERS}}", peers_str)
+        .replace("{{CRATES}}", crates_str)
+    )
+
     if dry_run:
-        print(f"  [dry-run] would upload {DATASET_CARD_REL} -> README.md")
+        print(f"  [dry-run] would upload {DATASET_CARD_REL} -> README.md (stamp={stamp})")
         return
     from huggingface_hub import HfApi
+    import io
 
     api = HfApi(token=token)
     api.upload_file(
-        path_or_fileobj=str(card),
+        path_or_fileobj=io.BytesIO(rendered.encode()),
         path_in_repo="README.md",
         repo_id=repo_id,
         repo_type="dataset",
-        commit_message="docs: sync dataset card from repo",
+        commit_message=f"docs: sync dataset card from repo (snapshot {stamp})",
     )
-    print(f"  README.md <- {DATASET_CARD_REL}")
+    print(f"  README.md <- {DATASET_CARD_REL} (stamp={stamp})")
 
 
 def cleanup_old_loose(token, repo_id, dry_run):
@@ -361,7 +376,7 @@ def main():
         upload_blobs(token, args.repo, blobs_dir, f"fixtures: snapshot {stamp}", args.dry_run)
 
         print("\nUploading dataset card…")
-        upload_readme(token, args.repo, args.dry_run)
+        upload_readme(token, args.repo, stamp, created_pt, crates, peers, args.dry_run)
 
         if args.cleanup_old:
             print(f"\nCleaning up old loose files in {args.repo}…")


### PR DESCRIPTION
## Overview

I'm adding this because the `conformance-fixtures` dataset had no README, so its Hub page was blank and nothing said what the fixtures are. This adds the dataset card, keeps it in sync with the repo, and the card is already published to the Hub.

**These are software test fixtures, not a training dataset** — deterministic parser input / expected-output test cases used only to test text parsers in CI. There is **no machine learning here: no model training, no fine-tuning, no model evaluation**, and nothing here is or produces model weights.

The fixtures are a **composite**: hand-authored cases, fuzzer/randomizer-generated cases, and cases **adapted from the vLLM and SGLang test suites** (both **Apache-2.0**, same as this dataset — redistributed with modifications and attributed via each fixture's `ref`/`upstream` pointer). The card documents this and the third-party attribution.

## Details

- `conformance/utils/dataset_card.md` — the dataset card (Apache-2.0): what the fixtures are, their composite provenance + vLLM/SGLang Apache-2.0 attribution, structure, intended/out-of-scope use, an explicit "test fixtures, not training data / no ML" statement, and a no-PII/no-customer-data section.
- `package_and_publish.py` — new `upload_readme()` uploads that file as the dataset `README.md` on every publish, so the live card can't drift (`--dry-run` prints, skips the upload). The current card is already uploaded.

## Verification

- `python3 -m py_compile conformance/utils/src/package_and_publish.py` → OK.
- `--dry-run` prints the upload it would do, then skips it.

---

Reviewer, start here: `package_and_publish.py` — `upload_readme()` + its call in `main()`; then skim the card's Source Data + Licensing sections.

@coderabbitai review