### PR TITLE
fix: relax tokio pin =1.48.0 -> 1.48 so consumers can build on tokio 1.52.3+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "dynamo-parsers",
@@ -1044,7 +1044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2231,7 +2231,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3418,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3725,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3742,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ strum = "0.27"
 tempfile = "3"
 thiserror = "2.0.17"
 tiktoken-rs = { version = "0.9", default-features = false }
-tokio = "=1.48.0"
+tokio = "1.48"
 tokio-test = "0.4.4"
 tokenizers = { version = "0.21.4", default-features = false }
 tracing = "0.1"

--- a/parsers/v2/Cargo.toml
+++ b/parsers/v2/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name = "dynamo-parsers-v2"
-version = "0.1.17"
+version = "0.1.18"
 edition.workspace = true
 license = "Apache-2.0"
 description = "Token-incremental tool-call streaming parsers for Dynamo"


### PR DESCRIPTION
#### Overview:

The workspace pinned `tokio = "=1.48.0"`, blocking any consumer that also depends on tokio >=1.52.3. This PR relaxes the pin to `"1.48"` (caret, >=1.48 <2) so downstream crates — including the vLLM Dynamo parser integration ([vllm-project/vllm#45451](https://github.com/vllm-project/vllm/pull/45451)) — can unify the dependency graph. Cargo.lock is updated to tokio 1.52.3 (current latest).

#### Details:

- `tokio = "=1.48.0"` → `tokio = "1.48"` in workspace `Cargo.toml`; no individual crate manifests changed
- `cargo update -p tokio` advances the lock to 1.52.3 (tokio-macros 2.7.0 along with it)
- `dynamo-parsers-v2` bumped 0.1.17 → 0.1.18 to publish the relaxed constraint

#### Verification:

`cargo build && cargo test` — all 1004 tests pass on tokio 1.52.3 with no changes to test code.

#### Where should the reviewer start?

`Cargo.toml` (line 62), then `parsers/v2/Cargo.toml`

Linear: https://linear.app/nvidia/issue/DIS-2388

/coderabbit profile chill
