### PR TITLE
ci: switch release flow back to blanket release-plz update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,57 +63,117 @@ jobs:
             | tar xz -C /usr/local/bin
           cargo-semver-checks --version
 
-      # Path-scoped auto-bump (DIS-2414). A blanket `release-plz update` cascades:
-      # a change to one crate re-releases its dependents even when their code
-      # didn't change (all inter-crate deps are caret reqs, so a compatible bump
-      # never requires re-releasing a dependent). That churned versions — e.g.
-      # dynamo-parsers-v2 went 0.1.17 -> 0.1.21 in days, and v1/v2 were bumped
-      # in lockstep despite sharing no code. Instead, run `release-plz update
-      # -p <crate>` only for crates whose OWN directory changed since their last
-      # release tag, and never touch a version a human already bumped:
-      #   - version != last release tag  -> manually PEGGED: leave it alone;
-      #     the publish step below ships exactly that version (same number the
-      #     HF fixture upload embeds — Cargo.toml is the single source of truth)
-      #   - version == last tag, no changes under the crate dir -> nothing
-      #   - version == last tag, changes under the crate dir -> auto-bump this
-      #     crate only (release-plz still sizes the bump from conventional
-      #     commits, writes the changelog, and runs cargo-semver-checks)
-      - name: Bump versions for crates whose own files changed
+      # Native release-plz cascade. With MAJOR-precision workspace pins (root
+      # Cargo.toml, e.g. dynamo-protocols = { version = "4" }) a single blanket
+      # `release-plz update` does the right thing per crate:
+      #   - bumps each crate whose OWN packaged source changed, sized from
+      #     Conventional Commits (gated by release_commits) and validated by
+      #     cargo-semver-checks;
+      #   - re-releases a dependent ONLY when a workspace dependency's MAJOR
+      #     changes: a compatible bump leaves the `"4"` requirement text unchanged
+      #     so nothing is touched (no churn); a breaking bump rewrites it to `"5"`
+      #     and cascades a PATCH bump;
+      #   - respects a MANUAL PEG (local version already ahead of the last
+      #     published release -> "only changelog will be updated", published
+      #     as-is — the fixture-synced release flow) and FIRST releases (an
+      #     untagged crate stays put).
+      - name: Update versions (release-plz)
         run: |
-          # `--allow-dirty` below is intentional: each package update leaves
-          # its version/changelog edits for the final combined release commit.
-          # Fail here so it cannot mask changes that predate this loop.
           if [ -n "$(git status --porcelain)" ]; then
             git status --short
             echo "Release checkout must start clean."
             exit 1
           fi
+          release-plz update
 
-          members=$(sed -n '/^members = \[/,/^]/p' Cargo.toml | grep -oE '"[^"]+"' | tr -d '"')
-          for dir in $members; do
+      # release-plz can only PATCH-cascade a dependent on a breaking dependency
+      # release: it cannot see that the dependency's types leak into the
+      # dependent's OWN public API ("dependency-surface drift" — cargo-semver-
+      # checks misses it too, so it can't size the bump either). So for HEAVY
+      # dependents — crates that re-export or expose a dependency's public types
+      # — a MAJOR dependency bump must force a MAJOR bump of the dependent.
+      #
+      # HEAVY entries are "<dir>:<dep-crate>[,<dep-crate>...]". dynamo-renderer
+      # exposes dynamo-protocols types (OAIChatLikeRequest::typed_messages) and
+      # re-exports dynamo-tokenizers (renderer/src/lib.rs), so a protocols OR a
+      # tokenizers major forces a renderer major. Add a crate here when it
+      # starts exposing another workspace crate's types in its public API.
+      - name: Escalate heavy dependents on a breaking dependency major
+        run: |
+          HEAVY="renderer:dynamo-protocols,dynamo-tokenizers"
+
+          # Safety-net: warn if a NON-heavy published crate looks like it exposes
+          # a workspace dependency's types in its public API (`pub use <dep>`, or a
+          # `pub` item naming `<dep>::Type`). Such a crate needs to be HEAVY too,
+          # or a breaking <dep> release would ship it as a semver-wrong PATCH.
+          # Heuristic only (misses trait-method signatures and glob re-exports) —
+          # a nudge to keep the HEAVY list honest, never a gate.
+          heavy_dirs=$(for e in $HEAVY; do echo "${e%%:*}"; done)
+          for dir in $(sed -n '/^members = \[/,/^]/p' Cargo.toml | grep -oE '"[^"]+"' | tr -d '"'); do
             grep -q '^publish *= *false' "$dir/Cargo.toml" && continue
