### PR TITLE
chore(renderer)!: release v4.0.0 with dynamo-protocols v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ clap = "4"
 derive_builder = "0.20"
 dynamo-parsers = { path = "parsers/v1", version = "6.0.1" }
 dynamo-protocols = { path = "protocols", version = "5.0.0" }
-dynamo-renderer = { path = "renderer", version = "3.0.0" }
+dynamo-renderer = { path = "renderer", version = "4.0.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.5.4" }
 either = { version = "1.13", features = ["serde"] }
 fastokens = "0.2.0"

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v3.0.0...dynamo-renderer-v4.0.0) - 2026-07-27
+
+### Changed
+
+- **Breaking:** Public request types exposed by `OAIChatLikeRequest` now use `dynamo-protocols` 5.x; consumers must upgrade `dynamo-protocols` when moving to `dynamo-renderer` 4.0.0.
+
+### Miscellaneous
+
+- Updated the following local packages: dynamo-protocols
+
 ## [3.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-renderer-v2.0.0...dynamo-renderer-v3.0.0) - 2026-07-22
 
 ### Changed

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "dynamo-renderer"
 readme = "README.md"
-version = "3.0.0"
+version = "4.0.0"
 edition.workspace = true
 description = "Standalone OpenAI chat-template / prompt formatting (HF chat_template via minijinja)."
 authors.workspace = true


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Release `dynamo-renderer` v4.0.0 with its `dynamo-protocols` v5 boundary. This keeps the renderer's public request-type API aligned for Dynamo consumers.

### How This Was Implemented
- Manually pegs `dynamo-renderer` to v4.0.0.
- Aligns the workspace dependency used by the demo server.
- Records the breaking protocol-type boundary in the renderer changelog.

<details>
<summary>Walkthrough</summary>

`OAIChatLikeRequest::typed_messages()` exposes `dynamo_protocols` types in the renderer's public API. The renderer therefore needs a major release when its protocol dependency moves from v4 to v5; the manual version peg makes the release workflow run `cargo-semver-checks` and publish exactly v4.0.0.

No renderer behavior changes in this PR.

</details>

### Validation
- `cargo check -p dynamo-renderer`
- `git diff --check`
<!-- codex-pr-description:end -->
