### PR TITLE
feat: add batches and file apis from openai to frontend crates

### DIFF
--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -24,10 +24,12 @@ include = ["src/**/*", "Cargo.toml", "README.md"]
 [dependencies]
 # Upstream OpenAI types (types-only, no HTTP client)
 async-openai = { workspace = true, features = [
+    "batch-types",
     "chat-completion-types",
     "response-types",
     "completion-types",
     "embedding-types",
+    "file-types",
     "image-types",
     "realtime-types",
 ] }

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -5,6 +5,8 @@ Request/response types for OpenAI- and Anthropic-compatible inference servers. B
 ## What's included
 
 - **Chat Completions** — multimodal content, reasoning content (DeepSeek-R1 / QwQ), continuous usage stats, tool-calling.
+- **Batch API** — re-exported from upstream.
+- **Files API** — re-exported from upstream.
 - **Responses API** — input chain owned (relaxed for Codex / Agents SDK); output chain re-exported from upstream.
 - **Completions** — re-exported.
 - **Anthropic Messages** — fully owned (no upstream equivalent).

--- a/protocols/src/lib.rs
+++ b/protocols/src/lib.rs
@@ -12,6 +12,8 @@
 //!
 //! This crate provides types for multiple inference API protocols:
 //! - **OpenAI Chat Completions & Completions** (via upstream `async-openai` re-exports + extensions)
+//! - **OpenAI Batch API** (via upstream `async-openai` re-exports)
+//! - **OpenAI Files API** (via upstream `async-openai` re-exports)
 //! - **OpenAI Responses API** (via upstream `async-openai` re-exports)
 //! - **Anthropic Messages API** (fully custom)
 //!

--- a/protocols/src/types/mod.rs
+++ b/protocols/src/types/mod.rs
@@ -25,6 +25,12 @@ pub use completion::*;
 // re-exported from `async_openai::types::embeddings::*`.
 pub use embeddings::*;
 
+// Batches: re-exported wholesale from async-openai (no Dynamo overrides).
+pub use async_openai::types::batches::*;
+
+// Files: re-exported wholesale from async-openai (no Dynamo overrides).
+pub use async_openai::types::files::*;
+
 // Images: re-exported wholesale from async-openai (no Dynamo overrides).
 pub use async_openai::types::images::*;
 

--- a/protocols/tests/batches.rs
+++ b/protocols/tests/batches.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_protocols::types::{
+    BatchCompletionWindow, BatchEndpoint, BatchRequest, BatchRequestArgs, OpenAIFile,
+};
+
+#[test]
+fn batch_request_types_are_reexported() {
+    let request = BatchRequestArgs::default()
+        .input_file_id("file-123")
+        .endpoint(BatchEndpoint::V1Completions)
+        .completion_window(BatchCompletionWindow::W24H)
+        .build()
+        .unwrap();
+
+    let value = serde_json::to_value(&request).unwrap();
+    assert_eq!(value["input_file_id"], "file-123");
+    assert_eq!(value["endpoint"], "/v1/completions");
+    assert_eq!(value["completion_window"], "24h");
+
+    let round_trip: BatchRequest = serde_json::from_value(value).unwrap();
+    assert_eq!(round_trip, request);
+}
+
+#[test]
+fn file_response_types_are_reexported() {
+    let file: OpenAIFile = serde_json::from_value(serde_json::json!({
+        "id": "file-123",
+        "object": "file",
+        "bytes": 42,
+        "created_at": 1_700_000_000,
+        "expires_at": null,
+        "filename": "batch.jsonl",
+        "purpose": "batch",
+        "status": null,
+        "status_details": null
+    }))
+    .unwrap();
+
+    assert_eq!(file.id, "file-123");
+    assert_eq!(file.filename, "batch.jsonl");
+}


### PR DESCRIPTION
Enable and re-export the OpenAI upstream batch/file types