### PR TITLE
feat(protocols)!: support media in tool results

### DIFF
--- a/protocols/src/types/anthropic.rs
+++ b/protocols/src/types/anthropic.rs
@@ -333,7 +333,7 @@ impl ToolResultContent {
                 .into_iter()
                 .filter_map(|b| match b {
                     ToolResultContentBlock::Text { text } => Some(text),
-                    ToolResultContentBlock::Other(_) => None,
+                    ToolResultContentBlock::Image { .. } | ToolResultContentBlock::Other(_) => None,
                 })
                 .collect::<Vec<_>>()
                 .join(""),
@@ -342,14 +342,75 @@ impl ToolResultContent {
 }
 
 /// A content block within a `tool_result.content` array.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum ToolResultContentBlock {
     Text {
         text: String,
     },
-    /// Catch-all for non-text blocks (images, etc.) in tool results.
+    /// Image returned by a tool.
+    Image {
+        source: AnthropicImageSource,
+    },
+    /// Catch-all for other non-text blocks in tool results.
     Other(serde_json::Value),
+}
+
+impl Serialize for ToolResultContentBlock {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Text { text } => serde_json::json!({
+                "type": "text",
+                "text": text,
+            })
+            .serialize(serializer),
+            Self::Image { source } => serde_json::json!({
+                "type": "image",
+                "source": source,
+            })
+            .serialize(serializer),
+            Self::Other(value) => value.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ToolResultContentBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value.get("type").and_then(|value| value.as_str()) {
+            Some("text") => {
+                let text = value
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .ok_or_else(|| serde::de::Error::missing_field("text"))?;
+                Ok(Self::Text {
+                    text: text.to_string(),
+                })
+            }
+            Some("image") => {
+                let source = value
+                    .get("source")
+                    .cloned()
+                    .ok_or_else(|| serde::de::Error::missing_field("source"))
+                    .and_then(|value| {
+                        serde_json::from_value(value).map_err(serde::de::Error::custom)
+                    })?;
+                Ok(Self::Image { source })
+            }
+            None => match value.get("text").and_then(|value| value.as_str()) {
+                Some(text) => Ok(Self::Text {
+                    text: text.to_string(),
+                }),
+                None => Ok(Self::Other(value)),
+            },
+            _ => Ok(Self::Other(value)),
+        }
+    }
 }
 
 /// Custom deserializer for `AnthropicContentBlock` that handles unknown types
@@ -861,6 +922,7 @@ fn estimate_block_len(block: &AnthropicContentBlock) -> usize {
                     .iter()
                     .map(|b| match b {
                         ToolResultContentBlock::Text { text } => text.len(),
+                        ToolResultContentBlock::Image { .. } => 256,
                         ToolResultContentBlock::Other(v) => v.to_string().len(),
                     })
                     .sum(),
@@ -897,5 +959,40 @@ mod tests {
         let nvext = request.nvext.expect("opaque nvext value");
         assert_eq!(nvext["unknown_future_extension"]["nested"], true);
         assert_eq!(nvext["agent_context"]["trajectory_id"], 7);
+    }
+
+    #[test]
+    fn tool_result_blocks_preserve_image_and_reject_document() {
+        let input = serde_json::json!([
+            {"type": "text", "text": "Screenshot captured"},
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "aGVsbG8="
+                }
+            },
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "aGVsbG8="
+                }
+            }
+        ]);
+        let content: ToolResultContent = serde_json::from_value(input.clone()).unwrap();
+
+        let ToolResultContent::Blocks(blocks) = &content else {
+            panic!("expected content blocks");
+        };
+        assert!(matches!(blocks[1], ToolResultContentBlock::Image { .. }));
+        assert!(matches!(blocks[2], ToolResultContentBlock::Other(_)));
+        assert_eq!(serde_json::to_value(content).unwrap(), input);
+
+        let legacy: ToolResultContentBlock =
+            serde_json::from_value(serde_json::json!({"text": "legacy"})).unwrap();
+        assert!(matches!(legacy, ToolResultContentBlock::Text { .. }));
     }
 }

--- a/protocols/src/types/chat.rs
+++ b/protocols/src/types/chat.rs
@@ -45,10 +45,6 @@ pub use async_openai::types::chat::{
     ChatCompletionRequestSystemMessageArgs,
     ChatCompletionRequestSystemMessageContent,
     ChatCompletionRequestSystemMessageContentPart,
-    ChatCompletionRequestToolMessage,
-    ChatCompletionRequestToolMessageArgs,
-    ChatCompletionRequestToolMessageContent,
-    ChatCompletionRequestToolMessageContentPart,
     ChatCompletionResponseMessageAudio,
     ChatCompletionTokenLogprob,
     Choice,
@@ -307,6 +303,59 @@ pub struct ImageUrl {
     #[deprecated(note = "use the content-part `uuid` field for vLLM cache identities")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<Uuid>,
+}
+
+/// Tool message content part with media observation support.
+///
+/// OpenAI's schema currently limits tool content parts to text, but
+/// OpenAI-compatible multimodal backends also accept image, video, and audio
+/// observations returned by tools.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum ChatCompletionRequestToolMessageContentPart {
+    Text(ChatCompletionRequestMessageContentPartText),
+    ImageUrl(ChatCompletionRequestMessageContentPartImage),
+    VideoUrl(ChatCompletionRequestMessageContentPartVideo),
+    AudioUrl(ChatCompletionRequestMessageContentPartAudioUrl),
+}
+
+/// Tool message content, extended to preserve media observations.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum ChatCompletionRequestToolMessageContent {
+    Text(String),
+    Array(Vec<ChatCompletionRequestToolMessageContentPart>),
+}
+
+impl Default for ChatCompletionRequestToolMessageContent {
+    fn default() -> Self {
+        Self::Text(String::new())
+    }
+}
+
+impl From<&str> for ChatCompletionRequestToolMessageContent {
+    fn from(value: &str) -> Self {
+        Self::Text(value.into())
+    }
+}
+
+impl From<String> for ChatCompletionRequestToolMessageContent {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+/// Tool message using Dynamo's media-capable content type.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[builder(name = "ChatCompletionRequestToolMessageArgs")]
+#[builder(pattern = "mutable")]
+#[builder(setter(into, strip_option), default)]
+#[builder(derive(Debug))]
+#[builder(build_fn(error = "OpenAIError"))]
+pub struct ChatCompletionRequestToolMessage {
+    pub content: ChatCompletionRequestToolMessageContent,
+    pub tool_call_id: String,
 }
 
 #[derive(Clone, Serialize, Default, Debug, Deserialize, PartialEq)]
@@ -1308,5 +1357,54 @@ mod tests {
             }
             _ => panic!("parts[2] should be image_url"),
         }
