### PR TITLE
chore(conformance): prune old all-*.tar.gz snapshots after publish (keep last N)

### DIFF
--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -243,7 +243,7 @@ git commit -m "fixtures: snapshot <stamp printed by publish script>"
 
 The publish script builds deterministic per-version shard tarballs plus a monolith `all-<stamp>.tar.gz`, uploads each blob individually (one commit per blob on HF), and writes the new manifest. Unchanged shards are LFS-deduped by HF and are not re-uploaded.
 
-After uploading, the script prunes old `all-<stamp>.tar.gz` monoliths from the HF repo, keeping only the `--keep-last N` most recent (default 5; `--keep-last 0` disables pruning). Shard tarballs live at fixed paths and are overwritten in place, so only the stamped monoliths accumulate. Pruning never touches the snapshot pinned by the committed manifest as long as it is within the last N.
+After uploading, the script prunes old `all-<stamp>.tar.gz` monoliths from the HF repo, keeping only the `--keep-last N` most recent (default 5; `--keep-last 0` disables pruning). Shard tarballs live at fixed paths and are overwritten in place, so only the stamped monoliths accumulate. The snapshot pinned by `conformance/fixtures-manifest.json` is never deleted, even when it falls outside the last N — checkouts on the committed manifest still download it.
 
 ### Add new fixtures (new SGLang / vLLM / Dynamo family)
 

--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -232,8 +232,8 @@ After re-capturing YAML locally with `capture.sh`, publish a new snapshot and co
 ```bash
 # 1. Re-capture (see capture.sh commands above)
 
-# 2. Publish to HF — requires a write-capable token
-export HF_TOKEN=<your-write-token>
+# 2. Publish to HF — requires a write-capable token (kept at ~/.cache/huggingface/token.write)
+export HF_TOKEN=$(cat ~/.cache/huggingface/token.write)
 python3 conformance/utils/src/package_and_publish.py
 
 # 3. Commit the manifest pin
@@ -242,6 +242,8 @@ git commit -m "fixtures: snapshot <stamp printed by publish script>"
 ```
 
 The publish script builds deterministic per-version shard tarballs plus a monolith `all-<stamp>.tar.gz`, uploads each blob individually (one commit per blob on HF), and writes the new manifest. Unchanged shards are LFS-deduped by HF and are not re-uploaded.
+
+After uploading, the script prunes old `all-<stamp>.tar.gz` monoliths from the HF repo, keeping only the `--keep-last N` most recent (default 5; `--keep-last 0` disables pruning). Shard tarballs live at fixed paths and are overwritten in place, so only the stamped monoliths accumulate. Pruning never touches the snapshot pinned by the committed manifest as long as it is within the last N.
 
 ### Add new fixtures (new SGLang / vLLM / Dynamo family)
 

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -18,7 +18,8 @@ Shard layout (relative to HF repo root):
 Usage:
   export HF_TOKEN=<your-write-token>
   python3 package_and_publish.py [--dry-run] [--snapshot YYYYMMDD_HHMMSS]
-  python3 package_and_publish.py --cleanup-old   # delete old loose files from HF repo
+  python3 package_and_publish.py --cleanup-old        # delete old loose files from HF repo
+  python3 package_and_publish.py --keep-last 5        # prune old all-*.tar.gz after publish (default: 5)
 
 HF_TOKEN must be set to a write-capable token before running. The script does not
 search personal token caches — callers are responsible for exporting the right token.
@@ -257,6 +258,47 @@ def cleanup_old_loose(token, repo_id, dry_run):
     print(f"  Deleted {len(to_delete)} old loose files.")
 
 
