### PR TITLE
feat(conformance): parser-authoring docs + process — coverage taxonomy, CI lint, single-source markers (part 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,30 +114,15 @@ jobs:
           # the render + guard steps extract them locally on first use.
           lfs: true
 
-      - name: Render conformance matrix (no engines)
+      # Single stable entry point: render both charts, structural sanity, fixture-
+      # coverage + marker-registration lint (DIS-2442), chart-invariant guards.
+      # Add/change conformance gates in check.sh's run_ci(), NOT here — this
+      # workflow step should never need another edit for a new gate.
+      - name: Conformance gate (render + lint + invariants)
         run: |
           python3 -m venv /tmp/pvenv
           /tmp/pvenv/bin/pip install --quiet pyyaml jinja2 pytest
-          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_table_v1.sh
-          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/render_table_v2.sh
-          OUT=conformance/PARITY_v1.html
-          test -s "$OUT"
-          grep -q "TOOLCALLING.batch" "$OUT"
-          grep -q "REASONING.batch" "$OUT"
-          test -s conformance/CONFORMANCE_v2.html
-          echo "conformance matrix rendered: $(wc -c < "$OUT") bytes"
-          cp "$OUT" conformance/utils/CONFORMITY.html
-
-      # Structural regression guards on the rendered charts + JSON data model: parser
-      # selectors present, every candidate versioned from fixture provenance (not the
-      # live Cargo.toml), all peer versions present, no "not yet implemented", coloring
-      # intact, and the model's structural invariants (DIS-2434). Reuse the HTML above.
-      # See test_chart_invariants.py / test_model.py / test_stream_on_batch.py.
-      - name: Model + parser invariants
-        run: |
-          PATH="/tmp/pvenv/bin:$PATH" python3 -m pytest \
-            conformance/utils/tests/test_model.py \
-            conformance/utils/tests/test_stream_on_batch.py -q
+          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/check.sh ci
 
       - name: Upload conformance matrix
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -116,7 +116,7 @@ The `rust` CI job checks out the LFS store (`lfs: true`), extracts the manifest-
 - `parity_toolcalling_stream`: v2 code vs `expected.dynamo_v2` folded from the LOWEST `dynamo_v2-<ver>/` dir — the v2 anchor. (The v1-jail reference lives in its own `dynamo_v1-3.0.0/` namespace and never enters the v2 fold. Overlay folding up to the pinned crate version is a follow-up; until then an intended v2 output change must be reflected in the anchor's expected blocks at re-capture.)
 - `parity_toolcalling_batch_via_stream`: v2 code vs the `fixtures-batch-on-stream-v2` expectations.
 
-A parser change that alters output fails CI until the fixtures are re-captured and committed (workflow 2) — CI compares Dynamo against the pinned shard YAMLs, nothing else. The `conformance-table` CI job additionally re-renders both HTML pages from the same pinned store and runs the chart-invariant guards (`utils/tests/test_chart_invariants.py`).
+A parser change that alters output fails CI until the fixtures are re-captured and committed (workflow 2) — CI compares Dynamo against the pinned shard YAMLs, nothing else. The `conformance-table` CI job runs exactly one command, `conformance/utils/check.sh ci`, which re-renders both HTML pages from the same pinned store, runs the coverage/marker lint (section 8), and the chart-invariant guards. To add or change a conformance gate, edit `run_ci()` in `check.sh`; the workflow file stays untouched.
 
 ### 5. Add a new test case (e.g. a new `TOOLCALLING.streamv2.5.h`)
 
@@ -141,7 +141,25 @@ How `.patchN` is treated: **HTML** folds it into its base `<ver>` display column
 
 `parity_toolcalling_batch_via_stream` compares the v2 stream parser on batch text against v1's `expected.dynamo_v1`. v1 and v2 differ **by design** (v2 preserves surrounding/inter-call prose that v1 batch trims; v2 recovers bare calls v1 drops). When a case legitimately diverges, add it to `toolcalling/known-divergences.yaml` under `<family> → TOOLCALLING.batch.<case> → stream_vs_batch: <note>` (reuse the `*svb-surrounding-text` / `*svb-recovery` anchors). An entry with a note is an allowed, documented difference; a MISSING entry fails the test — so the file is also the audit trail of "v2 improved on v1 here." Do NOT add an entry to paper over an actual regression (v2 dropping text, leaking markup, corrupting args) — fix the parser instead.
 
+### 8. Coverage taxonomy: what "complete fixtures for a family" means (DIS-2442)
+
+`conformance/case-taxonomy.yaml` is the machine-readable definition of complete coverage — every batch/stream/reasoning case group and sub-case, with per-case requiredness and applicability rules. It replaces the old implicit standard (the union of `description:` fields across ~20 families that reviewers had to reverse-engineer per PR).
+
+```bash
+# The authoring loop for a new family: the FAIL list is the fixture TODO list.
+conformance/utils/check.sh coverage --family <family>
+
+# Whole-corpus gate (what CI runs in the conformance-table job):
+conformance/utils/check.sh coverage
+```
+
+Rules the lint enforces: a required case must exist as real input (`model_text`/`chunks`) or as a placeholder carrying an `explanation:` (silence fails; "not yet authored" placeholders warn — they are the acknowledged backfill list). A family registered in `parser_families.yaml` with no fixtures dir for a suite fails (the "ALL stream cases missing" class). Case IDs unknown to the taxonomy fail, so a PR that invents a new group/sub-case must extend `case-taxonomy.yaml` in the same PR. Pre-taxonomy gaps are grandfathered under `known_gaps:` — remove the ID when the fixture lands.
+
+The same command runs the marker-registration lint: each family declares its grammar tokens once in the `markers:` section of `parser_families.yaml` (`pairs` / `singletons` / `leak`), from which the `↯` leak regex (`markers.py`) and the popup token coloring (`tests/parity/markup.py`) are derived.
+
 ### Invariants the tooling now enforces (so you don't have to remember)
 
 - **Renders/tests read the manifest-pinned snapshot dir directly**, not the shared `<cache>/toolcalling` symlink — sibling `frontend-crates*` checkouts pinning other snapshots used to race to repoint it, so a render could read a snapshot missing the newest version. Enforced in `utils/src/_common.sh`.
 - **`package_fixtures.py` recomputes the sha256 of every kept shard from disk**, never copying the prior manifest's value — a restored/re-pinned store file can no longer produce a manifest that lies about its content (which broke `extract_fixtures`' sha-verify).
+- **Fixture coverage is diffed against `case-taxonomy.yaml` in CI** (`check_family_coverage.py`, section 8) — a new family missing required case groups, a whole stream corpus, or an unexplained placeholder fails the conformance-table job before human review (the PR #120 gap classes).
+- **Family grammar tokens are declared once in `parser_families.yaml` `markers:`** — the leak detector and popup colorizer derive from it, and a family without a declaration fails the coverage lint (undeclared tokens used to render leaks as clean cells and every token as a red orphan).

--- a/conformance/case-taxonomy.yaml
+++ b/conformance/case-taxonomy.yaml
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Machine-readable case taxonomy for the conformance fixture corpus (DIS-2442).
+#
+# This file enumerates what "complete fixture coverage" means for a parser family.
+# Before it existed the taxonomy lived implicitly in the union of `description:`
+# fields across ~20 families' fixture YAMLs, and every new-parser PR re-discovered
+# it during review (PR #120: batch groups 6/8/30 and the whole stream-v2 corpus
+# were missing and no tool could say so). `check_family_coverage.py --family <f>`
+# diffs a family's case IDs against this file and fails on unexplained gaps.
+#
+# Semantics:
+#   * A case ID is COVERED when the family's fixture YAML has an entry with real
+#     input (`model_text` for batch, `chunks` for stream).
+#   * A case entry WITHOUT real input is a placeholder and MUST carry an
+#     `explanation:`. Description containing "not yet authored" = acknowledged
+#     TODO (lint warns); anything else = explicit n/a (lint passes).
+#   * `required: true` on a case: every family must have the entry (real or
+#     placeholder). `required: true` on a group: every family must have at least
+#     one entry in the group (real or a group-level n/a placeholder such as
+#     `TOOLCALLING.batch.30`).
+#   * `applies_if_real_in: <suite>`: the group is required only for families that
+#     have at least one REAL case in the same-numbered group of that suite
+#     (e.g. stream group 30 applies iff the family authored real batch 30.x).
+#   * Case keys are the ID suffix after the suite prefix; "" is the bare group
+#     case (e.g. TOOLCALLING.batch.10).
+#
+# Editing rules: when a fixture PR introduces a new group or sub-case, add it here
+# in the same PR (the lint fails on case IDs unknown to the taxonomy). Keep
+# descriptions family-neutral; family-specific phrasing belongs in the fixture's
+# own `description:`.
+
+version: 1
+
+suites:
+  toolcalling.batch:
+    prefix: TOOLCALLING.batch
+    fixtures: conformance/fixtures/toolcalling/fixtures-batch-v1
+    groups:
+      "1":
+        title: Single tool call (happy path)
+        required: true
+        cases:
+          "": {desc: Single tool call (happy path), required: true}
+      "2":
+        title: Multiple / parallel calls
+        required: true
+        cases:
+          a: {desc: Parallel calls inside one wrapper / JSON array, required: true}
+          b: {desc: Two back-to-back fence/wrapper pairs, required: true, note: n/a placeholder where the grammar has no repeated-fence form}
+          c: {desc: Parallel calls with surrounding narration, required: true}
+          d: {desc: Same name twice (id distinctness), required: true}
+      "3":
+        title: No tool call (plain text)
+        required: true
+        cases:
+          "": {desc: No tool call (plain text passthrough), required: true}
+      "4":
+        title: Malformed call bodies
+        required: true
+        cases:
+          a: {desc: Wrapper with garbage / no parsable body, required: true}
+          b: {desc: Unterminated / invalid JSON in the call body, required: true}
+          c: {desc: Missing function-name key or token, required: true}
+          d: {desc: Missing a grammar-specific structural close (tag / fence), required: true}
+          e: {desc: Malformed prefix followed by a valid complete call, required: true, note: n/a placeholder where recovery has no meaning for the grammar}
+          f: {desc: Tool name emitted in a wrong-but-adjacent syntax (e.g. XML tag instead of function=), required: true, note: n/a placeholder where the grammar has no adjacent form}
+      "5":
+        title: Truncation and unbalanced markers
+        required: true
+        cases:
+          a: {desc: Missing end marker after a complete body (EOF recovery), required: true}
+          b: {desc: Orphan close marker without a matching open, required: true}
+          c: {desc: Truncation mid-arguments, required: true}
+          d: {desc: 'Multi-call, last call missing only the end marker (body complete)', required: true}
+          e: {desc: 'Multi-call, last call truncated mid-argument value', required: true}
+          f: {desc: Bare valid call before a complete wrapped call, required: false}
+          g: {desc: Orphan close marker after prefix prose, required: false}
+      "6":
+        title: Empty arguments
+        required: true
+        cases:
+          a: {desc: 'Canonical empty arguments ("arguments": {} or grammar equivalent)', required: true}
+          b: {desc: Whitespace inside the empty-arguments form, required: true}
+          c: {desc: Arguments key/section absent entirely, required: true}
+      "7":
+        title: Argument type and shape edges
+        required: true
+        cases:
+          a: {desc: Standard scalar types (string + int + bool), required: true}
+          b: {desc: Unicode + escaped characters in a string value, required: true}
+          c: {desc: Schema mismatch — string value where schema declares integer, required: true}
+          d: {desc: Nested object + array values, required: true}
+          e: {desc: Large / deep argument payload, required: true}
+          f: {desc: Numeric precision edge preserves integer-like literal, required: true}
+      "8":
+        title: Narration around calls
+        required: true
+        cases:
+          a: {desc: Narration before the tool call only, required: true}
+          b: {desc: Narration after the tool call only, required: true}
+          c: {desc: Narration both before and after (sandwich), required: true}
+          d: {desc: Narration between multiple tool calls, required: true}
+      "9":
+        title: Empty / blank input
+        required: true
+        cases:
+          a: {desc: Empty model text, required: true}
+          b: {desc: Blank / whitespace-only model text, required: true}
+      "10":
+        title: Duplicate calls
+        required: true
+        cases:
+          "": {desc: Duplicate calls (same name twice), required: true}
+      "13":
+        title: Unknown tool names
+        required: true
+        cases:
+          "": {desc: Unknown tool name absent from supplied tools, required: false}
+          a: {desc: Unknown-only call under default parser behavior, required: false}
+          b: {desc: Explicit forward-unknown-tools mode, required: false}
+          c: {desc: Mixed known and unknown calls in one response, required: true}
+          d: {desc: Unknown native tool index, required: false}
+      "30":
+        title: Own-grammar delimiters inside a string argument (single call)
+        required: true
+        note: Families whose grammar carries string-valued arguments author real 30.x cases; others carry a group-level n/a placeholder (bare .30 case).
+        cases:
+          "": {desc: Group-level n/a placeholder for grammars without string-argument delimiters, required: false}
+          a: {desc: Call/body separator characters inside one argument string value, required: false}
+          b: {desc: Structural delimiters (closing braces/brackets/tags) inside one argument string value, required: false}
+          c: {desc: The family's own tool-call marker text inside one argument string value, required: false}
+      "31":
+        title: Own-grammar delimiters inside a string argument (multi-call)
+        required: true
+        note: Same applicability as group 30, with later calls after the delimiter-carrying argument.
+        cases:
+          "": {desc: Group-level n/a placeholder for grammars without string-argument delimiters, required: false}
+          a: {desc: Multi-call response with a call separator inside the first argument string, required: false}
+          b: {desc: Multi-call response with structural delimiters inside one argument string value, required: false}
+
+  toolcalling.stream:
+    prefix: TOOLCALLING.streamv2
+    fixtures: conformance/fixtures/toolcalling/fixtures-stream-v2
+    groups:
+      "1":
+        title: Single tool call (happy path)
+        required: true
+        cases:
+          "": {desc: Single tool call (happy path), required: true}
+      "2":
+        title: Multiple / parallel calls
+        required: true
+        cases:
+          a: {desc: Parallel calls inside one wrapper / JSON array, required: true}
+          b: {desc: Two back-to-back fence/wrapper pairs, required: false}
+          c: {desc: Parallel calls with surrounding narration, required: true}
+          d: {desc: Same name twice (id distinctness), required: true}
+      "3":
+        title: No tool call (plain text)
+        required: true
+        cases:
+          "": {desc: No tool call (plain text passthrough), required: true}
+      "4":
+        title: Malformed call bodies
+        required: true
+        cases:
+          a: {desc: Wrapper with garbage / no parsable body, required: true}
+          b: {desc: Unterminated / invalid JSON in the call body, required: false}
+          c: {desc: Missing function-name key or token, required: false}
+          d: {desc: Missing a grammar-specific structural close (tag / fence), required: false}
+          e: {desc: Malformed prefix followed by a valid complete call, required: false}
+          f: {desc: Tool name emitted in a wrong-but-adjacent syntax, required: false}
+      "5":
+        title: Truncation and unbalanced markers
+        required: true
+        cases:
+          a: {desc: Missing end marker after a complete body (EOF recovery), required: true}
+          b: {desc: Orphan close marker without a matching open, required: true}
+          c: {desc: Truncation mid-arguments, required: true}
+          d: {desc: 'Multi-call, last call missing only the end marker (body complete)', required: true}
+          e: {desc: 'Multi-call, last call truncated mid-argument value', required: true}
+          f: {desc: Bare valid call before a complete wrapped call, required: false}
+          g: {desc: Orphan close marker after prefix prose, required: false}
+          h: {desc: Orphan close marker split across chunks after prefix prose, required: false}
+      "6":
+        title: Empty arguments
+        required: true
+        cases:
+          a: {desc: 'Canonical empty arguments ("arguments": {} or grammar equivalent)', required: true}
+          b: {desc: Whitespace inside the empty-arguments form, required: true}
+          c: {desc: Arguments key/section absent entirely, required: false}
+      "7":
+        title: Argument type and shape edges
+        required: true
+        cases:
+          a: {desc: Standard scalar types (string + int + bool), required: true}
+          b: {desc: Unicode + escaped characters in a string value, required: true}
+          c: {desc: Schema mismatch — string value where schema declares integer, required: false}
+          d: {desc: Nested object + array values, required: false}
+          e: {desc: Large / deep argument payload, required: false}
+          f: {desc: Numeric precision edge preserves integer-like literal, required: false}
+      "8":
+        title: Narration around calls
+        required: true
+        cases:
+          a: {desc: Narration before the tool call only, required: true}
+          b: {desc: Narration after the tool call only, required: true}
+          c: {desc: Narration both before and after (sandwich), required: true}
+          d: {desc: Narration between multiple tool calls, required: true}
+      "9":
+        title: Empty / blank input
+        required: true
+        cases:
+          a: {desc: Empty model text, required: true}
+          b: {desc: Blank / whitespace-only model text, required: true}
+      "10":
+        title: Duplicate calls
+        required: true
+        cases:
+          "": {desc: Duplicate calls (same name twice), required: true}
+      "13":
+        title: Unknown tool names
+        required: true
+        cases:
+          "": {desc: Unknown tool name absent from supplied tools, required: false}
+          a: {desc: Unknown-only call under default parser behavior, required: false}
+          c: {desc: Mixed known and unknown calls in one response, required: false}
+      "30":
+        title: Own-grammar delimiters inside a string argument (single call)
+        applies_if_real_in: toolcalling.batch
+        cases:
+          a: {desc: Call/body separator characters inside one argument string value, required: false}
+          b: {desc: Structural delimiters inside one argument string value, required: false}
+          c: {desc: The family's own tool-call marker text inside one argument string value, required: false}
+      "31":
+        title: Own-grammar delimiters inside a string argument (multi-call)
+        applies_if_real_in: toolcalling.batch
+        cases:
+          a: {desc: Multi-call response with a call separator inside the first argument string, required: false}
+          b: {desc: Multi-call response with structural delimiters inside one argument string value, required: false}
+      "50":
+        title: Chunk-boundary splits
+        required: true
+        cases:
+          "": {desc: Complete single tool call with a grammar token split across chunk boundaries, required: true}
+
+  reasoning.batch:
+    prefix: REASONING.batch
+    fixtures: conformance/fixtures/reasoning/fixtures-v1
+    groups:
+      "1":
+        title: Empty / plain input
+        required: true
+        cases:
+          a: {desc: Empty input, required: true}
+          b: {desc: Plain text without reasoning markers, required: true}
+      "2":
+        title: Reasoning-span content variants
+        required: true
+        cases:
+          a: {desc: Explicit reasoning span (or force-reasoning equivalent), required: true}
+          b: {desc: Normal prefix before a reasoning block, required: false}
+          c: {desc: Reasoning followed by normal answer text, required: true}
+          d: {desc: Normal text around the reasoning span, required: true}
+          e: {desc: Empty reasoning block, required: true}
+          f: {desc: Complex reasoning content with Unicode and newlines, required: true}
+      "3":
+        title: Tool-call handoff
+        required: true
+        cases:
+          a: {desc: Reasoning followed by downstream tool-call text, required: true}
+          b: {desc: Tool-call section marker force-exits an open reasoning block, required: true}
+          c: {desc: Recipientless commentary channel is visible normal text (Harmony-shaped grammars), required: true}
+          d: {desc: Directed commentary tool call is not visible normal text (Harmony-shaped grammars), required: true}
+          e: {desc: Directed analysis tool call is handed off to the tool-call parser (Harmony-shaped grammars), required: true}
+          f: {desc: Analysis / directed commentary / final answer channel sequencing (Harmony-shaped grammars), required: true}
+      "4":
+        title: Dangling close markers
+        required: true
+        cases:
+          "": {desc: Dangling end marker without an opening reasoning marker, required: true}
+      "5":
+        title: Unterminated reasoning
+        required: true
+        cases:
+          "": {desc: Missing end marker keeps the remaining text as reasoning, required: true}
+      "6":
+        title: Multiple spans and stray markers
+        required: true
+        cases:
+          a: {desc: Multiple reasoning spans, required: true}
+          b: {desc: Stray end marker after a complete reasoning span (unbalanced tag), required: true}
+
+  reasoning.stream:
+    prefix: REASONING.stream
+    fixtures: conformance/fixtures/reasoning/fixtures-v1
+    groups:
+      "1":
+        title: Empty / plain input
+        required: true
+        cases:
+          a: {desc: Empty stream chunk, required: true}
+          b: {desc: Plain text without reasoning markers, required: true}
+      "2":
+        title: Reasoning spans across chunks
+        required: true
+        cases:
+          a: {desc: Single reasoning block across chunks, required: true}
+          b: {desc: Multiple reasoning spans across chunks, required: true}
+          c: {desc: Stray end marker after a complete reasoning span across chunks (unbalanced tag), required: true}
+      "3":
+        title: Marker splits across chunks
+        required: true
+        cases:
+          a: {desc: Start marker split across chunks, required: true}
+          b: {desc: End marker split across chunks, required: true}
+          c: {desc: Partial start-marker prefix later becomes normal text, required: true}
+      "4":
+        title: Dangling markers and downstream boundaries
+        required: true
+        cases:
+          "": {desc: Dangling end marker split across chunks, required: false}
+          a: {desc: Close marker only is stripped as prompt-prefilled reasoning close, required: true}
+          b: {desc: Downstream tool-call boundary split across chunks, required: true}
+          c: {desc: Two directed downstream tool calls in one stream, required: true}
+          d: {desc: Partial downstream boundary recovery, required: true}
+
+# Suites a family is exempt from entirely, with the reason (renders as n/a, not a
+# gap). Toolcalling suites are otherwise expected for every parser_families.yaml row.
+suite_exemptions:
+  harmony_text:
+    toolcalling.batch: harmony_text is the text-driven conformance variant of harmony; the v1 batch corpus is captured under the harmony family.
+
+# Pre-taxonomy coverage gaps, grandfathered so the lint stays green on the current
+# corpus while still holding NEW families to the full bar. Each entry is a backfill
+# TODO; remove the ID from the list when the fixture lands.
+known_gaps:
+  toolcalling.stream:
+    llama3_json: ["5.b"]
+    minimax_m3: ["2.a", "2.c", "2.d", "4.a", "5.b", "5.c", "5.d", "5.e", "6.a", "6.b", "8.a", "8.b", "8.c", "8.d", "50"]
+  reasoning.stream:
+    minimax_m3: ["4.b", "4.c", "4.d"]

--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -74,6 +74,12 @@ conformance/utils/check.sh vllm --container vllm-localdev
 # Example: check SGLang Python batch and stream behavior against extracted legacy `expected.sglang` and v2 `expected.sglang_python` blocks.
 conformance/utils/check.sh sglang --container sglang-localdev
 
+# Fixture-coverage + marker-registration lint: diffs each family's case IDs against
+# conformance/case-taxonomy.yaml and checks its `markers:` declaration in
+# parser_families.yaml. Default is all families; --family narrows it.
+conformance/utils/check.sh coverage
+conformance/utils/check.sh coverage --family gemma4
+
 # Formats Rust changes.
 cargo fmt
 

--- a/conformance/utils/check.sh
+++ b/conformance/utils/check.sh
@@ -2,22 +2,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# check.sh <dynamo|vllm|sglang|all> [batch|stream|all] [--container N|--pip] [--dry-run]
+# check.sh <dynamo|vllm|sglang|coverage|ci|all> [batch|stream|all] [--container N|--pip] [--dry-run]
 #   Run a parser against the committed fixtures and report pass/fail (read-only).
 #     dynamo [batch|stream|all]  Dynamo Rust parser vs expected.dynamo_v2 / expected.dynamo_v1 (cargo test)
 #     vllm   [--container N|--pip]   vLLM Python parser vs expected.vllm_python / expected.vllm
 #     sglang [--container N|--pip]   SGLang Python parser vs expected.sglang_python
+#     coverage [--family F ...]      fixture-coverage + marker-registration lint vs
+#                                    case-taxonomy.yaml (defaults to --all families)
+#     ci     what the conformance-table CI job runs, and the ONLY thing it runs:
+#            render both charts, structural sanity, coverage lint, invariant pytest.
+#            Add/change conformance gates in run_ci below — never in .github/workflows.
 #     all    [--container-vllm N --container-sglang M] [--allow-peer-failures]
-#            dynamo(all) + vllm + sglang. Fails the run on any parser failure;
-#            pass --allow-peer-failures (alias --best-effort-peers) to keep the
-#            old behavior of reporting peer failures without failing the command.
+#            dynamo(all) + vllm + sglang + coverage. Fails the run on any parser
+#            failure; pass --allow-peer-failures (alias --best-effort-peers) to keep
+#            the old behavior of reporting peer failures without failing the command.
 
 DRY=0; args=()
 while [ $# -gt 0 ]; do case "$1" in --dry-run|--dryrun) DRY=1; shift;; *) args+=("$1"); shift;; esac; done
 set -- ${args+"${args[@]}"}
 source "$(dirname "$0")/src/_common.sh"
 
-usage() { echo "usage: conformance/utils/check.sh <dynamo|vllm|sglang|all> [batch|stream|all] [--container N|--pip]" >&2; exit 2; }
+usage() { echo "usage: conformance/utils/check.sh <dynamo|vllm|sglang|coverage|ci|all> [batch|stream|all] [--container N|--pip]" >&2; exit 2; }
 
 run_dynamo() {  # $1 = batch|stream|all ; returns non-zero if any target fails
   local targets=() rc=0
@@ -42,12 +47,40 @@ run_engine() {  # $1=vllm|sglang  $2..=passthrough (--container N|--pip)
     --fixtures "$STAGE/tests/parity/toolcalling/fixtures" "$@"
 }
 
+run_coverage() {  # $@ = passthrough (--family F ...); defaults to --all
+  if [ "$DRY" = 1 ]; then echo "[dry-run] python3 $TOOLS/check_family_coverage.py ${*:---all}"; return; fi
+  if [ $# -gt 0 ]; then python3 "$TOOLS/check_family_coverage.py" "$@"
+  else python3 "$TOOLS/check_family_coverage.py" --all; fi
+}
+
+run_ci() {  # the conformance-table CI gate; fail-fast, also runnable locally
+  if [ "$DRY" = 1 ]; then echo "[dry-run] render v1+v2, sanity greps, coverage lint, invariant pytest"; return; fi
+  set -e
+  "$UTILS/render_table_v1.sh"
+  "$UTILS/render_table_v2.sh"
+  local out="$ROOT/conformance/PARITY_v1.html"
+  test -s "$out"
+  grep -q "TOOLCALLING.batch" "$out"
+  grep -q "REASONING.batch" "$out"
+  test -s "$ROOT/conformance/CONFORMANCE_v2.html"
+  echo "conformance matrix rendered: $(wc -c < "$out") bytes"
+  # The uploaded CI artifact name predates the v1/v2 split; keep it stable.
+  \cp -f "$out" "$UTILS/CONFORMITY.html"
+  run_coverage
+  python3 -m pytest \
+    "$UTILS/tests/test_model.py" \
+    "$UTILS/tests/test_stream_on_batch.py" \
+    "$UTILS/tests/test_family_coverage.py" -q
+}
+
 engine="${1:-}"; shift || true
 [ -n "$engine" ] || usage
 case "$engine" in
   dynamo) run_dynamo "${1:-all}" ;;
   vllm)   run_engine vllm "$@" ;;
   sglang) run_engine sglang "$@" ;;
+  coverage) run_coverage "$@" ;;
+  ci)     run_ci ;;
   all)
     cv=""; cs=""; allow_peer=0; rc=0
     while [ $# -gt 0 ]; do case "$1" in
@@ -57,6 +90,7 @@ case "$engine" in
         *) shift ;;
       esac; done
     run_dynamo all || rc=1
+    run_coverage || rc=1
     peer_rc=0
     if [ -n "$cv" ]; then run_engine vllm --container "$cv" || peer_rc=1
     else echo "(skipped vllm: pass --container-vllm NAME or 'check.sh vllm --pip')"; fi

--- a/conformance/utils/src/_common.sh
+++ b/conformance/utils/src/_common.sh
@@ -57,6 +57,10 @@ _build_stage_base() {
   # COPY the vendored python package so resolved __file__ -> REPO_ROOT == $STAGE.
   \cp -Rf "$UTILS/tests/parity" "$STAGE/tests/parity"
   \cp -f "$UTILS/tests/__init__.py" "$STAGE/tests/__init__.py"
+  # Family marker declarations (DIS-2442): the staged tests/parity/markup.py resolves
+  # its registry at <stage-root>/src/parser_families.yaml, mirroring the repo layout.
+  mkdir -p "$STAGE/src"
+  \cp -f "$TOOLS/parser_families.yaml" "$STAGE/src/parser_families.yaml"
   # Shared static CSS/JS inlined into BOTH pages at render time (v1 parity + v2
   # conformance both read tests/parity/assets/*). Staged here in the base so the v1
   # render finds them too — the compare-bar/coloring logic lives in one place now.

--- a/conformance/utils/src/check_family_coverage.py
+++ b/conformance/utils/src/check_family_coverage.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture-coverage and marker-registration lint (DIS-2442).
+
+Diffs each parser family's fixture case IDs against the machine-readable case
+taxonomy (conformance/case-taxonomy.yaml) and fails on unexplained gaps, so
+"complete coverage" is a tool answer instead of a review-time reverse-engineering
+exercise (PR #120: batch groups 6/8/30 and the whole stream-v2 corpus were
+missing and nothing said so before human review).
+
+Checks, per family:
+  * family present in parser_families.yaml (toolcalling registry);
+  * a fixtures dir exists for every applicable suite (catches "ALL stream test
+    cases missing" — a registry family with no fixtures-stream-v2/inputs dir);
+  * every `required:` taxonomy group/case is present, either as real input
+    (model_text / chunks) or as an explicit placeholder with an `explanation:`;
+  * placeholders without an `explanation:` fail; "not yet authored" placeholders
+    warn (acknowledged TODO);
+  * case IDs unknown to the taxonomy fail (forces taxonomy updates in the same
+    PR that introduces a new group/sub-case);
+  * every registry family declares its grammar tokens in the `markers:` section
+    of parser_families.yaml, each declared token is matched by the leak detector
+    (markers._TOOL_CALL_MARKUP_RE) and renders non-orphan in the popup colorizer
+    (tests.parity.markup) — the two registries nobody knew existed in PR #120.
+
+Reasoning suites are checked when the family has a reasoning fixtures dir, or
+always with --expect-reasoning (use when the PR adds a reasoning parser).
+
+Exit code 1 on any FAIL. Warnings (TODO placeholders, grandfathered known_gaps)
+never fail the run; they are the backfill work list.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parents[0]))  # conformance/utils, for tests.parity.markup
+
+import markers as markers_mod  # noqa: E402
+from tests.parity import markup  # noqa: E402
+
+TAXONOMY_PATH = HERE.parents[1] / "case-taxonomy.yaml"
+REGISTRY_PATH = HERE / "parser_families.yaml"
+
+SUITE_INPUTS = {
+    "toolcalling.batch": ("toolcalling/fixtures-batch-v1", "TOOLCALLING.batch"),
+    "toolcalling.stream": ("toolcalling/fixtures-stream-v2", "TOOLCALLING.streamv2"),
+    "reasoning.batch": ("reasoning/fixtures-v1", "REASONING.batch"),
+    "reasoning.stream": ("reasoning/fixtures-v1", "REASONING.stream"),
+}
+TOOLCALLING_SUITES = ("toolcalling.batch", "toolcalling.stream")
+REASONING_SUITES = ("reasoning.batch", "reasoning.stream")
+
+# Placeholder-case classification (see case-taxonomy.yaml "Semantics").
+_TODO_MARKER = "not yet authored"
+
+
+def resolve_fixtures_root() -> Path:
+    """The manifest-pinned snapshot dir. Runs extract_fixtures.py (instant on cache
+    hit) and reads the snapshot path it prints — NEVER the shared
+    `<cache>/toolcalling` symlink, which sibling checkouts pinning other snapshots
+    race to repoint mid-run (see conformance/README "Invariants"). An exported
+    CONFORMANCE_FIXTURES_ROOT (set by _common.sh) wins."""
+    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
+    if env:
+        root = Path(env)
+        if not (root / "toolcalling").is_dir():
+            sys.exit(f"fixtures root {root} has no toolcalling/ dir")
+        return root
+    proc = subprocess.run(
+        [sys.executable, str(HERE / "extract_fixtures.py")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    snap = Path(proc.stdout.strip().splitlines()[-1])
+    if not (snap / "toolcalling").is_dir():
+        sys.exit(f"extract_fixtures.py returned an unusable snapshot dir: {snap}")
+    return snap
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+
+    def fail(self, msg: str) -> None:
+        self.failures.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+
+def load_family_cases(root: Path, suite: str, family: str) -> dict[str, dict] | None:
+    """All of `family`'s cases for `suite`, keyed by ID suffix ('' for the bare
+    group case). None when the family has no fixtures dir for the suite."""
+    subdir, prefix = SUITE_INPUTS[suite]
+    fam_dir = root / subdir / "inputs" / family
+    if not fam_dir.is_dir():
+        return None
+    cases: dict[str, dict] = {}
+    for path in sorted(fam_dir.glob(f"{prefix}*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        for cid, case in (data.get("cases") or {}).items():
+            if not cid.startswith(prefix + "."):
+                continue
+            cases[cid[len(prefix) + 1 :]] = case if isinstance(case, dict) else {}
+    return cases if cases else None
+
+
+def case_status(case: dict) -> str:
+    """'real' | 'todo' | 'na' | 'bad' (placeholder without explanation)."""
+    if "model_text" in case or "chunks" in case:
+        return "real"
+    if not (case.get("explanation") or case.get("reason")):
+        return "bad"
+    if _TODO_MARKER in str(case.get("description", "")):
+        return "todo"
+    return "na"
+
+
+def group_of(suffix: str) -> str:
+    return re.match(r"\d+", suffix).group(0)
+
+
+def sub_of(suffix: str) -> str:
+    group = group_of(suffix)
+    return suffix[len(group) + 1 :] if len(suffix) > len(group) else ""
+
+
+def check_suite(
+    report: Report,
+    taxonomy: dict,
+    root: Path,
+    suite: str,
+    family: str,
+    batch_real_groups: set[str],
+) -> None:
+    spec = taxonomy["suites"][suite]
+    exemption = (taxonomy.get("suite_exemptions") or {}).get(family, {}).get(suite)
+    if exemption:
+        return
+    gaps = set((taxonomy.get("known_gaps") or {}).get(suite, {}).get(family, []))
+    subdir, prefix = SUITE_INPUTS[suite]
+    cases = load_family_cases(root, suite, family)
+    if cases is None:
+        report.fail(
+            f"{family} {suite}: NO fixtures under {subdir}/inputs/{family} — the entire"
+            f" {suite} corpus is missing (author {prefix}.* input YAMLs)"
+        )
+        return
+
+    by_group: dict[str, dict[str, str]] = {}
+    for suffix, case in cases.items():
+        by_group.setdefault(group_of(suffix), {})[sub_of(suffix)] = case_status(case)
+
+    for suffix, case in sorted(cases.items()):
+        status = case_status(case)
+        if status == "bad":
+            report.fail(
+                f"{family} {suite}: {prefix}.{suffix} is a placeholder without an"
+                " explanation: — annotate why it is n/a or author the input"
+            )
+        elif status == "todo":
+            report.warn(f"{family} {suite}: {prefix}.{suffix} not yet authored (TODO placeholder)")
+        if group_of(suffix) not in spec["groups"]:
+            report.fail(
+                f"{family} {suite}: {prefix}.{suffix} belongs to no taxonomy group — add"
+                f" group {group_of(suffix)} to case-taxonomy.yaml in this PR"
+            )
+        elif sub_of(suffix) not in spec["groups"][group_of(suffix)]["cases"]:
+            report.fail(
+                f"{family} {suite}: {prefix}.{suffix} is not in the taxonomy — add the"
+                " sub-case to case-taxonomy.yaml in this PR"
+            )
+
+    for gid, group in spec["groups"].items():
+        applies_ref = group.get("applies_if_real_in")
+        if applies_ref is not None:
+            if gid not in batch_real_groups:
+                continue
+            group_required = True
+        else:
+            group_required = bool(group.get("required"))
+        present = by_group.get(gid, {})
+        if not present:
+            if not group_required:
+                continue
+            required_ids = [
+                f"{prefix}.{gid}" + (f".{sub}" if sub else "")
+                for sub, case in group["cases"].items()
+                if case.get("required")
+            ] or [f"{prefix}.{gid}.*"]
+            report_line = (
+                f"{family} {suite}: group {gid} ({group['title']}) has NO cases — author"
+                f" {', '.join(required_ids)} or an explicit n/a placeholder"
+            )
+            if _all_grandfathered(gid, group, gaps):
+                report.warn(f"{report_line} [grandfathered known_gap]")
+            else:
+                report.fail(report_line)
+            continue
+        for sub, case in group["cases"].items():
+            if not case.get("required") or sub in present:
+                continue
+            case_id = f"{prefix}.{gid}" + (f".{sub}" if sub else "")
+            if (f"{gid}.{sub}" if sub else gid) in gaps:
+                report.warn(f"{family} {suite}: {case_id} missing [grandfathered known_gap — backfill]")
+            else:
+                report.fail(
+                    f"{family} {suite}: required case {case_id} is missing —"
+                    f" \"{case['desc']}\" (author it or add an n/a placeholder with explanation)"
+                )
+
+
+def _all_grandfathered(gid: str, group: dict, gaps: set[str]) -> bool:
+    required = [
+        (f"{gid}.{sub}" if sub else gid)
+        for sub, case in group["cases"].items()
+        if case.get("required")
+    ]
+    return bool(required) and all(rid in gaps for rid in required)
+
+
+def real_groups(root: Path, suite: str, family: str) -> set[str]:
+    cases = load_family_cases(root, suite, family) or {}
+    return {
+        group_of(suffix)
+        for suffix, case in cases.items()
+        if case_status(case) == "real"
+    }
+
+
+def check_markers(report: Report, registry: dict, family: str) -> None:
+    """Marker-registration lint: the family's grammar tokens must be declared in
+    parser_families.yaml `markers:`, leak-detectable, and popup-colorizable."""
+    declared = (registry.get("markers") or {}).get(family)
+    if declared is None:
+        report.fail(
+            f"{family} markers: no `markers:` entry in parser_families.yaml — declare the"
+            " family's grammar tokens (pairs/singletons/leak), or an explicit empty {} for"
+            " markup-less grammars; without it the leak detector and popup colorizer are blind"
+        )
+        return
+    pairs = declared.get("pairs") or []
+    singletons = declared.get("singletons") or []
+    leak = declared.get("leak") or []
+    for token in [t for pair in pairs for t in pair] + list(singletons) + list(leak):
+        if not markers_mod._TOOL_CALL_MARKUP_RE.search(token):
+            report.fail(
+                f"{family} markers: declared token {token!r} is NOT matched by the leak"
+                " detector (markers._TOOL_CALL_MARKUP_RE) — a leak of this token would"
+                " render as a clean green cell"
+            )
+    for open_tok, close_tok in pairs:
+        html = markup.colorize_markup(f"{open_tok}x{close_tok}", family=family)
+        if "tt-orphan" in html:
+            report.fail(
+                f"{family} markers: pair {open_tok!r}/{close_tok!r} renders as tt-orphan in"
+                " the popup colorizer — register/classify it in tests/parity/markup.py"
+            )
+    for token in singletons:
+        html = markup.colorize_markup(str(token), family=family)
+        if "tt-orphan" in html:
+            report.fail(
+                f"{family} markers: singleton {token!r} renders as tt-orphan in the popup"
+                " colorizer — register/classify it in tests/parity/markup.py"
+            )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--family", action="append", default=[], help="family to check (repeatable)")
+    ap.add_argument("--all", action="store_true", help="check every registry + fixtures family")
+    ap.add_argument(
+        "--expect-reasoning",
+        action="store_true",
+        help="fail when a checked family has no reasoning fixtures (use when the PR adds a reasoning parser)",
+    )
+    ap.add_argument("--fixtures-root", type=Path, default=None, help="override the extracted-fixtures root")
+    ap.add_argument("--taxonomy", type=Path, default=TAXONOMY_PATH)
+    ap.add_argument("--registry", type=Path, default=REGISTRY_PATH)
+    ap.add_argument("--skip-markers", action="store_true", help="skip the marker-registration lint")
+    ap.add_argument("-q", "--quiet", action="store_true", help="suppress warnings, print failures only")
+    args = ap.parse_args()
+    if not args.family and not args.all:
+        ap.error("pass --family <f> (repeatable) or --all")
+
+    if args.fixtures_root:
+        root = args.fixtures_root
+        if not (root / "toolcalling").is_dir():
+            sys.exit(f"fixtures root {root} has no toolcalling/ dir")
+    else:
+        root = resolve_fixtures_root()
+    taxonomy = yaml.safe_load(args.taxonomy.read_text())
+    registry = yaml.safe_load(args.registry.read_text())
+    registry_families = set(registry["families"])
+
+    tc_dir_families = {
+        p.name
+        for suite in TOOLCALLING_SUITES
+        for p in (root / SUITE_INPUTS[suite][0] / "inputs").glob("*")
+        if p.is_dir()
+    }
+    reasoning_dir_families = {
+        p.name for p in (root / SUITE_INPUTS["reasoning.batch"][0] / "inputs").glob("*") if p.is_dir()
+    }
+
+    report = Report()
+    if args.all:
+        toolcalling_families = sorted(registry_families | tc_dir_families)
+        reasoning_families = sorted(reasoning_dir_families)
+        for fam in sorted(tc_dir_families - registry_families):
+            report.fail(f"{fam}: fixtures dir exists but family has no parser_families.yaml row")
+    else:
+        requested = sorted(set(args.family))
+        # A family known ONLY to the reasoning corpus (e.g. gpt_oss, granite) skips
+        # the toolcalling suites. Unknown families still default to toolcalling so a
+        # brand-new family fails loudly before registration.
+        reasoning_only = {
+            f
+            for f in requested
+            if f in reasoning_dir_families
+            and f not in registry_families
+            and f not in tc_dir_families
+        }
+        toolcalling_families = sorted(set(requested) - reasoning_only)
+        reasoning_families = sorted(
+            f for f in requested if f in reasoning_dir_families or args.expect_reasoning
+        )
+
+    for fam in toolcalling_families:
+        if fam not in registry_families:
+            report.fail(f"{fam}: not in parser_families.yaml — register the family row first")
+        batch_real = real_groups(root, "toolcalling.batch", fam)
+        for suite in TOOLCALLING_SUITES:
+            check_suite(report, taxonomy, root, suite, fam, batch_real)
+        if not args.skip_markers:
+            check_markers(report, registry, fam)
+    for fam in reasoning_families:
+        for suite in REASONING_SUITES:
+            check_suite(report, taxonomy, root, suite, fam, set())
+
+    if not args.quiet:
+        for msg in report.warnings:
+            print(f"WARN  {msg}")
+    for msg in report.failures:
+        print(f"FAIL  {msg}")
+    checked = ", ".join(toolcalling_families) or "(none)"
+    print(
+        f"coverage lint: {len(report.failures)} failure(s), {len(report.warnings)} warning(s)"
+        f" — toolcalling: {checked}; reasoning: {', '.join(reasoning_families) or '(none)'}"
+    )
+    return 1 if report.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/utils/src/markers.py
+++ b/conformance/utils/src/markers.py
@@ -15,7 +15,10 @@ the generator's import graph.
 import html as html_lib
 import json
 import re
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from impls import (
     BASELINE_IMPLS,
@@ -117,11 +120,50 @@ def peer_status(case: dict, dyn: dict, impl: str) -> tuple[str, bool]:
     return ("na", False)
 
 
+# Tool-call markup leak detector (the `↯` marker): derived from the union of every
+# family's declared grammar tokens in parser_families.yaml `markers:` (DIS-2442) —
+# registering a family's tokens there is the ONLY step to make its leaks detectable.
+#
+# Truncation cases (taxonomy group 5) leak PARTIAL markers (`<tool_call`,
+# `[/TOOL_CALLS`, `<｜tool▁sep｜`), so each pair/singleton token also matches by any
+# prefix of at least _LEAK_PREFIX_MIN chars — the stem semantics the old hardcoded
+# regex had (`</?tool_call`, `TOOL_CALLS`, ...). Tokens shorter than the minimum
+# match whole only (short stems are false-positive-prone). `leak:` entries are
+# already stems of parameterized tags (e.g. "<invoke" for `<invoke name="x">`) and
+# are matched verbatim. Substring semantics (no anchors), longest-first alternation.
+_LEAK_PREFIX_MIN = 7
+
+
+def _parser_families_path() -> Path:
+    """The registry lives at src/parser_families.yaml in the repo; the render stage
+    copies this module flat into tests/parity/ and the registry to <stage>/src/."""
+    here = Path(__file__).resolve()
+    for cand in (
+        here.parent / "parser_families.yaml",
+        here.parents[2] / "src" / "parser_families.yaml",
+    ):
+        if cand.is_file():
+            return cand
+    raise FileNotFoundError(f"parser_families.yaml not found relative to {here}")
+
+
+def _declared_leak_patterns() -> list[str]:
+    spec = yaml.safe_load(_parser_families_path().read_text())
+    patterns: set[str] = set()
+    for decl in (spec.get("markers") or {}).values():
+        tokens = [t for pair in decl.get("pairs") or [] for t in pair]
+        tokens += decl.get("singletons") or []
+        for tok in tokens:
+            patterns.update(tok[:n] for n in range(_LEAK_PREFIX_MIN, len(tok) + 1))
+            patterns.add(tok)
+        patterns.update(decl.get("leak") or [])
+    if not patterns:
+        raise ValueError("parser_families.yaml declares no family markers")
+    return sorted(patterns, key=len, reverse=True)
+
+
 _TOOL_CALL_MARKUP_RE = re.compile(
-    r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
-    r"<\|(?:channel|message|call|python_tag)\|>|"
-    r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
-    r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
+    "|".join(re.escape(p) for p in _declared_leak_patterns())
 )
 
 

--- a/conformance/utils/src/parser_families.yaml
+++ b/conformance/utils/src/parser_families.yaml
@@ -37,3 +37,77 @@ families:
   # harmony-specific flow, not the peer maps above; listed for registry coverage.
   harmony:        {vllm_python: null,           vllm_rust: null,         sglang_python: null,        dynamo_v2: harmony,      preferred_input: tokens}
   harmony_text:   {vllm_python: null,           vllm_rust: null,         sglang_python: null,        dynamo_v2: harmony,      preferred_input: text}
+
+# Family grammar tokens (DIS-2442): the single source both derived registries consume.
+#   * markers.py builds the tool-call leak detector (_TOOL_CALL_MARKUP_RE) from the
+#     union of every family's tokens — an undeclared token makes a markup leak render
+#     as a clean green cell.
+#   * tests/parity/markup.py consults the family's pairs/singletons when its heuristic
+#     classifier cannot type a token — an unclassifiable token renders as a red
+#     tt-orphan in the conformance popups (looks like a parse error).
+# Keys per family (all optional, but the family key itself is REQUIRED — the coverage
+# lint fails families without an entry; use an explicit {} for markup-less grammars):
+#   pairs:      [[open, close], ...] exact-literal open/close token pairs
+#   singletons: [tok, ...]           standalone tokens with no open/close semantics
+#   leak:       [s, ...]             extra substrings for the leak detector only —
+#                                    prefixes of parameterized tags (e.g. "<invoke"),
+#                                    tokens the colorizer already handles specially
+markers:
+  deepseek_v3:
+    pairs: [["<｜tool▁calls▁begin｜>", "<｜tool▁calls▁end｜>"], ["<｜tool▁call▁begin｜>", "<｜tool▁call▁end｜>"]]
+    singletons: ["<｜tool▁sep｜>"]
+  deepseek_v3_1:
+    pairs: [["<｜tool▁calls▁begin｜>", "<｜tool▁calls▁end｜>"], ["<｜tool▁call▁begin｜>", "<｜tool▁call▁end｜>"]]
+    singletons: ["<｜tool▁sep｜>"]
+  deepseek_v3_2:
+    pairs: [["<｜DSML｜function_calls>", "</｜DSML｜function_calls>"]]
+    leak: ["<｜DSML｜", "</｜DSML｜"]
+  deepseek_v4:
+    pairs: [["<｜DSML｜tool_calls>", "</｜DSML｜tool_calls>"]]
+    leak: ["<｜DSML｜", "</｜DSML｜"]
+  gemma4:
+    pairs: [["<|tool_call>", "<tool_call|>"]]
+    leak: ['<|"|>']
+  glm47:
+    pairs: [["<tool_call>", "</tool_call>"], ["<arg_key>", "</arg_key>"], ["<arg_value>", "</arg_value>"]]
+  hermes:
+    pairs: [["<tool_call>", "</tool_call>"]]
+  jamba:
+    pairs: [["<tool_calls>", "</tool_calls>"]]
+  kimi_k2:
+    pairs: [["<|tool_calls_section_begin|>", "<|tool_calls_section_end|>"], ["<|tool_call_begin|>", "<|tool_call_end|>"]]
+    singletons: ["<|tool_call_argument_begin|>"]
+  llama3_json:
+    singletons: ["<|python_tag|>"]
+  minimax_m2:
+    pairs: [["<minimax:tool_call>", "</minimax:tool_call>"]]
+    leak: ["<invoke", "</invoke", "<parameter", "</parameter"]
+  minimax_m3:
+    pairs: [["<tool_call>", "</tool_call>"]]
+    singletons: ["]<]minimax[>["]
+    leak: ["<invoke", "</invoke"]
+  mistral:
+    pairs: [["[TOOL_CALLS]", "[/TOOL_CALLS]"]]
+  nemotron_deci:
+    pairs: [["<TOOLCALL>", "</TOOLCALL>"]]
+  nemotron_nano:
+    pairs: [["<tool_call>", "</tool_call>"]]
+    leak: ["<function=", "</function", "<parameter=", "</parameter"]
+  phi4:
+    leak: ["functools["]
+  # Pythonic output is a bare `[func(...)]` python list — no grammar markup exists to
+  # leak or colorize; explicit empty declaration.
+  pythonic: {}
+  qwen25:
+    pairs: [["<tool_call>", "</tool_call>"]]
+  qwen3_coder:
+    pairs: [["<tool_call>", "</tool_call>"]]
+    leak: ["<function=", "</function", "<parameter=", "</parameter"]
+  # Harmony's linear turn tokens pseudo-pair (`<|start|>` closes with `<|end|>` /
+  # `<|return|>` / `<|call|>`) — richer than the pairs/singletons schema, so the
+  # colorizer keeps its dedicated harmony logic and the tokens are declared for the
+  # leak detector only.
+  harmony:
+    leak: ["<|start|>", "<|channel|>", "<|constrain|>", "<|message|>", "<|end|>", "<|return|>", "<|call|>"]
+  harmony_text:
+    leak: ["<|start|>", "<|channel|>", "<|constrain|>", "<|message|>", "<|end|>", "<|return|>", "<|call|>"]

--- a/conformance/utils/tests/parity/markup.py
+++ b/conformance/utils/tests/parity/markup.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 import html as html_lib
 import re
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 # MiniMax M3 prefixes every structural tag with the `]<]minimax[>[` namespace
 # special token (tokenizer id 200058), e.g. `]<]minimax[>[<tool_call>`. It must
@@ -108,10 +111,53 @@ def _colorize_harmony(text: str) -> str:
     return "".join(pieces)
 
 
+# Declared per-family grammar tokens from the parser-family registry (DIS-2442).
+# Consulted BEFORE the heuristic classifier, so a token the heuristics cannot type
+# (e.g. Inkling's `<|message_model|>`: pipe-both-sides, no `_begin`/`_end` suffix)
+# renders with its declared pairing/coloring instead of as a red `tt-orphan` that
+# looks like a parse error. Registering a family's tokens in parser_families.yaml
+# is the ONLY step; this module derives its classification from that file.
+def _parser_families_path() -> Path:
+    """In the repo this module lives at tests/parity/ with the registry at
+    ../../src/; the render stage keeps that shape (<stage>/src/). The same-dir
+    candidate covers flat copies (mirrors markers._parser_families_path)."""
+    here = Path(__file__).resolve()
+    for cand in (
+        here.parent / "parser_families.yaml",
+        here.parents[2] / "src" / "parser_families.yaml",
+    ):
+        if cand.is_file():
+            return cand
+    raise FileNotFoundError(f"parser_families.yaml not found relative to {here}")
+
+
+_FAMILY_MARKERS: dict[str, dict] = (
+    yaml.safe_load(_parser_families_path().read_text()).get("markers") or {}
+)
+_declared_cache: dict[str, dict[str, tuple[str, str]]] = {}
+
+
+def _declared_lookup(family: str | None) -> dict[str, tuple[str, str]]:
+    """Full-token -> (kind, pair_id) table for the family's declared markers."""
+    if not family or family not in _FAMILY_MARKERS:
+        return {}
+    table = _declared_cache.get(family)
+    if table is None:
+        decl = _FAMILY_MARKERS[family]
+        table = {}
+        for open_tok, close_tok in decl.get("pairs") or []:
+            table[open_tok] = ("open", open_tok)
+            table[close_tok] = ("close", open_tok)
+        for tok in decl.get("singletons") or []:
+            table[tok] = ("singleton", tok)
+        _declared_cache[family] = table
+    return table
+
+
 def colorize_markup(text: str, family: str | None = None) -> str:
     if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
         return _colorize_harmony(text)
-    return _colorize_xml(text)
+    return _colorize_xml(text, family)
 
 
 def _strip_suffix(s: str, suffixes: tuple[str, ...]) -> str | None:
@@ -175,19 +221,22 @@ def _tag_kind_and_name(inner: str) -> tuple[str | None, str, str | None]:
     return ("open", _name_of(inner), None)
 
 
-def _colorize_xml(text: str) -> str:
+def _colorize_xml(text: str, family: str | None = None) -> str:
     """HTML-escape `text` and wrap each `<...>` token in a span.
     Paired open/close (stack match by tag name) -> class 'tt-paired'.
     Unmatched close, or open that never closes -> class 'tt-orphan'.
 
-    Pairs standard XML (`<X>...</X>`) AND alt pipe-marker conventions:
+    The family's declared markers (parser_families.yaml `markers:`) classify a
+    token first; heuristics cover undeclared/parameterized tokens. Heuristics
+    pair standard XML (`<X>...</X>`) AND alt pipe-marker conventions:
       `<|X>...<X|>`          (boundary ASCII pipes)
       `<|X_begin|>...<|X_end|>`  (both-side pipes with _begin/_end suffix)
     Lenient pop-through: a close looks down the stack for the nearest
     name-match; anything un-closed above it is marked orphan. Lets
-    no-close singletons (e.g. `<|tool_call_argument_begin|>`) localize
-    their orphan-ness without poisoning the surrounding pairs.
+    no-close singletons localize their orphan-ness without poisoning the
+    surrounding pairs.
     """
+    declared = _declared_lookup(family)
     pieces: list[str] = []
     stack: list[tuple[str, int]] = []
     last = 0
@@ -199,7 +248,11 @@ def _colorize_xml(text: str) -> str:
             pieces.append(f'<span class="{_NS_CLASS}">{html_lib.escape(tok)}</span>')
             last = m.end()
             continue
-        kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
+        hit = declared.get(tok)
+        if hit is not None:
+            kind, pair_id, color_override = hit[0], hit[1], None
+        else:
+            kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
         esc = html_lib.escape(tok)
         if kind is None:
             pieces.append(f'<span class="tt-orphan">{esc}</span>')
@@ -263,7 +316,8 @@ def _colorize_xml(text: str) -> str:
     return "".join(pieces)
 
 
-def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
+def _xml_token_intervals(text: str, family: str | None = None) -> list[dict[str, Any]]:
+    declared = _declared_lookup(family)
     intervals: list[dict[str, Any]] = []
     stack: list[tuple[str, int]] = []
     for match in _TAG_RE.finditer(text):
@@ -274,7 +328,11 @@ def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
             )
             continue
         idx = len(intervals)
-        kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
+        hit = declared.get(tok)
+        if hit is not None:
+            kind, pair_id = hit
+        else:
+            kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
         intervals.append({"start": match.start(), "end": match.end(), "class": None})
         if kind is None:
             intervals[idx]["class"] = "tt-orphan"
@@ -342,7 +400,7 @@ def _harmony_intervals(text: str) -> list[dict[str, Any]]:
 def _markup_intervals(text: str, family: str | None) -> list[dict[str, Any]]:
     if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
         return _harmony_intervals(text)
-    return _xml_token_intervals(text)
+    return _xml_token_intervals(text, family)
 
 
 def _render_harmony_interval_slice(

--- a/conformance/utils/tests/test_family_coverage.py
+++ b/conformance/utils/tests/test_family_coverage.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Guards for the fixture-coverage lint and the single-source family markers
+(DIS-2442, distilled from the PR #120 review):
+
+  * the lint is green on the committed corpus (CI gate stays meaningful);
+  * an inkling-shaped family (batch groups 6/8/30 missing, no stream corpus, no
+    marker registration) FAILS the lint — the exact gap class three reviewers had
+    to find by hand on PR #120;
+  * every parser_families.yaml row has a markers declaration and vice versa;
+  * the YAML-derived leak detector is a strict superset of the retired hardcoded
+    regex on the committed corpus (no silently-lost `↯` detections);
+  * declared marker tokens render non-orphan in the popup colorizer, including
+    tokens the heuristics cannot classify (the red-orphan popup class).
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(UTILS) not in sys.path:
+    sys.path.insert(0, str(UTILS))
+
+import check_family_coverage as cfc  # noqa: E402
+import markers as markers_mod  # noqa: E402
+from tests.parity import markup  # noqa: E402
+
+
+def _ensure_fixtures() -> Path:
+    # Manifest-pinned snapshot, immune to sibling checkouts repointing the shared
+    # cache symlink mid-run (the flake class conformance/README documents).
+    return cfc.resolve_fixtures_root()
+
+
+def _registry() -> dict:
+    return yaml.safe_load((SRC / "parser_families.yaml").read_text())
+
+
+def _taxonomy() -> dict:
+    return yaml.safe_load(cfc.TAXONOMY_PATH.read_text())
+
+
+def test_lint_green_on_committed_corpus() -> None:
+    """The committed corpus passes with zero failures (warnings — TODO placeholders
+    and grandfathered known_gaps — are the backfill list, never CI-red)."""
+    root = _ensure_fixtures()
+    taxonomy = _taxonomy()
+    registry = _registry()
+    report = cfc.Report()
+    for fam in sorted(registry["families"]):
+        batch_real = cfc.real_groups(root, "toolcalling.batch", fam)
+        for suite in cfc.TOOLCALLING_SUITES:
+            cfc.check_suite(report, taxonomy, root, suite, fam, batch_real)
+        cfc.check_markers(report, registry, fam)
+    assert report.failures == []
+
+
+def test_lint_fails_on_inkling_shaped_family(tmp_path) -> None:
+    """A family with the PR #120 gap profile fails the lint: batch groups 6/8/30
+    absent, the entire stream-v2 corpus missing, and no `markers:` registration."""
+    root = _ensure_fixtures()
+    fake_root = tmp_path / "fixtures"
+    src_fam = root / "toolcalling/fixtures-batch-v1/inputs/hermes"
+    dst_fam = fake_root / "toolcalling/fixtures-batch-v1/inputs/newfam"
+    dst_fam.mkdir(parents=True)
+    (fake_root / "toolcalling/fixtures-stream-v2/inputs").mkdir(parents=True)
+    (fake_root / "reasoning/fixtures-v1/inputs").mkdir(parents=True)
+    for path in src_fam.glob("TOOLCALLING.batch*.yaml"):
+        data = yaml.safe_load(path.read_text())
+        data["family"] = "newfam"
+        cases = {
+            cid: case
+            for cid, case in data["cases"].items()
+            if cfc.group_of(cid[len("TOOLCALLING.batch") + 1 :]) not in ("6", "8", "30")
+        }
+        if not cases:
+            continue
+        data["cases"] = cases
+        (dst_fam / path.name).write_text(yaml.safe_dump(data, allow_unicode=True, sort_keys=False))
+
+    registry = _registry()
+    registry["families"]["newfam"] = {"vllm_python": None}
+    taxonomy = _taxonomy()
+    report = cfc.Report()
+    batch_real = cfc.real_groups(fake_root, "toolcalling.batch", "newfam")
+    for suite in cfc.TOOLCALLING_SUITES:
+        cfc.check_suite(report, taxonomy, fake_root, suite, "newfam", batch_real)
+    cfc.check_markers(report, registry, "newfam")
+
+    text = "\n".join(report.failures)
+    assert "group 6 (Empty arguments) has NO cases" in text
+    assert "group 8 (Narration around calls) has NO cases" in text
+    assert "group 30 (Own-grammar delimiters inside a string argument (single call)) has NO cases" in text
+    assert "the entire toolcalling.stream corpus is missing" in text
+    assert "no `markers:` entry in parser_families.yaml" in text
+
+
+def test_taxonomy_case_entries_well_formed() -> None:
+    """Every taxonomy case entry is exactly {desc, required[, note]} with a non-empty
+    desc — catches YAML flow-mapping typos (an unquoted comma inside a desc silently
+    splits the entry into junk keys)."""
+    for suite, spec in _taxonomy()["suites"].items():
+        for gid, group in spec["groups"].items():
+            assert group.get("title"), (suite, gid)
+            for sub, case in group["cases"].items():
+                assert set(case) <= {"desc", "required", "note"}, (suite, gid, sub, case)
+                assert isinstance(case.get("desc"), str) and case["desc"], (suite, gid, sub)
+                assert isinstance(case.get("required"), bool), (suite, gid, sub)
+
+
+def test_markers_declared_for_every_family() -> None:
+    """markers: and families: stay key-aligned — a new family cannot register a
+    parser row without declaring (possibly empty) grammar tokens."""
+    registry = _registry()
+    assert set(registry["markers"]) == set(registry["families"])
+
+
+def test_leak_regex_superset_of_retired_hardcoded_regex() -> None:
+    """The YAML-derived leak detector matches everywhere the retired hardcoded
+    regex did, on every normal_text in the committed corpus — token registration
+    can only ADD detections, never silently lose them."""
+    old = re.compile(
+        r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
+        r"<\|(?:channel|message|call|python_tag)\|>|"
+        r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
+        r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
+    )
+    root = _ensure_fixtures()
+    texts: set[str] = set()
+
+    def walk(node) -> None:
+        if isinstance(node, dict):
+            nt = node.get("normal_text")
+            if isinstance(nt, str):
+                texts.add(nt)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    for path in root.glob("toolcalling/**/*.yaml"):
+        walk(yaml.safe_load(path.read_text()))
+    assert texts, "no corpus normal_texts found — fixtures not extracted?"
+    lost = [t for t in texts if old.search(t) and not markers_mod._TOOL_CALL_MARKUP_RE.search(t)]
+    assert lost == []
+
+
+def test_declared_tokens_render_non_orphan() -> None:
+    """Every declared pair/singleton renders without tt-orphan, including tokens the
+    heuristic classifier cannot type (deepseek `<｜tool▁sep｜>` was a red orphan
+    before the declared-marker lookup; Inkling's `<|message_model|>` class)."""
+    registry = _registry()
+    for fam, decl in registry["markers"].items():
+        for open_tok, close_tok in decl.get("pairs") or []:
+            assert "tt-orphan" not in markup.colorize_markup(f"{open_tok}x{close_tok}", family=fam), (fam, open_tok)
+        for tok in decl.get("singletons") or []:
+            assert "tt-orphan" not in markup.colorize_markup(str(tok), family=fam), (fam, tok)
+
+
+def test_reasoning_only_family_skips_toolcalling_suites() -> None:
+    """`--family gpt_oss` (reasoning-only corpus family) must check the reasoning
+    suites ONLY — not fail on missing toolcalling registry/fixtures."""
+    proc = subprocess.run(
+        [sys.executable, str(SRC / "check_family_coverage.py"), "--family", "gpt_oss", "--expect-reasoning"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "toolcalling" not in "".join(
+        line for line in proc.stdout.splitlines() if line.startswith("FAIL")
+    )
+    assert "reasoning: gpt_oss" in proc.stdout
+
+
+def test_undeclared_pipe_token_still_orphans() -> None:
+    """The declared-marker lookup is per-family and exact: an Inkling-style token
+    that is NOT declared keeps rendering as tt-orphan (the lint, not the colorizer,
+    is what forces registration)."""
+    assert "tt-orphan" in markup.colorize_markup("<|message_model|>hello<|end_message|>", family="hermes")

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -32,16 +32,30 @@ REPO = UTILS.parents[1]
 if str(UTILS / "src") not in sys.path:
     sys.path.insert(0, str(UTILS / "src"))
 
+import check_family_coverage as _cfc  # noqa: E402
 import model as model_mod  # noqa: E402
 
 
+def _resolve_cache_root() -> Path:
+    """Manifest-pinned snapshot dir — NEVER the shared `<cache>/toolcalling`
+    symlink, which sibling checkouts race to repoint mid-run (the peer-version
+    guards below flaked exactly that way; see conformance/README "Invariants").
+    Honors CONFORMANCE_FIXTURES_ROOT (exported by _common.sh). Falls back to the
+    symlink path when extraction is impossible so _HAVE_FIXTURES turns into a
+    clean skip instead of a collection error."""
+    try:
+        return _cfc.resolve_fixtures_root()
+    except (SystemExit, subprocess.CalledProcessError):
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        base = Path(xdg) if xdg else Path.home() / ".cache"
+        return base / "dynamo/conformance-fixtures"
+
+
+_CACHE_ROOT = _resolve_cache_root()
+
+
 def _cache_root() -> Path:
-    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "dynamo/conformance-fixtures"
+    return _CACHE_ROOT
 
 
 _HAVE_FIXTURES = (_cache_root() / "toolcalling").is_dir()

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -41,16 +41,11 @@ if str(SRC) not in sys.path:
 
 
 def _fixtures_cache_root() -> Path:
-    """Fixture extraction cache root. Fixture YAMLs are extracted from the
-    in-repo LFS shard store (conformance/fixtures/), so path-existence checks
-    resolve against the cache. `_common.sh` exports CONFORMANCE_FIXTURES_ROOT
-    pointing here."""
-    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "dynamo/conformance-fixtures"
+    """Manifest-pinned fixture snapshot dir (honors CONFORMANCE_FIXTURES_ROOT,
+    which `_common.sh` exports). Resolved via check_family_coverage's shared
+    resolver — never the shared `<cache>/toolcalling` symlink, which sibling
+    checkouts race to repoint mid-run (conformance/README "Invariants")."""
+    return cfc.resolve_fixtures_root()
 
 
 def _resolve_conformance_ref(ref: str) -> Path:
@@ -63,6 +58,7 @@ def _resolve_conformance_ref(ref: str) -> Path:
 
 import build_stream_fixtures as b  # noqa: E402
 import capture_vllm_rust as r  # noqa: E402
+import check_family_coverage as cfc  # noqa: E402
 import generate_conformance_table as g  # noqa: E402
 import impls  # noqa: E402
 import validate_fixtures as vf  # noqa: E402

--- a/parsers/v2/README.md
+++ b/parsers/v2/README.md
@@ -194,11 +194,11 @@ In order:
 1. Read the model's tool-call output spec and its tokenizer / special-token behavior — token boundaries decide whether the parser is text- or token-native.
 2. Inspect the vLLM **Rust** parser first: `Tool`, `ToolCallDelta`, `ToolParseResult`, and `ToolParser` are the API target (Rust vs. Rust). Do not shape the parser like vLLM Python wire deltas.
 3. Inspect vLLM **Python** and **SGLang** for behavior and coverage — they are the peer references the matrix compares against.
-4. Decide the parser family id and peer parser names; add a row to `conformance/utils/src/parser_families.yaml` (`vllm_python` / `vllm_rust` / `sglang_python` / `dynamo_v2` / `preferred_input`).
+4. Decide the parser family id and peer parser names; add a row to `conformance/utils/src/parser_families.yaml` (`vllm_python` / `vllm_rust` / `sglang_python` / `dynamo_v2` / `preferred_input`), AND declare the family's grammar tokens in the `markers:` section of the same file (`pairs` / `singletons` / `leak`; explicit `{}` for markup-less grammars). The `↯` leak detector and the popup token coloring are derived from that declaration — skipping it makes leaks render as clean cells and every token render as a red orphan, and `check.sh coverage` fails on it.
 5. Implement `parsers/v2/src/tool_calling/<family>.rs`, returning `ToolParseResult` from every chunk; start from `harmony.rs` (token/channel grammar) or `dsml.rs` (text incremental state machine).
 6. Register the family in `create_tool_parser_for_family` in `parsers/v2/src/tool_calling/mod.rs`; override `prefers_tokens()` if the parser is token-native.
 7. Add Rust unit tests for: one call, multiple calls, partial chunks, malformed recovery, `normal_text`, and EOF.
-8. Add or update fixture files (see "Which Fixture Do I Edit?").
+8. Add or update fixture files (see "Which Fixture Do I Edit?"). What "complete" means is machine-readable: `conformance/case-taxonomy.yaml` lists every case group and sub-case with requiredness. Run `conformance/utils/check.sh coverage --family <family>` — its FAIL list IS your fixture TODO list; a case your grammar cannot express gets a placeholder entry with an `explanation:` instead of silence.
 9. Capture one case (`conformance/utils/capture.sh dynamo-stream --fixture … --output …`), inspect, fix the parser, then capture all peer behavior (`capture.sh stream` / `capture.sh batch-on-stream`, optionally `--family <family>`).
 10. Verify (`conformance/utils/check.sh`), render the HTML matrix (`conformance/utils/render_table_v2.sh`), and record any intentional divergence (see "How To Record Divergences").
 
@@ -228,10 +228,11 @@ A divergent peer block with no `reason:` renders `?` (research needed) — never
 For a new parser family, done means:
 
 - Rust parser unit tests pass and the Dynamo fixture tests pass.
+- `conformance/utils/check.sh coverage --family <family>` passes: every group/sub-case in `conformance/case-taxonomy.yaml` is covered or carries an explicit n/a `explanation:` (this includes the stream-v2 corpus — a family with batch fixtures only FAILS), and the family's `markers:` are declared in `parser_families.yaml`.
 - vLLM Python / SGLang live checks pass, or each failure is explicitly recorded (`error`/`unavailable` with exact text).
 - vLLM Rust captures include the source tag/commit in `captured_with` when available.
-- The HTML matrix is regenerated locally and has no unexplained `?` and no accidental tool-call markup leaks (`↯`).
-- Case descriptions exist for every new sub-case.
+- The HTML matrix is regenerated locally and has no unexplained `?`, no accidental tool-call markup leaks (`↯`), and no red-orphan tokens in the popups (undeclared markers).
+- Case descriptions exist for every new sub-case, and any NEW case group/sub-case is added to `conformance/case-taxonomy.yaml` in the same PR (the coverage lint fails on IDs unknown to the taxonomy).
 
 ## Commands
 


### PR DESCRIPTION
#### Overview:

This PR writes down the parser-authoring process and makes CI enforce it, for all parser families: what "complete fixture coverage" means is now a machine-readable taxonomy + lint instead of tribal knowledge. On PR #120 (Inkling), three reviewers hand-derived the case list and still missed whole groups — those gap classes now fail CI before human review. Not docs-only: deriving the leak detector from declared markers also fixes real blind spots, so 17 previously-clean cells now correctly show `↯`. DIS-2442 ([Linear](https://linear.app/nvidia/issue/DIS-2442)), part 1; part 2 adds the shared property-test harness.

#### Example (before → after):

`conformance/utils/check.sh coverage --family inkling` on PR #120's fixtures:

```
before:  CI green; reviewers manually diff ~20 families' YAMLs to find the gaps
after:   45 FAILs — batch groups 6/8/30 missing, entire stream corpus missing,
         grammar tokens unregistered (leak detector + popup colorizer blind)
```

#### Details:

- Process: `conformance/case-taxonomy.yaml` defines "complete" (all four suites); `check_family_coverage.py` enforces it — unexplained gap = FAIL, placeholder with `explanation:` = pass, pre-existing gaps grandfathered as a visible backfill list, reasoning-only families check reasoning suites only.
- Single-sourcing: each family's grammar tokens are declared once in `parser_families.yaml markers:`; the `↯` leak regex (truncation-tolerant) and popup token coloring are derived from it. Registering a new family's tokens is one YAML edit.
- Docs + CI: authoring steps and Done-Means gates written into `parsers/v2/README.md` and `conformance/README.md` §8; the conformance-table CI job runs exactly one command, `check.sh ci` — future gates edit `run_ci()`, never `.github/workflows/`.

#### Verification:

Corpus lint 0 failures; 73 pytest green incl. a superset guard (derived leak regex loses zero detections vs the old hardcoded one); replaying PR #120's Inkling fixtures reproduces all review findings; both charts re-rendered.

#### Where should the reviewer start?

`conformance/case-taxonomy.yaml`, then `conformance/utils/src/check_family_coverage.py`

/coderabbit profile chill
