### PR TITLE
fix(parser-v2): parser bugs due to chunking in gemma4 and deepseek_v4

### DIFF
--- a/conformance/toolcalling/known-chunking-divergences.yaml
+++ b/conformance/toolcalling/known-chunking-divergences.yaml
@@ -18,13 +18,5 @@
 #
 # Schema: family -> case id -> note.
 
-gemma4:
-  TOOLCALLING.streamv2.5.b: &gemma4-bare-call-chunked "FIXME (chunked side wrong): bare-call recovery (a `call:...` body with no `<|tool_call>` opener) only fires when the whole pattern is already in the buffer. Streamed in small chunks, the prose flush releases `c`, `ca`, ... before `call:` can accumulate, so the chunked parse emits the call body as normal_text while the single-shot parse recovers the call. Fix: the opener holdback must also hold suffixes that are prefixes of `call:` (planned in the shared-streaming-core refactor)."
-  TOOLCALLING.streamv2.5.f: *gemma4-bare-call-chunked
-  TOOLCALLING.streamv2.5.g: *gemma4-bare-call-chunked
-
 glm47:
   TOOLCALLING.streamv2.5.h: "FIXME (single-shot side wrong): on `I will check that. </tool_call> ok` the single-shot parse misreads the prose word `that.` as a bare function name attached to the orphan `</tool_call>` and emits a call named `that.`; the chunked path strips the orphan close and preserves the prose, which is the correct output. Fix requires tightening single-shot bare-name recovery and re-recording the dynamo_v2 overlay for this case."
-
-deepseek_v4:
-  TOOLCALLING.streamv2.5.f: "FIXME (chunked side wrong): whitespace-only normal_text between two adjacent `<｜DSML｜tool_calls>` blocks is dropped when a chunk boundary lands inside it; the single-shot parse preserves the ` ` separator. The inter-block text emission in the drain loop loses held-back whitespace when the next block opener completes across a split (planned fix in the shared-streaming-core refactor)."

--- a/parsers/v2/src/tool_calling/dsml.rs
+++ b/parsers/v2/src/tool_calling/dsml.rs
@@ -5,6 +5,7 @@
 
 use serde_json::{Map, Value};
 
+use crate::tool_calling::scan;
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
 
 const BLOCK_START: &str = "<｜DSML｜tool_calls>";
@@ -310,20 +311,14 @@ enum Marker {
     BareInvoke,
 }
 
