### PR TITLE
chore(renderer)!: release v2.0.0 with dynamo-protocols v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.12"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ clap = "4"
 derive_builder = "0.20"
 dynamo-parsers = { path = "parsers/v1", version = "5.1.0" }
 dynamo-protocols = { path = "protocols", version = "3.0.0" }
-dynamo-renderer = { path = "renderer", version = "1.3.12" }
+dynamo-renderer = { path = "renderer", version = "2.0.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.5.3" }
 either = { version = "1.13", features = ["serde"] }
 fastokens = "0.2.0"

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v1.3.12...dynamo-renderer-v2.0.0) - 2026-07-17
+
+### Miscellaneous
+
+- Updated the following local packages: dynamo-protocols
+
 ## [1.3.12](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v1.3.11...dynamo-renderer-v1.3.12) - 2026-07-14
 
 ### Miscellaneous

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v1.3.12...dynamo-renderer-v2.0.0) - 2026-07-17
 
+### Changed
+
+- **Breaking:** Public request types exposed by `OAIChatLikeRequest` now use `dynamo-protocols` 3.x; consumers must upgrade `dynamo-protocols` when moving to `dynamo-renderer` 2.0.0.
+
 ### Miscellaneous
 
 - Updated the following local packages: dynamo-protocols

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "dynamo-renderer"
 readme = "README.md"
-version = "1.3.12"
+version = "2.0.0"
 edition.workspace = true
 description = "Standalone OpenAI chat-template / prompt formatting (HF chat_template via minijinja)."
 authors.workspace = true


### PR DESCRIPTION

## Why

[`dynamo-protocols` 3.0.0](https://crates.io/crates/dynamo-protocols/3.0.0) introduced cached multimodal UUID content parts in [#119](https://github.com/ai-dynamo/frontend-crates/pull/119), while the latest published [`dynamo-renderer` 1.3.12](https://crates.io/crates/dynamo-renderer/1.3.12) still depends on `dynamo-protocols` 2.0.2.

`dynamo-renderer` exposes `dynamo-protocols` message types through its public `OAIChatLikeRequest` API. Mixing renderer on protocols v2 with consumers on protocols v3 therefore creates distinct, incompatible Rust types and prevents the dependency graph from compiling. Since this changes a public dependency type, the renderer requires a major-version release.

Publishing this release helps unblock [ai-dynamo/dynamo#8957](https://github.com/ai-dynamo/dynamo/pull/8957), allowing Dynamo to replace its temporary frontend-crates git pin with published crates while supporting vLLM cached multimodal UUID passthrough.

## What Change

- Bump `dynamo-renderer` from 1.3.12 to 2.0.0.
- Release the renderer against the workspace's `dynamo-protocols` 3.0.0.
- Update the workspace dependency, lockfile, and renderer changelog.

There are no renderer behavior changes in this PR; the major bump reflects the public protocol-type dependency change.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-renderer --all-targets -- -D warnings`
- `cargo test -p dynamo-renderer` — 104 passed, 1 ignored
- `cargo check --workspace --all-targets`
- `cargo package -p dynamo-renderer --allow-dirty --no-verify`
- Verified the packaged renderer manifest depends on `dynamo-protocols` 3.0.0
