### PR TITLE
fix(tokenizers): bypass cache when adding special tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "tiktoken-rs",
  "tokenizers",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -37,3 +37,4 @@ tokenizers = { workspace = true, features = [
 
 [dev-dependencies]
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -48,6 +48,19 @@ impl HuggingFaceTokenizer {
         merge_special_tokens_from_config(&mut tokenizer, model_dir);
         Self::from_tokenizer(tokenizer)
     }
+
+    pub(crate) fn special_tokens(&self) -> Vec<String> {
+        let mut special_tokens: Vec<String> = self
+            .tokenizer
+            .get_added_tokens_decoder()
+            .values()
+            .filter(|token| token.special)
+            .map(|token| token.content.clone())
+            .collect();
+        special_tokens.sort();
+        special_tokens.dedup();
+        special_tokens
+    }
 }
 
 /// Promote `tokenizer_config.json`'s `special: true` `added_tokens_decoder`

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -241,6 +241,59 @@ pub struct TokenizerOptions {
     pub add_special_tokens: bool,
 }
 
+/// L1 prefix-cache configuration used by [`TokenizerConfig`].
+#[derive(Debug, Clone, Copy)]
+pub struct TokenizerCacheConfig {
+    max_memory_bytes: usize,
+    extend_on_hit: bool,
+}
+
+impl TokenizerCacheConfig {
+    pub fn new(max_memory_bytes: usize) -> Self {
+        Self {
+            max_memory_bytes,
+            extend_on_hit: false,
+        }
+    }
+
+    pub fn with_extend(mut self, enabled: bool) -> Self {
+        self.extend_on_hit = enabled;
+        self
+    }
+}
+
+/// Complete construction configuration for the top-level tokenizer factory.
+///
+/// Cache policy belongs here, before the concrete tokenizer is hidden behind a
+/// trait object. In particular, HuggingFace tokenizers configured with
+/// `add_special_tokens=true` stay uncached because the L1 cache tokenizes prompt
+/// segments independently and would apply the post-processor more than once.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokenizerConfig {
+    options: TokenizerOptions,
+    cache: Option<TokenizerCacheConfig>,
+}
+
+impl TokenizerConfig {
+    pub fn new(options: TokenizerOptions) -> Self {
+        Self {
+            options,
+            cache: None,
+        }
+    }
+
+    pub fn with_cache(mut self, cache: TokenizerCacheConfig) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+}
+
+impl From<TokenizerOptions> for TokenizerConfig {
+    fn from(options: TokenizerOptions) -> Self {
+        Self::new(options)
+    }
+}
+
 /// Main tokenizer wrapper that provides a unified interface for different tokenizer implementations
 #[derive(Clone)]
 pub struct Tokenizer(Arc<dyn traits::Tokenizer>);