+            printf '%s\n' $heavy_dirs | grep -qx "$dir" && continue
+            sname=$(grep -m1 '^name *=' "$dir/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+            for dep in $(awk '/^\[dependencies\]/{f=1;next}/^\[/{f=0}f' "$dir/Cargo.toml" | grep -oE 'dynamo-[a-z0-9-]+' | sort -u | grep -vx "$sname" || true); do
+              mod=$(echo "$dep" | tr '-' '_')
+              if grep -rqE "pub use (::)?${mod}\b|pub [^;{=]*\b${mod}::" "$dir/src" 2>/dev/null; then
+                echo "::warning::$sname (dir '$dir') appears to expose $dep types in its public API but is NOT on the HEAVY list. A breaking $dep release would ship $sname as a semver-wrong PATCH — if it re-exports/returns $dep types, add \"$dir:$dep\" to HEAVY in this step."
+              fi
+            done
+          done
+
+          maj() { echo "${1%%.*}"; }
+          # version string of workspace dep $1 from a root Cargo.toml on stdin
+          # (handles both "4" and "4.0.0" precision).
+          pin() { grep -E "^[[:space:]]*$1[[:space:]]*=" | grep -oE 'version[[:space:]]*=[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'; }
+
+          for entry in $HEAVY; do
+            dir="${entry%%:*}"; deps="${entry#*:}"
             name=$(grep -m1 '^name *=' "$dir/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')
-            ver=$(grep -m1 '^version *=' "$dir/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')
-            # Exact-match this crate's tags: the glob "dynamo-parsers-v*" would
-            # also match dynamo-parsers-v2-v0.1.21, so require <name>-v<semver>.
-            last=$(git tag -l "$name-v*" | grep -E "^$name-v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
-            if [ -z "$last" ]; then
-              echo "$name: no release tag yet -> first release is manual, skipping"
-            elif [ "$ver" != "${last#"$name"-v}" ]; then
-              echo "$name: $ver != last released ${last#"$name"-v} -> manually pegged"
-              # A manual peg bypasses release-plz update — the only path that
-              # runs cargo-semver-checks — so validate here that the pegged
-              # jump is big enough for the actual API diff vs the last release.
-              cargo semver-checks check-release --package "$name" --baseline-rev "$last"
-              echo "$name: peg passes semver-checks, publish as-is"
-            # The root Cargo.toml is part of every crate's change scope:
-            # workspace-inherited dependency versions and [workspace.package]
-            # metadata land in the published manifest of each member crate.
-            elif git diff --quiet "$last"..HEAD -- "$dir" Cargo.toml; then
-              echo "$name: no changes under $dir/ or the root Cargo.toml since $last"
+            last=$(git tag -l "$name-v*" | grep -E "^$name-v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1 || true)
+            if [ -z "$last" ]; then echo "$name: no release tag yet -> first release is manual"; continue; fi
+            lastver="${last#"$name"-v}"
+            curver=$(grep -m1 '^version *=' "$dir/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+            # Already a major bump over the last release (own breaking change, or
+            # a prior escalation this run)? Then there is nothing to force.
+            if [ "$(maj "$curver")" -gt "$(maj "$lastver")" ]; then
+              echo "$name: already a major bump ($lastver -> $curver)"; continue
+            fi
+
+            forced=""
+            OLDIFS=$IFS; IFS=','
+            for dep in $deps; do
+              old=$(git show "$last:Cargo.toml" | pin "$dep" || true)
+              new=$(pin "$dep" < Cargo.toml || true)
+              if [ -z "$old" ] || [ -z "$new" ]; then continue; fi
+              if [ "$(maj "$new")" -gt "$(maj "$old")" ]; then
+                echo "$name: heavy dependency $dep majored ($old -> $new) since $last"
+                forced=yes
+              fi
+            done
+            IFS=$OLDIFS
+
+            if [ -n "$forced" ]; then
+              # In the normal flow release-plz has already PATCH-cascaded this
+              # crate (a fresh top changelog entry), and set-version just relabels
+              # that pending entry to the major. If release-plz did NOT re-release
+              # it this run (working-tree version still equals HEAD), there is no
+              # pending entry and set-version would instead rewrite the last
+              # RELEASED entry — corrupting changelog history. That happens only in
+              # a one-time catch-up (a dependency major that predates this commit,
+              # e.g. right after enabling this workflow); skip and let a human ship
+              # the major once rather than clobber history.
+              headver=$(git show "HEAD:$dir/Cargo.toml" 2>/dev/null | grep -m1 '^version *=' | sed -E 's/.*"([^"]+)".*/\1/')
+              if [ "$curver" = "$headver" ]; then
+                echo "::warning::$name needs a major re-release for a breaking dependency, but release-plz did not cascade it this run (the dependency major predates this commit). Skipping auto-escalation; ship a one-off manual major release (merge a 'chore($name)!: release' PR). Future breaking bumps escalate automatically."
+                continue
+              fi
+              target="$(( $(maj "$lastver") + 1 )).0.0"
+              echo "$name: forcing major re-release $lastver -> $target"
+              release-plz set-version "$name@$target"
+              # release-plz 0.3.158 set-version does not refresh Cargo.lock.
+              cargo update --workspace >/dev/null 2>&1 || true
             else
-              echo "$name: changes under $dir/ (or root Cargo.toml) since $last -> auto-bump"
-              release-plz update --allow-dirty -p "$name"
+              echo "$name: no heavy dependency majored since $last -> no escalation"
             fi
           done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,15 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 clap = "4"
 derive_builder = "0.20"
-dynamo-parsers = { path = "parsers/v1", version = "5.1.2" }
-dynamo-protocols = { path = "protocols", version = "4.0.0" }
-dynamo-renderer = { path = "renderer", version = "2.0.0" }
-dynamo-tokenizers = { path = "tokenizers", version = "1.5.3" }
+# Internal crates are pinned at MAJOR precision on purpose: release-plz re-releases a
+# dependent only when a dependency bump changes this requirement text, so `"4"` triggers
+# a dependent release on a breaking 4 -> 5 bump but not on compatible 4.x bumps. Do NOT
+# tighten to `"4.0.0"` — that re-releases every dependent on every bump. See RELEASING.md.
+# (0.x crates would use minor precision, e.g. `"0.1"`.)
+dynamo-parsers = { path = "parsers/v1", version = "5" }
+dynamo-protocols = { path = "protocols", version = "4" }
+dynamo-renderer = { path = "renderer", version = "2" }
+dynamo-tokenizers = { path = "tokenizers", version = "1" }
 either = { version = "1.13", features = ["serde"] }
 fastokens = "0.2.0"
 futures = "0.3"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,30 +13,31 @@ what one-time setup it requires, and how to recover when it goes wrong.
 ## What happens on every push to `main`
 
 1. The `release` workflow runs.
-2. The workflow decides **per crate, path-scoped** (DIS-2414). For each publishable workspace crate it compares the crate's `Cargo.toml` version against the crate's latest release tag (e.g. `dynamo-protocols-v2.0.2`):
-   - **version ≠ last tag** → the version was **manually pegged** in a PR. The workflow does not touch it; the publish step ships exactly that version. See "Manual version peg" below.
-   - **version == last tag, no changes under the crate's own directory** since that tag → nothing happens. In particular, a change to one crate never re-releases its dependents: all inter-crate deps are caret reqs, so a compatible bump never requires a dependent re-release (the old blanket `release-plz update` cascaded these, churning versions of crates whose code never changed).
-   - **version == last tag, changes under the crate's own directory** → `release-plz update -p <crate>` bumps that crate only. Within the crate, release-plz still applies its own two filters: only **packaged contents** count (the `include = [...]` list in the crate's `Cargo.toml`: `src/**/*`, `Cargo.toml`, `README.md` — not `tests/` etc.), and only commits matching `release_commits` in `release-plz.toml` count (`feat:`, `fix:`, `perf:`, `refactor:`, `sync:`, plus — temporarily, for the dynamo→frontend-crates transition — `chore:`). If neither filter passes, no bump is proposed even though the directory changed.
-3. If any bumps were proposed, the workflow commits them with an informative
+2. **A single blanket `release-plz update`** decides every crate at once. This works — without the version churn it used to cause — because the workspace pins internal crates at **major precision** (`dynamo-protocols = { version = "4" }`, not `"4.0.0"`; see "Why the pins are `"4"`" below). release-plz then:
+   - bumps a crate whose **own packaged source** changed, sized from Conventional Commits (only `release_commits` types count: `feat:`/`fix:`/`perf:`/`refactor:`/`sync:`, plus — temporarily, for the dynamo→frontend-crates transition — `chore:`) and validated by `cargo-semver-checks`;
+   - re-releases a **dependent** ONLY when a workspace dependency has a **breaking (major)** release. A compatible dependency bump leaves the `"4"` requirement text unchanged, so no dependent is touched (this is what removed the version churn; the old `-p` path-scoped loop existed only because full-precision pins made release-plz cascade on *every* bump). A breaking bump rewrites the pin to `"5"` and cascades a **patch** bump to the dependent — just enough to move its requirement;
+   - respects a **manual peg**: if `Cargo.toml`'s version is already ahead of the last published release, release-plz reports *"local version > registry version, only changelog will be updated"* and the publish step ships exactly that version (the fixture-synced release flow). A **first release** (untagged crate) stays at its current version.
+3. **Heavy-dependent escalation** (`Escalate heavy dependents on a breaking dependency major` step). release-plz only ever *patch*-cascades a dependent, because it cannot detect that a dependency's types appear in the dependent's **own** public API — "dependency-surface drift", which `cargo-semver-checks` also misses. So for crates listed as **HEAVY** in the workflow, a **major** bump of a listed dependency forces a **major** bump of the dependent (via `release-plz set-version`). Currently the only entry is `dynamo-renderer:dynamo-protocols,dynamo-tokenizers` — renderer exposes `dynamo-protocols` types (`OAIChatLikeRequest::typed_messages`) and re-exports `dynamo-tokenizers` (`renderer/src/lib.rs`). **Add a crate to the HEAVY list when it starts exposing another workspace crate's types in its public API**, or its consumers will get a semver-wrong patch.
+4. If any versions changed, the workflow commits them with an informative
    subject listing every crate whose version changed this run — e.g.
-   `chore: release dynamo-protocols v1.4.0, dynamo-renderer v1.3.1` (with
+   `chore: release dynamo-protocols v5.0.0, dynamo-renderer v3.0.0` (with
    `Signed-off-by:` for DCO) — and pushes to `main`.
-4. `release-plz release` always runs (not gated on step 3 — a merge that only
+5. `release-plz release` always runs (not gated on step 4 — a merge that only
    manually pegged a version produces no bump commit but must still publish).
    It publishes every crate whose `Cargo.toml` version isn't on crates.io yet
    and creates the per-crate git tags; it's a no-op otherwise. GitHub Releases
    are disabled (`git_release_enable = false`); the per-crate `CHANGELOG.md`
    files plus the `*-v*` tags are the release record.
-5. The push from step 3 retriggers the workflow. A recursion guard on the
+6. The push from step 4 retriggers the workflow. A recursion guard on the
    `chore: release` commit message short-circuits the second run.
 
 ## Manual version peg (fixture-synced releases)
 
-To release a crate at a **specific, deliberate version** — e.g. so a conformance fixture snapshot (`conformance/fixtures/`, git-lfs) and the crates.io release carry the same pegged number — edit the crate's `version` in its `Cargo.toml` in your PR (any jump you want: patch, minor, major). On merge, the workflow sees the version differs from the last release tag, skips any auto-bump for that crate, and publishes exactly that version. `Cargo.toml` is the single source of truth: fixture provenance embeds the built crate's version, so both artifacts stay in sync by construction.
+To release a crate at a **specific, deliberate version** — e.g. so a conformance fixture snapshot (`conformance/fixtures/`, git-lfs) and the crates.io release carry the same pegged number — edit the crate's `version` in its `Cargo.toml` in your PR (any jump you want: patch, minor, major). On merge, `release-plz update` sees the local version is already ahead of the last published release (*"local version > registry version, only changelog will be updated"*), leaves the number alone, and the publish step ships exactly that version. `Cargo.toml` is the single source of truth: fixture provenance embeds the built crate's version, so both artifacts stay in sync by construction.
 
-The same mechanism covers a crate's **first release**: a crate with no release tag yet is never auto-bumped — set its version manually and merge.
+The same mechanism covers a crate's **first release**: a crate with no release tag yet stays at its current version — set it manually and merge.
 
-Note: a manual peg skips the auto-changelog; add a `CHANGELOG.md` entry in the same PR if the release warrants one.
+Note: release-plz writes a changelog entry for a pegged version automatically; add extra `CHANGELOG.md` prose in the same PR if the release warrants it.
 
 ## Bump policy
 
@@ -54,7 +55,26 @@ breaking position), so the bump depends on whether a crate has reached `1.0.0`.
 | `feat!:` / `BREAKING CHANGE:`   | 2.0.0 (major)   |
 | `chore:`, `ci:`, `build:`, etc. | no bump         |
 
-`dynamo-parsers-v2` is at `0.x`, where the minor slot is the breaking position (cargo treats `0.1.21 -> 0.2.0` as breaking, `0.1.21 -> 0.1.22` as compatible), so compatible changes bump the patch slot and breaking changes bump the minor slot. Lifecycle note: v1 (`dynamo-parsers`) is interim and will be removed outright once v2 reaches parity; v2 is the ultimate implementation (WIP), so expect its `0.x` line to keep moving while v1 stays quiet. Downstream exact pins like vLLM's `dynamo-parsers-v2 = "=0.1.x"` only move when their owners update them — another reason auto-bumps stay scoped to crates whose own code changed.
+`dynamo-parsers-v2` is at `0.x`, where the minor slot is the breaking position (cargo treats `0.1.21 -> 0.2.0` as breaking, `0.1.21 -> 0.1.22` as compatible), so compatible changes bump the patch slot and breaking changes bump the minor slot. Lifecycle note: v1 (`dynamo-parsers`) is interim and will be removed outright once v2 reaches parity; v2 is the ultimate implementation (WIP), so expect its `0.x` line to keep moving while v1 stays quiet. Downstream exact pins like vLLM's `dynamo-parsers-v2 = "=0.1.x"` only move when their owners update them.
+
+## Why the internal pins are `"4"`, not `"4.0.0"`
+
+The `[workspace.dependencies]` entries pin sibling crates at **major precision** (`dynamo-protocols = { path = "protocols", version = "4" }`). This is load-bearing, not a style choice, and it is verified against release-plz's source (`cargo_utils::upgrade_requirement`):
+
+release-plz re-releases a dependent **iff a dependency bump forces that requirement string to be rewritten**, at the precision it is written. With `"4"`, a compatible `4.x` bump leaves the text `"4"` unchanged → the dependent is **not** re-released (no churn). A breaking `4.x → 5.0` rewrites it to `"5"` → the dependent **is** re-released. So major-precision pins express exactly "re-release dependents only on a breaking dependency bump".
+
+**Do not tighten these to `"4.0.0"`.** Full precision rewrites the requirement on *every* dependency bump (patch/minor included), so release-plz re-releases every dependent every time — churning versions of crates whose code never changed. `0.x` crates, if any are ever depended on internally, would use minor precision (`"0.1"`) since `0.x`'s breaking slot is the minor.
+
+Note the tradeoff this accepts: a published dependent's requirement floor is only the major (`^4`), so it no longer auto-tightens to a specific minimum minor. In-workspace builds always use the current sibling via the `path`, and consumers normally take matched versions, so this is a deliberate, low-risk trade for churn-free releases.
+
+## Cascade and heavy-dependent escalation (worked example)
+
+When `dynamo-protocols` has a **breaking** release (`3.x → 4.0.0`):
+
+- `dynamo-parsers` depends on protocols but exposes **none** of its types publicly → release-plz patch-cascades it (`5.1.1 → 5.1.2`) only to move its requirement to `^4`. Correct and sufficient.
+- `dynamo-renderer` **exposes** protocols types in its public API and re-exports `dynamo-tokenizers` → it is on the HEAVY list, so the escalation step upgrades release-plz's patch cascade to a **major** (`2.0.0 → 3.0.0`). Without this it would ship a semver-wrong patch, because neither release-plz nor `cargo-semver-checks` can see that a dependency's type change broke renderer's own API (this was validated empirically).
+
+A **compatible** protocols release (`4.0.0 → 4.1.0`) re-releases neither: `^4` still admits it.
 
 ### What `cargo-semver-checks` validates
 


### PR DESCRIPTION
Switch the release workflow to a blanket release-plz update and pin internal crates at major precision, so a dependent is re-released only when a dependency has a breaking (major) bump, never on a compatible one.

Add a heavy-dependent escalation step that forces a major bump on crates exposing a dependency's public types (dynamo-renderer), because release-plz only patch-cascades and cargo-semver-checks cannot detect dependency-surface drift. Include a grep safety-net that warns when an unlisted crate looks like it exposes a dependency's types, and a catch-up guard that avoids rewriting released changelog history.

closes: OPS-7773