+/// BLOCK_END is held back too: under a bare-invoke suppression latch, a split
+/// orphan `</｜DSML｜tool_calls>` used to be DISCARDED char-by-char (the drain
+/// drops suppressed text), so the complete close never assembled, the latch
+/// never cleared, and the whitespace between adjacent blocks was silently
+/// dropped (streamv2.5.f). Retaining the partial close lets the orphan-close
+/// path match it and clear the latch, exactly like the wrapped families.
 fn marker_prefix_suffix_len(text: &str) -> usize {
-    [BLOCK_START, INVOKE_START_PREFIX]
-        .into_iter()
-        .filter_map(|marker| {
-            marker
-                .char_indices()
-                .map(|(idx, _)| idx)
-                .filter(|idx| *idx > 0)
-                .filter(|idx| *idx < marker.len())
-                .rev()
-                .find(|&len| text.ends_with(&marker[..len]))
-        })
-        .max()
-        .unwrap_or(0)
+    scan::marker_prefix_suffix_len(text, [BLOCK_START, INVOKE_START_PREFIX, BLOCK_END])
 }
 
 fn parse_parameters(body: &str) -> anyhow::Result<Map<String, Value>> {

--- a/parsers/v2/src/tool_calling/gemma4.rs
+++ b/parsers/v2/src/tool_calling/gemma4.rs
@@ -29,8 +29,7 @@
 //! exact JSON string in the model-emitted order (the order vLLM's Rust parser also
 //! preserves), so order has to be pinned to source order.
 
-use std::collections::HashSet;
-
+use crate::tool_calling::scan::reorder_arguments;
 use crate::tool_calling::v1core::ToolDefinition;
 use crate::tool_calling::v1core::gemma4::{
     detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
@@ -249,14 +248,19 @@ impl Gemma4ToolStreamParser {
     }
 
     /// Bytes to hold back from the tail when no complete opener is present: the
-    /// longest of a trailing partial `<|tool_call>` prefix, or a trailing boundary
+    /// longest of a trailing partial `<|tool_call>` prefix, a trailing boundary
     /// `call:`-prefixed run that `detect_tool_call_start_gemma4` thinks may still
     /// grow into a tool call (so a bare call whose end marker has not yet arrived
-    /// is buffered, not leaked).
+    /// is buffered, not leaked), or a trailing run the v1 probe cannot see YET —
+    /// a partial `call:` prefix or a `call:NAME` tail still awaiting its `{`.
+    /// Without that last component, streaming in small chunks releases `c`,
+    /// `ca`, ... as normal_text before `call:` can ever accumulate, and a bare
+    /// call that single-shot parsing recovers is lost (streamv2.5.b/f/g).
     fn opener_holdback_len(&self) -> usize {
         let partial_start = start_marker_suffix_len(&self.buffer);
         let partial_bare = pending_bare_call_suffix_len(&self.buffer);
-        partial_start.max(partial_bare)
+        let partial_opener = partial_bare_opener_suffix_len(&self.buffer);
+        partial_start.max(partial_bare).max(partial_opener)
     }
 
     /// Parse one complete call block into a delta, delegating name + value typing
@@ -288,7 +292,7 @@ impl Gemma4ToolStreamParser {
                 "Gemma 4 stream recovered a bare call (no <|tool_call> opener) instead of leaking it as normal_text"
             );
         }
-        let arguments = reorder_arguments(&call.function.arguments, block);
+        let arguments = reorder_arguments(&call.function.arguments, &source_key_order(block));
         out.calls.push(ToolCallDelta {
             tool_index: self.next_index,
             name: Some(call.function.name),
@@ -394,43 +398,29 @@ fn pending_bare_call_suffix_len(text: &str) -> usize {
     best
 }
 
-/// Re-serialize a v1 arguments JSON object in source key order. The v1 parser
-/// emits alphabetically-sorted keys (`serde_json::Map` is a `BTreeMap` here); the
-/// fixtures want the model-emitted order, so we read the top-level key order
-/// directly from the call body and rebuild the JSON in that order.
-fn reorder_arguments(arguments: &str, block: &str) -> String {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
-        return arguments.to_string();
-    };
-    let Some(obj) = value.as_object() else {
-        return arguments.to_string();
-    };
-    let mut parts: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for name in source_key_order(block) {
-        // seen.insert guards a REPEATED key in the source (the v1 object holds
-        // one value per key): emit it once.
-        if let Some(val) = obj.get(&name)
-            && seen.insert(name.clone())
-        {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(&name).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
+/// Trailing run that may still grow into a recoverable bare call but that the
+/// v1 probes cannot detect yet: a partial `call:` prefix at a word boundary
+/// (`c`, `ca`, ..., `call:`), or a complete boundary `call:` followed only by
+/// identifier characters (the function name, awaiting its `{`). Once the `{`
+/// arrives, `detect_tool_call_start_gemma4` takes over via
+/// `pending_bare_call_suffix_len`. Held-back bytes are flushed on the next
+/// chunk (or at EOF), so the concatenated normal_text is unchanged — only its
+/// chunk boundaries shift.
+fn partial_bare_opener_suffix_len(text: &str) -> usize {
+    for len in (1..=CALL_PREFIX.len()).rev() {
+        if text.ends_with(&CALL_PREFIX[..len]) && is_call_boundary(text, text.len() - len) {
+            return len;
         }
     }
-    // Append any keys not matched in source order (defensive; normally empty).
-    for (key, val) in obj {
-        if !seen.contains(key) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(key).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
+    if let Some(idx) = text.rfind(CALL_PREFIX)
+        && is_call_boundary(text, idx)
+        && text[idx + CALL_PREFIX.len()..]
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return text.len() - idx;
     }
-    format!("{{{}}}", parts.join(","))
+    0
 }
 
 /// Top-level argument key names in the order they appear in a Gemma 4 call body

--- a/parsers/v2/src/tool_calling/glm47.rs
+++ b/parsers/v2/src/tool_calling/glm47.rs
@@ -18,8 +18,7 @@
 //! fixtures store the arguments as an exact JSON string, so order is pinned to
 //! the model-emitted order (the order vLLM's Rust parser also preserves).
 
-use std::collections::HashSet;
-
+use crate::tool_calling::scan::reorder_arguments;
 use crate::tool_calling::v1core::{Glm47ParserConfig, ToolDefinition, try_tool_call_parse_glm47};
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
@@ -249,7 +248,7 @@ impl Glm47ToolStreamParser {
         let Some(call) = calls.into_iter().next() else {
             return Ok(None);
         };
-        let arguments = reorder_arguments(&call.function.arguments, block);
+        let arguments = reorder_arguments(&call.function.arguments, &source_arg_key_order(block));
         Ok(Some(ToolCallDelta {
             tool_index: self.next_index,
             name: Some(call.function.name),
@@ -345,43 +344,6 @@ fn trailing_holdback_len(text: &str) -> usize {
         .map(|(idx, _)| idx)
         .unwrap_or(ident_end);
     text.len() - name_start
-}
-
-/// Re-serialize a v1 arguments JSON object in source `<arg_key>...</arg_key>`
-/// order.
-fn reorder_arguments(arguments: &str, block: &str) -> String {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
-        return arguments.to_string();
-    };
-    let Some(obj) = value.as_object() else {
-        return arguments.to_string();
-    };
-    let mut parts: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for name in source_arg_key_order(block) {
-        // seen.insert guards a REPEATED key in the source (the v1 object holds
-        // one value per key): emit it once.
-        if let Some(val) = obj.get(&name)
-            && seen.insert(name.clone())
-        {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(&name).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    // Append any keys not matched in source order (defensive; normally empty).
-    for (key, val) in obj {
-        if !seen.contains(key) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(key).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    format!("{{{}}}", parts.join(","))
 }
 
 /// Argument key names in the order they appear in a tool-call block.

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -13,293 +13,84 @@
 //! `section_end` entirely on max_tokens / EOS truncation.
 //!
 //! The streaming concern (buffering, chunk-split marker safety, normal_text
-//! suppression) is owned here. The per-call typing (function-id parsing, JSON
-//! validation, raw-string fallback for malformed args) is delegated to the v1
-//! batch parser `try_tool_call_parse_kimi_k2` driven by the same
-//! `KimiK2ParserConfig` `dynamo_parsers` uses for batch parsing, so a streamed
-//! call matches exactly what the batch parser produces. A complete call is
-//! wrapped in the section markers before delegating so the v1 parser always
-//! takes its normal section path.
+//! suppression) is owned by the shared [`scan::WrappedBlockScanner`]; the K2
+//! grammar maps onto it with section variants as multi-token block markers,
+//! the inner `call_end`/`argument_begin` markers as extra orphan markers, and
+//! two K2-specific spec fields: the suppression latch engages after every
+//! in-section call parse even when the call is malformed (`InvokeLatch::Always`),
+//! and a call whose `call_end` never arrives before the section close is
+//! dropped rather than swallowing the fence (`drop_invoke_crossing_block_end`).
+//!
+//! The per-call typing (function-id parsing, JSON validation, raw-string
+//! fallback for malformed args) is delegated to the v1 batch parser
+//! `try_tool_call_parse_kimi_k2` driven by the same `KimiK2ParserConfig`
+//! `dynamo_parsers` uses for batch parsing, so a streamed call matches exactly
+//! what the batch parser produces. A complete call is wrapped in the section
+//! markers before delegating so the v1 parser always takes its normal section
+//! path.
 //!
 //! The per-call arguments are already a JSON object string, so no key-order
 //! reserialization is needed (unlike the XML families): the v1 parser
 //! round-trips compact JSON byte-for-byte and falls back to the raw string for
 //! malformed payloads, which is exactly what the fixtures expect.
 
+use crate::tool_calling::scan::{
+    BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
+};
 use crate::tool_calling::v1core::{
     KimiK2ParserConfig, ToolDefinition, try_tool_call_parse_kimi_k2,
 };
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
 
-/// Stream parser for Kimi K2 tool calls.
-pub struct KimiK2ToolStreamParser {
-    buffer: String,
-    in_section: bool,
-    suppress_normal_text: bool,
-    next_index: usize,
-    config: KimiK2ParserConfig,
-    tools: Vec<ToolDefinition>,
-    /// All start markers (section variants + bare call start) that can open a
-    /// tool region, plus the inner markers, so a marker split across a chunk
-    /// boundary is held back instead of leaked as `normal_text`.
-    markers: Vec<String>,
+fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
+    // Orphan markers: inner markers (`call_end`, `argument_begin`) and every
+    // section-end variant only appear legitimately inside an open section;
+    // outside one they are stray grammar markup to be stripped. Mirrors the v1
+    // batch parser's `first_orphan_kimi_marker_index` (minus `call_start`,
+    // which the bare-call recovery path already opens).
+    let mut orphan_markers = vec![config.call_end.clone(), config.argument_begin.clone()];
+    orphan_markers.extend(config.section_end_variants.clone());
+
+    // Every grammar marker that must never be split-leaked as normal_text.
+    let mut holdback_markers = config.section_start_variants.clone();
+    holdback_markers.extend(config.section_end_variants.clone());
+    holdback_markers.push(config.call_start.clone());
+    holdback_markers.push(config.call_end.clone());
+    holdback_markers.push(config.argument_begin.clone());
+
+    WrappedBlockSpec {
+        family: "kimi_k2",
+        block_starts: config.section_start_variants.clone(),
+        block_ends: config.section_end_variants.clone(),
+        invoke_start: config.call_start.clone(),
+        invoke_end: config.call_end.clone(),
+        orphan_markers,
+        holdback_markers,
+        bare_recovery_latch: BareRecoveryLatch::Set,
+        invoke_latch: InvokeLatch::Always,
+        drop_invoke_crossing_block_end: true,
+    }
 }
 
-impl KimiK2ToolStreamParser {
-    pub fn new(tools: &[Tool]) -> Self {
-        let config = KimiK2ParserConfig::default();
-        // Every grammar marker that must never be split-leaked as normal_text.
-        let mut markers: Vec<String> = config.section_start_variants.clone();
-        markers.extend(config.section_end_variants.clone());
-        markers.push(config.call_start.clone());
-        markers.push(config.call_end.clone());
-        markers.push(config.argument_begin.clone());
-        Self {
-            buffer: String::new(),
-            in_section: false,
-            suppress_normal_text: false,
-            next_index: 0,
-            config,
-            tools: tools.iter().map(ToolDefinition::from).collect(),
-            markers,
-        }
-    }
+/// Value-typing hook: wraps one complete
+/// `<|tool_call_begin|>...<|tool_call_end|>` call in the section markers so
+/// the v1 parser takes its normal section path, then emits `name` + JSON
+/// `arguments` as one delta.
+struct K2Emitter {
+    config: KimiK2ParserConfig,
+    tools: Vec<ToolDefinition>,
+}
 
-    /// First occurrence of any section-start variant in `self.buffer`, returning
-    /// `(position, matched_token_len)`.
-    fn find_section_start(&self) -> Option<(usize, usize)> {
-        self.config
-            .section_start_variants
-            .iter()
-            .filter_map(|v| self.buffer.find(v.as_str()).map(|p| (p, v.len())))
-            .min_by_key(|(p, _)| *p)
-    }
-
-    /// First occurrence of any section-end variant in `self.buffer` at/after
-    /// `from`, returning `(absolute_position, matched_token_len)`.
-    fn find_section_end_from(&self, from: usize) -> Option<(usize, usize)> {
-        self.config
-            .section_end_variants
-            .iter()
-            .filter_map(|v| {
-                self.buffer[from..]
-                    .find(v.as_str())
-                    .map(|p| (from + p, v.len()))
-            })
-            .min_by_key(|(p, _)| *p)
-    }
-
-    /// Earliest COMPLETE orphan close/inner marker in `self.buffer` — a
-    /// `call_end`, an `argument_begin`, or any `section_end` variant — returning
-    /// `(position, matched_token_len)`. These only appear legitimately inside an
-    /// open section; outside one they are stray grammar markup to be stripped.
-    /// Mirrors the v1 batch parser's `first_orphan_kimi_marker_index` (minus
-    /// `call_start`, which the bare-call recovery path already opens).
-    fn find_orphan_close(&self) -> Option<(usize, usize)> {
-        [
-            self.config.call_end.as_str(),
-            self.config.argument_begin.as_str(),
-        ]
-        .into_iter()
-        .chain(self.config.section_end_variants.iter().map(String::as_str))
-        .filter_map(|m| self.buffer.find(m).map(|p| (p, m.len())))
-        .min_by_key(|(p, _)| *p)
-    }
-
-    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
-        let mut out = ToolParseResult::default();
-
-        loop {
-            if self.in_section {
-                let call_start = self.buffer.find(self.config.call_start.as_str());
-                let section_end = self.find_section_end_from(0);
-
-                // Close the section once no more complete calls precede its end.
-                if let Some((end_pos, end_len)) = section_end {
-                    let call_before_end = call_start.is_some_and(|s| s < end_pos);
-                    if !call_before_end {
-                        // Complete section fully closed: drop its markup and resume
-                        // keeping natural text (inter-section / post-wrapper
-                        // narration). Any later section re-enters `in_section` and
-                        // re-suppresses its markup. Matches the v1 batch parser,
-                        // which preserves surrounding natural text verbatim
-                        // (cases 8.b/8.c/8.d).
-                        self.buffer.drain(..end_pos + end_len);
-                        self.in_section = false;
-                        self.suppress_normal_text = false;
-                        continue;
-                    }
-                }
-
-                let Some(start) = call_start else {
-                    // No call_start yet and no closing section_end consumed
-                    // above: the section body has not produced a complete call.
-                    if flush {
-                        tracing::warn!(
-                            why = "kimi_k2_incomplete_tool_call",
-                            "Kimi K2 stream dropped incomplete section at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_section = false;
-                    }
-                    break;
-                };
-                if start > 0 {
-                    self.buffer.drain(..start);
-                }
-                // A complete call needs both call_start and call_end. The call
-                // body ends at the first call_end; refuse to cross a section_end
-                // (mismatched fences) so a call_end-less call is dropped rather
-                // than swallowing the section close.
-                let Some(end) = self.buffer.find(self.config.call_end.as_str()) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "kimi_k2_incomplete_tool_call",
-                            "Kimi K2 stream dropped call missing call_end at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_section = false;
-                    }
-                    break;
-                };
-                // If a section_end sits before this call_end, the call is
-                // malformed (no per-call end inside the fences). Drop it.
-                if let Some((se_pos, se_len)) = self.find_section_end_from(0)
-                    && se_pos < end
-                {
-                    tracing::warn!(
-                        why = "kimi_k2_incomplete_tool_call",
-                        "Kimi K2 stream dropped call missing call_end before section_end"
-                    );
-                    self.buffer.drain(..se_pos + se_len);
-                    self.in_section = false;
-                    // The section is CLOSED here — narration after it is the
-                    // user's text, same as the clean-close path above. Keeping
-                    // the latch on dropped trailing prose after a malformed
-                    // section (text loss is the worse failure).
-                    self.suppress_normal_text = false;
-                    continue;
-                }
-                let call = self.buffer[..end + self.config.call_end.len()].to_string();
-                self.buffer.drain(..end + self.config.call_end.len());
-                if let Some(delta) = self.parse_call_delta(&call)? {
-                    out.calls.push(delta);
-                    self.next_index += 1;
-                }
-                self.suppress_normal_text = true;
-                continue;
-            }
-
-            // Not in a section. A COMPLETE orphan close/inner marker (`call_end`,
-            // `argument_begin`, or a `section_end` variant) that arrives outside
-            // any open section is stray double-close markup: the `next_marker`
-            // lookup below only recognizes section-start variants and `call_start`,
-            // so such an orphan would otherwise flow straight into `normal_text`.
-            // Strip it, mirroring the v1 batch parser's
-            // `first_orphan_kimi_marker_index` policy. Emit any genuine text before
-            // it (unless suppressing), drain through the marker, and clear the
-            // suppression latch — the markup context has ended.
-            if let Some((pos, len)) = self.find_orphan_close() {
-                let next_open = self
-                    .find_section_start()
-                    .map(|(p, _)| p)
-                    .into_iter()
-                    .chain(self.buffer.find(self.config.call_start.as_str()))
-                    .min();
-                if next_open.is_none_or(|open| pos < open) {
-                    if !self.suppress_normal_text && pos > 0 {
-                        out.normal_text.push_str(&self.buffer[..pos]);
-                    }
-                    self.buffer.drain(..pos + len);
-                    self.suppress_normal_text = false;
-                    continue;
-                }
-            }
-
-            // Not in a section. Look for the earliest section-start variant, or a
-            // bare `call_start` (recovery: a complete call without section_begin,
-            // mirroring the v1 parser's `recover_bare_kimi_calls_in_span`).
-            let section = self.find_section_start();
-            let bare_call = self.buffer.find(self.config.call_start.as_str());
-            let next_marker = match (section, bare_call) {
-                (Some((s, slen)), Some(c)) if s <= c => Some((s, Marker::Section(slen))),
-                (Some(_), Some(c)) => Some((c, Marker::BareCall)),
-                (Some((s, slen)), None) => Some((s, Marker::Section(slen))),
-                (None, Some(c)) => Some((c, Marker::BareCall)),
-                (None, None) => None,
-            };
-
-            let Some((start, marker)) = next_marker else {
-                // No marker present: emit buffered text, but hold back a trailing
-                // partial marker (split across this chunk boundary) unless flushing.
-                let keep = if flush {
-                    0
-                } else {
-                    self.marker_prefix_suffix_len()
-                };
-                let emit_len = self.buffer.len().saturating_sub(keep);
-                if emit_len > 0 {
-                    if !self.suppress_normal_text {
-                        out.normal_text.push_str(&self.buffer[..emit_len]);
-                    }
-                    self.buffer.drain(..emit_len);
-                }
-                break;
-            };
-
-            if start > 0 {
-                if !self.suppress_normal_text {
-                    out.normal_text.push_str(&self.buffer[..start]);
-                }
-                self.buffer.drain(..start);
-            }
-
-            match marker {
-                Marker::Section(slen) => {
-                    self.buffer.drain(..slen);
-                    self.in_section = true;
-                    self.suppress_normal_text = true;
-                }
-                Marker::BareCall => {
-                    // A bare call (no section_begin) is recovered only when its
-                    // call_end has streamed; otherwise wait for more input.
-                    let Some(end) = self.buffer.find(self.config.call_end.as_str()) else {
-                        if flush {
-                            tracing::warn!(
-                                why = "kimi_k2_incomplete_tool_call",
-                                "Kimi K2 stream dropped incomplete bare call at EOF"
-                            );
-                            self.buffer.clear();
-                        }
-                        break;
-                    };
-                    let call = self.buffer[..end + self.config.call_end.len()].to_string();
-                    self.buffer.drain(..end + self.config.call_end.len());
-                    if let Some(delta) = self.parse_call_delta(&call)? {
-                        tracing::warn!(
-                            why = "kimi_k2_bare_call_recovery",
-                            tool_index = delta.tool_index,
-                            "Kimi K2 stream recovered a complete bare call"
-                        );
-                        out.calls.push(delta);
-                        self.next_index += 1;
-                        self.suppress_normal_text = true;
-                    }
-                }
-            }
-        }
-
-        Ok(out)
-    }
-
-    /// Parse one complete `<|tool_call_begin|>...<|tool_call_end|>` call into a
-    /// delta. Wraps the call in the section markers so the v1 parser takes its
-    /// normal section path, then emits `name` + JSON `arguments` as one delta.
-    fn parse_call_delta(&self, call: &str) -> anyhow::Result<Option<ToolCallDelta>> {
+impl InvokeEmitter for K2Emitter {
+    fn parse_invoke(
+        &self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
         let wrapped = format!(
             "{}{}{}",
-            self.config.section_start, call, self.config.section_end
+            self.config.section_start, invoke, self.config.section_end
         );
         let (calls, _content) =
             try_tool_call_parse_kimi_k2(&wrapped, &self.config, Some(&self.tools))?;
@@ -307,28 +98,30 @@ impl KimiK2ToolStreamParser {
             return Ok(None);
         };
         Ok(Some(ToolCallDelta {
-            tool_index: self.next_index,
+            tool_index,
             name: Some(parsed.function.name),
             arguments: parsed.function.arguments,
         }))
     }
+}
 
-    /// Longest non-empty proper prefix of any grammar marker that `self.buffer`
-    /// ends with, so a marker split across chunk boundaries is held back instead
-    /// of leaked as text.
-    fn marker_prefix_suffix_len(&self) -> usize {
-        self.markers
-            .iter()
-            .filter_map(|marker| {
-                marker
-                    .char_indices()
-                    .map(|(idx, _)| idx)
-                    .filter(|idx| *idx > 0 && *idx < marker.len())
-                    .rev()
-                    .find(|&len| self.buffer.ends_with(&marker[..len]))
-            })
-            .max()
-            .unwrap_or(0)
+/// Stream parser for Kimi K2 tool calls.
+pub struct KimiK2ToolStreamParser {
+    scanner: WrappedBlockScanner<K2Emitter>,
+}
+
+impl KimiK2ToolStreamParser {
+    pub fn new(tools: &[Tool]) -> Self {
+        let config = KimiK2ParserConfig::default();
+        Self {
+            scanner: WrappedBlockScanner::new(
+                spec(&config),
+                K2Emitter {
+                    config,
+                    tools: tools.iter().map(ToolDefinition::from).collect(),
+                },
+            ),
+        }
     }
 }
 
@@ -345,21 +138,12 @@ impl ToolParser for KimiK2ToolStreamParser {
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
-        self.buffer.push_str(chunk);
-        self.drain(false)
+        self.scanner.push(chunk)
     }
 
     fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
-        self.drain(true)
+        self.scanner.finish()
     }
-}
-
-#[derive(Clone, Copy)]
-enum Marker {
-    /// A section-start variant; carries the matched token length.
-    Section(usize),
-    /// A bare `<|tool_call_begin|>` with no section wrapper (recovery path).
-    BareCall,
 }
 
 #[cfg(test)]

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -9,17 +9,25 @@
 //! wrapper is absent (the v1 config sets `backoff_when_no_wrapper`).
 //!
 //! The streaming concern (buffering, chunk-split marker safety, normal_text
-//! suppression) is owned here. The per-block value typing is delegated to the v1
-//! batch XML parser `try_tool_call_parse_xml` driven by the same MiniMax config
-//! `dynamo_parsers` uses for batch parsing, so a streamed call matches exactly
-//! what the batch parser produces. Arguments are re-serialized in source
+//! suppression) is owned by the shared [`scan::WrappedBlockScanner`]. The
+//! per-block value typing is delegated to the v1 batch XML parser
+//! `try_tool_call_parse_xml` driven by the same MiniMax config `dynamo_parsers`
+//! uses for batch parsing, so a streamed call matches exactly what the batch
+//! parser produces. Arguments are re-serialized in source
 //! `<parameter name="...">` order because the v1 parser builds them from a
 //! `HashMap` whose key order is non-deterministic; the fixtures store the
 //! arguments as an exact JSON string, so order is pinned to the model-emitted
 //! order (the order vLLM's Rust parser also preserves).
+//!
+//! M2-specific semantics (explicit spec fields, not copy drift): a bare-invoke
+//! recovery CLEARS the suppression latch — when the optional outer close is
+//! absent, later narration (e.g. ` Done.`) must still reach normal_text; a
+//! stray close that does follow is stripped by the orphan-close handling.
 
-use std::collections::HashSet;
-
+use crate::tool_calling::scan::{
+    BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
+    reorder_arguments,
+};
 use crate::tool_calling::v1core::{ToolDefinition, XmlParserConfig, try_tool_call_parse_xml};
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
@@ -47,202 +55,73 @@ fn minimax_config() -> XmlParserConfig {
     }
 }
 
-/// Stream parser for MiniMax-M2 XML tool calls.
-pub struct MiniMaxM2ToolStreamParser {
-    buffer: String,
-    in_block: bool,
-    suppress_normal_text: bool,
-    next_index: usize,
+fn spec() -> WrappedBlockSpec {
+    WrappedBlockSpec {
+        family: "minimax_m2",
+        block_starts: vec![BLOCK_START.to_string()],
+        block_ends: vec![BLOCK_END.to_string()],
+        invoke_start: FUNCTION_START.to_string(),
+        invoke_end: FUNCTION_END.to_string(),
+        orphan_markers: vec![BLOCK_END.to_string()],
+        // BLOCK_END is held back too: a lone orphan close that arrives split
+        // across chunks must be retained whole so the orphan-close path (which
+        // strips it and never lets it leak) can match it.
+        holdback_markers: vec![
+            BLOCK_START.to_string(),
+            FUNCTION_START.to_string(),
+            BLOCK_END.to_string(),
+        ],
+        bare_recovery_latch: BareRecoveryLatch::Clear,
+        invoke_latch: InvokeLatch::IfEmitted,
+        drop_invoke_crossing_block_end: false,
+    }
+}
+
+/// Value-typing hook: wraps one complete `<invoke ...>...</invoke>` in the
+/// block markers so the v1 parser takes its normal wrapped path, then re-orders
+/// the arguments to source order.
+struct M2Emitter {
     config: XmlParserConfig,
     tools: Vec<ToolDefinition>,
+}
+
+impl InvokeEmitter for M2Emitter {
+    fn parse_invoke(
+        &self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
+        let wrapped = format!("{BLOCK_START}{invoke}{BLOCK_END}");
+        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
+        let Some(call) = calls.into_iter().next() else {
+            return Ok(None);
+        };
+        let arguments =
+            reorder_arguments(&call.function.arguments, &source_parameter_order(invoke));
+        Ok(Some(ToolCallDelta {
+            tool_index,
+            name: Some(call.function.name),
+            arguments,
+        }))
+    }
+}
+
+/// Stream parser for MiniMax-M2 XML tool calls.
+pub struct MiniMaxM2ToolStreamParser {
+    scanner: WrappedBlockScanner<M2Emitter>,
 }
 
 impl MiniMaxM2ToolStreamParser {
     pub fn new(tools: &[Tool]) -> Self {
         Self {
-            buffer: String::new(),
-            in_block: false,
-            suppress_normal_text: false,
-            next_index: 0,
-            config: minimax_config(),
-            tools: tools.iter().map(ToolDefinition::from).collect(),
+            scanner: WrappedBlockScanner::new(
+                spec(),
+                M2Emitter {
+                    config: minimax_config(),
+                    tools: tools.iter().map(ToolDefinition::from).collect(),
+                },
+            ),
         }
-    }
-
-    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
-        let mut out = ToolParseResult::default();
-
-        loop {
-            if self.in_block {
-                // Close the block once no more complete invokes precede its end.
-                if let Some(end) = self.buffer.find(BLOCK_END) {
-                    let invoke_before_end = self
-                        .buffer
-                        .find(FUNCTION_START)
-                        .is_some_and(|start| start < end);
-                    if !invoke_before_end {
-                        // Complete block fully closed: drop its markup and resume
-                        // keeping natural text (inter-block / trailing). Any later
-                        // block re-enters `in_block` and re-suppresses its markup.
-                        // Matches the v1 batch parser (cases 8.b/8.c/8.d).
-                        self.buffer.drain(..end + BLOCK_END.len());
-                        self.in_block = false;
-                        self.suppress_normal_text = false;
-                        continue;
-                    }
-                }
-
-                let Some(start) = self.buffer.find(FUNCTION_START) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "minimax_m2_block_without_complete_invoke",
-                            "MiniMax-M2 stream dropped incomplete block at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                if start > 0 {
-                    self.buffer.drain(..start);
-                }
-                let Some(end) = self.buffer.find(FUNCTION_END) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "minimax_m2_incomplete_invoke",
-                            "MiniMax-M2 stream dropped incomplete invoke at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                self.buffer.drain(..end + FUNCTION_END.len());
-                if let Some(delta) = self.parse_function_delta(&function)? {
-                    out.calls.push(delta);
-                    self.next_index += 1;
-                    self.suppress_normal_text = true;
-                }
-                continue;
-            }
-
-            // A recovered bare invoke suppresses its trailing markup; its stray
-            // `</minimax:tool_call>` close (cases 5.b/5.f) ENDS that markup context.
-            // Consume the orphan close and clear the latch so inter-call text —
-            // e.g. the single separator space before the next block — flows
-            // through verbatim, matching the v1 jail+batch output.
-            // A stray/orphan close (`BLOCK_END`) before any opener is malformed
-            // double-close markup. Drop it so it can NEVER leak into normal_text;
-            // when suppression is off, first emit the natural text preceding it.
-            // Clear the latch either way (the markup context has ended).
-            if let Some(pos) = self.buffer.find(BLOCK_END) {
-                let next_open = [BLOCK_START, FUNCTION_START]
-                    .into_iter()
-                    .filter_map(|m| self.buffer.find(m))
-                    .min();
-                if next_open.is_none_or(|open| pos < open) {
-                    if !self.suppress_normal_text && pos > 0 {
-                        out.normal_text.push_str(&self.buffer[..pos]);
-                    }
-                    self.buffer.drain(..pos + BLOCK_END.len());
-                    self.suppress_normal_text = false;
-                    continue;
-                }
-            }
-
-            let block_start = self.buffer.find(BLOCK_START);
-            let bare_invoke_start = self.buffer.find(FUNCTION_START);
-            let next_marker = match (block_start, bare_invoke_start) {
-                (Some(b), Some(f)) if b <= f => Some((b, Marker::Block)),
-                (Some(_), Some(f)) => Some((f, Marker::BareInvoke)),
-                (Some(b), None) => Some((b, Marker::Block)),
-                (None, Some(f)) => Some((f, Marker::BareInvoke)),
-                (None, None) => None,
-            };
-
-            let Some((start, marker)) = next_marker else {
-                // No marker present: emit buffered text, but hold back a trailing
-                // partial marker (split across this chunk boundary) unless flushing.
-                let keep = if flush {
-                    0
-                } else {
-                    marker_prefix_suffix_len(&self.buffer)
-                };
-                let emit_len = self.buffer.len().saturating_sub(keep);
-                if emit_len > 0 {
-                    if !self.suppress_normal_text {
-                        out.normal_text.push_str(&self.buffer[..emit_len]);
-                    }
-                    self.buffer.drain(..emit_len);
-                }
-                break;
-            };
-
-            if start > 0 {
-                if !self.suppress_normal_text {
-                    out.normal_text.push_str(&self.buffer[..start]);
-                }
-                self.buffer.drain(..start);
-            }
-
-            match marker {
-                Marker::Block => {
-                    self.buffer.drain(..BLOCK_START.len());
-                    self.in_block = true;
-                    self.suppress_normal_text = true;
-                }
-                Marker::BareInvoke => {
-                    let Some(end) = self.buffer.find(FUNCTION_END) else {
-                        if flush {
-                            tracing::warn!(
-                                why = "minimax_m2_incomplete_bare_invoke",
-                                "MiniMax-M2 stream dropped incomplete bare invoke at EOF"
-                            );
-                            self.buffer.clear();
-                        }
-                        break;
-                    };
-                    let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                    self.buffer.drain(..end + FUNCTION_END.len());
-                    if let Some(delta) = self.parse_function_delta(&function)? {
-                        tracing::warn!(
-                            why = "minimax_m2_bare_invoke_recovery",
-                            tool_index = delta.tool_index,
-                            "MiniMax-M2 stream recovered a complete bare invoke"
-                        );
-                        out.calls.push(delta);
-                        self.next_index += 1;
-                        // Do NOT latch suppression after a bare invoke: when the
-                        // optional outer close (`BLOCK_END`) is absent, later
-                        // narration (e.g. ` Done.`) must still reach normal_text.
-                        // A stray `BLOCK_END` that DOES follow is stripped by the
-                        // orphan-close handling above, so the close never leaks.
-                        self.suppress_normal_text = false;
-                    }
-                }
-            }
-        }
-
-        Ok(out)
-    }
-
-    /// Parse one complete `<invoke name="...">...</invoke>` block into a delta.
-    ///
-    /// Wraps the invoke in `<minimax:tool_call>` so the v1 parser always takes
-    /// its normal wrapped path, then re-orders the arguments to source order.
-    fn parse_function_delta(&self, function: &str) -> anyhow::Result<Option<ToolCallDelta>> {
-        let wrapped = format!("{BLOCK_START}{function}{BLOCK_END}");
-        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
-        let Some(call) = calls.into_iter().next() else {
-            return Ok(None);
-        };
-        let arguments = reorder_arguments(&call.function.arguments, function);
-        Ok(Some(ToolCallDelta {
-            tool_index: self.next_index,
-            name: Some(call.function.name),
-            arguments,
-        }))
     }
 }
 
@@ -259,78 +138,12 @@ impl ToolParser for MiniMaxM2ToolStreamParser {
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
-        self.buffer.push_str(chunk);
-        self.drain(false)
+        self.scanner.push(chunk)
     }
 
     fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
-        self.drain(true)
+        self.scanner.finish()
     }
-}
-
-#[derive(Clone, Copy)]
-enum Marker {
-    Block,
-    BareInvoke,
-}
-
-/// Longest non-empty proper prefix of a marker that `text` ends with, so a
-/// marker split across chunk boundaries is held back instead of leaked as text.
-/// `BLOCK_END` is included: a lone orphan `</minimax:tool_call>` that arrives
-/// split across chunks must be retained whole so the orphan-close path (which
-/// strips it and never lets it leak) can match it — otherwise the partial suffix
-/// is emitted as normal_text and the marker leaks.
-fn marker_prefix_suffix_len(text: &str) -> usize {
-    [BLOCK_START, FUNCTION_START, BLOCK_END]
-        .into_iter()
-        .filter_map(|marker| {
-            marker
-                .char_indices()
-                .map(|(idx, _)| idx)
-                .filter(|idx| *idx > 0)
-                .filter(|idx| *idx < marker.len())
-                .rev()
-                .find(|&len| text.ends_with(&marker[..len]))
-        })
-        .max()
-        .unwrap_or(0)
-}
-
-/// Re-serialize a v1 arguments JSON object in source `<parameter name="...">`
-/// order.
-fn reorder_arguments(arguments: &str, function: &str) -> String {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
-        return arguments.to_string();
-    };
-    let Some(obj) = value.as_object() else {
-        return arguments.to_string();
-    };
-    let mut parts: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for name in source_parameter_order(function) {
-        // seen.insert guards a REPEATED parameter tag (same name twice in the
-        // source): the v1 object holds one value per key, so emit it once.
-        if let Some(val) = obj.get(&name)
-            && seen.insert(name.clone())
-        {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(&name).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    // Append any keys not matched in source order (defensive; normally empty).
-    for (key, val) in obj {
-        if !seen.contains(key) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(key).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    format!("{{{}}}", parts.join(","))
 }
 
 /// Parameter names in the order they appear in an invoke block.

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -14,16 +14,19 @@
 //! outer wrapper is absent.
 //!
 //! The streaming concern (buffering, chunk-split marker safety, normal_text
-//! suppression) is owned here. The per-invoke value typing is delegated to the
-//! v1 batch parser `try_tool_call_parse_minimax_m3` driven by the same config
-//! `dynamo_parsers` uses for batch parsing, so a streamed call matches exactly
-//! what the batch parser produces. Arguments are re-serialized in source
-//! parameter-tag order because the v1 parser builds them from a `HashMap`
-//! whose key order is non-deterministic; the fixtures store the arguments as
-//! an exact JSON string, so order is pinned to the model-emitted order.
+//! suppression) is owned by the shared [`scan::WrappedBlockScanner`]; all
+//! three markers begin with the namespace token, so the shared holdback also
+//! retains a split `]<]minimax[>[` run. The per-invoke value typing is
+//! delegated to the v1 batch parser `try_tool_call_parse_minimax_m3` driven by
+//! the same config `dynamo_parsers` uses for batch parsing, so a streamed call
+//! matches exactly what the batch parser produces. Arguments are re-serialized
+//! in source parameter-tag order because the v1 parser builds them from a
+//! `HashMap` whose key order is non-deterministic.
 
-use std::collections::HashSet;
-
+use crate::tool_calling::scan::{
+    BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
+    reorder_arguments,
+};
 use crate::tool_calling::v1core::{
     MiniMaxM3ParserConfig, ToolDefinition, try_tool_call_parse_minimax_m3,
 };
@@ -39,201 +42,76 @@ const BLOCK_END: &str = "]<]minimax[>[</tool_call>";
 const FUNCTION_START: &str = "]<]minimax[>[<invoke";
 const FUNCTION_END: &str = "]<]minimax[>[</invoke>";
 
-/// Stream parser for MiniMax-M3 tool calls.
-pub struct MiniMaxM3ToolStreamParser {
-    buffer: String,
-    in_block: bool,
-    suppress_normal_text: bool,
-    next_index: usize,
+fn spec() -> WrappedBlockSpec {
+    WrappedBlockSpec {
+        family: "minimax_m3",
+        block_starts: vec![BLOCK_START.to_string()],
+        block_ends: vec![BLOCK_END.to_string()],
+        invoke_start: FUNCTION_START.to_string(),
+        invoke_end: FUNCTION_END.to_string(),
+        orphan_markers: vec![BLOCK_END.to_string()],
+        // BLOCK_END is held back too: after a bare-invoke recovery latches
+        // suppression, a split closing marker must be retained whole so the
+        // orphan-close path (which clears the latch) can match it.
+        holdback_markers: vec![
+            BLOCK_START.to_string(),
+            FUNCTION_START.to_string(),
+            BLOCK_END.to_string(),
+        ],
+        bare_recovery_latch: BareRecoveryLatch::Set,
+        invoke_latch: InvokeLatch::IfEmitted,
+        drop_invoke_crossing_block_end: false,
+    }
+}
+
+/// Value-typing hook: wraps one complete invoke run in the M3 `<tool_call>`
+/// block so the v1 parser takes its normal wrapped path, then re-orders the
+/// arguments to source parameter-tag order.
+struct M3Emitter {
     config: MiniMaxM3ParserConfig,
     tools: Vec<ToolDefinition>,
 }
 
-impl MiniMaxM3ToolStreamParser {
-    pub fn new(tools: &[Tool]) -> Self {
-        Self {
-            buffer: String::new(),
-            in_block: false,
-            suppress_normal_text: false,
-            next_index: 0,
-            // Identical to `dynamo_parsers`' batch config so the streamed value
-            // typing matches the v1 batch parser exactly.
-            config: MiniMaxM3ParserConfig::default(),
-            tools: tools.iter().map(ToolDefinition::from).collect(),
-        }
-    }
-
-    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
-        let mut out = ToolParseResult::default();
-
-        loop {
-            if self.in_block {
-                // Close the block once no more complete invokes precede its end.
-                if let Some(end) = self.buffer.find(BLOCK_END) {
-                    let invoke_before_end = self
-                        .buffer
-                        .find(FUNCTION_START)
-                        .is_some_and(|start| start < end);
-                    if !invoke_before_end {
-                        // Complete block fully closed: drop its markup and resume
-                        // keeping natural text (inter-block / trailing). Any later
-                        // block re-enters `in_block` and re-suppresses its markup.
-                        // Matches the v1 batch parser (cases 8.b/8.c).
-                        self.buffer.drain(..end + BLOCK_END.len());
-                        self.in_block = false;
-                        self.suppress_normal_text = false;
-                        continue;
-                    }
-                }
-
-                let Some(start) = self.buffer.find(FUNCTION_START) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "minimax_m3_block_without_complete_invoke",
-                            "MiniMax-M3 stream dropped incomplete block at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                if start > 0 {
-                    self.buffer.drain(..start);
-                }
-                let Some(end) = self.buffer.find(FUNCTION_END) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "minimax_m3_incomplete_invoke",
-                            "MiniMax-M3 stream dropped incomplete invoke at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                self.buffer.drain(..end + FUNCTION_END.len());
-                if let Some(delta) = self.parse_function_delta(&function)? {
-                    out.calls.push(delta);
-                    self.next_index += 1;
-                    self.suppress_normal_text = true;
-                }
-                continue;
-            }
-
-            // A recovered bare invoke suppresses its trailing markup; its stray
-            // namespaced `</tool_call>` close (cases 5.b/5.f) ENDS that markup context.
-            // Consume the orphan close and clear the latch so inter-call text —
-            // e.g. the single separator space before the next block — flows
-            // through verbatim, matching the v1 jail+batch output.
-            // A stray/orphan close (`BLOCK_END`) before any opener is malformed
-            // double-close markup. Drop it so it can NEVER leak into normal_text;
-            // when suppression is off, first emit the natural text preceding it.
-            // Clear the latch either way (the markup context has ended).
-            if let Some(pos) = self.buffer.find(BLOCK_END) {
-                let next_open = [BLOCK_START, FUNCTION_START]
-                    .into_iter()
-                    .filter_map(|m| self.buffer.find(m))
-                    .min();
-                if next_open.is_none_or(|open| pos < open) {
-                    if !self.suppress_normal_text && pos > 0 {
-                        out.normal_text.push_str(&self.buffer[..pos]);
-                    }
-                    self.buffer.drain(..pos + BLOCK_END.len());
-                    self.suppress_normal_text = false;
-                    continue;
-                }
-            }
-
-            let block_start = self.buffer.find(BLOCK_START);
-            let bare_invoke_start = self.buffer.find(FUNCTION_START);
-            let next_marker = match (block_start, bare_invoke_start) {
-                (Some(b), Some(f)) if b <= f => Some((b, Marker::Block)),
-                (Some(_), Some(f)) => Some((f, Marker::BareInvoke)),
-                (Some(b), None) => Some((b, Marker::Block)),
-                (None, Some(f)) => Some((f, Marker::BareInvoke)),
-                (None, None) => None,
-            };
-
-            let Some((start, marker)) = next_marker else {
-                // No marker present: emit buffered text, but hold back a trailing
-                // partial marker (split across this chunk boundary) unless flushing.
-                let keep = if flush {
-                    0
-                } else {
-                    marker_prefix_suffix_len(&self.buffer)
-                };
-                let emit_len = self.buffer.len().saturating_sub(keep);
-                if emit_len > 0 {
-                    if !self.suppress_normal_text {
-                        out.normal_text.push_str(&self.buffer[..emit_len]);
-                    }
-                    self.buffer.drain(..emit_len);
-                }
-                break;
-            };
-
-            if start > 0 {
-                if !self.suppress_normal_text {
-                    out.normal_text.push_str(&self.buffer[..start]);
-                }
-                self.buffer.drain(..start);
-            }
-
-            match marker {
-                Marker::Block => {
-                    self.buffer.drain(..BLOCK_START.len());
-                    self.in_block = true;
-                    self.suppress_normal_text = true;
-                }
-                Marker::BareInvoke => {
-                    let Some(end) = self.buffer.find(FUNCTION_END) else {
-                        if flush {
-                            tracing::warn!(
-                                why = "minimax_m3_incomplete_bare_invoke",
-                                "MiniMax-M3 stream dropped incomplete bare invoke at EOF"
-                            );
-                            self.buffer.clear();
-                        }
-                        break;
-                    };
-                    let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                    self.buffer.drain(..end + FUNCTION_END.len());
-                    if let Some(delta) = self.parse_function_delta(&function)? {
-                        tracing::warn!(
-                            why = "minimax_m3_bare_invoke_recovery",
-                            tool_index = delta.tool_index,
-                            "MiniMax-M3 stream recovered a complete bare invoke"
-                        );
-                        out.calls.push(delta);
-                        self.next_index += 1;
-                        self.suppress_normal_text = true;
-                    }
-                }
-            }
-        }
-
-        Ok(out)
-    }
-
-    /// Parse one complete `<invoke ...>...</invoke>` run into a delta.
-    ///
-    /// Wraps the invoke in the M3 `<tool_call>` block so the v1 parser always
-    /// takes its normal wrapped path, then re-orders the arguments to source
-    /// parameter-tag order.
-    fn parse_function_delta(&self, function: &str) -> anyhow::Result<Option<ToolCallDelta>> {
-        let wrapped = format!("{BLOCK_START}{function}{BLOCK_END}");
+impl InvokeEmitter for M3Emitter {
+    fn parse_invoke(
+        &self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
+        let wrapped = format!("{BLOCK_START}{invoke}{BLOCK_END}");
         let tools_opt = (!self.tools.is_empty()).then_some(self.tools.as_slice());
         let (calls, _content) = try_tool_call_parse_minimax_m3(&wrapped, &self.config, tools_opt)?;
         let Some(call) = calls.into_iter().next() else {
             return Ok(None);
         };
-        let arguments = reorder_arguments(&call.function.arguments, function);
+        let arguments =
+            reorder_arguments(&call.function.arguments, &source_parameter_order(invoke));
         Ok(Some(ToolCallDelta {
-            tool_index: self.next_index,
+            tool_index,
             name: Some(call.function.name),
             arguments,
         }))
+    }
+}
+
+/// Stream parser for MiniMax-M3 tool calls.
+pub struct MiniMaxM3ToolStreamParser {
+    scanner: WrappedBlockScanner<M3Emitter>,
+}
+
+impl MiniMaxM3ToolStreamParser {
+    pub fn new(tools: &[Tool]) -> Self {
+        Self {
+            scanner: WrappedBlockScanner::new(
+                spec(),
+                M3Emitter {
+                    // Identical to `dynamo_parsers`' batch config so the streamed
+                    // value typing matches the v1 batch parser exactly.
+                    config: MiniMaxM3ParserConfig::default(),
+                    tools: tools.iter().map(ToolDefinition::from).collect(),
+                },
+            ),
+        }
     }
 }
 
@@ -250,76 +128,12 @@ impl ToolParser for MiniMaxM3ToolStreamParser {
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
-        self.buffer.push_str(chunk);
-        self.drain(false)
+        self.scanner.push(chunk)
     }
 
     fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
-        self.drain(true)
+        self.scanner.finish()
     }
-}
-
-#[derive(Clone, Copy)]
-enum Marker {
-    Block,
-    BareInvoke,
-}
-
-/// Longest non-empty proper prefix of an M3 marker that `text` ends with, so a
-/// marker split across chunk boundaries is held back instead of leaked as text.
-/// All three markers begin with the namespace token, so this also holds back a
-/// split `]<]minimax[>[` run. `BLOCK_END` is included: after a bare-invoke
-/// recovery latches `suppress_normal_text`, a split closing marker must be
-/// retained whole so the orphan-close path (which clears the latch) can match it
-/// — otherwise its remainder is unrecognizable and later prose is dropped.
-fn marker_prefix_suffix_len(text: &str) -> usize {
-    [BLOCK_START, FUNCTION_START, BLOCK_END]
-        .into_iter()
-        .filter_map(|marker| {
-            marker
-                .char_indices()
-                .map(|(idx, _)| idx)
-                .filter(|idx| *idx > 0)
-                .filter(|idx| *idx < marker.len())
-                .rev()
-                .find(|&len| text.ends_with(&marker[..len]))
-        })
-        .max()
-        .unwrap_or(0)
-}
-
-/// Re-serialize a v1 arguments JSON object in source parameter-tag order.
-fn reorder_arguments(arguments: &str, function: &str) -> String {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
-        return arguments.to_string();
-    };
-    let Some(obj) = value.as_object() else {
-        return arguments.to_string();
-    };
-    let mut parts: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for name in source_parameter_order(function) {
-        if let Some(val) = obj.get(&name)
-            && seen.insert(name.clone())
-        {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(&name).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    // Append any keys not matched in source order (defensive; normally empty).
-    for (key, val) in obj {
-        if !seen.contains(key) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(key).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    format!("{{{}}}", parts.join(","))
 }
 
 /// TOP-LEVEL parameter tag names in the order they appear in an invoke run.

--- a/parsers/v2/src/tool_calling/mod.rs
+++ b/parsers/v2/src/tool_calling/mod.rs
@@ -12,6 +12,7 @@ pub mod kimi_k2;
 pub mod minimax_m2;
 pub mod minimax_m3;
 pub mod qwen3_coder;
+mod scan;
 pub mod traits;
 /// Vendored batch extraction copied from v1 so v2 is standalone (see module docs).
 mod v1core;

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -9,16 +9,19 @@
 //! is absent (shared with nemotron_nano).
 //!
 //! The streaming concern (buffering, chunk-split marker safety, normal_text
-//! suppression) is owned here. The per-block value typing is delegated to the v1
-//! batch XML parser `try_tool_call_parse_xml`, so a streamed call matches exactly
-//! what the batch parser produces (the DIS-2209 bar). Arguments are re-serialized
-//! in the source parameter order because the v1 parser builds them from a
-//! `HashMap` whose key order is non-deterministic; streaming fixtures store the
-//! arguments as an exact JSON string, so order has to be pinned to the
-//! model-emitted order (the order vLLM's Rust parser also preserves).
+//! suppression) is owned by the shared [`scan::WrappedBlockScanner`]. The
+//! per-block value typing is delegated to the v1 batch XML parser
+//! `try_tool_call_parse_xml`, so a streamed call matches exactly what the batch
+//! parser produces (the DIS-2209 bar). Arguments are re-serialized in the
+//! source parameter order because the v1 parser builds them from a `HashMap`
+//! whose key order is non-deterministic; streaming fixtures store the arguments
+//! as an exact JSON string, so order has to be pinned to the model-emitted
+//! order (the order vLLM's Rust parser also preserves).
 
-use std::collections::HashSet;
-
+use crate::tool_calling::scan::{
+    BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
+    reorder_arguments,
+};
 use crate::tool_calling::v1core::{ToolDefinition, XmlParserConfig, try_tool_call_parse_xml};
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
@@ -29,197 +32,73 @@ const FUNCTION_START: &str = "<function=";
 const FUNCTION_END: &str = "</function>";
 const PARAMETER_START: &str = "<parameter=";
 
-/// Stream parser for Qwen3-Coder XML tool calls.
-pub struct Qwen3CoderToolStreamParser {
-    buffer: String,
-    in_block: bool,
-    suppress_normal_text: bool,
-    next_index: usize,
+fn spec() -> WrappedBlockSpec {
+    WrappedBlockSpec {
+        family: "qwen3_coder",
+        block_starts: vec![BLOCK_START.to_string()],
+        block_ends: vec![BLOCK_END.to_string()],
+        invoke_start: FUNCTION_START.to_string(),
+        invoke_end: FUNCTION_END.to_string(),
+        orphan_markers: vec![BLOCK_END.to_string()],
+        // BLOCK_END is held back too so a split stray/orphan close (consumed
+        // and dropped by the orphan-close handler once complete) never emits
+        // its first half as text.
+        holdback_markers: vec![
+            BLOCK_START.to_string(),
+            BLOCK_END.to_string(),
+            FUNCTION_START.to_string(),
+        ],
+        bare_recovery_latch: BareRecoveryLatch::Set,
+        invoke_latch: InvokeLatch::IfEmitted,
+        drop_invoke_crossing_block_end: false,
+    }
+}
+
+/// Value-typing hook: wraps one complete `<function=...></function>` block in
+/// `<tool_call>` so the v1 parser takes its normal wrapped path, then re-orders
+/// the arguments to source order.
+struct Qwen3Emitter {
     config: XmlParserConfig,
     tools: Vec<ToolDefinition>,
+}
+
+impl InvokeEmitter for Qwen3Emitter {
+    fn parse_invoke(
+        &self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
+        let wrapped = format!("{BLOCK_START}{invoke}{BLOCK_END}");
+        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
+        let Some(call) = calls.into_iter().next() else {
+            return Ok(None);
+        };
+        let arguments =
+            reorder_arguments(&call.function.arguments, &source_parameter_order(invoke));
+        Ok(Some(ToolCallDelta {
+            tool_index,
+            name: Some(call.function.name),
+            arguments,
+        }))
+    }
+}
+
+/// Stream parser for Qwen3-Coder XML tool calls.
+pub struct Qwen3CoderToolStreamParser {
+    scanner: WrappedBlockScanner<Qwen3Emitter>,
 }
 
 impl Qwen3CoderToolStreamParser {
     pub fn new(tools: &[Tool]) -> Self {
         Self {
-            buffer: String::new(),
-            in_block: false,
-            suppress_normal_text: false,
-            next_index: 0,
-            config: XmlParserConfig::default(),
-            tools: tools.iter().map(ToolDefinition::from).collect(),
+            scanner: WrappedBlockScanner::new(
+                spec(),
+                Qwen3Emitter {
+                    config: XmlParserConfig::default(),
+                    tools: tools.iter().map(ToolDefinition::from).collect(),
+                },
+            ),
         }
-    }
-
-    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
-        let mut out = ToolParseResult::default();
-
-        loop {
-            if self.in_block {
-                // Close the block once no more complete functions precede its end.
-                if let Some(end) = self.buffer.find(BLOCK_END) {
-                    let function_before_end = self
-                        .buffer
-                        .find(FUNCTION_START)
-                        .is_some_and(|start| start < end);
-                    if !function_before_end {
-                        // Complete block fully closed: drop its markup and resume
-                        // keeping natural text (inter-block / trailing). Any later
-                        // block re-enters `in_block` and re-suppresses its markup.
-                        // Matches the v1 batch parser (cases 8.b/8.c/8.d).
-                        self.buffer.drain(..end + BLOCK_END.len());
-                        self.in_block = false;
-                        self.suppress_normal_text = false;
-                        continue;
-                    }
-                }
-
-                let Some(start) = self.buffer.find(FUNCTION_START) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "qwen3_coder_block_without_complete_function",
-                            "Qwen3-Coder stream dropped incomplete block at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                if start > 0 {
-                    self.buffer.drain(..start);
-                }
-                let Some(end) = self.buffer.find(FUNCTION_END) else {
-                    if flush {
-                        tracing::warn!(
-                            why = "qwen3_coder_incomplete_function",
-                            "Qwen3-Coder stream dropped incomplete function at EOF"
-                        );
-                        self.buffer.clear();
-                        self.in_block = false;
-                    }
-                    break;
-                };
-                let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                self.buffer.drain(..end + FUNCTION_END.len());
-                if let Some(delta) = self.parse_function_delta(&function)? {
-                    out.calls.push(delta);
-                    self.next_index += 1;
-                    self.suppress_normal_text = true;
-                }
-                continue;
-            }
-
-            // A recovered bare function suppresses its trailing markup; its stray
-            // `</tool_call>` close (cases 5.b/5.f) ENDS that markup context.
-            // Consume the orphan close and clear the latch so inter-call text —
-            // e.g. the single separator space before the next `<tool_call>` —
-            // flows through verbatim, matching the v1 jail+batch output.
-            // A stray/orphan close (`BLOCK_END`) before any opener is malformed
-            // double-close markup. Drop it so it can NEVER leak into normal_text;
-            // when suppression is off, first emit the natural text preceding it.
-            // Clear the latch either way (the markup context has ended).
-            if let Some(pos) = self.buffer.find(BLOCK_END) {
-                let next_open = [BLOCK_START, FUNCTION_START]
-                    .into_iter()
-                    .filter_map(|m| self.buffer.find(m))
-                    .min();
-                if next_open.is_none_or(|open| pos < open) {
-                    if !self.suppress_normal_text && pos > 0 {
-                        out.normal_text.push_str(&self.buffer[..pos]);
-                    }
-                    self.buffer.drain(..pos + BLOCK_END.len());
-                    self.suppress_normal_text = false;
-                    continue;
-                }
-            }
-
-            let block_start = self.buffer.find(BLOCK_START);
-            let bare_function_start = self.buffer.find(FUNCTION_START);
-            let next_marker = match (block_start, bare_function_start) {
-                (Some(b), Some(f)) if b <= f => Some((b, Marker::Block)),
-                (Some(_), Some(f)) => Some((f, Marker::BareFunction)),
-                (Some(b), None) => Some((b, Marker::Block)),
-                (None, Some(f)) => Some((f, Marker::BareFunction)),
-                (None, None) => None,
-            };
-
-            let Some((start, marker)) = next_marker else {
-                // No marker present: emit buffered text, but hold back a trailing
-                // partial marker (split across this chunk boundary) unless flushing.
-                let keep = if flush {
-                    0
-                } else {
-                    marker_prefix_suffix_len(&self.buffer)
-                };
-                let emit_len = self.buffer.len().saturating_sub(keep);
-                if emit_len > 0 {
-                    if !self.suppress_normal_text {
-                        out.normal_text.push_str(&self.buffer[..emit_len]);
-                    }
-                    self.buffer.drain(..emit_len);
-                }
-                break;
-            };
-
-            if start > 0 {
-                if !self.suppress_normal_text {
-                    out.normal_text.push_str(&self.buffer[..start]);
-                }
-                self.buffer.drain(..start);
-            }
-
-            match marker {
-                Marker::Block => {
-                    self.buffer.drain(..BLOCK_START.len());
-                    self.in_block = true;
-                    self.suppress_normal_text = true;
-                }
-                Marker::BareFunction => {
-                    let Some(end) = self.buffer.find(FUNCTION_END) else {
-                        if flush {
-                            tracing::warn!(
-                                why = "qwen3_coder_incomplete_bare_function",
-                                "Qwen3-Coder stream dropped incomplete bare function at EOF"
-                            );
-                            self.buffer.clear();
-                        }
-                        break;
-                    };
-                    let function = self.buffer[..end + FUNCTION_END.len()].to_string();
-                    self.buffer.drain(..end + FUNCTION_END.len());
-                    if let Some(delta) = self.parse_function_delta(&function)? {
-                        tracing::warn!(
-                            why = "qwen3_coder_bare_function_recovery",
-                            tool_index = delta.tool_index,
-                            "Qwen3-Coder stream recovered a complete bare function"
-                        );
-                        out.calls.push(delta);
-                        self.next_index += 1;
-                        self.suppress_normal_text = true;
-                    }
-                }
-            }
-        }
-
-        Ok(out)
-    }
-
-    /// Parse one complete `<function=...></function>` block into a delta.
-    ///
-    /// Wraps the function in `<tool_call>` so the v1 parser always takes its
-    /// normal wrapped path, then re-orders the arguments to source order.
-    fn parse_function_delta(&self, function: &str) -> anyhow::Result<Option<ToolCallDelta>> {
-        let wrapped = format!("{BLOCK_START}{function}{BLOCK_END}");
-        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
-        let Some(call) = calls.into_iter().next() else {
-            return Ok(None);
-        };
-        let arguments = reorder_arguments(&call.function.arguments, function);
-        Ok(Some(ToolCallDelta {
-            tool_index: self.next_index,
-            name: Some(call.function.name),
-            arguments,
-        }))
     }
 }
 
@@ -236,72 +115,12 @@ impl ToolParser for Qwen3CoderToolStreamParser {
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
-        self.buffer.push_str(chunk);
-        self.drain(false)
+        self.scanner.push(chunk)
     }
 
     fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
-        self.drain(true)
+        self.scanner.finish()
     }
-}
-
-#[derive(Clone, Copy)]
-enum Marker {
-    Block,
-    BareFunction,
-}
-
-/// Longest non-empty proper prefix of a marker that `text` ends with, so a
-/// marker split across chunk boundaries is held back instead of leaked as text.
-/// `BLOCK_END` is included so a split stray/orphan close (consumed and dropped by
-/// the orphan-close handler once complete) never emits its first half as text.
-fn marker_prefix_suffix_len(text: &str) -> usize {
-    [BLOCK_START, BLOCK_END, FUNCTION_START]
-        .into_iter()
-        .filter_map(|marker| {
-            marker
-                .char_indices()
-                .map(|(idx, _)| idx)
-                .filter(|idx| *idx > 0)
-                .filter(|idx| *idx < marker.len())
-                .rev()
-                .find(|&len| text.ends_with(&marker[..len]))
-        })
-        .max()
-        .unwrap_or(0)
-}
-
-/// Re-serialize a v1 arguments JSON object in source `<parameter=...>` order.
-fn reorder_arguments(arguments: &str, function: &str) -> String {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
-        return arguments.to_string();
-    };
-    let Some(obj) = value.as_object() else {
-        return arguments.to_string();
-    };
-    let mut parts: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for name in source_parameter_order(function) {
-        if let Some(val) = obj.get(&name) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(&name).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-            seen.insert(name);
-        }
-    }
-    // Append any keys not matched in source order (defensive; normally empty).
-    for (key, val) in obj {
-        if !seen.contains(key) {
-            parts.push(format!(
-                "{}:{}",
-                serde_json::to_string(key).unwrap_or_default(),
-                serde_json::to_string(val).unwrap_or_default()
-            ));
-        }
-    }
-    format!("{{{}}}", parts.join(","))
 }
 
 /// Parameter names in the order they appear in a function block.

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared streaming-scan core for the marker-delimited tool-call families.
+//!
+//! Before this module, every family reimplemented the same streaming concerns
+//! by copy-paste-and-edit: the longest-prefix marker holdback existed 7 times,
+//! the source-order argument reserialization 5 times, and the buffer-and-scan
+//! `drain(flush)` loop 7 times (the MiniMax M2 vs M3 copies were ~90%
+//! line-identical). Divergent copies are how chunk-boundary bugs get fixed in
+//! one family and stay broken in the others; this module is the single parent.
+//!
+//! Three layers, adopted per family as far as its grammar allows:
+//!
+//! * [`marker_prefix_suffix_len`] — partial-marker holdback, used by ALL
+//!   scan families (the bespoke ones compose it with extra components).
+//! * [`reorder_arguments`] — source-order argument reserialization for the
+//!   families that delegate typing to a v1core batch parser (which builds
+//!   arguments from a `HashMap` with nondeterministic key order).
+//! * [`WrappedBlockScanner`] — the whole drain loop for the four families
+//!   whose grammar is `BLOCK_START (INVOKE .. INVOKE_END)* BLOCK_END` with a
+//!   bare-invoke back-off: qwen3_coder, minimax_m2, minimax_m3, kimi_k2.
+//!   dsml (incremental invoke-header state), glm47 (identifier-anchored bare
+//!   recovery), and gemma4 (brace/string-aware end scanning) keep bespoke
+//!   drains and share the primitives.
+//!
+//! Behavior differences between the wrapped families are explicit
+//! [`WrappedBlockSpec`] fields, not silent copy drift — e.g. MiniMax M2
+//! clears the normal-text suppression latch after a bare-invoke recovery
+//! while M3/qwen3/kimi keep it latched ([`BareRecoveryLatch`]).
+
+use std::collections::HashSet;
+
+use crate::tool_calling::traits::{ToolCallDelta, ToolParseResult};
+
+/// Longest non-empty proper prefix of any `marker` that `text` ends with, so a
+/// marker split across chunk boundaries is held back instead of leaked as
+/// normal_text. Closing markers belong in the list too: a split stray/orphan
+/// close must be retained whole so the orphan-close path (which strips it and
+/// never lets it leak) can match it — otherwise the partial suffix is emitted
+/// (or, under a suppression latch, silently discarded) and the remainder is
+/// unrecognizable.
+pub(crate) fn marker_prefix_suffix_len<'a, I>(text: &str, markers: I) -> usize
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    markers
+        .into_iter()
+        .filter_map(|marker| {
+            marker
+                .char_indices()
+                .map(|(idx, _)| idx)
+                .filter(|idx| *idx > 0 && *idx < marker.len())
+                .rev()
+                .find(|&len| text.ends_with(&marker[..len]))
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// Re-serialize a v1core arguments JSON object in the model-emitted source
+/// order (`source_names`, extracted from the raw invoke body by the family).
+/// A repeated source name is emitted once (the v1 object holds one value per
+/// key); keys absent from the source order are appended in object order
+/// (defensive; normally empty). Non-object payloads pass through untouched.
+pub(crate) fn reorder_arguments(arguments: &str, source_names: &[String]) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(arguments) else {
+        return arguments.to_string();
+    };
+    let Some(obj) = value.as_object() else {
+        return arguments.to_string();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+    for name in source_names {
+        if let Some(val) = obj.get(name)
+            && seen.insert(name.as_str())
+        {
+            parts.push(format!(
+                "{}:{}",
+                serde_json::to_string(name).unwrap_or_default(),
+                serde_json::to_string(val).unwrap_or_default()
+            ));
+        }
+    }
+    for (key, val) in obj {
+        if !seen.contains(key.as_str()) {
+            parts.push(format!(
+                "{}:{}",
+                serde_json::to_string(key).unwrap_or_default(),
+                serde_json::to_string(val).unwrap_or_default()
+            ));
+        }
+    }
+    format!("{{{}}}", parts.join(","))
+}
+
+/// What happens to the normal-text suppression latch after a bare-invoke
+/// recovery emits a call.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BareRecoveryLatch {
+    /// Clear the latch: when the optional outer close is absent, later
+    /// narration must still reach normal_text (MiniMax M2 semantics; a stray
+    /// close that DOES follow is stripped by the orphan-close handling).
+    Clear,
+    /// Keep the latch set: trailing markup around the recovered invoke is
+    /// dropped until an orphan close ends the markup context
+    /// (MiniMax M3 / Qwen3-Coder / Kimi K2 semantics).
+    Set,
+}
+
+/// When the in-block invoke latch engages after parsing a complete invoke.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InvokeLatch {
+    /// Only when the invoke produced a call delta (XML families).
+    IfEmitted,
+    /// Always — even when the invoke parsed to nothing (Kimi K2).
+    Always,
+}
+
+/// Declarative description of one wrapped-invoke grammar.
+pub(crate) struct WrappedBlockSpec {
+    /// Family name used in tracing `why` diagnostics.
+    pub family: &'static str,
+    /// Block openers (Kimi has singular/plural section variants).
+    pub block_starts: Vec<String>,
+    /// Block closers, matched earliest-first.
+    pub block_ends: Vec<String>,
+    /// Invoke opener (prefix form is fine — it only anchors scanning).
+    pub invoke_start: String,
+    /// Invoke closer; an invoke is parsed only once this has streamed.
+    pub invoke_end: String,
+    /// Markers that are stray markup when seen OUTSIDE a block before any
+    /// opener; stripped so they never leak (always includes `block_ends`).
+    pub orphan_markers: Vec<String>,
+    /// Markers whose split prefixes are held back at chunk boundaries.
+    pub holdback_markers: Vec<String>,
+    pub bare_recovery_latch: BareRecoveryLatch,
+    pub invoke_latch: InvokeLatch,
+    /// Refuse to let an invoke body cross a block close: a `block_end` before
+    /// the `invoke_end` means the call is malformed — drop it and close the
+    /// block (Kimi K2's mismatched-fences rule).
+    pub drop_invoke_crossing_block_end: bool,
+}
+
+/// Per-family hook: parse one complete invoke (opener..closer inclusive) into
+/// a call delta. `None` means the invoke was malformed and is dropped.
+pub(crate) trait InvokeEmitter {
+    fn parse_invoke(
+        &self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>>;
+}
+
+/// First occurrence of any of `markers` in `text`: `(position, marker_len)`.
+fn find_first(text: &str, markers: &[String]) -> Option<(usize, usize)> {
+    markers
+        .iter()
+        .filter_map(|m| text.find(m.as_str()).map(|p| (p, m.len())))
+        .min_by_key(|(p, _)| *p)
+}
+
+#[derive(Clone, Copy)]
+enum Marker {
+    /// A block opener; carries the matched token length.
+    Block(usize),
+    /// A bare invoke opener with no block wrapper (recovery path).
+    BareInvoke,
+}
+
+/// The shared buffer-and-scan drain loop for wrapped-invoke grammars.
+///
+/// Streaming contract (identical to the loops it replaces): natural text
+/// around COMPLETE blocks is preserved verbatim (prefix / inter-block /
+/// trailing); markup of complete blocks is stripped; a bare invoke without
+/// its wrapper is recovered once complete; stray orphan closes are stripped
+/// and never leak; a partial marker at a chunk boundary is held back; at
+/// flush (EOF) incomplete blocks/invokes are dropped with a `why=` warning
+/// rather than leaked.
+pub(crate) struct WrappedBlockScanner<E: InvokeEmitter> {
+    spec: WrappedBlockSpec,
+    emitter: E,
+    buffer: String,
+    in_block: bool,
+    suppress_normal_text: bool,
+    next_index: usize,
+}
+
+impl<E: InvokeEmitter> WrappedBlockScanner<E> {
+    pub(crate) fn new(spec: WrappedBlockSpec, emitter: E) -> Self {
+        Self {
+            spec,
+            emitter,
+            buffer: String::new(),
+            in_block: false,
+            suppress_normal_text: false,
+            next_index: 0,
+        }
+    }
+
+    pub(crate) fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
+        self.buffer.push_str(chunk);
+        self.drain(false)
+    }
+
+    pub(crate) fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
+        self.drain(true)
+    }
+
+    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
+        let mut out = ToolParseResult::default();
+
+        loop {
+            if self.in_block {
+                let invoke_start = self.buffer.find(self.spec.invoke_start.as_str());
+
+                // Close the block once no more complete invokes precede its end.
+                if let Some((end_pos, end_len)) = find_first(&self.buffer, &self.spec.block_ends) {
+                    let invoke_before_end = invoke_start.is_some_and(|start| start < end_pos);
+                    if !invoke_before_end {
+                        // Complete block fully closed: drop its markup and resume
+                        // keeping natural text (inter-block / trailing). Any later
+                        // block re-enters `in_block` and re-suppresses its markup.
+                        // Matches the v1 batch parsers (cases 8.b/8.c/8.d).
+                        self.buffer.drain(..end_pos + end_len);
+                        self.in_block = false;
+                        self.suppress_normal_text = false;
+                        continue;
+                    }
+                }
+
+                let Some(start) = invoke_start else {
+                    if flush {
+                        tracing::warn!(
+                            why = %format!("{}_block_without_complete_invoke", self.spec.family),
+                            "stream dropped incomplete block at EOF"
+                        );
+                        self.buffer.clear();
+                        self.in_block = false;
+                    }
+                    break;
+                };
+                if start > 0 {
+                    self.buffer.drain(..start);
+                }
+                let Some(end) = self.buffer.find(self.spec.invoke_end.as_str()) else {
+                    if flush {
+                        tracing::warn!(
+                            why = %format!("{}_incomplete_invoke", self.spec.family),
+                            "stream dropped incomplete invoke at EOF"
+                        );
+                        self.buffer.clear();
+                        self.in_block = false;
+                    }
+                    break;
+                };
+                // Mismatched fences: a block close inside the invoke body means
+                // the invoke never closed. Drop it and close the block; narration
+                // after the close is the user's text again.
+                if self.spec.drop_invoke_crossing_block_end
+                    && let Some((be_pos, be_len)) = find_first(&self.buffer, &self.spec.block_ends)
+                    && be_pos < end
+                {
+                    tracing::warn!(
+                        why = %format!("{}_incomplete_invoke", self.spec.family),
+                        "stream dropped invoke missing its close before the block end"
+                    );
+                    self.buffer.drain(..be_pos + be_len);
+                    self.in_block = false;
+                    self.suppress_normal_text = false;
+                    continue;
+                }
+                let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
+                self.buffer.drain(..end + self.spec.invoke_end.len());
+                if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
+                    out.calls.push(delta);
+                    self.next_index += 1;
+                    if self.spec.invoke_latch == InvokeLatch::IfEmitted {
+                        self.suppress_normal_text = true;
+                    }
+                }
+                if self.spec.invoke_latch == InvokeLatch::Always {
+                    self.suppress_normal_text = true;
+                }
+                continue;
+            }
+
+            // Not in a block. A COMPLETE orphan marker (stray close / inner
+            // marker) before any opener is malformed markup: strip it so it can
+            // NEVER leak into normal_text; when suppression is off, first emit
+            // the natural text preceding it. Clear the latch either way (the
+            // markup context has ended).
+            if let Some((pos, len)) = find_first(&self.buffer, &self.spec.orphan_markers) {
+                let next_open = find_first(&self.buffer, &self.spec.block_starts)
+                    .map(|(p, _)| p)
+                    .into_iter()
+                    .chain(self.buffer.find(self.spec.invoke_start.as_str()))
+                    .min();
+                if next_open.is_none_or(|open| pos < open) {
+                    if !self.suppress_normal_text && pos > 0 {
+                        out.normal_text.push_str(&self.buffer[..pos]);
+                    }
+                    self.buffer.drain(..pos + len);
+                    self.suppress_normal_text = false;
+                    continue;
+                }
+            }
+
+            let block = find_first(&self.buffer, &self.spec.block_starts);
+            let bare = self.buffer.find(self.spec.invoke_start.as_str());
+            let next_marker = match (block, bare) {
+                (Some((b, blen)), Some(f)) if b <= f => Some((b, Marker::Block(blen))),
+                (Some(_), Some(f)) => Some((f, Marker::BareInvoke)),
+                (Some((b, blen)), None) => Some((b, Marker::Block(blen))),
+                (None, Some(f)) => Some((f, Marker::BareInvoke)),
+                (None, None) => None,
+            };
+
+            let Some((start, marker)) = next_marker else {
+                // No marker present: emit buffered text, but hold back a trailing
+                // partial marker (split across this chunk boundary) unless flushing.
+                let keep = if flush {
+                    0
+                } else {
+                    marker_prefix_suffix_len(
+                        &self.buffer,
+                        self.spec.holdback_markers.iter().map(String::as_str),
+                    )
+                };
+                let emit_len = self.buffer.len().saturating_sub(keep);
+                if emit_len > 0 {
+                    if !self.suppress_normal_text {
+                        out.normal_text.push_str(&self.buffer[..emit_len]);
+                    }
+                    self.buffer.drain(..emit_len);
+                }
+                break;
+            };
+
+            if start > 0 {
+                if !self.suppress_normal_text {
+                    out.normal_text.push_str(&self.buffer[..start]);
+                }
+                self.buffer.drain(..start);
+            }
+
+            match marker {
+                Marker::Block(blen) => {
+                    self.buffer.drain(..blen);
+                    self.in_block = true;
+                    self.suppress_normal_text = true;
+                }
+                Marker::BareInvoke => {
+                    // A bare invoke (no wrapper) is recovered only once its close
+                    // has streamed; otherwise wait for more input.
+                    let Some(end) = self.buffer.find(self.spec.invoke_end.as_str()) else {
+                        if flush {
+                            tracing::warn!(
+                                why = %format!("{}_incomplete_bare_invoke", self.spec.family),
+                                "stream dropped incomplete bare invoke at EOF"
+                            );
+                            self.buffer.clear();
+                        }
+                        break;
+                    };
+                    let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
+                    self.buffer.drain(..end + self.spec.invoke_end.len());
+                    if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
+                        tracing::warn!(
+                            why = %format!("{}_bare_invoke_recovery", self.spec.family),
+                            tool_index = delta.tool_index,
+                            "stream recovered a complete bare invoke"
+                        );
+                        out.calls.push(delta);
+                        self.next_index += 1;
+                        self.suppress_normal_text =
+                            self.spec.bare_recovery_latch == BareRecoveryLatch::Set;
+                    }
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}


### PR DESCRIPTION
Linear: [DIS-2408](https://linear.app/nvidia/issue/DIS-2408/research-vllm-0250-new-streaming-parser-engine)

Stacked on #131 (its split sweep is the safety net for this refactor).

#### Overview:

v2 streaming tool-call parsers only — this PR gives them ONE shared streaming core (seven families had copy-pasted the same holdback/drain/reorder code with small drifts) and fixes the gemma4 and deepseek_v4 chunking bugs #131 caught. `qwen3_coder`, `minimax_m2`, `minimax_m3`, `kimi_k2` collapse to a spec + typing hook; `dsml`, `glm47`, `gemma4` keep bespoke drains (different grammars) and adopt the shared primitives. Net −444 lines, all family unit tests kept verbatim.

#### Example (before → after):

Fixture `TOOLCALLING.streamv2.5.g` (gemma4), streamed **char-by-char** (sweep `k=1`): `I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>`

```
before:  calls = []
         normal_text = "I will check that. call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>"
after:   calls = [get_weather {"location":"NYC"}]
         normal_text = "I will check that. "
```

(The conformance table shows this case green even pre-fix: its recorded capture chunking delivers the whole `call:...` run in one chunk, which never triggers the bug — the failure only appears at finer splits, exactly what #131's sweep exercises.)

Fixture `TOOLCALLING.streamv2.5.f` (deepseek_v4) — a bare invoke + orphan `</｜DSML｜tool_calls>` + a space + a wrapped block, split inside the orphan close:

```
before:  normal_text = ""     ← inter-block " " silently dropped (suppression latch never cleared)
after:   normal_text = " "    ← matches the single-shot parse
```

#### Details:

- `scan.rs`: `marker_prefix_suffix_len` (was 7 copies), `reorder_arguments` (was 5), and `WrappedBlockScanner` — the whole drain loop for the 4 wrapped-invoke families; per-family differences are explicit spec fields (`BareRecoveryLatch`, `InvokeLatch`, `drop_invoke_crossing_block_end`), not copy drift
- Fix mechanics: gemma4 (`streamv2.5.b/f/g`) holdback now retains a partial `call:` prefix / `call:NAME` tail; dsml (`streamv2.5.f`) holdback now retains a split block close so the latch can clear — both allowlist entries deleted, and the sweep's stale-detection proves the fixes
- glm47 streamv2.5.h stays allowlisted: there the single-shot side is wrong (prose `that.` misread as a function name); needs a dynamo_v2 overlay re-record

#### Verification:

121 parsers-v2 unit tests (kept verbatim), per-chunk stream parity, batch-via-stream parity, and the ~48k-chunking sweep all green; clippy -D warnings; HTML render unchanged.

#### Where should the reviewer start?

`parsers/v2/src/tool_calling/scan.rs`, then `minimax_m2.rs` (smallest conversion), then `gemma4.rs` + `dsml.rs` (bug fixes)

/coderabbit profile chill




