### PR TITLE
fix(parsers): DeepSeek DSML malformed-recovery is too strong — recovers wrapper-less invokes into spurious calls

### DIFF
--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,8 +1,8 @@
 {
-  "snapshot": "20260717_113426",
-  "created_pt": "2026-07-17 11:34:26 America/Los_Angeles",
+  "snapshot": "20260717_144801",
+  "created_pt": "2026-07-17 14:48:01 America/Los_Angeles",
   "crates": {
-    "dynamo-parsers": "5.0.1",
+    "dynamo-parsers": "5.1.0",
     "dynamo-parsers-v2": "0.1.22"
   },
   "peers": {
@@ -27,8 +27,8 @@
     },
     {
       "path": "toolcalling/fixtures-batch-on-stream-v2.tar.gz",
-      "sha256": "ca3f863df80647ab171a3a3ab7ae58839fbfabe0aae942c7299cb20751850bf7",
-      "size": 15168
+      "sha256": "0e867626c779f657d1e95c857af9950c43ee7d1b4b0ca2c63304638ed5c177dc",
+      "size": 15180
     },
     {
       "path": "toolcalling/fixtures-batch-v1/dynamo_v1-3.0.0.tar.gz",
@@ -39,6 +39,11 @@
       "path": "toolcalling/fixtures-batch-v1/dynamo_v1-5.0.1.tar.gz",
       "sha256": "e1f327e90c054e29c67d6db7667da77519ea4785818b31d77aeb66db1017d5fd",
       "size": 9794
+    },
+    {
+      "path": "toolcalling/fixtures-batch-v1/dynamo_v1-5.1.0.tar.gz",
+      "sha256": "dc8d26c3f21f97fc3c60e38c2bedd38215eac8704b459c968a2ed7e850067edb",
+      "size": 9816
     },
     {
       "path": "toolcalling/fixtures-batch-v1/inputs.tar.gz",
@@ -82,8 +87,8 @@
     },
     {
       "path": "toolcalling/fixtures-stream-v2/dynamo_v2-0.1.22.tar.gz",
-      "sha256": "431f5ad324dc94d9d2d5d45ccc71aae8ec9abcf39e2db65c6c7b5b8afdef2cbc",
-      "size": 5911
+      "sha256": "24949a3d2bf74dfce90504937380923619a25fea0e3dee7ea234a71d21b09fb1",
+      "size": 5912
     },
     {
       "path": "toolcalling/fixtures-stream-v2/inputs.tar.gz",

--- a/conformance/fixtures/toolcalling/fixtures-batch-on-stream-v2.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-batch-on-stream-v2.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca3f863df80647ab171a3a3ab7ae58839fbfabe0aae942c7299cb20751850bf7
-size 15168
+oid sha256:0e867626c779f657d1e95c857af9950c43ee7d1b4b0ca2c63304638ed5c177dc
+size 15180

--- a/conformance/fixtures/toolcalling/fixtures-batch-v1/dynamo_v1-5.1.0.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-batch-v1/dynamo_v1-5.1.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8d26c3f21f97fc3c60e38c2bedd38215eac8704b459c968a2ed7e850067edb
+size 9816

--- a/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.1.22.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.1.22.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:431f5ad324dc94d9d2d5d45ccc71aae8ec9abcf39e2db65c6c7b5b8afdef2cbc
-size 5911
+oid sha256:24949a3d2bf74dfce90504937380923619a25fea0e3dee7ea234a71d21b09fb1
+size 5912

--- a/parsers/v1/src/tool_calling/config.rs
+++ b/parsers/v1/src/tool_calling/config.rs
@@ -204,6 +204,16 @@ pub struct DsmlParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// Require the outer DSML block wrapper (`<｜DSML｜function_calls>` /
+    /// `<｜DSML｜tool_calls>`) before an `<｜DSML｜invoke>` is treated as a tool
+    /// call. The DeepSeek DSML spec (DeepSeek-V4 `encoding/README.md`) defines a
+    /// tool call AS a wrapper block, so a bare invoke without the wrapper is not
+    /// conformant. When `true`, wrapper-less invokes are NOT recovered: they
+    /// yield no calls and the orphan markup is suppressed from `normal_text`.
+    /// Defaults to `false` (lenient bare-invoke recovery) for back-compat.
+    #[serde(default)]
+    pub require_wrapper: bool,
 }
 
 impl Default for DsmlParserConfig {
@@ -216,6 +226,7 @@ impl Default for DsmlParserConfig {
             parameter_prefix: "<｜DSML｜parameter name=".to_string(),
             parameter_end: "</｜DSML｜parameter>".to_string(),
             allow_eof_recovery: false,
+            require_wrapper: false,
         }
     }
 }
