### PR TITLE
chore(conformance): backfill missing dynamo_v1-5.0.1 / dynamo_v2-0.1.22 captures

### DIFF
--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,6 +1,6 @@
 {
-  "snapshot": "20260716_165310",
-  "created_pt": "2026-07-16 16:53:10 America/Los_Angeles",
+  "snapshot": "20260717_094525",
+  "created_pt": "2026-07-17 09:45:25 America/Los_Angeles",
   "crates": {
     "dynamo-parsers": "5.0.1",
     "dynamo-parsers-v2": "0.1.22"
@@ -27,13 +27,18 @@
     },
     {
       "path": "toolcalling/fixtures-batch-on-stream-v2.tar.gz",
-      "sha256": "ca3f863df80647ab171a3a3ab7ae58839fbfabe0aae942c7299cb20751850bf7",
-      "size": 15168
+      "sha256": "0d3a76abadf557d406a0c7f501207ad56c8ed4c2005263deb47b50380966069d",
+      "size": 15175
     },
     {
       "path": "toolcalling/fixtures-batch-v1/dynamo_v1-3.0.0.tar.gz",
       "sha256": "65290c8070e6a5f7b50665375a99335257625419b672fc2379bb77506b2f14b2",
       "size": 10667
+    },
+    {
+      "path": "toolcalling/fixtures-batch-v1/dynamo_v1-5.0.1.tar.gz",
+      "sha256": "3a6a2740d91a5b573cc9ee02b66cedaf33f424b95c61418d5150773d271f8619",
+      "size": 9821
     },
     {
       "path": "toolcalling/fixtures-batch-v1/inputs.tar.gz",

--- a/conformance/fixtures/toolcalling/fixtures-batch-on-stream-v2.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-batch-on-stream-v2.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca3f863df80647ab171a3a3ab7ae58839fbfabe0aae942c7299cb20751850bf7
-size 15168
+oid sha256:0d3a76abadf557d406a0c7f501207ad56c8ed4c2005263deb47b50380966069d
+size 15175

--- a/conformance/fixtures/toolcalling/fixtures-batch-v1/dynamo_v1-5.0.1.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-batch-v1/dynamo_v1-5.0.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a6a2740d91a5b573cc9ee02b66cedaf33f424b95c61418d5150773d271f8619
+size 9821

--- a/conformance/toolcalling/known-divergences.yaml
+++ b/conformance/toolcalling/known-divergences.yaml
@@ -65,6 +65,11 @@ deepseek_v4:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
+  TOOLCALLING.batch.9.b:
+    stream_vs_batch: &svb-whitespace >-
+      Whitespace-only input: v2 passes the bare whitespace through as
+      normal_text; v1 batch trims it to "". Calls identical (both empty);
+      normal_text-only divergence, intended.
 
 gemma4:
   TOOLCALLING.batch.2.c:
@@ -79,6 +84,8 @@ gemma4:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
+  TOOLCALLING.batch.9.b:
+    stream_vs_batch: *svb-whitespace
 
 glm47:
   TOOLCALLING.batch.2.c:
@@ -91,6 +98,8 @@ glm47:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
+  TOOLCALLING.batch.9.b:
+    stream_vs_batch: *svb-whitespace
   TOOLCALLING.batch.13:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.streamv2.7.a:
@@ -122,10 +131,6 @@ harmony:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
-  TOOLCALLING.batch.9.b:
-    stream_vs_batch: >-
-      Whitespace-only input: v2 passes the bare whitespace through as
-      normal_text; v1 batch returns "". Intended.
 
 kimi_k2:
   TOOLCALLING.batch.2.c:
@@ -138,6 +143,8 @@ kimi_k2:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
+  TOOLCALLING.batch.9.b:
+    stream_vs_batch: *svb-whitespace
 
 minimax_m2:
   TOOLCALLING.batch.2.b:
@@ -156,6 +163,8 @@ minimax_m2:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.8.d:
     stream_vs_batch: *svb-surrounding-text
+  TOOLCALLING.batch.9.b:
+    stream_vs_batch: *svb-whitespace
   TOOLCALLING.streamv2.7.a:
     jail: *jail-stringifies-scalars
   TOOLCALLING.streamv2.7.f:
@@ -165,6 +174,8 @@ minimax_m3:
   TOOLCALLING.batch.2.c:
     stream_vs_batch: *svb-surrounding-text
   TOOLCALLING.batch.5.f:
+    stream_vs_batch: *svb-recovery
+  TOOLCALLING.batch.5.g:
     stream_vs_batch: *svb-recovery
   TOOLCALLING.batch.8.b:
     stream_vs_batch: *svb-surrounding-text


### PR DESCRIPTION
## Overview

**Backfill of missing conformance captures — no parser code changes.**

The recorded frontend-crates conformance baseline was `dynamo_v1-3.0.0` / `dynamo_v2-0.1.11` — two majors behind the current crates (`dynamo-parsers` 5.0.1, `dynamo-parsers-v2` 0.1.22). Parser changes merged since (e.g. #80 / #81 "preserve surrounding text") were never re-recorded, so the conformance table showed **stale expected values** for many families (gemma4, glm47, kimi_k2, minimax, …).

This backfills the missing captures at the current crate versions — **additive**: a new `dynamo_v1-5.0.1` batch dir + refreshed batch-on-stream overlay alongside the old ones (latest fold wins per case). The stream capture `dynamo_v2-0.1.22` was already current, so it's untouched.

It also documents the benign **"v1 trims / v2 preserves"** whitespace divergences the backfill surfaced (`*:9.b`, `minimax_m3:5.g`) in `known-divergences.yaml`, and drops the now-stale `harmony:9.b` entry.

All 3 parity suites green.

## Stacked

Base for the `require_wrapper` DeepSeek fix ([DIS-2237](https://linear.app/nvidia/issue/DIS-2237)) — that PR re-records only the deepseek delta on top of this backfill.

Tracks [DIS-2440](https://linear.app/nvidia/issue/DIS-2440).
