### PR TITLE
ci: make crate version bumps manual, stop release-plz auto-bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,41 @@ jobs:
       - name: Verify crates are publishable
         run: cargo publish --workspace --dry-run --locked
 
+  # Public-API SemVer gate. With version bumps now manual (DIS-2414), nothing in
+  # CI auto-computes the required bump anymore, so this job is the safety net:
+  # cargo-semver-checks compares each publishable crate's current public API
+  # against its latest crates.io release and fails if the change needs a bigger
+  # bump than the crate's [package] version reflects. A breaking change must
+  # therefore also bump the version IN THE SAME PR, before merge — a stricter,
+  # earlier gate than the old post-merge `release-plz update` check it replaces.
+  # Runs on stable via RUSTC_BOOTSTRAP (cargo-semver-checks handles this); the
+  # three `publish = false` crates are skipped automatically.
+  semver:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # cargo-semver-checks builds each crate's rustdoc; mirror the `rust` job's
+      # fixture token in case a build path pulls the private dataset.
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Rust
+        run: rustup toolchain install
+
+      - name: Install cargo-semver-checks
+        run: |
+          curl -sSLf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.48.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin
+          cargo-semver-checks --version
+
+      - name: Install fixture download dependencies
+        run: pip install --quiet huggingface_hub
+
+      - name: Check public API SemVer
+        run: cargo semver-checks --workspace
+
   # Render-smoke for the vendored conformance-table generator. Catches generator/fixture
   # breakage. Python + pyyaml/jinja2 only — no engines (vLLM/SGLang conformance runs in
   # dynamo's CI lanes; here the engine lanes are on-demand/local).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,15 @@ jobs:
     # publish even if it lands on main.
     environment: automated-release
     permissions:
-      contents: write       # push the release commit + tags
+      contents: write       # push the release git tags
       pull-requests: write  # release-plz may interact with PRs
       id-token: write       # OIDC for crates.io trusted publishing
-    # Recursion guard: skip the run triggered by our own "chore: release" push.
-    # workflow_dispatch bypasses the guard so a partial publish can be re-run.
-    if: "${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Version bumps are MANUAL (see DIS-2414): a human edits each crate's
+    # [package] version in their PR. This job never bumps versions or pushes
+    # commits — it only publishes whatever version already sits in Cargo.toml
+    # but isn't yet on crates.io. `release-plz release` is a no-op when every
+    # crate's version is already published, so running on every push to main
+    # is safe and cheap.
     steps:
       - name: Generate release app token
         id: release-token
@@ -44,6 +47,8 @@ jobs:
           token: ${{ steps.release-token.outputs.token }}
 
       - name: Configure git identity
+        # release-plz release pushes per-crate git tags (git_tag_enable=true);
+        # tagging needs a committer identity.
         run: |
           git config user.name  "release-plz[bot]"
           git config user.email "release-plz[bot]@users.noreply.github.com"
@@ -57,46 +62,12 @@ jobs:
             | tar xz -C /usr/local/bin release-plz
           release-plz --version
 
-      - name: Install cargo-semver-checks
-        run: |
-          curl -sSLf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.48.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
-            | tar xz -C /usr/local/bin
-          cargo-semver-checks --version
-
-      - name: Bump versions and changelogs
-        run: release-plz update
-
-      - name: Commit and push version bumps (if any)
-        id: bump
-        run: |
-          if git diff --quiet; then
-            echo "No version bumps proposed."
-            echo "bumped=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Informative subject listing every crate whose [package] version
-          # changed this run, e.g. "chore: release dynamo-protocols v1.4.0,
-          # dynamo-renderer v0.1.1". Comparing the package version (not the
-          # changelog) also catches dependency-cascade bumps, which re-release
-          # a dependent without adding a changelog entry. The name + literal
-          # version guard skips the workspace root. The "chore: release" prefix
-          # is mandatory — the recursion guard above keys off it.
-          git add -A
-          summary=$(for toml in $(git ls-files | grep -E '(^|/)Cargo\.toml$'); do
-            name=$(grep -m1 '^name *=' "$toml" | sed -E 's/.*"([^"]+)".*/\1/')
-            newver=$(grep -m1 '^version *=' "$toml" | sed -E 's/.*"([^"]+)".*/\1/')
-            oldver=$(git show "HEAD:$toml" 2>/dev/null | grep -m1 '^version *=' | sed -E 's/.*"([^"]+)".*/\1/')
-            if [ -n "$name" ] && [ -n "$newver" ] && [ "$newver" != "$oldver" ]; then
-              printf '%s v%s, ' "$name" "$newver"
-            fi
-          done | sed 's/, $//')
-          [ -z "$summary" ] && summary="version bumps"
-          git commit -s -m "chore: release $summary"
-          git push origin HEAD:main
-          echo "bumped=true" >> "$GITHUB_OUTPUT"
-
       - name: Publish to crates.io (trusted publishing)
-        if: steps.bump.outputs.bumped == 'true' || github.event_name == 'workflow_dispatch'
+        # Publishes every workspace crate whose Cargo.toml version isn't on
+        # crates.io yet — i.e. the versions a human manually bumped — and pushes
+        # the matching git tags. No auto-bump, no `release-plz update`: nothing
+        # here changes a version number.
+        #
         # The release-plz binary needs the forge token passed explicitly via
         # --git-token; unlike release-plz/action it does NOT read GITHUB_TOKEN
         # from the env. Even with git_release_enable=false, `release` builds a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,19 @@ jobs:
     # but isn't yet on crates.io. `release-plz release` is a no-op when every
     # crate's version is already published, so running on every push to main
     # is safe and cheap.