@@ -656,6 +667,10 @@ impl ToolCallConfig {
         let dsml_config = DsmlParserConfig {
             block_start: format!("<｜DSML｜{}>", block_name),
             block_end: format!("</｜DSML｜{}>", block_name),
+            // DeepSeek DSML spec: the outer block wrapper is mandatory; a bare
+            // invoke without it is not a conformant tool call. Both V3.2 and V4
+            // inherit this from the shared helper.
+            require_wrapper: true,
             ..Default::default()
         };
         let structural_tag = StructuralTagBuilder::DsmlToolCalls(DsmlToolCallsConfig {

--- a/parsers/v1/src/tool_calling/dsml/parser.rs
+++ b/parsers/v1/src/tool_calling/dsml/parser.rs
@@ -86,7 +86,8 @@ pub fn try_tool_call_parse_dsml(
     let Some(start_idx) = trimmed.find(&config.block_start) else {
         if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
             let marker_tail = &trimmed[marker_idx..];
-            if marker_tail.starts_with(config.invoke_start_prefix.as_str())
+            if !config.require_wrapper
+                && marker_tail.starts_with(config.invoke_start_prefix.as_str())
                 && (marker_tail.contains(config.block_end.as_str()) || config.allow_eof_recovery)
             {
                 let tool_calls = extract_invokes(marker_tail, config)?;
@@ -232,6 +233,11 @@ fn recover_orphan_invokes_in_span(
     span: &str,
     config: &DsmlParserConfig,
 ) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    // Spec-strict configs require the outer wrapper, so a bare invoke (with no
+    // enclosing block, even one preceding a later block) is not recovered.
+    if config.require_wrapper {
+        return Ok(None);
+    }
     let Some(marker_idx) = first_orphan_dsml_marker_index(span, config) else {
         return Ok(None);
     };
@@ -380,6 +386,78 @@ mod tests {
             allow_eof_recovery: true,
             ..get_v4_test_config()
         }
+    }
+
+    /// Strict config (`require_wrapper: true`, as the deepseek_v3_2 / deepseek_v4
+    /// factories set) layered on the recovery test config, so this exercises the
+    /// production finalize shape: even with `allow_eof_recovery`, `require_wrapper`
+    /// wins and a wrapper-less invoke is rejected.
+    fn get_v4_strict_test_config() -> DsmlParserConfig {
+        DsmlParserConfig {
+            require_wrapper: true,
+            ..get_v4_recovery_test_config()
+        }
+    }
+
+    /// DeepSeek DSML spec: the outer `<｜DSML｜tool_calls>` wrapper is mandatory.
+    /// A complete but wrapper-less `<｜DSML｜invoke>` is NOT a conformant tool
+    /// call, so a strict config recovers nothing and suppresses the orphan
+    /// markup (no leak into normal_text).
+    #[test]
+    fn test_parse_deepseek_v4_strict_bare_invoke_without_wrapper_rejected() {
+        let input = "<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, normal_text) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 0, "bare invoke without wrapper is not a call");
+        assert_eq!(
+            normal_text.as_deref(),
+            Some(""),
+            "orphan DSML markup must be suppressed, not leaked into normal_text"
+        );
+    }
+
+    /// Strict config still parses a properly wrapped tool call — strictness only
+    /// rejects the missing wrapper, it does not break the conformant path.
+    #[test]
+    fn test_parse_deepseek_v4_strict_wrapped_invoke_still_parsed() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜tool_calls>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        let (name, args) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    /// Strict config: a bare invoke preceding a properly wrapped block is dropped
+    /// (and its markup suppressed), while the wrapped block is still parsed.
+    #[test]
+    fn test_parse_deepseek_v4_strict_bare_invoke_before_block_dropped() {
+        let input = "<｜DSML｜invoke name=\"orphan\">\n\
+<｜DSML｜parameter name=\"x\" string=\"true\">1</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"wrapped\">\n\
+<｜DSML｜parameter name=\"y\" string=\"true\">2</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜tool_calls>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1, "only the wrapped invoke is a tool call");
+        let (name, _) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "wrapped");
     }
 
     #[test] // helper

--- a/parsers/v1/tests/jail.rs
+++ b/parsers/v1/tests/jail.rs
@@ -4139,10 +4139,20 @@ fahrenheit
                 .collect()
                 .await;
 
+            // DeepSeek V3.2/V4 require the outer DSML wrapper (`require_wrapper`):
+            // a bare `<｜DSML｜invoke>` with no opening `<｜DSML｜tool_calls>` is not a
+            // conformant tool call, so it is dropped — the markup is still jailed
+            // (never leaked into content), just no call is recovered. Every other
+            // parser here recovers the bare call.
+            let expected_calls: Vec<String> = if parser == "deepseek_v4" {
+                vec![]
+            } else {
+                vec!["get_weather".to_string()]
+            };
             assert_eq!(
                 tool_call_names(&results),
-                vec!["get_weather".to_string()],
-                "{label}: expected recovered get_weather call"
+                expected_calls,
+                "{label}: recovered-call expectation"
             );
             assert_eq!(
                 test_utils::reconstruct_content(&results),

--- a/parsers/v2/src/tool_calling/dsml.rs
+++ b/parsers/v2/src/tool_calling/dsml.rs
@@ -44,16 +44,35 @@ pub struct DeepSeekV4ToolStreamParser {
     /// while we buffer the body and wait for `</｜DSML｜invoke>`. Nothing is
     /// emitted until the close arrives; if it never does, the call is dropped.
     open_invoke: Option<(usize, String)>,
+    /// Spec-strict mode (DeepSeek DSML): when `true`, a bare `<｜DSML｜invoke>`
+    /// without the outer `<｜DSML｜tool_calls>` wrapper is NOT a conformant tool
+    /// call — it is dropped and its markup suppressed instead of recovered,
+    /// matching the v1 batch parser's `require_wrapper`. Production DeepSeek-V4
+    /// (`create`) is strict; `new()` stays lenient for the generic recovery path.
+    require_wrapper: bool,
 }
 
 impl DeepSeekV4ToolStreamParser {
     pub fn new() -> Self {
+        Self::with_require_wrapper(false)
+    }
+
+    /// Spec-strict constructor: a bare `<｜DSML｜invoke>` without the outer
+    /// `<｜DSML｜tool_calls>` wrapper is dropped (markup suppressed) rather than
+    /// recovered. This is the production DeepSeek-V4 behavior (see `create`);
+    /// `new()` stays lenient so the generic bare-invoke recovery path is testable.
+    pub fn new_strict() -> Self {
+        Self::with_require_wrapper(true)
+    }
+
+    fn with_require_wrapper(require_wrapper: bool) -> Self {
         Self {
             buffer: String::new(),
             in_block: false,
             suppress_normal_text: false,
             next_index: 0,
             open_invoke: None,
+            require_wrapper,
         }
     }
 
@@ -215,29 +234,46 @@ impl DeepSeekV4ToolStreamParser {
                     self.in_block = true;
                     self.suppress_normal_text = true;
                 }
-                Marker::BareInvoke => match self.open_invoke_header()? {
-                    Some(tool_index) => {
-                        // Degraded recovery: latch suppression so the orphan
-                        // markup tail around a bare invoke is dropped, not leaked
-                        // (matches the v1 batch recovery contract).
+                Marker::BareInvoke => {
+                    if self.require_wrapper {
+                        // Spec-strict (DeepSeek DSML): a bare invoke without the
+                        // outer <｜DSML｜tool_calls> wrapper is not a conformant
+                        // tool call. Consume the marker prefix and latch
+                        // suppression so the orphan invoke markup is dropped, not
+                        // leaked, and no call is emitted — matching the v1 batch
+                        // `require_wrapper` rule.
+                        self.buffer.drain(..INVOKE_START_PREFIX.len());
                         self.suppress_normal_text = true;
                         tracing::warn!(
-                            why = "dsv4_bare_invoke_recovery",
-                            tool_index,
-                            "DSML stream recovering a bare invoke (buffered until close)"
+                            why = "dsv4_bare_invoke_rejected_require_wrapper",
+                            "DSML stream dropping bare invoke without outer wrapper (require_wrapper)"
                         );
+                        continue;
                     }
-                    None => {
-                        if flush {
+                    match self.open_invoke_header()? {
+                        Some(tool_index) => {
+                            // Degraded recovery: latch suppression so the orphan
+                            // markup tail around a bare invoke is dropped, not
+                            // leaked (matches the v1 batch recovery contract).
+                            self.suppress_normal_text = true;
                             tracing::warn!(
-                                why = "dsv4_incomplete_bare_invoke",
-                                "DSML stream dropped incomplete bare invoke at EOF"
+                                why = "dsv4_bare_invoke_recovery",
+                                tool_index,
+                                "DSML stream recovering a bare invoke (buffered until close)"
                             );
-                            self.buffer.clear();
                         }
-                        break;
+                        None => {
+                            if flush {
+                                tracing::warn!(
+                                    why = "dsv4_incomplete_bare_invoke",
+                                    "DSML stream dropped incomplete bare invoke at EOF"
+                                );
+                                self.buffer.clear();
+                            }
+                            break;
+                        }
                     }
-                },
+                }
             }
         }
 
@@ -287,7 +323,9 @@ impl ToolParser for DeepSeekV4ToolStreamParser {
     where
         Self: Sized + 'static,
     {
-        Ok(Box::new(Self::new()))
+        // Production DeepSeek-V4 is spec-strict: bare invokes without the outer
+        // wrapper are not conformant tool calls.
+        Ok(Box::new(Self::new_strict()))
     }
 
     fn preserve_special_tokens(&self) -> bool {
@@ -372,6 +410,71 @@ mod tests {
         }
         out.append(parser.finish().expect("finish"));
         out
+    }
+
+    fn parse_chunks_strict(chunks: &[&str]) -> ToolParseResult {
+        let mut parser = DeepSeekV4ToolStreamParser::new_strict();
+        let mut out = ToolParseResult::default();
+        for chunk in chunks {
+            out.append(parser.push(chunk).expect("push"));
+        }
+        out.append(parser.finish().expect("finish"));
+        out
+    }
+
+    /// Spec-strict (production DeepSeek-V4 via `create`/`new_strict`): a bare
+    /// `<｜DSML｜invoke>` with no outer `<｜DSML｜tool_calls>` wrapper is not a
+    /// conformant call — dropped, its markup suppressed, nothing leaked. Contrast
+    /// with `recovers_complete_bare_invoke` (lenient `new()`).
+    #[test]
+    fn strict_drops_bare_invoke_without_wrapper() {
+        let out = parse_chunks_strict(&[
+            "I will check that. <｜DSML｜invoke name=\"get_weather\">",
+            " <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>",
+            " </｜DSML｜invoke>",
+        ]);
+        let normal_text = out.normal_text.clone();
+        assert!(
+            out.coalesce_calls().calls.is_empty(),
+            "bare invoke without wrapper must not become a call"
+        );
+        assert!(
+            !normal_text.contains("DSML"),
+            "orphan DSML markup leaked into normal_text: {normal_text:?}"
+        );
+        assert_eq!(normal_text, "I will check that. ");
+    }
+
+    /// Strict mode still parses a properly wrapped streamed call.
+    #[test]
+    fn strict_still_parses_wrapped_call() {
+        let out = parse_chunks_strict(&[
+            "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weather\">",
+            " <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter> </｜DSML｜invoke>",
+            " </｜DSML｜tool_calls>",
+        ]);
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    /// Strict mode: a bare invoke preceding a wrapped block is dropped; the
+    /// wrapped block still parses and no markup leaks.
+    #[test]
+    fn strict_drops_bare_invoke_before_wrapped_block() {
+        let out = parse_chunks_strict(&[
+            "<｜DSML｜invoke name=\"orphan\"> <｜DSML｜parameter name=\"x\" string=\"true\">1</｜DSML｜parameter> </｜DSML｜invoke>",
+            " <｜DSML｜tool_calls> <｜DSML｜invoke name=\"wrapped\"> <｜DSML｜parameter name=\"y\" string=\"true\">2</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>",
+        ]);
+        let normal_text = out.normal_text.clone();
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1, "only the wrapped invoke is a call");
+        assert_eq!(merged.calls[0].name.as_deref(), Some("wrapped"));
+        assert!(
+            !normal_text.contains("DSML"),
+            "orphan markup leaked: {normal_text:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Overview

**The DeepSeek DSML parser's malformed-recovery is too strong — it manufactures tool calls the spec says don't exist.**

DSML parsers carry a recovery layer that salvages slightly-broken output (truncated close tags, orphan closes, whitespace drift) into well-formed calls rather than leaking raw markup into `content`. That's usually the right thing. But one recovery path overreached: a bare `<｜DSML｜invoke>` — emitted **without** its mandatory outer `<｜DSML｜tool_calls>` / `<｜DSML｜function_calls>` wrapper — was recovered into a real, dispatched tool call. Per the DeepSeek DSML spec (DeepSeek-V4 `encoding/README.md`) a tool call *is* the wrapper block, so a wrapper-less invoke is not conformant. Recovering it fabricates a call the model never committed to.

**Why this is the dangerous kind of recovery.** For a truncated-but-*wrapped* call the intent to call is unambiguous, so salvaging is safe. A bare invoke with no wrapper is ambiguous — it can be the model echoing/narrating markup, not opening a tool-call block. Recovering it silently dispatches e.g. `get_weather` when no call was ever committed: a false-positive execution, not a visible parse error.

**The fix** makes the DeepSeek parsers require the wrapper: a bare invoke now yields **no call** and its markup is suppressed (never leaked into `content`). It disables only that one over-eager recovery path — all legitimate truncation / orphan-close recovery is untouched.

Affected models: **DeepSeek V3.2 and V4 (DSML tool calls).** Ports the idea from closed [ai-dynamo/dynamo#10731](https://github.com/ai-dynamo/dynamo/pull/10731) into frontend-crates, across **both** parser generations. Tracks [DIS-2237](https://linear.app/nvidia/issue/DIS-2237).

### Concrete behavior

Input (bare invoke, no opening wrapper):

```
<｜DSML｜invoke name="get_weather"><｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter></｜DSML｜invoke>
```

| | before | after |
|---|---|---|
| `tool_calls` | `get_weather({"location":"NYC"})` | *(none)* |
| `content` | `""` | `""` (markup suppressed) |

A properly wrapped call is unaffected; a bare invoke *preceding* a wrapped block is dropped while the wrapped block still parses.

## Changes

- **v1 (batch/jail):** add `DsmlParserConfig::require_wrapper` (default `false`); gate bare-invoke recovery on it (two sites); set it `true` once in the shared `deepseek_dsml()` factory so V3.2 and V4 inherit it.
- **v2 (streaming):** add `require_wrapper` to `DeepSeekV4ToolStreamParser` — `create()` (the production `deepseek_v4` registration) is strict, `new()` stays lenient; a bare invoke is dropped + suppressed when strict.
- **Tests:** 6 new strict unit tests (3 v1 ported from #10731, 3 v2); the split-bare-recovery jail test now asserts DeepSeek V4 = no-call + markup-jailed while the other parsers still recover.
- **Conformance:** re-records **only the deepseek delta** on top of current `main` — the `dynamo_v1-5.0.1` baseline backfill already landed via #126, so this adds `dynamo_v1-5.1.0` (deepseek strict) + the `deepseek_v4` stream/overlay captures. No other family's fixtures or `known-divergences` change. All 3 parity suites + clippy green.

## Note for reviewers
`require_wrapper` is a new `pub` field on `DsmlParserConfig` (all-pub, not `#[non_exhaustive]`), so release-plz's cargo-semver-checks may propose a version bump on merge. The fixture capture is at the current `5.1.0`; if release-plz bumps, re-record at the bumped version.