@@ -251,8 +304,12 @@ impl Tokenizer {
     }
 
     pub fn from_file_with_options(file_path: &str, options: TokenizerOptions) -> Result<Tokenizer> {
-        Ok(Tokenizer(create_tokenizer_from_file_with_options(
-            file_path, options,
+        Self::from_file_with_config(file_path, options.into())
+    }
+
+    pub fn from_file_with_config(file_path: &str, config: TokenizerConfig) -> Result<Tokenizer> {
+        Ok(Tokenizer(create_tokenizer_from_file_with_config(
+            file_path, config,
         )?))
     }
 
@@ -309,6 +366,18 @@ pub fn create_tokenizer_from_file_with_options(
     file_path: &str,
     options: TokenizerOptions,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
+    create_tokenizer_from_file_with_config(file_path, options.into())
+}
+
+/// Create a tokenizer with both concrete-tokenizer options and optional L1 caching.
+///
+/// When a HuggingFace tokenizer requests `add_special_tokens=true`, caching is
+/// bypassed at construction time. If a cache was requested, this emits one warning;
+/// encoding itself does not log.
+pub fn create_tokenizer_from_file_with_config(
+    file_path: &str,
+    config: TokenizerConfig,
+) -> Result<Arc<dyn traits::Tokenizer>> {
     use traits::Tokenizer as _;
 
     let path = Path::new(file_path);
@@ -319,12 +388,45 @@ pub fn create_tokenizer_from_file_with_options(
 
     match extension {
         "json" => {
-            let tokenizer = HuggingFaceTokenizer::from_file(file_path)?.with_options(options);
-            Ok(Arc::new(tokenizer))
+            let tokenizer =
+                HuggingFaceTokenizer::from_file(file_path)?.with_options(config.options);
+
+            if config.options.add_special_tokens {
+                if config.cache.is_some() {
+                    tracing::warn!(
+                        target: "tokenizer",
+                        "add_special_tokens=true is incompatible with tokenizer caching; using uncached HuggingFace tokenizer"
+                    );
+                }
+                return Ok(Arc::new(tokenizer));
+            }
+
+            match config.cache {
+                Some(cache) => {
+                    let special_tokens = tokenizer.special_tokens();
+                    let tokenizer: Arc<dyn traits::Tokenizer> = Arc::new(tokenizer);
+                    Ok(Arc::new(
+                        CachedTokenizer::new(tokenizer, special_tokens, cache.max_memory_bytes)
+                            .with_extend(cache.extend_on_hit),
+                    ))
+                }
+                None => Ok(Arc::new(tokenizer)),
+            }
         }
         "model" | "tiktoken" => {
-            let tokenizer = TikTokenTokenizer::from_file_auto(file_path)?.with_options(options);
-            Ok(Arc::new(tokenizer))
+            let tokenizer =
+                TikTokenTokenizer::from_file_auto(file_path)?.with_options(config.options);
+            match config.cache {
+                Some(cache) => {
+                    let special_tokens = tokenizer.special_tokens().to_vec();
+                    let tokenizer: Arc<dyn traits::Tokenizer> = Arc::new(tokenizer);
+                    Ok(Arc::new(
+                        CachedTokenizer::new(tokenizer, special_tokens, cache.max_memory_bytes)
+                            .with_extend(cache.extend_on_hit),
+                    ))
+                }
+                None => Ok(Arc::new(tokenizer)),
+            }
         }
         _ => Err(Error::msg(format!(
             "Unsupported tokenizer file type: .{extension}"

--- a/tokenizers/tests/add_special_tokens_cache_fallback.rs
+++ b/tokenizers/tests/add_special_tokens_cache_fallback.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    fs,
+    io::Write,
+    sync::{Arc, Mutex},
+};
+
+use dynamo_tokenizers::{
+    Encoding, HuggingFaceTokenizer, Tokenizer, TokenizerCacheConfig, TokenizerConfig,
+    TokenizerOptions,
+    traits::{Encoder, Tokenizer as _},
+};
+use tempfile::TempDir;
+use tracing_subscriber::fmt::MakeWriter;
+
+const FALLBACK_WARNING: &str = "add_special_tokens=true is incompatible with tokenizer caching; using uncached HuggingFace tokenizer";
+
+const TOKENIZER_JSON: &str = r#"{
+    "version": "1.0",
+    "truncation": null,
+    "padding": null,
+    "added_tokens": [
+        {"id": 0, "content": "<unk>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+        {"id": 1, "content": "<bos>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+        {"id": 2, "content": "<eos>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+        {"id": 3, "content": "<|im_start|>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+        {"id": 4, "content": "<|im_end|>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false}
+    ],
+    "normalizer": null,
+    "pre_tokenizer": {"type": "WhitespaceSplit"},
+    "post_processor": {
+        "type": "TemplateProcessing",
+        "single": [
+            {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+            {"Sequence": {"id": "A", "type_id": 0}},
+            {"SpecialToken": {"id": "<eos>", "type_id": 0}}
+        ],
+        "pair": [
+            {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+            {"Sequence": {"id": "A", "type_id": 0}},
+            {"Sequence": {"id": "B", "type_id": 1}},
+            {"SpecialToken": {"id": "<eos>", "type_id": 1}}
+        ],
+        "special_tokens": {
+            "<bos>": {"id": "<bos>", "ids": [1], "tokens": ["<bos>"]},
+            "<eos>": {"id": "<eos>", "ids": [2], "tokens": ["<eos>"]}
+        }
+    },
+    "decoder": null,
+    "model": {
+        "type": "WordLevel",
+        "vocab": {
+            "<unk>": 0,
+            "<bos>": 1,
+            "<eos>": 2,
+            "<|im_start|>": 3,
+            "<|im_end|>": 4,
+            "system": 5,
+            "user": 6,
+            "hello": 7,
+            "world": 8,
+            "again": 9
+        },
+        "unk_token": "<unk>"
+    }
+}"#;
+
+#[derive(Clone, Default)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+struct LockedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for LockedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedWriter {
+    type Writer = LockedWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LockedWriter(self.0.clone())
+    }
+}
+
+impl SharedWriter {
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+fn tokenizer_fixture() -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("tokenizer.json");
+    fs::write(&path, TOKENIZER_JSON).unwrap();
+    (dir, path.to_string_lossy().into_owned())
+}
+
+fn ids(encoding: &Encoding) -> &[u32] {
+    encoding.token_ids()
+}
+
+#[test]
+fn cache_request_with_add_special_tokens_falls_back_to_hf() {
+    let (_dir, path) = tokenizer_fixture();
+    let options = TokenizerOptions {
+        add_special_tokens: true,
+    };
+    let direct = HuggingFaceTokenizer::from_file(&path)
+        .unwrap()
+        .with_options(options);
+    let logs = SharedWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(logs.clone())
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let selected = Tokenizer::from_file_with_config(
+            &path,
+            TokenizerConfig::new(options)
+                .with_cache(TokenizerCacheConfig::new(1024 * 1024).with_extend(true)),
+        )
+        .unwrap();
+
+        let warning_after_construction = logs.contents();
+        assert_eq!(
+            warning_after_construction.matches(FALLBACK_WARNING).count(),
+            1
+        );
+
+        let prompts = [
+            "<|im_start|> system <|im_end|> <|im_start|> user hello world <|im_end|>",
+            "<|im_start|> user hello again <|im_end|>",
+        ];
+
+        for prompt in prompts {
+            let expected = direct.encode(prompt).unwrap();
+            for _ in 0..3 {
+                let actual = selected.encode(prompt).unwrap();
+                assert!(matches!(actual, Encoding::Hf(_)));
+                assert_eq!(ids(&actual), ids(&expected));
+            }
+        }
+
+        let expected_batch = direct.encode_batch(&prompts).unwrap();
+        let actual_batch = selected.encode_batch(&prompts).unwrap();
+        assert_eq!(actual_batch.len(), expected_batch.len());
+        for (actual, expected) in actual_batch.iter().zip(&expected_batch) {
+            assert!(matches!(actual, Encoding::Hf(_)));
+            assert_eq!(ids(actual), ids(expected));
+        }
+
+        let first = ids(&actual_batch[0]);
+        assert_eq!(first.first(), Some(&1));
+        assert_eq!(first.last(), Some(&2));
+        assert_eq!(first.iter().filter(|&&id| id == 1).count(), 1);
+        assert_eq!(first.iter().filter(|&&id| id == 2).count(), 1);
+
+        assert_eq!(logs.contents(), warning_after_construction);
+    });
+}


### PR DESCRIPTION
## Summary

- add cache-aware tokenizer construction to the frontend-crates tokenizer factory
- when `add_special_tokens=true` and caching is requested, emit one construction-time warning and return the plain Hugging Face tokenizer
- leave `CachedTokenizer`, tokenizer traits, cache statistics, and existing default/false behavior unchanged
- add a self-contained HF parity regression covering repeated scalar calls, batch encoding, multiple cache-boundary tokens, BOS/EOS, encoding type, and warning count

Follow-up to the tokenizer-cache correctness issue identified on #110.

## Validation

- `cargo test -p dynamo-tokenizers --test add_special_tokens_cache_fallback`
- `cargo test -p dynamo-tokenizers`
- `cargo test --workspace --exclude dynamo-conformance-fixtures-v2`
- `cargo test --workspace --doc --exclude dynamo-conformance-fixtures-v2`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --exclude dynamo-conformance-fixtures-v2 -- -D warnings`

The unexcluded workspace test reaches the external conformance fixture downloader and requires `HF_TOKEN` plus Python `huggingface_hub`; validation above excludes only that package.