+    #
+    # Why manual: auto-bumping every merge (the old `release-plz update` step)
+    # was flaky and undesirable — it churned versions on every push, burned
+    # version space (dynamo-parsers-v2 went 0.1.17 -> 0.1.21 in days), and made
+    # downstream pins (e.g. vLLM's `dynamo-parsers-v2 = =0.1.x`) go stale
+    # constantly. A human deciding when/what to bump keeps versions meaningful.
+    #
+    # NOTE: dropping `release-plz update` from CI does NOT drop SemVer safety.
+    # `semver_check = true` in release-plz.toml is STILL used — it validates the
+    # proposed bump against the crate's real public-API diff (removed/renamed
+    # pub items force a major bump) when a human runs `release-plz update`
+    # locally to compute the manual bump. The check just moved from CI to that
+    # local step; publishing here never needs cargo-semver-checks. No worries.
     steps:
       - name: Generate release app token
         id: release-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,12 @@ jobs:
     # constantly. A human deciding when/what to bump keeps versions meaningful.
     #
     # NOTE: dropping `release-plz update` from CI does NOT drop SemVer safety.
-    # `semver_check = true` in release-plz.toml is STILL used — it validates the
-    # proposed bump against the crate's real public-API diff (removed/renamed
-    # pub items force a major bump) when a human runs `release-plz update`
-    # locally to compute the manual bump. The check just moved from CI to that
-    # local step; publishing here never needs cargo-semver-checks. No worries.
+    # Public-API compatibility is still gated automatically — by the `semver`
+    # job in ci.yml, which runs cargo-semver-checks on every PR and fails if a
+    # breaking change isn't matched by a version bump (earlier than the old
+    # post-merge check). `semver_check = true` in release-plz.toml additionally
+    # applies whenever a human runs `release-plz update` locally. Publishing
+    # here never needs cargo-semver-checks. No worries.
     steps:
       - name: Generate release app token
         id: release-token

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,14 +6,16 @@
 # release fails before anything is published.
 semver_check = true
 
-# Only commits matching this regex count toward "is there anything to release".
+# Only commits matching this regex count toward "is there anything to release"
+# when a human runs `release-plz update` locally to compute a manual bump.
+# CI no longer runs `release-plz update` (version bumps are manual — DIS-2414),
+# so this no longer drives any automatic publish; it only shapes the bump a
+# human sees when they choose to run update.
 # TEMPORARY (transition only): `chore` is included so `chore: trivial parser
 # sync from dynamo` commits — how parser updates land during the
-# dynamo -> frontend-crates migration — actually trigger a version bump and
-# publish. Without it those syncs propose no bump, so the workflow's publish
-# step (gated on `bumped == 'true'`) is skipped and the synced fixes never
-# reach crates.io. REMOVE `chore` after the transition completes; it also lets
-# unrelated chore: commits (incl. dependabot `chore(deps):`) drive releases.
+# dynamo -> frontend-crates migration — are counted by a manual `update`.
+# REMOVE `chore` after the transition completes; it also lets unrelated
+# chore: commits (incl. dependabot `chore(deps):`) count toward a bump.
 release_commits = "^(feat|fix|perf|refactor|sync|chore)(\\(.+\\))?!?:"
 
 # Default tag format: per-crate, e.g. dynamo-protocols-v0.1.1

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,8 +2,11 @@
 
 [workspace]
 # Validate proposed bumps against the public API diff via cargo-semver-checks.
-# If a `fix:` or `chore:` commit actually removed/renamed a pub item, the
-# release fails before anything is published.
+# If a `fix:` or `chore:` commit actually removed/renamed a pub item, the bump
+# fails before anything is published. STILL ACTIVE after DIS-2414: CI no longer
+# runs `release-plz update`, but this check runs whenever a human runs
+# `release-plz update` locally to compute a manual bump — that's where SemVer
+# safety now lives.
 semver_check = true
 
 # Only commits matching this regex count toward "is there anything to release"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,8 +5,9 @@
 # If a `fix:` or `chore:` commit actually removed/renamed a pub item, the bump
 # fails before anything is published. STILL ACTIVE after DIS-2414: CI no longer
 # runs `release-plz update`, but this check runs whenever a human runs
-# `release-plz update` locally to compute a manual bump — that's where SemVer
-# safety now lives.
+# `release-plz update` locally to compute a manual bump. The primary automated
+# SemVer gate now lives in the `semver` job of .github/workflows/ci.yml, which
+# runs cargo-semver-checks on every PR.
 semver_check = true
 
 # Only commits matching this regex count toward "is there anything to release"


### PR DESCRIPTION
#### Overview:

In the past, every merge to main auto-bumped crate versions (release-plz ran on each push). That caused constant churn: `dynamo-parsers-v2` went 0.1.17 → 0.1.21 in days, it burned version space, downstream pins like vLLM's `dynamo-parsers-v2 = =0.1.x` went stale, and it kept re-releasing v1 and v2 together even though they share no code and one hadn't changed.

So now version bumps are manual: a human edits a crate's `[package]` version in their PR, and CI only publishes what was bumped.

#### Details:

- `release.yml`: dropped `release-plz update`, the self-commit/push, the recursion guard, and the `cargo-semver-checks` install; the publish step runs unconditionally and only publishes crates whose version isn't on crates.io yet.
- `ci.yml`: added a `semver` job so we don't lose API-compat safety — `cargo-semver-checks` runs on every PR and fails if a breaking change isn't matched by a version bump.
- `release-plz.toml`: comment-only; points at the new CI gate and notes `semver_check` still applies to a local `release-plz update`.

#### Verification:

YAML/TOML validated; the `semver` job's real run happens on this PR's CI mirror.

#### Where should the reviewer start?

`.github/workflows/release.yml`, then `.github/workflows/ci.yml`

/coderabbit profile chill
