### PR TITLE
test(parsers/v1): NO PARSER CHANGE — add n>1 per-choice interleave isolation lane (DIS-2381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "dynamo-conformance-fixtures-v2"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "dynamo-parsers",
  "dynamo-parsers-v2",
  "serde",

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -9,6 +9,7 @@ description = "Runs the vendored Dynamo parity fixtures against dynamo-parsers"
 publish = false
 
 [dev-dependencies]
+anyhow = { workspace = true }
 dynamo-parsers = { workspace = true }
 dynamo-parsers-v2 = { path = "../parsers/v2", version = "0.1.27" }
 serde = { workspace = true, features = ["derive"] }

--- a/conformance/tests/parity_toolcalling_stream_interleave.rs
+++ b/conformance/tests/parity_toolcalling_stream_interleave.rs
@@ -1,0 +1,1239 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-choice isolation sweep for Dynamo parser v2 (DIS-2381 step 3).
+//!
+//! Invariant under test, applied across the whole streamv2 corpus:
+//!
+//! ```text
+//!   demux(parse(interleave(A@0, B@1))) == (parse(A), parse(B))
+//! ```
+//!
+//! `parity_toolcalling_stream.rs` proves each case parses correctly on its own.
+//! It cannot prove a `ToolParser` keeps its state isolated per `choice.index`,
+//! because every fixture is single-choice. When a real `n>1` caller multiplexes
+//! several completions onto one wire, it must hand each choice's delta to that
+//! choice's own parser instance; a host that shared one parser across choices
+//! would splice one choice's partial marker/JSON into another.
+//!
+//! This lane builds the missing multi-choice stream from the existing corpus: it
+//! pairs cases *within a family* (same tools/parser), interleaves them under the
+//! deterministic schedules from `parsers/v1/tests/common/interleave.rs` (reused
+//! directly — one source of truth across crates), routes each tagged delta to a
+//! per-`choice.index` parser via a `ChoiceRouter`, then demuxes each choice.
+//!
+//! # Two oracles, and why the solo run alone is not enough
+//!
+//! Each demuxed choice is compared against TWO goldens:
+//!
+//! 1. **Recorded `dynamo_v2` capture (primary, absolute).** The corpus's own
+//!    per-chunk `expected:` / `normal_text`, folded to the assembled shape, with
+//!    `arguments` kept as the RAW recorded string.
+//! 2. **Solo run of that choice's demuxed subsequence (secondary, relative).**
+//!
+//! The solo run alone is NOT a sufficient oracle, and this is not hypothetical.
+//! It is produced in the same process as the interleaved run, so any
+//! process-global state — a `OnceLock`/`lazy_static` cache, anything memoised on
+//! the first tool set — corrupts BOTH sides identically and they still compare
+//! equal while both are wrong. rmccorm4 demonstrated exactly this on PR #135 by
+//! caching the first tool configuration in a `OnceLock`: this lane passed all
+//! 1088 pair-schedules while canonical parity reported real failures. Running the
+//! solos first does not help — that changes which side seeds the cache, not the
+//! fact that they share it. Only a golden recorded in an EARLIER process closes
+//! it, hence oracle 1.
+//!
+//! Oracle 2 is kept for two reasons. It localises a divergence to cross-choice
+//! leakage rather than to whole-corpus drift, and it is the ONLY oracle that can
+//! see emission TIMING: the recorded corpus stores totals, so oracle 1 compares
+//! totals alone. A parser that stalls a choice while a sibling is live and
+//! releases the correct bytes at `finish` has identical totals and is invisible
+//! to oracle 1; `EngineResult::emission_profile`, compared against the solo run,
+//! is what catches it.
+//!
+//! KNOWN LIMIT of oracle 2: it is produced in this process, so a defect that
+//! poisons state PERMANENTLY and process-globally (rather than only while two
+//! parsers coexist) degrades the solo run identically and compares equal. That
+//! is the same class oracle 1 exists to cover for totals; for timing there is no
+//! recorded baseline to anchor to, and closing it would need a baseline captured
+//! in a separate process. Coexistence-scoped stalls — the realistic per-request
+//! bug — are caught.
+//!
+//! `BoundarySplit` re-chunks the input while the recorded capture describes the
+//! ORIGINAL chunking, so oracle 1 is only meaningful there while the parser's
+//! assembled output is chunking-invariant. `sweep_toolcalling_stream.rs` enforces
+//! exactly that against `conformance/toolcalling/known-chunking-divergences.yaml`
+//! (empty today). This lane consults the SAME allow-list and drops oracle 1 for
+//! an allow-listed case under `BoundarySplit`, so adding an entry there can never
+//! turn into a spurious isolation failure here. Oracle 2 still applies, because
+//! the solo golden is built from the same re-chunked subsequence.
+
+#[path = "../../parsers/v1/tests/common/interleave.rs"]
+mod interleave;
+
+mod common;
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use common::{collect_yaml, ensure_fixtures, version_dirs_ascending};
+use dynamo_parsers_v2::{
+    Tool, ToolCallDelta, ToolParser, ToolParserInput, create_tool_parser_for_family,
+};
+use interleave::{Schedule, demux_items, interleave_items};
+use serde::Deserialize;
+
+// ── Family registry (single source of truth) ────────────────────────────────
+
+/// Rows of `conformance/utils/src/parser_families.yaml`. A family is exercised
+/// here iff it has a non-null `dynamo_v2` id — derived, never hardcoded, so
+/// registering a new v2 family auto-enrolls it.
+#[derive(Deserialize)]
+struct Registry {
+    families: BTreeMap<String, FamilyRow>,
+}
+
+#[derive(Deserialize)]
+struct FamilyRow {
+    dynamo_v2: Option<String>,
+    /// `tokens` (Harmony token-native path) or `text`.
+    preferred_input: String,
+}
+
+/// The chunking allow-list `sweep_toolcalling_stream.rs` enforces against.
+/// Loaded here so `BoundarySplit` can drop the recorded oracle for exactly the
+/// cases whose assembled output is known to depend on where the stream is split.
+fn load_chunking_allowlist() -> BTreeMap<String, BTreeMap<String, String>> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("toolcalling/known-chunking-divergences.yaml");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: read error: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("{}: parse error: {e}", path.display()))
+}
+
+fn load_registry() -> Registry {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("utils/src/parser_families.yaml");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: read error: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("{}: parse error: {e}", path.display()))
+}
+
+// ── Fixture schema ───────────────────────────────────────────────────────────
+//
+// Inputs (shared per-chunk deltas) live in `inputs/`; Dynamo's recorded output
+// lives in `dynamo_v2-<ver>/`. Both are loaded: the recorded output is the
+// PRIMARY oracle (see the module header on why the solo run alone is not enough).
+
+#[derive(Deserialize)]
+struct Fixture {
+    /// The fixture's OWN family key, as `conformance_toolcalling_stream.rs` and
+    /// `sweep_toolcalling_stream.rs` both read it. Deriving it from the parent
+    /// directory instead would diverge from those lanes the moment a fixture sits
+    /// deeper than `inputs/<family>/`, since `collect_yaml` recurses — and every
+    /// consequence of a wrong key here FAILS OPEN (the family looks like
+    /// `dynamo_v2=null` and is skipped, or the chunking allow-list never matches).
+    family: String,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    cases: BTreeMap<String, Case>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Case {
+    #[serde(default)]
+    tools: Vec<Tool>,
+    #[serde(default)]
+    chunks: Vec<Chunk>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Chunk {
+    #[serde(default)]
+    delta_text: String,
+    #[serde(default)]
+    delta_token_ids: Vec<u32>,
+    /// Deserialized only so a MID-STREAM terminator can be detected and the case
+    /// skipped. The canonical lane calls `finish()` at the chunk carrying
+    /// `finish_reason` and keeps pushing afterwards; this lane finishes once, at
+    /// end of stream. Those agree only while `finish_reason` sits on the last
+    /// chunk (true for all 272 enabled-family cases today). A fixture that
+    /// terminated mid-stream would assemble differently here and diverge from the
+    /// recorded oracle for reasons unrelated to per-choice isolation — so such a
+    /// case is skipped and named instead of silently mis-compared.
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+impl Case {
+    /// Why this case cannot be compared against the recorded oracle, if so.
+    ///
+    /// Two shapes are excluded, and BOTH must be, because this lane finishes each
+    /// choice exactly once at the end of its own stream:
+    ///
+    /// * a terminator before the last chunk — the canonical lane calls `finish()`
+    ///   there and keeps pushing, which assembles differently;
+    /// * NO terminator at all — the recorded reference was captured without the
+    ///   parser's closing output, so the closing output this lane produces would
+    ///   be reported as per-choice leakage when nothing about multiple choices is
+    ///   wrong.
+    ///
+    /// All 272 enabled-family cases carry exactly one terminator, on the last
+    /// chunk, so neither exclusion fires today.
+    fn unterminated_reason(&self) -> Option<&'static str> {
+        if self.chunks.is_empty() {
+            return Some("no chunks");
+        }
+        let last = self.chunks.len() - 1;
+        if self
+            .chunks
+            .iter()
+            .enumerate()
+            .any(|(i, c)| c.finish_reason.is_some() && i != last)
+        {
+            return Some("finish_reason mid-stream");
+        }
+        if self.chunks[last].finish_reason.is_none() {
+            return Some("no finish_reason on the last chunk");
+        }
+        None
+    }
+}
+
+// ── Recorded dynamo_v2 output (the absolute oracle) ──────────────────────────
+//
+// Same shape the canonical `conformance_toolcalling_stream.rs` overlay uses.
+// Capture dirs fold ASCENDING (latest wins per case), and a `unavailable`
+// entry means the v2 parser cannot handle that case — such cases are skipped
+// and NAMED, never silently counted as passing.
+
+#[derive(Deserialize)]
+struct DynFixture {
+    #[serde(default)]
+    cases: BTreeMap<String, DynCase>,
+}
+
+#[derive(Deserialize)]
+struct DynCase {
+    #[serde(default)]
+    unavailable: Option<String>,
+    #[serde(default)]
+    chunks: Vec<DynChunk>,
+}
+
+#[derive(Deserialize)]
+struct DynChunk {
+    #[serde(default)]
+    expected: Vec<FixtureDelta>,
+    #[serde(default)]
+    normal_text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FixtureDelta {
+    index: u32,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+/// One case's recorded dynamo_v2 output, already folded to the assembled shape
+/// this lane compares against. `None` = the case is unavailable for v2.
+type RecordedCases = BTreeMap<String, Option<EngineResult>>;
+
+/// Fold every `dynamo_v2-<ver>/<rel>` capture into the assembled per-case
+/// expectation.
+///
+/// Folding is PER CHUNK INDEX, matching `merge_dynamo` in the canonical
+/// `conformance_toolcalling_stream.rs`. Replacing the whole case instead would
+/// diverge from canonical the moment a newer capture recorded FEWER chunks than
+/// an older one for the same case: canonical keeps the older capture's
+/// expectations for the trailing chunks, a whole-case replace would silently
+/// truncate the oracle and report a spurious divergence. No committed capture
+/// does that today, but the two lanes must not disagree about what the corpus
+/// means.
+///
+/// `input_chunks` maps case id -> the INPUT's chunk count. Recorded chunks beyond
+/// that are DROPPED, matching canonical `merge_dynamo`, which only writes into
+/// `case.chunks.get_mut(i)`. Keeping them would let a stale longer recording of a
+/// since-shortened fixture demand output that no longer exists, and this lane
+/// would report it as an isolation divergence.
+fn load_recorded(
+    dyn_dirs: &[PathBuf],
+    rel: &Path,
+    input_chunks: &BTreeMap<String, usize>,
+) -> RecordedCases {
+    // Per case: the merged per-chunk overlay PLUS a separate unavailability flag.
+    //
+    // The flag must be tracked ALONGSIDE the chunks, never by replacing them with
+    // `None`: canonical `merge_dynamo` only sets/clears `unavailable` and leaves
+    // the merged chunks in place. Collapsing the case to `None` on an
+    // intermediate `unavailable` capture destroys everything merged so far, so
+    // the sequence old(chunks 0..n) -> mid(unavailable) -> new(chunk 0 only)
+    // would yield new-chunk-0 alone here while canonical yields
+    // new-chunk-0 + old-chunks-1..n. No committed capture history has that shape
+    // today, but the two lanes must not disagree about what the corpus means.
+    #[derive(Default)]
+    struct Merged {
+        chunks: Vec<DynChunk>,
+        unavailable: bool,
+    }
+    let mut merged: BTreeMap<String, Merged> = BTreeMap::new();
+    for dir in dyn_dirs {
+        let dfp = dir.join(rel);
+        // A missing overlay is benign; any other I/O error must surface.
+        let text = match std::fs::read_to_string(&dfp) {
+            Ok(t) => t,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => panic!("{}: dynamo overlay read error: {e}", dfp.display()),
+        };
+        let fx: DynFixture = serde_yaml::from_str(&text)
+            .unwrap_or_else(|e| panic!("{}: dynamo overlay parse error: {e}", dfp.display()));
+        for (cid, dcase) in fx.cases {
+            let cid_key = cid.clone();
+            let slot = merged.entry(cid).or_default();
+            if dcase.unavailable.is_some() {
+                // Flag it, but KEEP the chunks merged so far.
+                slot.unavailable = true;
+                continue;
+            }
+            // A later capture that supplies expectations CLEARS the flag without
+            // discarding what earlier captures recorded.
+            slot.unavailable = false;
+            // Bound by the INPUT's chunk count, exactly as merge_dynamo does.
+            let limit = input_chunks.get(&cid_key).copied().unwrap_or(0);
+            for (i, dchunk) in dcase.chunks.into_iter().enumerate() {
+                if i >= limit {
+                    break;
+                }
+                if i < slot.chunks.len() {
+                    slot.chunks[i] = dchunk;
+                } else {
+                    slot.chunks.push(dchunk);
+                }
+            }
+        }
+    }
+
+    merged
+        .into_iter()
+        .map(|(cid, m)| {
+            let assembled = (!m.unavailable).then(|| assemble_recorded(&m.chunks));
+            (cid, assembled)
+        })
+        .collect()
+}
+
+/// Concatenate a case's merged per-chunk capture into the assembled shape this
+/// lane compares against.
+fn assemble_recorded(chunks: &[DynChunk]) -> EngineResult {
+    let mut names: BTreeMap<u32, String> = BTreeMap::new();
+    let mut args: BTreeMap<u32, String> = BTreeMap::new();
+    let mut order: Vec<u32> = Vec::new();
+    let mut normal_text = String::new();
+    for chunk in chunks {
+        for d in &chunk.expected {
+            if !order.contains(&d.index) {
+                order.push(d.index);
+            }
+            if let Some(n) = &d.name {
+                names.entry(d.index).or_default().push_str(n);
+            }
+            if let Some(a) = &d.arguments {
+                args.entry(d.index).or_default().push_str(a);
+            }
+        }
+        if let Some(nt) = &chunk.normal_text {
+            normal_text.push_str(nt);
+        }
+    }
+    let calls = order
+        .into_iter()
+        .map(|i| {
+            (
+                names.get(&i).cloned().unwrap_or_default(),
+                args.get(&i).cloned().unwrap_or_default(),
+            )
+        })
+        .collect();
+    EngineResult {
+        calls,
+        normal_text,
+        emission_profile: Vec::new(),
+    }
+}
+
+// ── Assembled per-choice result ──────────────────────────────────────────────
+
+/// Assembled per-choice output. `arguments` stays a RAW string, never re-parsed
+/// into a `Value`: the corpus records it verbatim (`{"location":"NYC"}`), and
+/// round-tripping through `serde_json` would normalise key order and whitespace,
+/// hiding a formatting divergence the recorded oracle is there to catch.
+#[derive(Debug, PartialEq, Clone, Default)]
+struct EngineResult {
+    calls: Vec<(String, String)>,
+    normal_text: String,
+    /// STREAMING SHAPE: running `(delta count, normal-text length)` sampled after
+    /// each `push_input` for this choice, plus once after `finish`.
+    ///
+    /// Totals alone cannot see a defect that DELAYS a choice's output. A parser
+    /// that stalls as soon as a second instance exists and releases the correct
+    /// bytes at `finish` produces identical totals while a real client watches
+    /// choice 0 go silent for the whole of choice 1's stream. Sampling per push
+    /// puts emission timing INSIDE the compared value.
+    ///
+    /// Empty when the value came from the recorded corpus, which has no timing
+    /// information — the recorded oracle stays a totals-only comparison and the
+    /// profile is checked against the solo run.
+    emission_profile: Vec<(usize, usize)>,
+}
+
+/// Fold a choice's emitted tool-call deltas + normal text into assembled calls.
+/// `tool_index` is parser-local; each choice owns its parser so indices never
+/// collide across choices.
+fn assemble(deltas: &[ToolCallDelta], normal_text: String) -> EngineResult {
+    let mut names: BTreeMap<usize, String> = BTreeMap::new();
+    let mut args: BTreeMap<usize, String> = BTreeMap::new();
+    let mut order: Vec<usize> = Vec::new();
+    for d in deltas {
+        if !order.contains(&d.tool_index) {
+            order.push(d.tool_index);
+        }
+        if let Some(name) = &d.name {
+            names.entry(d.tool_index).or_default().push_str(name);
+        }
+        args.entry(d.tool_index).or_default().push_str(&d.arguments);
+    }
+    let calls = order
+        .into_iter()
+        .map(|idx| {
+            (
+                names.get(&idx).cloned().unwrap_or_default(),
+                args.get(&idx).cloned().unwrap_or_default(),
+            )
+        })
+        .collect();
+    EngineResult {
+        calls,
+        normal_text,
+        emission_profile: Vec::new(),
+    }
+}
+
+// ── ChoiceRouter: one parser instance per choice.index ───────────────────────
+
+/// Routes tagged deltas to a per-`choice.index` `ToolParser`, exactly what an
+/// `n>1` caller must do: a completion's deltas always reach the parser holding
+/// that completion's state, never a sibling's. Building one parser per index on
+/// first sight (with that index's tools) mirrors real per-request construction.
+struct ChoiceRouter {
+    /// The REGISTERED parser id (`parser_families.yaml` -> `dynamo_v2`), not the
+    /// fixture directory name. The registry explicitly allows the two to differ
+    /// (`harmony_text: {dynamo_v2: harmony}`); constructing from the directory
+    /// name only works by accident where the factory also matches the literal
+    /// key, and would bail for any future row whose id differs.
+    parser_id: String,
+    parsers: HashMap<u32, Box<dyn ToolParser>>,
+    deltas: HashMap<u32, Vec<ToolCallDelta>>,
+    normal: HashMap<u32, String>,
+    /// Per choice: running `(delta count, normal-text length)` sampled after each
+    /// push and once after that choice's finish.
+    profile: HashMap<u32, Vec<(usize, usize)>>,
+    finished: HashMap<u32, bool>,
+}
+
+impl ChoiceRouter {
+    fn new(parser_id: &str) -> Self {
+        Self {
+            parser_id: parser_id.to_string(),
+            parsers: HashMap::new(),
+            deltas: HashMap::new(),
+            normal: HashMap::new(),
+            profile: HashMap::new(),
+            finished: HashMap::new(),
+        }
+    }
+
+    fn push(
+        &mut self,
+        index: u32,
+        tools: &[Tool],
+        input: ToolParserInput<'_>,
+    ) -> anyhow::Result<()> {
+        let res = {
+            let parser_id = &self.parser_id;
+            let parser = match self.parsers.entry(index) {
+                std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(create_tool_parser_for_family(parser_id, tools)?)
+                }
+            };
+            parser.push_input(input)?
+        };
+        self.normal
+            .entry(index)
+            .or_default()
+            .push_str(&res.normal_text);
+        self.deltas.entry(index).or_default().extend(res.calls);
+        self.sample(index);
+        Ok(())
+    }
+
+    fn sample(&mut self, index: u32) {
+        let calls = self.deltas.get(&index).map_or(0, Vec::len);
+        let text = self.normal.get(&index).map_or(0, String::len);
+        self.profile.entry(index).or_default().push((calls, text));
+    }
+
+    /// Finish ONE choice, at the point its own stream ends. Idempotent.
+    fn finish_choice(&mut self, index: u32) -> anyhow::Result<()> {
+        if self.finished.get(&index).copied().unwrap_or(false) {
+            return Ok(());
+        }
+        self.finished.insert(index, true);
+        if let Some(parser) = self.parsers.get_mut(&index) {
+            let res = parser.finish()?;
+            self.normal
+                .entry(index)
+                .or_default()
+                .push_str(&res.normal_text);
+            self.deltas.entry(index).or_default().extend(res.calls);
+        }
+        self.sample(index);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> anyhow::Result<()> {
+        let indices: Vec<u32> = self.parsers.keys().copied().collect();
+        for index in indices {
+            self.finish_choice(index)?;
+        }
+        Ok(())
+    }
+
+    fn assembled(&self, index: u32) -> EngineResult {
+        let mut r = assemble(
+            self.deltas.get(&index).map(Vec::as_slice).unwrap_or(&[]),
+            self.normal.get(&index).cloned().unwrap_or_default(),
+        );
+        r.emission_profile = self.profile.get(&index).cloned().unwrap_or_default();
+        r
+    }
+}
+
+/// Run one choice's items solo through a fresh single parser (the golden).
+fn solo<T>(
+    parser_id: &str,
+    tools: &[Tool],
+    items: &[T],
+    to_input: fn(&T) -> ToolParserInput<'_>,
+) -> anyhow::Result<EngineResult> {
+    let mut router = ChoiceRouter::new(parser_id);
+    for item in items {
+        router.push(0, tools, to_input(item))?;
+    }
+    router.finish()?;
+    Ok(router.assembled(0))
+}
+
+// ── Generic pair check over one item representation ──────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn check_pair<T: interleave::Splittable>(
+    parser_id: &str,
+    tools_a: &[Tool],
+    seq_a: &[T],
+    tools_b: &[Tool],
+    seq_b: &[T],
+    schedule: Schedule,
+    to_input: fn(&T) -> ToolParserInput<'_>,
+    label: &str,
+    recorded: [&EngineResult; 2],
+    chunking_divergent: [bool; 2],
+    chunking_skips: &mut Vec<String>,
+    failures: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    let sequences = vec![seq_a.to_vec(), seq_b.to_vec()];
+    let tagged = interleave_items(&sequences, schedule);
+    let demuxed = demux_items(&tagged);
+    let tools_by_index = [tools_a, tools_b];
+
+    // Interleaved run through ONE router (per-choice parsers).
+    //
+    // STAGGERED TERMINATION: each choice is finished at the point ITS OWN stream
+    // ends, which for the shorter choice lands mid-wire while the sibling is
+    // still streaming. Finishing every parser together at the end of the wire —
+    // as this lane used to — cannot reach a defect that tears down sibling state
+    // when the first choice terminates.
+    let mut remaining: BTreeMap<u32, usize> = BTreeMap::new();
+    for (index, _) in &tagged {
+        *remaining.entry(*index).or_default() += 1;
+    }
+    let mut router = ChoiceRouter::new(parser_id);
+    let mut interleaved_err: Option<anyhow::Error> = None;
+    'wire: {
+        for (index, item) in &tagged {
+            if let Err(e) = router.push(*index, tools_by_index[*index as usize], to_input(item)) {
+                interleaved_err = Some(e);
+                break 'wire;
+            }
+            let left = remaining.get_mut(index).unwrap();
+            *left -= 1;
+            if *left == 0
+                && let Err(e) = router.finish_choice(*index)
+            {
+                interleaved_err = Some(e);
+                break 'wire;
+            }
+        }
+        if let Err(e) = router.finish() {
+            interleaved_err = Some(e);
+        }
+    }
+
+    // A parser error on the interleaved wire is NOT automatically a skip.
+    //
+    // Counting it as one is fail-open on the exact defect this lane exists to
+    // find: an error that appears ONLY while two choices are live is cross-choice
+    // interference, and skipping it lets the suite exit green over the real thing.
+    // So when the wire errors, re-run each choice ALONE on the same items. If both
+    // succeed solo, the error is caused by the sibling's presence -> FAILURE. If a
+    // solo run errors too, the parser simply cannot handle that shape -> the error
+    // propagates to the caller and is logged as a named skip.
+    if let Some(e) = interleaved_err {
+        // Drop the interleaved parsers FIRST. The probe must be a genuine
+        // single-parser run; leaving the wire's parsers alive would let a
+        // coexistence-triggered defect break the probe too and disguise itself as
+        // an unsupported shape — the precise fail-open being closed here.
+        drop(router);
+        let mut solo_ok = true;
+        for index in [0u32, 1] {
+            let items = demuxed.get(&index).cloned().unwrap_or_default();
+            if solo(parser_id, tools_by_index[index as usize], &items, to_input).is_err() {
+                solo_ok = false;
+            }
+        }
+        if solo_ok {
+            failures.push(format!(
+                "schedule={} {label}: interleaved run FAILED but both choices parse alone \
+                 -- this is cross-choice interference, not an unsupported shape: {e}",
+                schedule.label(),
+            ));
+            return Ok(());
+        }
+        return Err(e);
+    }
+
+    for index in [0u32, 1] {
+        let got = router.assembled(index);
+
+        // `BoundarySplit` RE-CHUNKS the input while the recorded capture describes
+        // the ORIGINAL chunking, so oracle 1 only means something there while this
+        // case's assembled output is chunking-invariant.
+        //
+        // The allow-list alone is NOT a sufficient guard for that. It is populated
+        // by `sweep_toolcalling_stream.rs`, whose invariance check is WEAKER than
+        // the comparison here: the sweep normalises arguments through
+        // `serde_json::from_str` and keys calls by name, while this lane compares
+        // the RAW argument string and orders calls by first appearance. A parser
+        // whose chunking sensitivity is confined to argument whitespace or key
+        // order, or to a call that never emits a name, would pass the sweep — so no
+        // allow-list entry would ever be added — and then fail HERE, reported as a
+        // per-choice isolation divergence it is not.
+        //
+        // So decide chunking-invariance BY THIS LANE'S OWN COMPARISON: run this
+        // choice solo at the original chunking and at the split chunking. If those
+        // disagree the case is chunking-sensitive by the standard actually being
+        // applied, and oracle 1 is skipped and NAMED rather than misattributed.
+        // The allow-list is still honoured as a cheap short-circuit.
+        let mut recorded_applies = true;
+        if matches!(schedule, Schedule::BoundarySplit { .. }) {
+            if chunking_divergent[index as usize] {
+                // NAME it: an allow-listed case dropped from oracle 1 silently would
+                // contradict the summary's claim that every skip is reported.
+                recorded_applies = false;
+                chunking_skips.push(format!(
+                    "{label} choice={index} schedule={}: allow-listed in \
+                     known-chunking-divergences.yaml; oracle 1 skipped",
+                    schedule.label()
+                ));
+            } else {
+                let split_items = demuxed.get(&index).cloned().unwrap_or_default();
+                let orig_items = sequences[index as usize].clone();
+                let at_split = solo(
+                    parser_id,
+                    tools_by_index[index as usize],
+                    &split_items,
+                    to_input,
+                )?;
+                let at_orig = solo(
+                    parser_id,
+                    tools_by_index[index as usize],
+                    &orig_items,
+                    to_input,
+                )?;
+                // Totals only: profiles differ by construction when the input is
+                // re-chunked, which is not what is being decided here.
+                let totals = |r: &EngineResult| (r.calls.clone(), r.normal_text.clone());
+                if totals(&at_split) != totals(&at_orig) {
+                    recorded_applies = false;
+                    chunking_skips.push(format!(
+                        "{label} choice={index} schedule={}: output is chunking-dependent \
+                         (solo differs between original and split chunking); oracle 1 \
+                         skipped, this is NOT an isolation failure",
+                        schedule.label()
+                    ));
+                }
+            }
+        }
+
+        // PRIMARY (absolute) oracle: the recorded dynamo_v2 capture for this case.
+        // Anchoring to a value produced in an EARLIER process is what makes this
+        // lane immune to shared-global corruption — an in-process golden would be
+        // corrupted identically and still compare equal.
+        // The recorded corpus has no timing information, so oracle 1 compares
+        // TOTALS only; the streaming profile is checked against the solo run below.
+        let got_totals = EngineResult {
+            emission_profile: Vec::new(),
+            ..got.clone()
+        };
+        if recorded_applies && &got_totals != recorded[index as usize] {
+            let want = recorded[index as usize];
+            failures.push(format!(
+                "schedule={} {label} choice={index} diverged from recorded dynamo_v2:\n     got  {got_totals:?}\n     want {want:?}",
+                schedule.label(),
+            ));
+            // Already failing against the absolute oracle; the relative one adds
+            // nothing but noise for this choice.
+            continue;
+        }
+
+        // SECONDARY (relative) oracle: the solo run of this choice's demuxed
+        // subsequence. Weaker than the recorded capture, but it is the check that
+        // localises a divergence to cross-choice leakage rather than to a
+        // whole-corpus drift, and it covers the split-boundary dimension the
+        // recorded capture has no chunking for.
+        let items = demuxed.get(&index).cloned().unwrap_or_default();
+        let golden = solo(parser_id, tools_by_index[index as usize], &items, to_input)?;
+        if got != golden {
+            failures.push(format!(
+                "schedule={} {label} choice={index} diverged from solo golden:\n     got  {got:?}\n     want {golden:?}",
+                schedule.label(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+// `&String` (not `&str`) so it can be passed as a fn pointer where the generic
+// item type is `String` — same reason as `token_input` below.
+#[allow(clippy::ptr_arg)]
+fn text_input(s: &String) -> ToolParserInput<'_> {
+    ToolParserInput::Text(s.as_str())
+}
+
+#[allow(clippy::ptr_arg)]
+fn token_input(v: &Vec<u32>) -> ToolParserInput<'_> {
+    ToolParserInput::Tokens(v.as_slice())
+}
+
+// ── Deterministic within-family pairing ──────────────────────────────────────
+
+/// Adjacent pairs + first-with-last over sorted case IDs. Budget-bounded (not
+/// all-pairs); deterministic (no RNG).
+fn pairs_for(ids: &[String]) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    for i in 0..ids.len().saturating_sub(1) {
+        out.push((i, i + 1));
+    }
+    if ids.len() >= 3 {
+        out.push((0, ids.len() - 1));
+    }
+    out
+}
+
+/// `BoundarySplit` is swept over both victims: a schedule that only ever splits
+/// choice 0 cannot see a parser that breaks when the SIBLING is the split one.
+/// Two ratios (not just the midpoint) cover non-midpoint boundaries such as
+/// `<tool_ | call>`; the corpus is large enough that a full split-point sweep
+/// belongs in the small hand-authored v1 lane rather than here.
+fn schedules() -> Vec<Schedule> {
+    vec![
+        Schedule::RoundRobin,
+        Schedule::FirstByteOffset(1),
+        Schedule::FirstByteOffset(2),
+        Schedule::BoundarySplit {
+            victim: 0,
+            num: 1,
+            den: 2,
+        },
+        Schedule::BoundarySplit {
+            victim: 1,
+            num: 1,
+            den: 3,
+        },
+    ]
+}
+
+// ── Test ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn toolcalling_stream_interleave_isolation() {
+    let started = Instant::now();
+    let registry = load_registry();
+    let allowlist = load_chunking_allowlist();
+    let enabled: BTreeMap<&str, &FamilyRow> = registry
+        .families
+        .iter()
+        .filter(|(_, row)| row.dynamo_v2.is_some())
+        .map(|(k, v)| (k.as_str(), v))
+        .collect();
+
+    let sv2 = ensure_fixtures().join("toolcalling/fixtures-stream-v2");
+    let inputs_root = sv2.join("inputs");
+    assert!(inputs_root.is_dir(), "missing {}", inputs_root.display());
+
+    // Capture history for the v2 parser, folded ascending (latest wins per case)
+    // via the shared helper the canonical parity test uses.
+    let dyn_dirs = version_dirs_ascending(&sv2, "dynamo_v2-");
+    assert!(
+        !dyn_dirs.is_empty(),
+        "no dynamo_v2-<version> dir under {}",
+        sv2.display()
+    );
+
+    // Discover fixture families (input subdirs) and load every case per family,
+    // alongside its recorded dynamo_v2 output.
+    let mut families: BTreeMap<String, BTreeMap<String, Case>> = BTreeMap::new();
+    let mut recorded: BTreeMap<String, RecordedCases> = BTreeMap::new();
+    let mut files = Vec::new();
+    collect_yaml(&inputs_root, &mut files);
+    files.sort();
+    for path in &files {
+        let yaml = std::fs::read_to_string(path).unwrap();
+        let fx: Fixture = match serde_yaml::from_str(&yaml) {
+            Ok(f) => f,
+            Err(e) => panic!("{}: YAML parse error: {e}", path.display()),
+        };
+        if !matches!(fx.mode.as_deref(), Some("stream" | "streamv2")) {
+            continue;
+        }
+        let family = fx.family.clone();
+        let rel = path
+            .strip_prefix(&inputs_root)
+            .expect("fixture under inputs root");
+        let input_chunks: BTreeMap<String, usize> = fx
+            .cases
+            .iter()
+            .map(|(cid, c)| (cid.clone(), c.chunks.len()))
+            .collect();
+        recorded
+            .entry(family.clone())
+            .or_default()
+            .extend(load_recorded(&dyn_dirs, rel, &input_chunks));
+        families.entry(family).or_default().extend(fx.cases);
+    }
+
+    let mut ran_pairs = 0usize;
+    let mut skipped_cases: Vec<String> = Vec::new();
+    let mut ran_families: Vec<String> = Vec::new();
+    let mut skipped_families: Vec<String> = Vec::new();
+    let mut errored_cases = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    let mut chunking_skips: Vec<String> = Vec::new();
+
+    for (family, cases) in &families {
+        let Some(row) = enabled.get(family.as_str()) else {
+            skipped_families.push(format!("{family} ({} cases, dynamo_v2=null)", cases.len()));
+            continue;
+        };
+        let use_tokens = row.preferred_input == "tokens";
+        // Construct from the REGISTERED id, not the fixture directory name.
+        let parser_id = row
+            .dynamo_v2
+            .as_deref()
+            .expect("enabled families have a dynamo_v2 id");
+        // HARD FAIL, not a skip: if an enabled family cannot even be constructed,
+        // every one of its pairs would error and be counted as a skip, the family
+        // would still be printed as exercised, and the run would exit 0 having
+        // silently tested nothing for it.
+        if let Err(e) = create_tool_parser_for_family(parser_id, &[]) {
+            panic!(
+                "enabled family {family} (dynamo_v2={parser_id}) cannot be constructed: {e}\n\
+                 An enabled family must be testable; fix the registry or the factory."
+            );
+        }
+        ran_families.push(family.clone());
+        let mut family_pairs = 0usize;
+
+        let fam_recorded = recorded.get(family.as_str());
+        // Only cases WITH a recorded dynamo_v2 expectation can be checked against
+        // the absolute oracle. A case that is missing or explicitly `unavailable`
+        // is skipped and named — never silently paired against a weaker check.
+        let ids: Vec<String> = cases
+            .keys()
+            .filter(|id| {
+                if let Some(why) = cases[id.as_str()].unterminated_reason() {
+                    skipped_cases.push(format!("{family}/{id} ({why})"));
+                    return false;
+                }
+                match fam_recorded.and_then(|r| r.get(id.as_str())) {
+                    Some(Some(_)) => true,
+                    Some(None) => {
+                        skipped_cases.push(format!("{family}/{id} (unavailable.dynamo_v2)"));
+                        false
+                    }
+                    None => {
+                        skipped_cases.push(format!("{family}/{id} (no recorded dynamo_v2)"));
+                        false
+                    }
+                }
+            })
+            .cloned()
+            .collect(); // BTreeMap => sorted
+        for (i, j) in pairs_for(&ids) {
+            let ca = &cases[&ids[i]];
+            let cb = &cases[&ids[j]];
+            let label = format!("{family} {}x{}", ids[i], ids[j]);
+            let divergent = [
+                allowlist
+                    .get(family.as_str())
+                    .is_some_and(|c| c.contains_key(&ids[i])),
+                allowlist
+                    .get(family.as_str())
+                    .is_some_and(|c| c.contains_key(&ids[j])),
+            ];
+            let exp_fwd = [
+                fam_recorded.unwrap()[&ids[i]].as_ref().unwrap(),
+                fam_recorded.unwrap()[&ids[j]].as_ref().unwrap(),
+            ];
+            // Both ROLE ASSIGNMENTS: the schedules always give choice 0 the first
+            // slot of a round, so running only (a@0, b@1) never exercises b
+            // arriving first.
+            for (role, ca, cb, exp) in [
+                ("AB", ca, cb, exp_fwd),
+                ("BA", cb, ca, [exp_fwd[1], exp_fwd[0]]),
+            ] {
+                let divergent = if role == "AB" {
+                    divergent
+                } else {
+                    [divergent[1], divergent[0]]
+                };
+                let label = format!("{label}/{role}");
+                for schedule in schedules() {
+                    let result = if use_tokens {
+                        let sa: Vec<Vec<u32>> = ca
+                            .chunks
+                            .iter()
+                            .map(|c| c.delta_token_ids.clone())
+                            .collect();
+                        let sb: Vec<Vec<u32>> = cb
+                            .chunks
+                            .iter()
+                            .map(|c| c.delta_token_ids.clone())
+                            .collect();
+                        check_pair(
+                            parser_id,
+                            &ca.tools,
+                            &sa,
+                            &cb.tools,
+                            &sb,
+                            schedule,
+                            token_input,
+                            &label,
+                            exp,
+                            divergent,
+                            &mut chunking_skips,
+                            &mut failures,
+                        )
+                    } else {
+                        let sa: Vec<String> =
+                            ca.chunks.iter().map(|c| c.delta_text.clone()).collect();
+                        let sb: Vec<String> =
+                            cb.chunks.iter().map(|c| c.delta_text.clone()).collect();
+                        check_pair(
+                            parser_id,
+                            &ca.tools,
+                            &sa,
+                            &cb.tools,
+                            &sb,
+                            schedule,
+                            text_input,
+                            &label,
+                            exp,
+                            divergent,
+                            &mut chunking_skips,
+                            &mut failures,
+                        )
+                    };
+                    match result {
+                        Ok(()) => {
+                            ran_pairs += 1;
+                            family_pairs += 1;
+                        }
+                        // A parser error on a specific shape is logged + skipped, not
+                        // silently passed — this lane is about isolation, not making
+                        // every corpus shape parseable.
+                        Err(e) => {
+                            errored_cases += 1;
+                            eprintln!(
+                                "SKIP {label} schedule={}: parser error: {e}",
+                                schedule.label()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        // A family that HAD pairs but ran none is a coverage hole and fails.
+        // A family with fewer than two pairable cases cannot form a pair at all —
+        // a legitimate corpus state (a newly registered v2 family with one fixture,
+        // or all-but-one case marked unavailable), so it is a NAMED skip instead of
+        // panicking the whole suite.
+        if pairs_for(&ids).is_empty() {
+            skipped_cases.push(format!(
+                "{family}: only {} pairable case(s), cannot form a pair",
+                ids.len()
+            ));
+        } else {
+            assert!(
+                family_pairs > 0,
+                "enabled family {family} had pairable cases but ran 0 pair-schedules"
+            );
+        }
+    }
+
+    eprintln!(
+        "v2 interleave isolation: {ran_pairs} pair-schedules over families [{}]",
+        ran_families.join(", ")
+    );
+    for s in &skipped_families {
+        eprintln!("SKIP family {s}");
+    }
+    // Never silently narrow coverage: a case without a usable recorded dynamo_v2
+    // expectation is dropped from the pairing set, so say which and why.
+    for s in &skipped_cases {
+        eprintln!("SKIP case {s}");
+    }
+    // Chunking-dependent cases are dropped from oracle 1 only, and always named.
+    for s in &chunking_skips {
+        eprintln!("SKIP oracle1 {s}");
+    }
+    eprintln!(
+        "skipped {} families, {} cases without a recorded dynamo_v2 expectation, \
+         {errored_cases} pair-schedules errored; elapsed {:.1}s",
+        skipped_families.len(),
+        skipped_cases.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    assert!(ran_pairs > 0, "no enabled families exercised");
+    if !failures.is_empty() {
+        for f in &failures {
+            eprintln!("FAIL {f}");
+        }
+        panic!("{} pair-schedules diverged", failures.len());
+    }
+}
+
+// ── Guards for the two folding/termination classes ──────────────────────────
+//
+// These pin the behaviour Devin flagged on PR #135. Neither condition occurs in
+// the committed corpus today, so without these the guards would be unexercised
+// and could rot silently.
+
+#[cfg(test)]
+mod recorded_fold_guards {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    /// A NEWER capture recording FEWER chunks must not truncate the oracle: the
+    /// older capture's trailing chunks survive, matching `merge_dynamo`'s
+    /// per-chunk-index overlay in the canonical lane.
+    #[test]
+    fn newer_capture_with_fewer_chunks_does_not_truncate() {
+        let root = std::env::temp_dir().join(format!("fold-guard-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let old = root.join("dynamo_v2-0.1.1/fam");
+        let new = root.join("dynamo_v2-0.1.2/fam");
+        // Old capture: name in chunk 0, args in chunk 1, trailing text in chunk 2.
+        write(
+            &old,
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: get_weather\n    - expected:\n      - index: 0\n        arguments: '{\"a\":1}'\n    - expected: []\n      normal_text: 'tail'\n",
+        );
+        // New capture: re-records ONLY chunk 0.
+        write(
+            &new,
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: get_weather_v2\n",
+        );
+
+        let dirs = vec![root.join("dynamo_v2-0.1.1"), root.join("dynamo_v2-0.1.2")];
+        let inputs = BTreeMap::from([("c1".to_string(), 8usize)]);
+        let got = load_recorded(&dirs, Path::new("fam/F.yaml"), &inputs);
+        let case = got.get("c1").unwrap().as_ref().unwrap();
+
+        // Chunk 0 comes from the newer capture; chunks 1-2 survive from the older.
+        assert_eq!(
+            case.calls,
+            vec![("get_weather_v2".to_string(), "{\"a\":1}".to_string())],
+            "newer capture must override chunk 0 but not drop the older trailing chunks"
+        );
+        assert_eq!(
+            case.normal_text, "tail",
+            "trailing normal_text was truncated"
+        );
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// old(full chunks) -> mid(`unavailable`) -> new(chunk 0 only): the newest
+    /// capture re-enables the case, and the older TRAILING chunks must survive the
+    /// intermediate unavailability. Collapsing the case to `None` on the mid
+    /// capture would drop them and disagree with canonical `merge_dynamo`.
+    #[test]
+    fn unavailable_then_reenabled_keeps_older_trailing_chunks() {
+        let root = std::env::temp_dir().join(format!("fold-guard-reenable-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        write(
+            &root.join("dynamo_v2-0.1.1/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: old_name\n    - expected:\n      - index: 0\n        arguments: '{\"a\":1}'\n    - expected: []\n      normal_text: 'tail'\n",
+        );
+        write(
+            &root.join("dynamo_v2-0.1.2/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    unavailable: 'temporarily unsupported'\n",
+        );
+        write(
+            &root.join("dynamo_v2-0.1.3/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: new_name\n",
+        );
+        let dirs = vec![
+            root.join("dynamo_v2-0.1.1"),
+            root.join("dynamo_v2-0.1.2"),
+            root.join("dynamo_v2-0.1.3"),
+        ];
+        let inputs = BTreeMap::from([("c1".to_string(), 8usize)]);
+        let got = load_recorded(&dirs, Path::new("fam/F.yaml"), &inputs);
+        let case = got
+            .get("c1")
+            .unwrap()
+            .as_ref()
+            .expect("newest capture re-enables the case");
+        assert_eq!(
+            case.calls,
+            vec![("new_name".to_string(), "{\"a\":1}".to_string())],
+            "intermediate `unavailable` must not destroy older trailing chunks"
+        );
+        assert_eq!(case.normal_text, "tail", "trailing normal_text was dropped");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// An `unavailable` marker in the newest capture wins over older expectations.
+    #[test]
+    fn newest_unavailable_marks_case_unusable() {
+        let root = std::env::temp_dir().join(format!("fold-guard-unavail-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        write(
+            &root.join("dynamo_v2-0.1.1/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: n\n",
+        );
+        write(
+            &root.join("dynamo_v2-0.1.2/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    unavailable: 'token parser cannot split this'\n",
+        );
+        let dirs = vec![root.join("dynamo_v2-0.1.1"), root.join("dynamo_v2-0.1.2")];
+        let inputs = BTreeMap::from([("c1".to_string(), 8usize)]);
+        let got = load_recorded(&dirs, Path::new("fam/F.yaml"), &inputs);
+        assert!(
+            got.get("c1").unwrap().is_none(),
+            "newest unavailable must win over an older recorded expectation"
+        );
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    fn case_with_finish_at(idx: usize, n: usize) -> Case {
+        Case {
+            tools: Vec::new(),
+            chunks: (0..n)
+                .map(|i| Chunk {
+                    delta_text: String::new(),
+                    delta_token_ids: Vec::new(),
+                    finish_reason: (i == idx).then(|| "stop".to_string()),
+                })
+                .collect(),
+        }
+    }
+
+    /// A stale recording LONGER than the current input must be truncated, not
+    /// kept: otherwise the oracle demands output the trimmed fixture can no
+    /// longer produce, and this lane reports it as an isolation divergence.
+    #[test]
+    fn recorded_chunks_beyond_the_input_are_dropped() {
+        let root = std::env::temp_dir().join(format!("fold-guard-trunc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        write(
+            &root.join("dynamo_v2-0.1.1/fam"),
+            "F.yaml",
+            "cases:\n  c1:\n    chunks:\n    - expected:\n      - index: 0\n        name: kept\n    - expected:\n      - index: 1\n        name: dropped\n      normal_text: 'gone'\n",
+        );
+        let dirs = vec![root.join("dynamo_v2-0.1.1")];
+        // Input has been trimmed to ONE chunk; the second recorded chunk is stale.
+        let inputs = BTreeMap::from([("c1".to_string(), 1usize)]);
+        let got = load_recorded(&dirs, Path::new("fam/F.yaml"), &inputs);
+        let case = got.get("c1").unwrap().as_ref().unwrap();
+        assert_eq!(
+            case.calls,
+            vec![("kept".to_string(), String::new())],
+            "recorded chunks beyond the input length must be dropped"
+        );
+        assert_eq!(
+            case.normal_text, "",
+            "stale trailing normal_text must be dropped"
+        );
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// A terminator on the last chunk is the normal shape and must NOT be skipped;
+    /// one before it must be, since this lane finishes only at end of stream.
+    #[test]
+    fn mid_stream_finish_reason_is_detected() {
+        assert!(
+            case_with_finish_at(2, 3).unterminated_reason().is_none(),
+            "finish_reason on the last chunk is the normal shape"
+        );
+        assert_eq!(
+            case_with_finish_at(0, 3).unterminated_reason(),
+            Some("finish_reason mid-stream"),
+            "finish_reason before the last chunk must be detected"
+        );
+        assert_eq!(
+            case_with_finish_at(1, 3).unterminated_reason(),
+            Some("finish_reason mid-stream"),
+            "finish_reason mid-stream must be detected"
+        );
+        // A case that never signals an end is excluded too: the recorded
+        // reference for it was captured without the parser's closing output, so
+        // comparing this lane's closing output against it would surface as a
+        // bogus per-choice leakage failure.
+        assert_eq!(
+            case_with_finish_at(99, 3).unterminated_reason(),
+            Some("no finish_reason on the last chunk"),
+            "a case with no terminator at all must be excluded"
+        );
+        assert_eq!(
+            case_with_finish_at(99, 0).unterminated_reason(),
+            Some("no chunks"),
+            "an empty case must be excluded"
+        );
+    }
+}

--- a/parsers/v1/tests/common/interleave.rs
+++ b/parsers/v1/tests/common/interleave.rs
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic per-choice interleave schedule core (DIS-2381).
+//!
+//! Invariant this module exists to test:
+//!
+//! ```text
+//!   demux(parse(interleave(A@0, B@1))) == (parse(A), parse(B))
+//! ```
+//!
+//! A streaming tool-calling parser (v1 jail or a v2 `ToolParser`) must keep its
+//! state isolated *per `choice.index`*. When a caller asks for `n>1` completions
+//! the transport interleaves the choices' deltas onto one wire in an arbitrary,
+//! runtime-dependent order. If the parser keys its buffer/marker/jail state off
+//! anything other than `choice.index` (e.g. one shared accumulator, or arrival
+//! order), one choice's partial marker or JSON leaks into another — producing
+//! empty `tool_calls`, duplicated calls, or leaked markup in `content`.
+//!
+//! Single-choice fixtures can never catch this: with one choice there is no
+//! second stream to bleed into, so a shared accumulator looks identical to a
+//! per-choice one. This module builds the missing second stream deterministically
+//! (no RNG) so the regression lanes can demux by `choice.index` and prove each
+//! choice's output is byte-for-byte what it would be if it had run alone.
+//!
+//! This file is intentionally dependency-free (only `std`). Both the v1 jail lane
+//! (`parsers/v1/tests/jail_interleave.rs`) and the v2 conformance lane
+//! (`conformance/tests/parity_toolcalling_stream_interleave.rs`) `#[path]`-include
+//! it so the schedule logic has exactly one source of truth across crates.
+
+use std::collections::BTreeMap;
+
+/// How to merge `k` per-choice item sequences onto one tagged wire.
+///
+/// Every variant is a pure function of the inputs — no RNG, no clock. The same
+/// `(sequences, schedule)` always yields the same tagged stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schedule {
+    /// Column-major merge: round `r` emits item `r` of choice 0, then choice 1,
+    /// ... skipping any choice already exhausted. The simplest fair interleave.
+    RoundRobin,
+    /// Choice `i` is delayed by `offset * i` rounds, so higher-index choices
+    /// "start late". `FirstByteOffset(2)` on a pair delays choice 1 by two rounds:
+    /// its first delta lands in the same round as choice 0's third, so choice 0
+    /// has already streamed several deltas (opening/continuing a tool-call marker)
+    /// before choice 1 produces a byte.
+    FirstByteOffset(usize),
+    /// Split each of `victim`'s deltas at `num/den` of its length and emit the
+    /// sibling's same-round delta *between* the halves. This lands a foreign
+    /// delta on a mid-delta boundary — the boundary a shared accumulator is most
+    /// likely to corrupt (partial marker / partial JSON straddling the split).
+    /// Requires exactly two choices.
+    ///
+    /// `victim` and the ratio are both parameters because a fixed
+    /// "always split choice 0, always at the midpoint" schedule cannot see a
+    /// parser that only breaks when the SIBLING is the one being split, or one
+    /// that breaks at a non-midpoint boundary such as `<tool_ | call>`.
+    BoundarySplit { victim: u32, num: usize, den: usize },
+}
+
+impl Schedule {
+    /// Human label for failure messages ("RoundRobin", "FirstByteOffset(2)", ...).
+    pub fn label(&self) -> String {
+        match self {
+            Schedule::RoundRobin => "RoundRobin".to_string(),
+            Schedule::FirstByteOffset(n) => format!("FirstByteOffset({n})"),
+            Schedule::BoundarySplit { victim, num, den } => {
+                format!("BoundarySplit(ch{victim}@{num}/{den})")
+            }
+        }
+    }
+}
+
+/// An item that `BoundarySplit` can cut in two. Concatenating the two halves
+/// must reproduce the original exactly (checked by the roundtrip test).
+pub trait Splittable: Clone {
+    /// Split at `num/den` of the item's length. Returns `None` when the item
+    /// cannot be split there (too small, or the ratio lands on an edge) — the
+    /// caller then emits it whole.
+    fn split_at_ratio(&self, num: usize, den: usize) -> Option<(Self, Self)>;
+}
+
+impl Splittable for String {
+    fn split_at_ratio(&self, num: usize, den: usize) -> Option<(Self, Self)> {
+        if self.chars().count() < 2 || den == 0 {
+            return None;
+        }
+        // Split on a char boundary at/after the target byte so we never cut a
+        // multi-byte UTF-8 sequence (fixtures include emoji and CJK markers).
+        //
+        // Clamp to at least byte 1 first: a small ratio on a short item rounds the
+        // target down to 0, which used to return `None` and emit the item WHOLE —
+        // so a split schedule was counted as exercised while behaving exactly like
+        // a non-splitting one. Any item of >= 2 chars must genuinely split.
+        let mut idx = ((self.len() * num) / den).max(1);
+        while idx < self.len() && !self.is_char_boundary(idx) {
+            idx += 1;
+        }
+        // The forward scan runs off the end when the target lands inside the FINAL
+        // character — every chunk ending in a multi-byte char (emoji, CJK) hit this
+        // and was emitted WHOLE, so the split schedule silently behaved like a
+        // non-splitting one for it. Fall back to the last interior boundary.
+        if idx >= self.len() {
+            idx = self.len() - 1;
+            while idx > 0 && !self.is_char_boundary(idx) {
+                idx -= 1;
+            }
+        }
+        if idx == 0 || idx >= self.len() {
+            return None;
+        }
+        Some((self[..idx].to_string(), self[idx..].to_string()))
+    }
+}
+
+impl Splittable for Vec<u32> {
+    fn split_at_ratio(&self, num: usize, den: usize) -> Option<(Self, Self)> {
+        if self.len() < 2 || den == 0 {
+            return None;
+        }
+        let at = ((self.len() * num) / den).clamp(1, self.len() - 1);
+        Some((self[..at].to_vec(), self[at..].to_vec()))
+    }
+}
+
+/// Merge `sequences` (indexed by `choice.index`, so `sequences[i]` is choice `i`)
+/// into a single `(choice_index, item)` stream ordered per `schedule`.
+///
+/// Pure and deterministic. `BoundarySplit` requires `sequences.len() == 2`.
+pub fn interleave_items<T: Splittable>(sequences: &[Vec<T>], schedule: Schedule) -> Vec<(u32, T)> {
+    match schedule {
+        Schedule::RoundRobin => offset_merge(sequences, 0),
+        Schedule::FirstByteOffset(n) => offset_merge(sequences, n),
+        Schedule::BoundarySplit { victim, num, den } => {
+            assert_eq!(
+                sequences.len(),
+                2,
+                "BoundarySplit is defined for exactly two choices"
+            );
+            assert!(victim < 2, "BoundarySplit victim must be choice 0 or 1");
+            boundary_split(&sequences[0], &sequences[1], victim, num, den)
+        }
+    }
+}
+
+/// Round-major merge where choice `i` is delayed by `offset * i` rounds.
+/// `offset == 0` is a plain round-robin.
+fn offset_merge<T: Clone>(sequences: &[Vec<T>], offset: usize) -> Vec<(u32, T)> {
+    let mut out = Vec::new();
+    let last_round = sequences
+        .iter()
+        .enumerate()
+        .map(|(i, s)| s.len() + offset * i)
+        .max()
+        .unwrap_or(0);
+    for round in 0..last_round {
+        for (i, seq) in sequences.iter().enumerate() {
+            let delay = offset * i;
+            if round < delay {
+                continue;
+            }
+            let local = round - delay;
+            if local < seq.len() {
+                out.push((i as u32, seq[local].clone()));
+            }
+        }
+    }
+    out
+}
+
+/// `BoundarySplit`: for each round, cut the VICTIM choice's delta at `num/den`
+/// and drop the sibling's same-round delta between the halves.
+fn boundary_split<T: Splittable>(
+    a: &[T],
+    b: &[T],
+    victim: u32,
+    num: usize,
+    den: usize,
+) -> Vec<(u32, T)> {
+    let (vic, sib) = if victim == 0 { (a, b) } else { (b, a) };
+    let sib_idx = 1 - victim;
+    let mut out = Vec::new();
+    let rounds = vic.len().max(sib.len());
+    for r in 0..rounds {
+        if r < vic.len() {
+            match vic[r].split_at_ratio(num, den) {
+                Some((head, tail)) => {
+                    out.push((victim, head));
+                    if r < sib.len() {
+                        out.push((sib_idx, sib[r].clone()));
+                    }
+                    out.push((victim, tail));
+                }
+                None => {
+                    out.push((victim, vic[r].clone()));
+                    if r < sib.len() {
+                        out.push((sib_idx, sib[r].clone()));
+                    }
+                }
+            }
+        } else if r < sib.len() {
+            out.push((sib_idx, sib[r].clone()));
+        }
+    }
+    out
+}
+
+/// Group a tagged stream back into per-`choice.index` item sequences.
+///
+/// Demux is by tag (`choice.index`), never by arrival order — the whole point is
+/// that a correct parser is order-independent within a choice but must not mix
+/// choices.
+pub fn demux_items<T: Clone>(tagged: &[(u32, T)]) -> BTreeMap<u32, Vec<T>> {
+    let mut out: BTreeMap<u32, Vec<T>> = BTreeMap::new();
+    for (index, item) in tagged {
+        out.entry(*index).or_default().push(item.clone());
+    }
+    out
+}
+
+// ── Schedule-core roundtrip tests ───────────────────────────────────────────
+//
+// These are compiled + run wherever this file is `#[path]`-included (the v1 jail
+// lane). They prove the merge itself is lossless before any parser is involved:
+// de-interleaving each schedule's output by `choice.index` recovers each input's
+// bytes exactly. If these fail, a downstream parity failure is the schedule's
+// fault, not the parser's.
+
+#[cfg(test)]
+mod schedule_core_roundtrip {
+    use super::*;
+
+    fn concat_strings(items: &[String]) -> String {
+        items.concat()
+    }
+
+    /// Byte-exact concatenation roundtrip for every schedule.
+    #[test]
+    fn concat_roundtrip_all_schedules() {
+        let a: Vec<String> = [
+            "<tool_call>",
+            "{\"name\":\"get_",
+            "weather\"}",
+            "</tool_call>",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let b: Vec<String> = ["plain ", "content ", "只是文本 ", "🧪 done"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let seqs = vec![a.clone(), b.clone()];
+
+        for schedule in [
+            Schedule::RoundRobin,
+            Schedule::FirstByteOffset(1),
+            Schedule::FirstByteOffset(3),
+            Schedule::BoundarySplit {
+                victim: 0,
+                num: 1,
+                den: 2,
+            },
+            Schedule::BoundarySplit {
+                victim: 1,
+                num: 1,
+                den: 3,
+            },
+        ] {
+            let tagged = interleave_items(&seqs, schedule);
+            let demuxed = demux_items(&tagged);
+            assert_eq!(
+                concat_strings(&demuxed[&0]),
+                concat_strings(&a),
+                "{}: choice 0 bytes not recovered",
+                schedule.label()
+            );
+            assert_eq!(
+                concat_strings(&demuxed[&1]),
+                concat_strings(&b),
+                "{}: choice 1 bytes not recovered",
+                schedule.label()
+            );
+        }
+    }
+
+    /// Non-splitting schedules preserve chunk boundaries item-for-item, not just
+    /// the concatenation.
+    #[test]
+    fn item_for_item_roundtrip_non_splitting() {
+        let a: Vec<String> = ["a0", "a1", "a2"].iter().map(|s| s.to_string()).collect();
+        let b: Vec<String> = ["b0", "b1"].iter().map(|s| s.to_string()).collect();
+        let seqs = vec![a.clone(), b.clone()];
+
+        for schedule in [Schedule::RoundRobin, Schedule::FirstByteOffset(2)] {
+            let demuxed = demux_items(&interleave_items(&seqs, schedule));
+            assert_eq!(demuxed[&0], a, "{}: choice 0 chunks", schedule.label());
+            assert_eq!(demuxed[&1], b, "{}: choice 1 chunks", schedule.label());
+        }
+    }
+
+    /// FirstByteOffset actually delays the higher-index choice: choice 1's first
+    /// delta only appears after choice 0 has been streaming for `offset` rounds
+    /// (choice 0's round-`offset` item linearizes just before it, hence
+    /// `offset + 1` choice-0 items precede choice 1's first).
+    #[test]
+    fn first_byte_offset_delays_second_choice() {
+        let a: Vec<String> = (0..4).map(|i| format!("a{i}")).collect();
+        let b: Vec<String> = (0..4).map(|i| format!("b{i}")).collect();
+        let offset = 2;
+        let tagged = interleave_items(&[a, b], Schedule::FirstByteOffset(offset));
+        let first_b_pos = tagged.iter().position(|(idx, _)| *idx == 1).unwrap();
+        let zero_before = tagged[..first_b_pos]
+            .iter()
+            .filter(|(idx, _)| *idx == 0)
+            .count();
+        assert_eq!(
+            zero_before,
+            offset + 1,
+            "choice 1 must not start until choice 0 has streamed {offset} rounds"
+        );
+    }
+
+    /// Roundtrip holds for token sequences too (the Harmony token-native path).
+    #[test]
+    fn concat_roundtrip_tokens() {
+        let a: Vec<Vec<u32>> = vec![vec![1, 2, 3], vec![4], vec![5, 6]];
+        let b: Vec<Vec<u32>> = vec![vec![7, 8], vec![9, 10, 11]];
+        let seqs = vec![a.clone(), b.clone()];
+        let flat = |v: &[Vec<u32>]| v.iter().flatten().copied().collect::<Vec<u32>>();
+
+        for schedule in [
+            Schedule::RoundRobin,
+            Schedule::FirstByteOffset(1),
+            Schedule::BoundarySplit {
+                victim: 0,
+                num: 1,
+                den: 2,
+            },
+            Schedule::BoundarySplit {
+                victim: 1,
+                num: 1,
+                den: 3,
+            },
+        ] {
+            let demuxed = demux_items(&interleave_items(&seqs, schedule));
+            assert_eq!(
+                flat(&demuxed[&0]),
+                flat(&a),
+                "{} tokens ch0",
+                schedule.label()
+            );
+            assert_eq!(
+                flat(&demuxed[&1]),
+                flat(&b),
+                "{} tokens ch1",
+                schedule.label()
+            );
+        }
+    }
+
+    /// Every item of >= 2 chars must ACTUALLY split at every ratio, including
+    /// when the target byte lands inside a trailing multi-byte character. A
+    /// silent `None` here would let a split schedule be counted as exercised
+    /// while behaving exactly like a non-splitting one.
+    #[test]
+    fn split_at_ratio_never_silently_declines() {
+        for s in [
+            "ab",
+            "xy",
+            "  ",
+            " \t ",
+            "ab€",
+            "x只",
+            "hi🧪",
+            "只是文本",
+            "a🧪",
+        ] {
+            for (num, den) in [(1usize, 4usize), (1, 3), (1, 2), (3, 4)] {
+                let got = s.to_string().split_at_ratio(num, den);
+                let (head, tail) = got.unwrap_or_else(|| {
+                    panic!(
+                        "{s:?} @{num}/{den}: refused to split a {}-char item",
+                        s.chars().count()
+                    )
+                });
+                assert!(
+                    !head.is_empty() && !tail.is_empty(),
+                    "{s:?} @{num}/{den}: empty half"
+                );
+                assert_eq!(
+                    format!("{head}{tail}"),
+                    s,
+                    "{s:?} @{num}/{den}: not lossless"
+                );
+            }
+        }
+    }
+
+    /// k=3 round-robin merges three choices losslessly.
+    #[test]
+    fn round_robin_three_choices() {
+        let a: Vec<String> = vec!["a0".into(), "a1".into()];
+        let b: Vec<String> = vec!["b0".into(), "b1".into(), "b2".into()];
+        let c: Vec<String> = vec!["c0".into()];
+        let demuxed = demux_items(&interleave_items(
+            &[a.clone(), b.clone(), c.clone()],
+            Schedule::RoundRobin,
+        ));
+        assert_eq!(demuxed[&0], a);
+        assert_eq!(demuxed[&1], b);
+        assert_eq!(demuxed[&2], c);
+    }
+}

--- a/parsers/v1/tests/jail_interleave.rs
+++ b/parsers/v1/tests/jail_interleave.rs
@@ -1,0 +1,841 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-choice isolation regression lane for the v1 jail (DIS-2381 step 3).
+//!
+//! Invariant under test:
+//!
+//! ```text
+//!   demux(parse(interleave(A@0, B@1))) == (parse(A), parse(B))
+//! ```
+//!
+//! `JailedStream` keys its jail/marker/tool-call state off `choice.index` via
+//! `ChoiceJailStateCollection`. A regression that shared one state across indices
+//! (or routed every delta to index 0) would still pass every existing test,
+//! because all existing jail tests are effectively single-choice: even
+//! `test_multiple_choices_independent_jailing` delivers each choice's deltas in
+//! its own slot of a packed multi-choice chunk, so a shared accumulator that
+//! processed choices in a fixed order could still look correct.
+//!
+//! This lane instead runs two independent choices through ONE `JailedStream` with
+//! their deltas *interleaved on the wire* under several deterministic schedules
+//! (round-robin, first-byte offset, mid-delta boundary split — see
+//! `common/interleave.rs`). It then demuxes the emitted chunks by `choice.index`
+//! and asserts each choice's assembled result (tool calls, normal text, finish
+//! handling) is byte-for-byte what that choice produced running ALONE. If jail
+//! state leaks across choices, one choice's partial marker/JSON corrupts the
+//! other and the demuxed assembly diverges from its solo golden.
+//!
+//! Two shapes get dedicated coverage because a per-choice bug can hide from the
+//! ordinary pairs entirely (both were found and closed in the sibling PR
+//! ai-dynamo/dynamo#11563):
+//!
+//!   * **Whitespace-only deltas** — the "undecided" arm, where a delta is neither
+//!     clearly content nor the start of a marker. Covered by the
+//!     `hermes_open_jail_x_ws_*` pairs, which hold choice 0's jail OPEN across the
+//!     rounds in which the sibling's whitespace arrives; that open-jail window is
+//!     the only one in which a shared undecided buffer is observable.
+//!   * **Packed multi-choice chunks with non-contiguous, unsorted indices** —
+//!     see `jail_interleave_packed_chunks_non_contiguous_indices`.
+//!
+//! Golden = the solo run (never a hand-authored n>1 expectation). Because the
+//! jail reassembles content across arbitrary delta boundaries, the assembled
+//! result is invariant to where a delta is split, so the same solo golden is
+//! valid for every schedule.
+//!
+//! # Known limitation of the solo golden
+//!
+//! The solo golden is computed in THIS process, so it cannot detect a defect that
+//! corrupts the interleaved run and the solo run identically — process-global
+//! state such as a `OnceLock`/`lazy_static` cache, or anything memoised on first
+//! use. Both sides would be wrong in the same way and still compare equal.
+//! (rmccorm4 demonstrated this class on PR #135 against the v2 lane; the v2 lane
+//! closes it by also asserting against the corpus's recorded `dynamo_v2` capture,
+//! which was produced in an earlier process.)
+//!
+//! That escape hatch is NOT closed here: these pairs are hand-authored, so there
+//! is no recorded capture to anchor to. What this lane does prove is per-choice
+//! isolation; a shared-global defect in the v1 jail would need either a recorded
+//! v1 corpus or a fresh-process baseline to catch.
+//!
+//! # What each dimension of the matrix exists for
+//!
+//! * **Both role assignments** (`AB` / `BA`) — the schedules give choice 0 the
+//!   first slot of every round, so a single ordering never exercises the higher
+//!   index arriving first.
+//! * **`BoundarySplit` over both victims and several ratios** — a fixed
+//!   "split choice 0 at the midpoint" cannot see a parser that breaks only when
+//!   the sibling is split, or one that breaks at a boundary like `<tool_ | call>`.
+//! * **Staggered terminators** — each choice's `finish_reason` rides its OWN last
+//!   delta, so a shorter choice terminates MID-WIRE while its sibling streams on.
+//!   A defect that tears down sibling state when the first choice finishes is
+//!   simply unreachable without that.
+//! * **`emission_profile`** — final totals cannot see a defect that merely DELAYS
+//!   a choice's output while a sibling is live.
+//! * **Modes and families** — `Mode::ToolChoice*` start the jail already jailed
+//!   (`JailMode::Immediate`), a different state machine from the marker path, and
+//!   a second marker family guards against Hermes-only scanner assumptions.
+
+#[path = "common/interleave.rs"]
+mod interleave;
+
+use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, FinishReason, Role,
+};
+use futures::{StreamExt, stream};
+use interleave::{Schedule, demux_items, interleave_items};
+use std::collections::BTreeMap;
+
+/// Build a single-choice content chunk tagged with `index` (mirrors the shape of
+/// `create_mock_response_chunk` in `jail.rs`).
+fn single_choice_chunk(
+    content: &str,
+    index: u32,
+    finish_reason: Option<FinishReason>,
+) -> Annotated<CreateChatCompletionStreamResponse> {
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role: Some(Role::Assistant),
+            content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs: None,
+    };
+    Annotated {
+        data: Some(CreateChatCompletionStreamResponse {
+            id: "jail-interleave".to_string(),
+            choices: vec![choice],
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        }),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+/// Assembled per-choice view of jail output: the parts a real n>1 client sees.
+#[derive(Debug, PartialEq)]
+struct Assembled {
+    /// `(name, arguments)` per tool call, accumulated by tool-call index.
+    tool_calls: Vec<(String, String)>,
+    /// Concatenated non-tool-call content.
+    normal_text: String,
+    /// Terminal finish reason the jail attributed to this choice, if any.
+    finish: Option<FinishReason>,
+    /// STREAMING SHAPE: after each chunk this choice emits, the running
+    /// `(tool-call count, normal-text length)`.
+    ///
+    /// Final totals alone cannot see a defect that DELAYS a choice's output —
+    /// e.g. a parser that stalls choice 0 the moment choice 1 appears and
+    /// releases the correct bytes only at finalize. Totals match, so an
+    /// assembled-only comparison passes while a real client sees choice 0 go
+    /// silent for the whole of choice 1's stream. The profile makes emission
+    /// timing part of the compared value: a correct per-choice implementation
+    /// emits the same chunks in the same order whether or not a sibling is
+    /// interleaved, so this must equal the solo run's profile exactly.
+    emission_profile: Vec<(usize, usize)>,
+}
+
+/// Assemble one choice's emitted chunks (already demuxed by `choice.index`).
+fn assemble(chunks: &[&ChatChoiceStream]) -> Assembled {
+    let mut normal_text = String::new();
+    let mut names: BTreeMap<u32, String> = BTreeMap::new();
+    let mut args: BTreeMap<u32, String> = BTreeMap::new();
+    let mut order: Vec<u32> = Vec::new();
+    let mut finish: Option<FinishReason> = None;
+    let mut emission_profile: Vec<(usize, usize)> = Vec::new();
+    let mut deltas_so_far = 0usize;
+
+    for choice in chunks {
+        if let Some(ChatCompletionMessageContent::Text(text)) = choice.delta.content.as_ref() {
+            normal_text.push_str(text);
+        }
+        if let Some(calls) = choice.delta.tool_calls.as_ref() {
+            for call in calls {
+                deltas_so_far += 1;
+                if !order.contains(&call.index) {
+                    order.push(call.index);
+                }
+                if let Some(function) = call.function.as_ref() {
+                    if let Some(name) = function.name.as_ref() {
+                        names.entry(call.index).or_default().push_str(name);
+                    }
+                    if let Some(a) = function.arguments.as_ref() {
+                        args.entry(call.index).or_default().push_str(a);
+                    }
+                }
+            }
+        }
+        if let Some(reason) = choice.finish_reason {
+            finish = Some(reason);
+        }
+        // One profile sample per emitted chunk for this choice.
+        //
+        // Counts emitted DELTAS and accumulated argument bytes, NOT distinct call
+        // indices: an index count only moves when a brand-new call first appears,
+        // so a stall that delays later argument fragments of an already-started
+        // call would leave every sample identical — precisely the shape this field
+        // exists to catch. (v2 samples its delta count for the same reason.)
+        let bytes_so_far = args.values().map(String::len).sum::<usize>() + normal_text.len();
+        emission_profile.push((deltas_so_far, bytes_so_far));
+    }
+
+    let tool_calls = order
+        .into_iter()
+        .map(|idx| {
+            (
+                names.get(&idx).cloned().unwrap_or_default(),
+                args.get(&idx).cloned().unwrap_or_default(),
+            )
+        })
+        .collect();
+
+    Assembled {
+        tool_calls,
+        normal_text,
+        finish,
+        emission_profile,
+    }
+}
+
+/// Build one chunk carrying SEVERAL choices at once (the `Packed` emission shape
+/// a real `n>1` engine produces). `entries` is `(choice.index, content)`; indices
+/// must be distinct within a chunk, but need not be sorted or contiguous.
+fn packed_chunk(
+    entries: &[(u32, String, Option<FinishReason>)],
+) -> Annotated<CreateChatCompletionStreamResponse> {
+    #[allow(deprecated)]
+    let choices: Vec<ChatChoiceStream> = entries
+        .iter()
+        .map(|(index, content, finish)| ChatChoiceStream {
+            index: *index,
+            delta: ChatCompletionStreamResponseDelta {
+                role: Some(Role::Assistant),
+                content: Some(ChatCompletionMessageContent::Text(content.clone())),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: *finish,
+            logprobs: None,
+        })
+        .collect();
+    Annotated {
+        data: Some(CreateChatCompletionStreamResponse {
+            id: "jail-interleave-packed".to_string(),
+            choices,
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        }),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+/// Run one choice's deltas solo through a fresh `JailedStream` and assemble the
+/// single-choice output. This is the golden the interleaved run must reproduce.
+///
+/// `index` is the `choice.index` the solo run uses. A correct jail keys state off
+/// the index but its *output* must not depend on the index's value, so goldens are
+/// taken at the same index the interleaved run uses — that way a divergence is
+/// attributable to cross-choice leakage, not to the index value itself.
+async fn solo_at(parser: &str, mode: Mode, deltas: &[String], index: u32) -> Assembled {
+    let last = deltas.len().saturating_sub(1);
+    let chunks: Vec<_> = deltas
+        .iter()
+        .enumerate()
+        .map(|(i, d)| {
+            // Real upstream terminator on this choice's OWN last delta.
+            let fin = (i == last).then_some(FinishReason::Stop);
+            single_choice_chunk(d, index, fin)
+        })
+        .collect();
+    let results: Vec<_> = build_jail(parser, mode)
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await;
+    let choices: Vec<&ChatChoiceStream> = results
+        .iter()
+        .filter_map(|r| r.data.as_ref())
+        .flat_map(|d| d.choices.iter())
+        .collect();
+    assemble(&choices)
+}
+
+/// Feed an interleaved multi-choice stream through ONE `JailedStream`, then demux
+/// the emitted chunks by `choice.index` and assemble each choice separately.
+async fn interleaved_by_choice(
+    parser: &str,
+    mode: Mode,
+    sequences: &[Vec<String>],
+    schedule: Schedule,
+) -> BTreeMap<u32, Assembled> {
+    let tagged = interleave_items(sequences, schedule);
+    // STAGGERED TERMINATION: each choice's terminator rides its OWN last delta,
+    // which for a shorter choice lands MID-WIRE while its sibling is still
+    // streaming. A defect that tears down every choice's state when the first
+    // choice finishes is only reachable this way; hanging every terminator off
+    // the end of the wire (or omitting them, as this lane used to) hides it.
+    let mut remaining: BTreeMap<u32, usize> = BTreeMap::new();
+    for (index, _) in &tagged {
+        *remaining.entry(*index).or_default() += 1;
+    }
+    let mut seen: BTreeMap<u32, usize> = BTreeMap::new();
+    let chunks: Vec<_> = tagged
+        .iter()
+        .map(|(index, content)| {
+            let n = seen.entry(*index).or_default();
+            *n += 1;
+            let fin = (*n == remaining[index]).then_some(FinishReason::Stop);
+            single_choice_chunk(content, *index, fin)
+        })
+        .collect();
+    let results: Vec<_> = build_jail(parser, mode)
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await;
+
+    // Demux by `choice.index` (NEVER by arrival order): flat_map every choice out
+    // of every emitted chunk — the jail may pack or split, so we must not assume
+    // one choice per chunk.
+    let mut per_choice: BTreeMap<u32, Vec<&ChatChoiceStream>> = BTreeMap::new();
+    for choice in results
+        .iter()
+        .filter_map(|r| r.data.as_ref())
+        .flat_map(|d| d.choices.iter())
+    {
+        per_choice.entry(choice.index).or_default().push(choice);
+    }
+    per_choice
+        .into_iter()
+        .map(|(index, chunks)| (index, assemble(&chunks)))
+        .collect()
+}
+
+/// Jail configuration under test. `MarkerBased` is the default streaming path;
+/// the `ToolChoice*` variants start the jail ALREADY jailed (`JailMode::Immediate`),
+/// which is a different per-choice state machine — `get_or_create_state` is
+/// called with `starts_jailed = true`, so a defect that shares state only on that
+/// path is invisible to a marker-based-only lane.
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+    MarkerBased,
+    ToolChoiceRequired,
+    ToolChoiceNamed(&'static str),
+}
+
+impl Mode {
+    fn label(&self) -> &'static str {
+        match self {
+            Mode::MarkerBased => "marker",
+            Mode::ToolChoiceRequired => "required",
+            Mode::ToolChoiceNamed(_) => "named",
+        }
+    }
+}
+
+/// Build a `JailedStream` for `parser` in `mode`.
+fn build_jail(parser: &str, mode: Mode) -> JailedStream {
+    let b = JailedStream::builder().tool_call_parser(parser);
+    match mode {
+        Mode::MarkerBased => b.build(),
+        Mode::ToolChoiceRequired => b.tool_choice_required().build(),
+        Mode::ToolChoiceNamed(name) => b.tool_choice_named(name.to_string()).build(),
+    }
+}
+
+/// A named divergent pair: two choices that produce structurally different output
+/// through the same parser, so a shared accumulator visibly corrupts one.
+struct Pair {
+    name: &'static str,
+    parser: &'static str,
+    mode: Mode,
+    sequences: Vec<Vec<String>>,
+}
+
+fn s(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|p| p.to_string()).collect()
+}
+
+fn divergent_pairs() -> Vec<Pair> {
+    vec![
+        // (tool call) x (plain content only): the classic n>1 leak — a jailed
+        // tool call in choice 0 must not swallow choice 1's plain prose.
+        Pair {
+            name: "hermes_toolcall_x_plain",
+            parser: "hermes",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    "Let me check. ",
+                    r#"<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>"#,
+                    " done.",
+                ]),
+                s(&["Just ", "plain ", "prose, no tools here."]),
+            ],
+        },
+        // (two different tool-call shapes): both choices emit tool calls but with
+        // different names/args — a shared buffer would cross-contaminate arguments.
+        Pair {
+            name: "hermes_two_distinct_calls",
+            parser: "hermes",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    r#"<tool_call>{"name":"get_weather","#,
+                    r#""arguments":{"city":"Paris"}}</tool_call>"#,
+                ]),
+                s(&[
+                    r#"<tool_call>{"name":"get_time","#,
+                    r#""arguments":{"tz":"UTC"}}</tool_call>"#,
+                ]),
+            ],
+        },
+        // (opening-marker-split-across-deltas) x (bare content): choice 0's
+        // `<tool_call>` marker is split across delta boundaries; a shared partial
+        // marker buffer would jail choice 1's bare content by mistake.
+        Pair {
+            name: "hermes_split_marker_x_bare",
+            parser: "hermes",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    "<tool",
+                    "_call>",
+                    r#"{"name":"lookup","arguments":{"q":"cats"}}"#,
+                    "</tool_call>",
+                ]),
+                s(&["bare content only, ", "never jailed"]),
+            ],
+        },
+        // (open jail) x (whitespace-only deltas, then prose): choice 1's leading
+        // deltas are pure whitespace, which the jail cannot yet classify as content
+        // or as the start of a marker — the "undecided" bypass arm. Choice 0's jail
+        // is deliberately held OPEN across those rounds (its marker and JSON are
+        // split across deltas), so the whitespace arrives mid-jail. That open-jail
+        // window is the only one in which a shared undecided buffer is observable:
+        // the whitespace is swallowed into choice 0's accumulation and choice 1's
+        // prose loses its leading run. The sibling PR ai-dynamo/dynamo#11563 closed
+        // exactly this arm on the preprocessor side.
+        Pair {
+            name: "hermes_open_jail_x_ws_then_prose",
+            parser: "hermes",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    "<tool_call>",
+                    r#"{"name":"ws_a","#,
+                    r#""arguments":{"k":1}}"#,
+                    "</tool_call>",
+                ]),
+                s(&["   ", "\n\n", " \t ", "plain tail after whitespace"]),
+            ],
+        },
+        // (open jail, marker split across deltas) x (whitespace for the WHOLE
+        // stream): the same undecided arm at its extreme — choice 1 never emits a
+        // non-whitespace byte, so a shared undecided buffer makes choice 1 vanish
+        // from the output entirely rather than merely losing a leading run.
+        Pair {
+            name: "hermes_open_jail_x_ws_only",
+            parser: "hermes",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    "<tool",
+                    "_call>",
+                    r#"{"name":"ws_c","arguments":{"k":3}}"#,
+                    "</tool_call>",
+                ]),
+                s(&[" ", "  \n  ", "\t"]),
+            ],
+        },
+        // A SECOND marker family. Every pair above is Hermes, so a defect in
+        // shared scanner/marker state that only manifests for another family's
+        // markers would never show up.
+        Pair {
+            name: "nemotron_deci_call_x_plain",
+            parser: "nemotron_deci",
+            mode: Mode::MarkerBased,
+            sequences: vec![
+                s(&[
+                    "<TOOLCALL>",
+                    r#"[{"name": "get_weather", "arguments": {"city": "Paris"}}]"#,
+                    "</TOOLCALL>",
+                ]),
+                s(&["plain prose ", "for nemotron, ", "never jailed"]),
+            ],
+        },
+        // tool_choice=required: the jail starts ALREADY jailed
+        // (`JailMode::Immediate`), a different per-choice state machine from the
+        // marker path — `get_or_create_state(index, starts_jailed = true)`.
+        Pair {
+            name: "required_mode_two_calls",
+            parser: "hermes",
+            mode: Mode::ToolChoiceRequired,
+            sequences: vec![
+                s(&[
+                    r#"[{"name": "get_weather", "#,
+                    r#""parameters": {"city": "Paris"}}]"#,
+                ]),
+                s(&[
+                    r#"[{"name": "get_time", "#,
+                    r#""parameters": {"tz": "UTC"}}]"#,
+                ]),
+            ],
+        },
+        // tool_choice=named: Immediate mode with a SingleObject format.
+        Pair {
+            name: "named_mode_two_objects",
+            parser: "hermes",
+            mode: Mode::ToolChoiceNamed("get_weather"),
+            sequences: vec![
+                s(&[r#"{"city": "#, r#""Paris"}"#]),
+                s(&[r#"{"city": "#, r#""Tokyo"}"#]),
+            ],
+        },
+    ]
+}
+
+/// Schedules for a k=2 pair. `BoundarySplit` is swept over BOTH victims and
+/// several split ratios: a fixed "split choice 0 at the midpoint" cannot see a
+/// parser that only breaks when the sibling is split, or one that breaks at a
+/// non-midpoint boundary such as `<tool_ | call>`.
+fn schedules_k2() -> Vec<Schedule> {
+    let mut v = vec![
+        Schedule::RoundRobin,
+        Schedule::FirstByteOffset(1),
+        Schedule::FirstByteOffset(2),
+    ];
+    for victim in [0u32, 1] {
+        for (num, den) in [(1usize, 4usize), (1, 2), (3, 4)] {
+            v.push(Schedule::BoundarySplit { victim, num, den });
+        }
+    }
+    v
+}
+
+/// Whether a schedule can be meaningfully applied to `sequences`. Un-applicable
+/// shapes are logged as skipped rather than silently counted as passing.
+fn applicable(sequences: &[Vec<String>], schedule: Schedule) -> Result<(), String> {
+    if sequences.iter().any(|s| s.is_empty()) {
+        return Err("a choice has no deltas".to_string());
+    }
+    match schedule {
+        Schedule::BoundarySplit { victim, .. } => {
+            if sequences.len() != 2 {
+                return Err("BoundarySplit requires exactly two choices".to_string());
+            }
+            if sequences[victim as usize]
+                .iter()
+                .all(|d| d.chars().count() < 2)
+            {
+                return Err(format!("choice {victim} has no splittable delta"));
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+#[tokio::test]
+async fn jail_interleave_preserves_per_choice_isolation() {
+    let mut ran = 0usize;
+    let mut skipped = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for pair in divergent_pairs() {
+        assert_eq!(pair.sequences.len(), 2, "k=2 pairs only in this loop");
+        // Both ROLE ASSIGNMENTS. The schedules give choice 0 the first slot of
+        // every round, so running only (A@0, B@1) never exercises B arriving
+        // first — a router that mishandles the higher-index choice leading would
+        // pass. Swapping is the cheapest way to cover both arrival orders.
+        for (role, sequences) in [
+            (
+                "AB",
+                vec![pair.sequences[0].clone(), pair.sequences[1].clone()],
+            ),
+            (
+                "BA",
+                vec![pair.sequences[1].clone(), pair.sequences[0].clone()],
+            ),
+        ] {
+            for schedule in schedules_k2() {
+                if let Err(reason) = applicable(&sequences, schedule) {
+                    eprintln!(
+                        "SKIP pair={}/{} mode={} schedule={}: {reason}",
+                        pair.name,
+                        role,
+                        pair.mode.label(),
+                        schedule.label()
+                    );
+                    skipped += 1;
+                    continue;
+                }
+                ran += 1;
+
+                // Golden = the solo run of THIS choice's DEMUXED subsequence, not
+                // of the original sequence. A splitting schedule re-chunks the
+                // victim's own deltas, so the victim legitimately emits more
+                // chunks than an unsplit run would; comparing against the original
+                // sequence would flag that as a divergence. Feeding solo the same
+                // post-split deltas keeps `emission_profile` an apples-to-apples
+                // comparison whose ONLY remaining variable is the sibling's
+                // presence on the wire — which is exactly the property under test.
+                let items = demux_items(&interleave_items(&sequences, schedule));
+                let golden_a = solo_at(pair.parser, pair.mode, items.get(&0).unwrap(), 0).await;
+                let golden_b = solo_at(pair.parser, pair.mode, items.get(&1).unwrap(), 1).await;
+
+                let demuxed =
+                    interleaved_by_choice(pair.parser, pair.mode, &sequences, schedule).await;
+                for (index, golden) in [(0u32, &golden_a), (1u32, &golden_b)] {
+                    match demuxed.get(&index) {
+                        Some(got) if got == golden => {}
+                        Some(got) => failures.push(format!(
+                            "schedule={} pair={}/{} mode={} choice={index} diverged:\n     got  {got:?}\n     want {golden:?}",
+                            schedule.label(),
+                            pair.name,
+                            role,
+                            pair.mode.label(),
+                        )),
+                        None => failures.push(format!(
+                            "schedule={} pair={}/{} mode={} choice={index}: no output demuxed",
+                            schedule.label(),
+                            pair.name,
+                            role,
+                            pair.mode.label(),
+                        )),
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!("v1 jail interleave: {ran} schedule-pairs ran, {skipped} skipped");
+    // 8 pairs x 2 roles x 9 schedules, minus shapes with no splittable victim.
+    // Guards against a pair, role, mode or schedule silently dropping out and
+    // leaving a vacuously-passing matrix.
+    assert!(
+        ran >= 120,
+        "expected the divergent-pair matrix to run, got {ran}"
+    );
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Group a tagged stream into PACKED chunks: consecutive items are merged into one
+/// chunk until an index would repeat, then the chunk is flushed. Round-robin input
+/// therefore yields chunks carrying every choice at once — the `Packed` emission
+/// shape, rather than one choice per chunk.
+fn pack_rounds(tagged: &[(u32, String)]) -> Vec<Vec<(u32, String)>> {
+    let mut chunks: Vec<Vec<(u32, String)>> = Vec::new();
+    let mut current: Vec<(u32, String)> = Vec::new();
+    for (index, item) in tagged {
+        if current.iter().any(|(i, _)| i == index) {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.push((*index, item.clone()));
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+/// Packed multi-choice chunks with NON-CONTIGUOUS, UNSORTED `choice.index` values.
+///
+/// Two blind spots this closes, both found and closed in the sibling PR
+/// ai-dynamo/dynamo#11563:
+///
+/// 1. **Packed chunks.** Every other lane here emits one choice per chunk, so a
+///    jail that processed only `choices[0]` of each chunk, or that carried
+///    per-chunk (rather than per-choice) scratch state across the inner loop,
+///    would still pass.
+/// 2. **Non-contiguous / unsorted indices.** `ChoiceJailStateCollection` stores
+///    states in a `Vec` kept sorted by index and looks them up with
+///    `binary_search_by_key`. With the usual contiguous `0..k` arriving in order,
+///    a state keyed by *vector position* is indistinguishable from one keyed by
+///    `choice.index` — position and index coincide. Here the indices are
+///    `[u32::MAX, 7, 2]` and they arrive in descending order, so every new state
+///    inserts at position 0 and shifts its predecessors: position and index now
+///    disagree for every choice, and a position-keyed lookup returns another
+///    choice's jail buffer. `u32::MAX` additionally pins the boundary value.
+#[tokio::test]
+async fn jail_interleave_packed_chunks_non_contiguous_indices() {
+    let parser = "hermes";
+    // Deliberately unsorted and non-contiguous, including the u32 boundary.
+    const INDICES: [u32; 3] = [u32::MAX, 7, 2];
+
+    let sequences = vec![
+        s(&[
+            "checking ",
+            r#"<tool_call>{"name":"max_idx_call","arguments":{"who":"max"}}</tool_call>"#,
+            " done",
+        ]),
+        s(&["plain prose for seven, ", "never jailed"]),
+        s(&[
+            "<tool",
+            "_call>",
+            r#"{"name":"two_idx_call","arguments":{"who":"two"}}"#,
+            "</tool_call>",
+        ]),
+    ];
+
+    for schedule in [
+        Schedule::RoundRobin,
+        Schedule::FirstByteOffset(1),
+        Schedule::FirstByteOffset(2),
+    ] {
+        // Golden: each choice alone, at the SAME index it uses interleaved.
+        let mut goldens: BTreeMap<u32, Assembled> = BTreeMap::new();
+        for (pos, seq) in sequences.iter().enumerate() {
+            goldens.insert(
+                INDICES[pos],
+                solo_at(parser, Mode::MarkerBased, seq, INDICES[pos]).await,
+            );
+        }
+
+        // Interleave by position, then remap position -> real choice.index.
+        let tagged: Vec<(u32, String)> = interleave_items(&sequences, schedule)
+            .into_iter()
+            .map(|(pos, item)| (INDICES[pos as usize], item))
+            .collect();
+
+        let packed = pack_rounds(&tagged);
+        assert!(
+            packed.iter().any(|c| c.len() > 1),
+            "{}: expected at least one genuinely packed multi-choice chunk",
+            schedule.label()
+        );
+
+        // Staggered terminators here too: each index's terminator rides its own
+        // last delta, which for the shorter choices lands mid-wire.
+        let mut totals: BTreeMap<u32, usize> = BTreeMap::new();
+        for (idx, _) in &tagged {
+            *totals.entry(*idx).or_default() += 1;
+        }
+        let mut seen: BTreeMap<u32, usize> = BTreeMap::new();
+        let chunks: Vec<_> = packed
+            .iter()
+            .map(|group| {
+                let entries: Vec<(u32, String, Option<FinishReason>)> = group
+                    .iter()
+                    .map(|(idx, item)| {
+                        let n = seen.entry(*idx).or_default();
+                        *n += 1;
+                        let fin = (*n == totals[idx]).then_some(FinishReason::Stop);
+                        (*idx, item.clone(), fin)
+                    })
+                    .collect();
+                packed_chunk(&entries)
+            })
+            .collect();
+        let results: Vec<_> = build_jail(parser, Mode::MarkerBased)
+            .apply_with_finish_reason(stream::iter(chunks))
+            .collect()
+            .await;
+
+        // Demux by `choice.index`, never by arrival order or slot position.
+        let mut per_choice: BTreeMap<u32, Vec<&ChatChoiceStream>> = BTreeMap::new();
+        for choice in results
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| d.choices.iter())
+        {
+            per_choice.entry(choice.index).or_default().push(choice);
+        }
+
+        let mut failures = Vec::new();
+        for index in INDICES {
+            let golden = &goldens[&index];
+            match per_choice.get(&index) {
+                Some(chunks) => {
+                    let got = assemble(chunks);
+                    if &got != golden {
+                        failures.push(format!(
+                            "schedule={} packed/non-contiguous choice={index} diverged:\n     got  {got:?}\n     want {golden:?}",
+                            schedule.label()
+                        ));
+                    }
+                }
+                None => failures.push(format!(
+                    "schedule={} packed/non-contiguous choice={index}: no output demuxed",
+                    schedule.label()
+                )),
+            }
+        }
+        // No index may be invented that was never sent (a position-keyed bug can
+        // emit under a neighbour's index).
+        for index in per_choice.keys() {
+            assert!(
+                INDICES.contains(index),
+                "{}: jail emitted unknown choice.index {index}",
+                schedule.label()
+            );
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+}
+
+/// One k=3 round-robin case: three choices (tool call / plain / tool call) share
+/// one `JailedStream`; each must demux to its own solo golden.
+#[tokio::test]
+async fn jail_interleave_three_choices_round_robin() {
+    let parser = "hermes";
+    let sequences = vec![
+        s(&[
+            r#"<tool_call>{"name":"a_call","arguments":{"x":1}}</tool_call>"#,
+            " after a",
+        ]),
+        s(&["plain ", "middle ", "content"]),
+        s(&[
+            "prefix ",
+            r#"<tool_call>{"name":"c_call","arguments":{"y":2}}</tool_call>"#,
+        ]),
+    ];
+
+    let goldens: Vec<Assembled> = {
+        let mut v = Vec::new();
+        // Golden at the SLOT each shape occupies, not always slot 0: comparing a
+        // slot-0 reference against slots 1 and 2 would misattribute (or hide) a
+        // defect whose behaviour depends on the choice index.
+        for (i, seq) in sequences.iter().enumerate() {
+            v.push(solo_at(parser, Mode::MarkerBased, seq, i as u32).await);
+        }
+        v
+    };
+
+    let demuxed =
+        interleaved_by_choice(parser, Mode::MarkerBased, &sequences, Schedule::RoundRobin).await;
+    let mut failures = Vec::new();
+    for (index, golden) in goldens.iter().enumerate() {
+        let index = index as u32;
+        match demuxed.get(&index) {
+            Some(got) if got == golden => {}
+            Some(got) => failures.push(format!(
+                "k=3 RoundRobin choice={index} diverged:\n     got  {got:?}\n     want {golden:?}"
+            )),
+            None => failures.push(format!("k=3 RoundRobin choice={index}: no output demuxed")),
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}


### PR DESCRIPTION
## Summary

Test-only regression lanes proving streaming tool-call parser state is isolated per `choice.index` for `n>1` requests — the frontend-crates half of DIS-2381 step 3. **No parser production code changes.**

Every existing fixture is effectively single-choice, so a shared or misrouted accumulator passes them all. These lanes supply the missing second interleaved stream that a per-response (rather than per-choice) state bug corrupts.

## Why v1 needs this and v2 does not

**The v1 jail owns a choice dimension; the v2 `ToolParser` API does not.**

`JailedStream` holds per-choice state in `ChoiceJailStateCollection`, looked up by `get_or_create_state(choice.index, ..)`. One instance keeps several completions' jail buffers, partial markers and accumulated content apart — real product state with a real way to get it wrong. **That is the lane that can catch a product bug.**

A v2 `ToolParser` instance handles exactly one stream and has no `choice.index` parameter; the caller must construct one parser per choice. There is no v2 code keyed by choice, so the v2 sweep tests a weaker property: that parser instances carry no hidden shared state and interleaved execution matches solo. Its `ChoiceRouter` is test harness, not product code.

## The lanes

- **v1 jail lane** — `parsers/v1/tests/jail_interleave.rs` + `parsers/v1/tests/common/interleave.rs` (std-only deterministic schedule core, no RNG). Feeds interleaved divergent pairs through one `JailedStream`, demuxes by `choice.index`, compares each choice to its solo golden. 8 pairs × 2 role assignments × 9 schedules, plus a k=3 case and a packed/non-contiguous-index case.
- **v2 corpus sweep** — `conformance/tests/parity_toolcalling_stream_interleave.rs`. Routes each tagged delta to a per-index `ToolParser` across the existing v2 stream corpus. **2720 pair-schedules** over 9 families derived from `parser_families.yaml` `dynamo_v2`, 13 families skipped and named.

## Oracles

Each demuxed choice is compared against:

1. **Recorded `dynamo_v2` capture (v2 only, absolute)** — the corpus's own `expected:` / `normal_text`, with `arguments` compared as the RAW recorded string. Produced in an *earlier process*, which is what makes it immune to shared-global corruption.
2. **Solo run of that choice's demuxed subsequence (relative)** — including an `emission_profile`: running (delta count, byte count) sampled per emission. Totals cannot see a defect that merely *delays* a choice's output while a sibling is live.

The solo run alone is **not** sufficient: it is produced in the same process, so process-global state corrupts both sides identically. rmccorm4 demonstrated this by caching the first tool configuration in a `OnceLock` — the lane passed all 1088 pair-schedules while canonical parity reported real failures.

## What each dimension exists for

- **Both role assignments** — schedules give choice 0 the first slot of each round, so one ordering never exercises the higher index arriving first.
- **`BoundarySplit` over both victims and several ratios** — a fixed "split choice 0 at the midpoint" cannot see a parser that breaks only when the sibling is split, or at a boundary like `<tool_ | call>`.
- **Staggered terminators** — each choice's `finish_reason` rides its own last delta, so a shorter choice terminates mid-wire. A defect that tears down sibling state when the first choice finishes is unreachable otherwise.
- **Modes and families** — `tool_choice` required/named start the jail already jailed (`JailMode::Immediate`), a different state machine; a second marker family guards against Hermes-only assumptions.
- **Non-contiguous unsorted indices** (`[u32::MAX, 7, 2]`) — `ChoiceJailStateCollection` binary-searches a sorted `Vec`, so under contiguous `0..k` a position-keyed state is indistinguishable from an index-keyed one.

## Fail-open guards

Coverage cannot narrow silently:

- An enabled family that cannot be constructed **panics** — it is not skipped. Construction uses the registered `dynamo_v2` id, not the fixture directory name.
- A parser error on the interleaved wire re-runs each choice alone; if both parse solo the error is **cross-choice interference and fails**, not an unsupported shape.
- Cases dropped from the recorded oracle (chunking-dependent, allow-listed, unterminated, no recorded expectation) are always **named** in the summary. Currently 0.

## Validation (head `8c33c034`, as merged)

- `cargo test -p dynamo-parsers --test jail_interleave` → **9 passed**
- `cargo test -p dynamo-conformance-fixtures-v2 --test parity_toolcalling_stream_interleave` → **12 passed** (2720 pair-schedules, ~31s)
- `cargo test -p dynamo-parsers` → all suites green
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` → clean
- Diff is test-only.

Every behaviour above is mutation-proven: the mutation is applied, the lane is shown to fail, the mutation is reverted, and the tree re-verified clean. Notable proofs — a coexistence-scoped stalling parser fails 832 times via the profile and 0 times via recorded totals; an injected family construction failure panics instead of exiting 0; cross-choice teardown on terminal fails both v1 tests and was unreachable before staggered terminators existed.

## Known limits

- A **permanently** process-global defect (as opposed to coexistence-scoped) degrades the in-process solo baseline identically and stays invisible. Closing it would need a baseline captured in a separate process. Coexistence-scoped stalls — the realistic per-request bug — are caught.
- The v1 lane's pairs are hand-authored, so it has no recorded corpus to anchor to; only the v2 lane has an absolute oracle.

Sibling PR https://github.com/ai-dynamo/dynamo/pull/11563 (merged) fixes the dynamo preprocessor stage the same way. `parsers/` is excluded from the dynamo sync per `PARSERS-SYNC.md`, so each repo tests its own layer.

## Review

Reviewed by rmccorm4 (approved) and Devin across 7 rounds, plus an independent codex audit. Findings closed include: the self-referential solo golden, three recorded-overlay fold divergences from canonical `merge_dynamo`, cross-choice streaming stalls, missing staggered termination, silently no-op split ratios, and two fail-opens that let coverage vanish while the suite exited green.