+def prune_old_snapshots(token, repo_id, keep_last, dry_run):
+    """Delete all but the keep_last most recent all-<stamp>.tar.gz monoliths from the HF repo.
+
+    Stamps are YYYYMMDD_HHMMSS, so lexicographic order == chronological order.
+    """
+    try:
+        from huggingface_hub import HfApi, CommitOperationDelete
+    except ImportError:
+        sys.exit("huggingface_hub is not installed.")
+
+    api = HfApi(token=token)
+    # Monoliths live at the repo root; non-recursive listing is enough.
+    entries = api.list_repo_tree(repo_id=repo_id, repo_type="dataset")
+    snapshots = sorted(
+        e.path
+        for e in entries
+        if hasattr(e, "size")  # RepoFile (not RepoFolder)
+        and re.fullmatch(r"all-\d{8}_\d{6}\.tar\.gz", e.path)
+    )
+    to_delete = snapshots[:-keep_last]
+    if not to_delete:
+        print(f"  {len(snapshots)} snapshot(s) present, nothing to prune.")
+        return
+
+    print(f"  {len(snapshots)} snapshots present, pruning {len(to_delete)} (keeping {keep_last} most recent):")
+    for path in to_delete:
+        print(f"    {path}")
+
+    if dry_run:
+        print("  [dry-run] skipping delete")
+        return
+
+    api.create_commit(
+        repo_id=repo_id,
+        repo_type="dataset",
+        operations=[CommitOperationDelete(path_in_repo=p) for p in to_delete],
+        commit_message=f"fixtures: prune old snapshots, keep last {keep_last}",
+    )
+    print(f"  Deleted {len(to_delete)} old snapshot(s).")
+
+
 def main():
     ap = argparse.ArgumentParser(
         description="Package and publish conformance fixtures to HuggingFace"
@@ -269,6 +311,13 @@ def main():
         "--cleanup-old",
         action="store_true",
         help="Delete old non-tarball files from HF repo after publishing",
+    )
+    ap.add_argument(
+        "--keep-last",
+        type=int,
+        default=5,
+        metavar="N",
+        help="After publishing, prune old all-<stamp>.tar.gz monoliths, keeping the N most recent (default: 5; 0 = disable)",
     )
     args = ap.parse_args()
 
@@ -334,6 +383,10 @@ def main():
         if args.cleanup_old:
             print(f"\nCleaning up old loose files in {args.repo}…")
             cleanup_old_loose(token, args.repo, args.dry_run)
+
+        if args.keep_last > 0:
+            print(f"\nPruning old snapshots in {args.repo} (keep_last={args.keep_last})…")
+            prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run)
 
         manifest = {
             "snapshot": stamp,

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -258,13 +258,14 @@ def cleanup_old_loose(token, repo_id, dry_run):
     print(f"  Deleted {len(to_delete)} old loose files.")
 
 
-def prune_old_snapshots(token, repo_id, keep_last, dry_run, pinned=None):
+def prune_old_snapshots(token, repo_id, keep_last, dry_run, protected=()):
     """Delete all but the keep_last most recent all-<stamp>.tar.gz monoliths from the HF repo.
 
     Stamps are YYYYMMDD_HHMMSS, so lexicographic order == chronological order.
-    The pinned monolith (manifest `all_tarball`) is NEVER deleted, even when it
-    falls outside the keep_last window — every checkout on the committed manifest
-    still downloads it.
+    Monoliths in `protected` are NEVER deleted, even when they fall outside the
+    keep_last window: the manifest `all_tarball` pin (every checkout on the
+    committed manifest still downloads it) and the just-uploaded monolith
+    (a backdated --snapshot stamp can sort it below the keep window).
     """
     try:
         from huggingface_hub import HfApi, CommitOperationDelete
@@ -281,9 +282,9 @@ def prune_old_snapshots(token, repo_id, keep_last, dry_run, pinned=None):
         and re.fullmatch(r"all-\d{8}_\d{6}\.tar\.gz", e.path)
     )
     to_delete = snapshots[:-keep_last]
-    if pinned in to_delete:
-        print(f"  keeping {pinned} — pinned by {MANIFEST_REL}")
-        to_delete = [p for p in to_delete if p != pinned]
+    for path in [p for p in to_delete if p in protected]:
+        print(f"  keeping {path} — protected (manifest pin or current upload)")
+        to_delete.remove(path)
     if not to_delete:
         print(f"  {len(snapshots)} snapshot(s) present, nothing to prune.")
         return
@@ -393,13 +394,17 @@ def main():
         if args.keep_last > 0:
             print(f"\nPruning old snapshots in {args.repo} (keep last {args.keep_last})…")
             if token:
-                # The working-tree manifest still holds the committed pin here —
+                # Protect the monolith just uploaded (a backdated --snapshot can
+                # sort it below the keep window) and the committed manifest pin —
+                # the working-tree manifest still holds the old pin here, since
                 # the new manifest is written below, after pruning.
-                pinned = None
+                protected = {all_name}
                 pinned_manifest = ROOT / MANIFEST_REL
                 if pinned_manifest.exists():
-                    pinned = json.loads(pinned_manifest.read_text()).get("all_tarball")
-                prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run, pinned=pinned)
+                    pin = json.loads(pinned_manifest.read_text()).get("all_tarball")
+                    if pin:
+                        protected.add(pin)
+                prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run, protected=protected)
             else:
                 # tokenless --dry-run can't list the private repo; keep it working
                 print("  [dry-run] no token, skipping snapshot listing")

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -258,10 +258,13 @@ def cleanup_old_loose(token, repo_id, dry_run):
     print(f"  Deleted {len(to_delete)} old loose files.")
 
 
-def prune_old_snapshots(token, repo_id, keep_last, dry_run):
+def prune_old_snapshots(token, repo_id, keep_last, dry_run, pinned=None):
     """Delete all but the keep_last most recent all-<stamp>.tar.gz monoliths from the HF repo.
 
     Stamps are YYYYMMDD_HHMMSS, so lexicographic order == chronological order.
+    The pinned monolith (manifest `all_tarball`) is NEVER deleted, even when it
+    falls outside the keep_last window — every checkout on the committed manifest
+    still downloads it.
     """
     try:
         from huggingface_hub import HfApi, CommitOperationDelete
@@ -278,6 +281,9 @@ def prune_old_snapshots(token, repo_id, keep_last, dry_run):
         and re.fullmatch(r"all-\d{8}_\d{6}\.tar\.gz", e.path)
     )
     to_delete = snapshots[:-keep_last]
+    if pinned in to_delete:
+        print(f"  keeping {pinned} — pinned by {MANIFEST_REL}")
+        to_delete = [p for p in to_delete if p != pinned]
     if not to_delete:
         print(f"  {len(snapshots)} snapshot(s) present, nothing to prune.")
         return
@@ -387,7 +393,13 @@ def main():
         if args.keep_last > 0:
             print(f"\nPruning old snapshots in {args.repo} (keep last {args.keep_last})…")
             if token:
-                prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run)
+                # The working-tree manifest still holds the committed pin here —
+                # the new manifest is written below, after pruning.
+                pinned = None
+                pinned_manifest = ROOT / MANIFEST_REL
+                if pinned_manifest.exists():
+                    pinned = json.loads(pinned_manifest.read_text()).get("all_tarball")
+                prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run, pinned=pinned)
             else:
                 # tokenless --dry-run can't list the private repo; keep it working
                 print("  [dry-run] no token, skipping snapshot listing")

--- a/conformance/utils/src/package_and_publish.py
+++ b/conformance/utils/src/package_and_publish.py
@@ -385,8 +385,12 @@ def main():
             cleanup_old_loose(token, args.repo, args.dry_run)
 
         if args.keep_last > 0:
-            print(f"\nPruning old snapshots in {args.repo} (keep_last={args.keep_last})…")
-            prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run)
+            print(f"\nPruning old snapshots in {args.repo} (keep last {args.keep_last})…")
+            if token:
+                prune_old_snapshots(token, args.repo, args.keep_last, args.dry_run)
+            else:
+                # tokenless --dry-run can't list the private repo; keep it working
+                print("  [dry-run] no token, skipping snapshot listing")
 
         manifest = {
             "snapshot": stamp,


### PR DESCRIPTION
## Summary

`package_and_publish.py` created a new `all-<stamp>.tar.gz` monolith on every publish run but never deleted old ones. After 11 snapshots accumulated, we had to manually prune 6.

Adds `--keep-last N` (default 5): after uploading a new snapshot, deletes all but the N most recent monoliths from the HF repo in a single batched commit. Set `--keep-last 0` to disable pruning. The snapshot pinned by `conformance/fixtures-manifest.json` is never deleted, even when it falls outside the last N.

Related: [DIS-2411](https://linear.app/nvidia/issue/DIS-2411)
