### PR TITLE
chore(renderer)!: release v3.0.0 with dynamo-protocols v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ clap = "4"
 derive_builder = "0.20"
 dynamo-parsers = { path = "parsers/v1", version = "5.1.2" }
 dynamo-protocols = { path = "protocols", version = "4.0.0" }
-dynamo-renderer = { path = "renderer", version = "2.0.0" }
+dynamo-renderer = { path = "renderer", version = "3.0.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.5.3" }
 either = { version = "1.13", features = ["serde"] }
 fastokens = "0.2.0"

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v2.0.0...dynamo-renderer-v3.0.0) - 2026-07-22
+
+### Changed
+
+- **Breaking:** Public request types exposed by `OAIChatLikeRequest` now use `dynamo-protocols` 4.x; consumers must upgrade `dynamo-protocols` when moving to `dynamo-renderer` 3.0.0.
+
+### Miscellaneous
+
+- Updated the following local packages: dynamo-protocols
+
 ## [2.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v1.3.12...dynamo-renderer-v2.0.0) - 2026-07-17
 
 ### Changed

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "dynamo-renderer"
 readme = "README.md"
-version = "2.0.0"
+version = "3.0.0"
 edition.workspace = true
 description = "Standalone OpenAI chat-template / prompt formatting (HF chat_template via minijinja)."
 authors.workspace = true


### PR DESCRIPTION
## Why

`dynamo-protocols` 4.0.0 upgraded its public async-openai types, while the published `dynamo-renderer` 2.0.0 package still depends on `dynamo-protocols` 3.x.

`dynamo-renderer` exposes protocol message types through `OAIChatLikeRequest`, so mixing renderer 2.x with protocols 4.x creates incompatible Rust types.

The automated release invoked the renderer package but did not detect the workspace path dependency change, so this PR prepares the required major release explicitly.

## What Changed

- Bump `dynamo-renderer` from 2.0.0 to 3.0.0.
- Release it against the workspace's `dynamo-protocols` 4.0.0 dependency while keeping `workspace = true` in `renderer/Cargo.toml`.
- Update the root workspace dependency, lockfile, and renderer changelog.

There are no renderer implementation changes; the major version reflects the public dependency type change.

## Validation

- `cargo fmt --all -- --check`
- `cargo semver-checks semver-checks check-release --package dynamo-renderer --baseline-rev dynamo-renderer-v2.0.0`
- `cargo test -p dynamo-renderer` (104 passed, 1 ignored)
- `cargo clippy -p dynamo-renderer --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo package -p dynamo-renderer --allow-dirty --no-verify`
- Verified the packaged manifest contains `dynamo-protocols = "4.0.0"` with no path dependency.