+    }
+
+    #[test]
+    fn tool_message_accepts_media_content() {
+        let message: ChatCompletionRequestMessage = serde_json::from_value(serde_json::json!({
+            "role": "tool",
+            "tool_call_id": "call_media",
+            "content": [
+                {"type": "text", "text": "Screenshot captured"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,aGVsbG8="
+                    }
+                },
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "https://example.com/clip.mp4"
+                    }
+                },
+                {
+                    "type": "audio_url",
+                    "audio_url": {
+                        "url": "https://example.com/audio.wav"
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        let ChatCompletionRequestMessage::Tool(tool) = message else {
+            panic!("expected tool message");
+        };
+        let ChatCompletionRequestToolMessageContent::Array(parts) = tool.content else {
+            panic!("expected array content");
+        };
+        assert!(matches!(
+            parts[1],
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(_)
+        ));
+        assert!(matches!(
+            parts[2],
+            ChatCompletionRequestToolMessageContentPart::VideoUrl(_)
+        ));
+        assert!(matches!(
+            parts[3],
+            ChatCompletionRequestToolMessageContentPart::AudioUrl(_)
+        ));
     }
 }

--- a/protocols/src/types/impls.rs
+++ b/protocols/src/types/impls.rs
@@ -11,8 +11,10 @@ use super::{
     ChatCompletionRequestAssistantMessageContent, ChatCompletionRequestMessage,
     ChatCompletionRequestMessageContentPartAudio, ChatCompletionRequestMessageContentPartAudioUrl,
     ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
-    ChatCompletionRequestMessageContentPartVideo, ChatCompletionRequestUserMessageContentPart,
-    ChatCompletionToolChoiceOption, ChatCompletionToolType, FunctionName, ImageUrl, VideoUrl,
+    ChatCompletionRequestMessageContentPartVideo, ChatCompletionRequestToolMessage,
+    ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
+    ChatCompletionRequestUserMessageContentPart, ChatCompletionToolChoiceOption,
+    ChatCompletionToolType, FunctionName, ImageUrl, VideoUrl,
 };
 
 use crate::error::OpenAIError;
@@ -99,6 +101,40 @@ impl From<async_openai::types::chat::ChatCompletionRequestToolMessage>
     for ChatCompletionRequestMessage
 {
     fn from(value: async_openai::types::chat::ChatCompletionRequestToolMessage) -> Self {
+        Self::Tool(value.into())
+    }
+}
+
+impl From<async_openai::types::chat::ChatCompletionRequestToolMessage>
+    for ChatCompletionRequestToolMessage
+{
+    fn from(value: async_openai::types::chat::ChatCompletionRequestToolMessage) -> Self {
+        let content = match value.content {
+            async_openai::types::chat::ChatCompletionRequestToolMessageContent::Text(text) => {
+                ChatCompletionRequestToolMessageContent::Text(text)
+            }
+            async_openai::types::chat::ChatCompletionRequestToolMessageContent::Array(parts) => {
+                ChatCompletionRequestToolMessageContent::Array(
+                    parts
+                        .into_iter()
+                        .map(|part| match part {
+                            async_openai::types::chat::ChatCompletionRequestToolMessageContentPart::Text(
+                                text,
+                            ) => ChatCompletionRequestToolMessageContentPart::Text(text),
+                        })
+                        .collect(),
+                )
+            }
+        };
+        Self {
+            content,
+            tool_call_id: value.tool_call_id,
+        }
+    }
+}
+
+impl From<ChatCompletionRequestToolMessage> for ChatCompletionRequestMessage {
+    fn from(value: ChatCompletionRequestToolMessage) -> Self {
         Self::Tool(value)
     }
 }


### PR DESCRIPTION
## Summary

Allow OpenAI-compatible tool messages to carry image, video, and audio URL parts, and Anthropic tool results to carry typed image blocks.

Text-only results are unchanged. This owns the tool-message request types, so the crate release is semver-major. Consumed by [ai-dynamo/dynamo#12180](<https://github.com/ai-dynamo/dynamo/issues/12180>).

## Validation

* `cargo test -p dynamo-protocols`
* `cargo clippy -p dynamo-protocols --tests -- -D warnings`
* `cargo fmt --all --check`

Related to ai-dynamo/dynamo#12179.