### PR TITLE
ci: allow path-scoped release bumps to accumulate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,15 @@ jobs:
       #     commits, writes the changelog, and runs cargo-semver-checks)
       - name: Bump versions for crates whose own files changed
         run: |
+          # `--allow-dirty` below is intentional: each package update leaves
+          # its version/changelog edits for the final combined release commit.
+          # Fail here so it cannot mask changes that predate this loop.
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --short
+            echo "Release checkout must start clean."
+            exit 1
+          fi
+
           members=$(sed -n '/^members = \[/,/^]/p' Cargo.toml | grep -oE '"[^"]+"' | tr -d '"')
           for dir in $members; do
             grep -q '^publish *= *false' "$dir/Cargo.toml" && continue
@@ -104,7 +113,7 @@ jobs:
               echo "$name: no changes under $dir/ or the root Cargo.toml since $last"
             else
               echo "$name: changes under $dir/ (or root Cargo.toml) since $last -> auto-bump"
-              release-plz update -p "$name"
+              release-plz update --allow-dirty -p "$name"
             fi
           done
 


### PR DESCRIPTION
## Why

The path-scoped release loop invokes `release-plz update` once per changed crate, but each successful invocation leaves version and changelog edits in the working tree. The next invocation rejects those expected edits as a dirty checkout, so the combined release commit and crates.io publish steps never run. The runner still starts clean; only edits generated inside the loop are allowed to accumulate.

When both `dynamo-protocols` and `dynamo-parsers` need releases in the same run, updating the first crate intentionally dirties their shared checkout. The second crate then mistakes those generated edits for pre-existing changes and aborts. This is a conflict between two valid release updates, not a dirty runner at job start.

## What Change

- Require a clean checkout before the package-update loop.
- Allow sequential package updates to accumulate pending release edits.

## Test Plan

- Validate the workflow with `actionlint`.
- Replay protocol and parser updates with release-plz 0.3.158.