### PR TITLE
feat(parsers): UnifiedParser for Qwen3 — one ordered reasoning/text/tool stream

### DIFF
--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,6 +1,6 @@
 {
-  "snapshot": "20260728_163542",
-  "created_pt": "2026-07-28 16:35:42 America/Los_Angeles",
+  "snapshot": "20260729_121209",
+  "created_pt": "2026-07-29 12:12:09 America/Los_Angeles",
   "crates": {
     "dynamo-parsers": "6.0.4",
     "dynamo-parsers-v2": "0.1.23"
@@ -137,8 +137,8 @@
     },
     {
       "path": "unified/dynamo_v2-0.1.23.tar.gz",
-      "sha256": "efc7eac9b2935c1e47a76930c881c9e8f7c7acf8dc734a2ec7a92593c7f38b16",
-      "size": 5183
+      "sha256": "7d8ec2aa4fd17b47afb2107bb3b90ad8461031eac575e88424c811845ef651b3",
+      "size": 5130
     },
     {
       "path": "unified/golden.tar.gz",

--- a/conformance/fixtures/unified/dynamo_v2-0.1.23.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.1.23.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efc7eac9b2935c1e47a76930c881c9e8f7c7acf8dc734a2ec7a92593c7f38b16
-size 5183
+oid sha256:7d8ec2aa4fd17b47afb2107bb3b90ad8461031eac575e88424c811845ef651b3
+size 5130

--- a/conformance/tests/unified_parity.rs
+++ b/conformance/tests/unified_parity.rs
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The acceptance gate for the unified parser: every `UNIFIED.*` case of every
+//! family that has a unified parser must assemble EXACTLY to the authored golden
+//! event list.
+//!
+//! `unified_schema_roundtrip` proves the corpus is well-formed and
+//! `unified_render` draws it; this file is what fails CI when a parser is wrong.
+//! It asserts the invariants from `conformance/utils/lib/parsers/UNIFIED_CASES.md`
+//! that are checkable from the single-stream corpus:
+//!
+//! * `I2` order preservation — the assembled list is compared order-sensitively
+//! * `I5` chunk-invariance — the same input under five chunk splittings
+//! * `I6` stream/batch parity — `parse_complete` against the streamed result
+//! * `I4` per-stream isolation — two concurrent parsers do not see each other
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use dynamo_parsers_v2::{
+    REGISTERED_UNIFIED_FAMILIES, Tool, UnifiedEvent, assemble, create_unified_parser_for_family,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize)]
+struct GoldenFile {
+    family: String,
+    cases: BTreeMap<String, GoldenCase>,
+}
+
+#[derive(Deserialize)]
+struct GoldenCase {
+    input: String,
+    golden: Vec<UnifiedEvent>,
+}
+
+/// Tool schemas the corpus is written against (string params, so a value like
+/// `1` stays the string `"1"` exactly as the golden records it). Mirrors
+/// `tools()` in `unified_render.rs`.
+fn tools() -> Vec<Tool> {
+    let mk = |name: &str, key: &str| Tool {
+        name: name.to_string(),
+        description: None,
+        parameters: json!({"type":"object","properties":{key:{"type":"string"}}}),
+        strict: None,
+    };
+    vec![
+        mk("get_weather", "city"),
+        mk("f", "x"),
+        mk("g", "y"),
+        mk("run", "cmd"),
+        mk("log", "note"),
+    ]
+}
+
+fn load_golden() -> Vec<GoldenFile> {
+    let dir = common::ensure_unified_golden();
+    let mut files: Vec<GoldenFile> = Vec::new();
+    for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display())) {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).unwrap();
+        files.push(
+            serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("{}: {e}", path.display())),
+        );
+    }
+    files.sort_by(|a, b| a.family.cmp(&b.family));
+    files
+}
+
+fn has_unified_parser(family: &str) -> bool {
+    create_unified_parser_for_family(family, &[]).is_ok()
+}
+
+fn events(family: &str, chunks: &[String]) -> Vec<UnifiedEvent> {
+    let mut parser = create_unified_parser_for_family(family, &tools())
+        .unwrap_or_else(|e| panic!("create unified parser for `{family}`: {e}"));
+    let mut deltas = Vec::new();
+    for chunk in chunks {
+        deltas.extend(parser.push(chunk).unwrap_or_else(|e| panic!("push: {e}")));
+    }
+    deltas.extend(parser.finish().unwrap_or_else(|e| panic!("finish: {e}")));
+    assemble(&deltas)
+}
+
+fn render(events: &[UnifiedEvent]) -> String {
+    events
+        .iter()
+        .map(|e| match e {
+            UnifiedEvent::Reasoning { text } => format!("reasoning({text:?})"),
+            UnifiedEvent::Text { text } => format!("text({text:?})"),
+            UnifiedEvent::ToolCall { name, arguments } => format!("tool_call({name}, {arguments})"),
+        })
+        .collect::<Vec<_>>()
+        .join("  |  ")
+}
+
+/// Marker-aligned chunking: each `<...>` control marker is its own chunk.
+fn chunk_markers(input: &str) -> Vec<String> {
+    let bytes = input.as_bytes();
+    let mut chunks = Vec::new();
+    let (mut i, mut text_start) = (0, 0);
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if text_start < i {
+                chunks.push(input[text_start..i].to_string());
+            }
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] != b'>' {
+                j += 1;
+            }
+            let end = (j + 1).min(bytes.len());
+            chunks.push(input[i..end].to_string());
+            i = end;
+            text_start = i;
+        } else {
+            i += 1;
+        }
+    }
+    if text_start < bytes.len() {
+        chunks.push(input[text_start..].to_string());
+    }
+    chunks
+}
+
+/// Split into chunks of at most `n` chars (never mid-char).
+fn chunk_every(input: &str, n: usize) -> Vec<String> {
+    input
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(n)
+        .map(|c| c.iter().collect())
+        .collect()
+}
+
+fn splittings(input: &str) -> Vec<(String, Vec<String>)> {
+    vec![
+        ("marker-aligned".into(), chunk_markers(input)),
+        ("whole".into(), vec![input.to_string()]),
+        ("1-char".into(), chunk_every(input, 1)),
+        ("3-char".into(), chunk_every(input, 3)),
+        ("7-char".into(), chunk_every(input, 7)),
+    ]
+}
+
+/// The gate: assembled events must equal the golden, exactly and in order.
+#[test]
+fn unified_parser_matches_the_golden_oracle() {
+    let files = load_golden();
+    let covered: Vec<&GoldenFile> = files
+        .iter()
+        .filter(|f| has_unified_parser(&f.family))
+        .collect();
+    assert!(
+        !covered.is_empty(),
+        "no golden family has a unified parser — the surface is unproven"
+    );
+
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+    for file in &covered {
+        for (id, case) in &file.cases {
+            checked += 1;
+            let got = events(&file.family, &chunk_markers(&case.input));
+            if got != case.golden {
+                failures.push(format!(
+                    "{id}\n     input: {:?}\n    golden: {}\n   unified: {}",
+                    case.input,
+                    render(&case.golden),
+                    render(&got),
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} unified cases diverge from the golden oracle:\n\n{}",
+        failures.len(),
+        failures.join("\n\n"),
+    );
+    assert!(checked >= 30, "expected the qwen3 corpus, got {checked}");
+}
+
+/// I5: the assembled list must not depend on where chunk boundaries fall.
+#[test]
+fn unified_parser_is_chunk_invariant() {
+    let mut failures = Vec::new();
+    for file in load_golden()
+        .iter()
+        .filter(|f| has_unified_parser(&f.family))
+    {
+        for (id, case) in &file.cases {
+            let baseline = events(&file.family, std::slice::from_ref(&case.input));
+            for (label, chunks) in splittings(&case.input) {
+                let got = events(&file.family, &chunks);
+                if got != baseline {
+                    failures.push(format!(
+                        "{id} [{label}, {} chunks]\n  whole: {}\n    got: {}",
+                        chunks.len(),
+                        render(&baseline),
+                        render(&got),
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "chunk splitting changed the assembled events ({}):\n\n{}",
+        failures.len(),
+        failures.join("\n\n"),
+    );
+}
+
+/// I6: parsing the whole output at once assembles to the streamed result.
+#[test]
+fn unified_parser_has_stream_batch_parity() {
+    for file in load_golden()
+        .iter()
+        .filter(|f| has_unified_parser(&f.family))
+    {
+        for (id, case) in &file.cases {
+            let streamed = events(&file.family, &chunk_markers(&case.input));
+            let mut parser = create_unified_parser_for_family(&file.family, &tools()).unwrap();
+            let batch = parser
+                .parse_complete(&case.input)
+                .unwrap_or_else(|e| panic!("{id}: parse_complete: {e}"));
+            assert_eq!(
+                batch,
+                streamed,
+                "{id}: batch and stream disagree\n   batch: {}\n  stream: {}",
+                render(&batch),
+                render(&streamed),
+            );
+        }
+    }
+}
+
+/// I4: one parser per stream, so interleaving two streams cannot contaminate
+/// either one.
+#[test]
+fn unified_parsers_are_isolated_per_stream() {
+    for file in load_golden()
+        .iter()
+        .filter(|f| has_unified_parser(&f.family))
+    {
+        let cases: Vec<_> = file.cases.iter().collect();
+        for pair in cases.windows(2) {
+            let [(id_a, a), (id_b, b)] = pair else {
+                continue;
+            };
+            let (ca, cb) = (chunk_markers(&a.input), chunk_markers(&b.input));
+            let solo_a = events(&file.family, &ca);
+            let solo_b = events(&file.family, &cb);
+
+            let mut pa = create_unified_parser_for_family(&file.family, &tools()).unwrap();
+            let mut pb = create_unified_parser_for_family(&file.family, &tools()).unwrap();
+            let (mut da, mut db) = (Vec::new(), Vec::new());
+            for i in 0..ca.len().max(cb.len()) {
+                if let Some(c) = ca.get(i) {
+                    da.extend(pa.push(c).unwrap());
+                }
+                if let Some(c) = cb.get(i) {
+                    db.extend(pb.push(c).unwrap());
+                }
+            }
+            da.extend(pa.finish().unwrap());
+            db.extend(pb.finish().unwrap());
+
+            assert_eq!(
+                assemble(&da),
+                solo_a,
+                "{id_a}: interleaving with {id_b} changed its events"
+            );
+            assert_eq!(
+                assemble(&db),
+                solo_b,
+                "{id_b}: interleaving with {id_a} changed its events"
+            );
+        }
+    }
+}
+
+/// Guard the registry against drift, the same way the tool-only suite does.
+#[test]
+fn registered_unified_families_all_create() {
+    for family in REGISTERED_UNIFIED_FAMILIES {
+        create_unified_parser_for_family(family, &[]).unwrap_or_else(|e| {
+            panic!("REGISTERED_UNIFIED_FAMILIES entry `{family}` does not create: {e}")
+        });
+    }
+    assert!(
+        load_golden().iter().any(|f| has_unified_parser(&f.family)),
+        "no golden family maps to a registered unified parser"
+    );
+}

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -1,22 +1,30 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! U2/U3 (spike) — compute the Dynamo v2 column LIVE and render the unified
-//! conformance tab to HTML.
+//! Compute the Dynamo v2 column LIVE, render the unified conformance tab, and
+//! write the capture the packaged shard is built from.
 //!
-//! Columns: GOLDEN (authored oracle) | vLLM 0.25.x unified (expected, from the
-//! golden `expect.vllm` — live capture is U1) | Dynamo v2 (v1 reasoning + v2
-//! tool, composed and stitched to how Dynamo serves today — computed this run).
+//! Columns: GOLDEN (authored oracle) | vLLM (captured) | Dynamo v2.
 //!
-//! Dynamo is the real "before" state: the split parses ALL reasoning first, so
-//! reasoning interleaved with tool calls loses order. Each diverging Dynamo cell
-//! carries a TODO in its hover popup. Output: conformance/unified/CONFORMANCE_unified.html
+//! The Dynamo column is a PER-FAMILY MIXTURE, the same shape as vLLM Rust's: the
+//! native UnifiedParser where one exists (qwen3 today), and the v1-reasoning +
+//! v2-tool split everywhere else. The split is the "before" state — it parses ALL
+//! reasoning first, so reasoning interleaved with tool calls loses its position.
+//!
+//! Output: `conformance/CONFORMANCE_unified.html` (standalone preview) and
+//! `conformance/unified/unified_results.yaml`. The exploder and packager turn that
+//! feed into the committed `dynamo_v2-<ver>` shard, which is what the
+//! CONFORMANCE_v2.html tab actually reads — the tab never runs these parsers. The
+//! `committed_dynamo_capture_matches_the_live_parsers` test below fails if that
+//! shard drifts from the parsers.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use dynamo_parsers::{ReasoningParser, ReasoningParserType};
-use dynamo_parsers_v2::{Tool, create_tool_parser_for_family};
+use dynamo_parsers_v2::{
+    Tool, assemble, create_tool_parser_for_family, create_unified_parser_for_family,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -138,11 +146,59 @@ fn feed(
     }
 }
 
-/// Compute the REAL Dynamo v2 unified event list for one input, exactly how
-/// Dynamo serves today: the v1 reasoning parser strips reasoning over the whole
-/// stream into ONE assembled field (the merge), then the v2 tool parser streams
-/// the leftover content (char-by-char) preserving text/call order.
+impl From<dynamo_parsers_v2::UnifiedEvent> for Ev {
+    fn from(e: dynamo_parsers_v2::UnifiedEvent) -> Self {
+        match e {
+            dynamo_parsers_v2::UnifiedEvent::Reasoning { text } => Ev::Reasoning { text },
+            dynamo_parsers_v2::UnifiedEvent::Text { text } => Ev::Text { text },
+            dynamo_parsers_v2::UnifiedEvent::ToolCall { name, arguments } => {
+                Ev::ToolCall { name, arguments }
+            }
+        }
+    }
+}
+
+fn unified_delta_json(d: &dynamo_parsers_v2::UnifiedDelta) -> Value {
+    match d {
+        dynamo_parsers_v2::UnifiedDelta::Reasoning { text } => {
+            json!({"kind": "reasoning", "text": text})
+        }
+        dynamo_parsers_v2::UnifiedDelta::Text { text } => json!({"kind": "text", "text": text}),
+        dynamo_parsers_v2::UnifiedDelta::ToolCall(c) => {
+            json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
+        }
+    }
+}
+
+/// Compute the Dynamo v2 unified event list for one input.
+///
+/// PER-FAMILY MIXTURE, the same shape as vLLM Rust's column: a family that has a
+/// unified parser is parsed by it — one state machine per stream owning
+/// reasoning + content + tool calls. Every other family still goes through the
+/// SPLIT Dynamo serves today: the v1 reasoning parser strips reasoning over the
+/// whole stream into ONE assembled field (the merge), then the v2 tool parser
+/// streams the leftover content (char-by-char) preserving text/call order.
+///
+/// Both paths are driven from the SAME chunking as `dynamo_chunks`, so the
+/// assembled row and the per-chunk rows in the popup describe one run.
 fn dynamo_events(family: &str, input: &str) -> Vec<Ev> {
+    if let Ok(mut parser) = create_unified_parser_for_family(family, &tools()) {
+        let mut deltas = Vec::new();
+        for chunk in chunk_input(input) {
+            deltas.extend(
+                parser
+                    .push(&chunk)
+                    .unwrap_or_else(|e| panic!("unified push `{family}`: {e}")),
+            );
+        }
+        deltas.extend(
+            parser
+                .finish()
+                .unwrap_or_else(|e| panic!("unified finish `{family}`: {e}")),
+        );
+        return assemble(&deltas).into_iter().map(Ev::from).collect();
+    }
+
     let (reasoning_name, tool_family) = parsers_for(family);
 
     let mut rp = ReasoningParserType::get_reasoning_parser_from_name(reasoning_name);
@@ -239,6 +295,31 @@ fn tool_deltas(res: &dynamo_parsers_v2::ToolParseResult, out: &mut Vec<Value>) {
 /// real per-chunk emitted deltas (v1 reasoning streaming incremental -> v2 tool
 /// streaming push on the leftover content).
 fn dynamo_chunks(family: &str, input: &str) -> Vec<ChunkRow> {
+    // Unified families: ONE parser, so a chunk's deltas are simply what it emitted.
+    if let Ok(mut parser) = create_unified_parser_for_family(family, &tools()) {
+        let mut rows = Vec::new();
+        for chunk in chunk_input(input) {
+            let deltas = parser.push(&chunk).unwrap_or_default();
+            rows.push(ChunkRow {
+                delta_text: chunk,
+                deltas: deltas.iter().map(unified_delta_json).collect(),
+            });
+        }
+        let tail: Vec<Value> = parser
+            .finish()
+            .unwrap_or_default()
+            .iter()
+            .map(unified_delta_json)
+            .collect();
+        if !tail.is_empty() {
+            rows.push(ChunkRow {
+                delta_text: "‹finish›".to_string(),
+                deltas: tail,
+            });
+        }
+        return rows;
+    }
+
     let (reasoning_name, tool_family) = parsers_for(family);
     let mut rp = ReasoningParserType::get_reasoning_parser_from_name(reasoning_name);
     let mut tp = create_tool_parser_for_family(tool_family, &tools())
@@ -624,6 +705,157 @@ td.c:hover .tip,td.gold:hover .tip{{display:block}}
         dynamo_red >= 3,
         "expected the split to fail the interleaving cases (got {dynamo_red})"
     );
+}
+
+/// One committed `dynamo_v2-<ver>/<family>/<key>.yaml` capture.
+#[derive(Deserialize)]
+struct CaptureDoc {
+    family: String,
+    cases: BTreeMap<String, CaptureCase>,
+}
+
+#[derive(Deserialize)]
+struct CaptureCase {
+    #[serde(default)]
+    assembled: Vec<Ev>,
+    #[serde(default)]
+    chunks: Vec<CaptureChunk>,
+}
+
+#[derive(Deserialize)]
+struct CaptureChunk {
+    #[serde(default)]
+    expected: Vec<Value>,
+}
+
+/// The scenario slug for each committed case key, read from the `inputs/` shard
+/// (the numbered `UNIFIED.<group>.<sub>` key lives only in the Python taxonomy).
+#[derive(Deserialize)]
+struct InputDoc {
+    family: String,
+    cases: BTreeMap<String, InputCase>,
+}
+
+#[derive(Deserialize)]
+struct InputCase {
+    #[serde(default)]
+    scenario: String,
+    #[serde(default)]
+    input: String,
+}
+
+/// GUARD: the COMMITTED Dynamo capture must equal what the parsers produce NOW.
+///
+/// The Unified tab is rendered by Python from the committed shard — it never runs
+/// the Rust parsers. So changing a parser without re-capturing leaves the page
+/// showing the OLD behavior while every Rust test still passes, and the two
+/// disagree silently. (That is exactly what happened when the unified parser
+/// landed: `unified_parity` was 33/33 green while the page still drew the split.)
+///
+/// This closes that gap: touch a parser, and the capture must be regenerated.
+#[test]
+fn committed_dynamo_capture_matches_the_live_parsers() {
+    let root = common::ensure_fixtures().join("unified");
+    if !root.join("inputs").is_dir() {
+        panic!(
+            "no committed unified fixtures under {} — extract them first",
+            root.display()
+        );
+    }
+    let capture_dir = std::fs::read_dir(&root)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("dynamo_v2-"))
+        })
+        .expect("no committed dynamo_v2-<ver> capture dir");
+
+    // key -> (family, scenario, input), from the inputs shard.
+    let mut meta: BTreeMap<(String, String), (String, String)> = BTreeMap::new();
+    for entry in glob_yaml(&root.join("inputs")) {
+        let doc: InputDoc = serde_yaml::from_str(&std::fs::read_to_string(&entry).unwrap())
+            .unwrap_or_else(|e| panic!("{}: {e}", entry.display()));
+        for (key, case) in doc.cases {
+            meta.insert((doc.family.clone(), key), (case.scenario, case.input));
+        }
+    }
+
+    let mut stale: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+    for entry in glob_yaml(&capture_dir) {
+        let doc: CaptureDoc = serde_yaml::from_str(&std::fs::read_to_string(&entry).unwrap())
+            .unwrap_or_else(|e| panic!("{}: {e}", entry.display()));
+        for (key, committed) in doc.cases {
+            let Some((scenario, input)) = meta.get(&(doc.family.clone(), key.clone())) else {
+                continue;
+            };
+            checked += 1;
+            let id = format!("UNIFIED.{scenario}.{}", doc.family);
+
+            let live_assembled = dynamo_events(&doc.family, input);
+            if live_assembled != committed.assembled {
+                stale.push(format!(
+                    "{id} [{key}] assembled\n    committed: {}\n         live: {}",
+                    committed
+                        .assembled
+                        .iter()
+                        .map(Ev::render)
+                        .collect::<Vec<_>>()
+                        .join("  |  "),
+                    live_assembled
+                        .iter()
+                        .map(Ev::render)
+                        .collect::<Vec<_>>()
+                        .join("  |  "),
+                ));
+                continue;
+            }
+            // The page assembles the Dynamo column from these per-chunk deltas, so
+            // they have to be current too — not just the assembled list.
+            let live_chunks: Vec<Vec<Value>> = dynamo_chunks(&doc.family, input)
+                .into_iter()
+                .map(|r| r.deltas)
+                .collect();
+            let committed_chunks: Vec<Vec<Value>> =
+                committed.chunks.into_iter().map(|c| c.expected).collect();
+            if live_chunks != committed_chunks {
+                stale.push(format!("{id} [{key}] per-chunk deltas differ"));
+            }
+        }
+    }
+
+    assert!(checked > 0, "no committed capture cases were compared");
+    assert!(
+        stale.is_empty(),
+        "{} of {checked} committed Dynamo capture cases are STALE — the HTML tab will \
+         show the old parser behavior. Regenerate:\n  \
+         cargo test -p dynamo-conformance-fixtures-v2 --test unified_render\n  \
+         python3 conformance/utils/src/explode_unified_fixtures.py\n  \
+         python3 conformance/utils/src/package_fixtures.py\n\n{}",
+        stale.len(),
+        stale.join("\n\n"),
+    );
+}
+
+fn glob_yaml(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for fam in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+        let p = fam.path();
+        if !p.is_dir() {
+            continue;
+        }
+        for f in std::fs::read_dir(&p).into_iter().flatten().flatten() {
+            let fp = f.path();
+            if fp.extension().and_then(|e| e.to_str()) == Some("yaml") {
+                out.push(fp);
+            }
+        }
+    }
+    out.sort();
+    out
 }
 
 fn label(v: &str) -> String {

--- a/conformance/utils/src/assets/colorize.js
+++ b/conformance/utils/src/assets/colorize.js
@@ -178,8 +178,49 @@
 
   // XML/pipe-marker path: escape text, wrap each `<...>` token in a span; stack-match
   // open/close (fresh palette color per pair), undeclared/unmatched -> tt-orphan.
+  // Regions whose body is argument DATA rather than markup. Inside one, nothing is a
+  // control token until that region's OWN terminator — the rule the parser follows
+  // when it reads a value to its terminator, so a marker-looking substring inside a
+  // value survives instead of being painted as a real marker (`I7`).
+  // Declared per family under `opaque:` in parser_families.yaml.
+  // Mirrors markup.py::_declared_opaque.
+  //   pairs: open (or toggle) .. that pair's own closer  (qwen3 `<parameter=K>`,
+  //          gemma4's `<|"|>` quote toggle)
+  //   spans: SINGLETON opener .. an explicitly named terminator (kimi's argument
+  //          blob). `json` marks a JSON body whose string literals hide a
+  //          terminator-looking token — kimi's terminator is the very token that can
+  //          appear in a value, so position alone cannot disambiguate it.
+  function declaredOpaque(family, markersMap) {
+    var out = { pairs: {}, spans: {} };
+    if (!family || !markersMap || !markersMap[family]) { return out; }
+    (markersMap[family].opaque || []).forEach(function (e) {
+      if (e && typeof e === 'object') {
+        out.spans[e.from] = [e.to, !!e.json];
+      } else {
+        out.pairs[e] = true;
+      }
+    });
+    return out;
+  }
+
+  // Is `pos` inside a JSON string literal of the object starting at `start`?
+  // Mirrors markup.py::_in_json_string.
+  function inJsonString(text, start, pos) {
+    var inStr = false;
+    for (var i = start; i < pos; i++) {
+      var c = text.charAt(i);
+      if (inStr && c === '\\') { i++; continue; }
+      if (c === '"') { inStr = !inStr; }
+    }
+    return inStr;
+  }
+
   function colorizeXml(text, family, markersMap) {
     var declared = declaredLookup(family, markersMap);
+    var opaque = declaredOpaque(family, markersMap);
+    // Argument-value region we are inside:
+    //   ['pair', pairId, false, 0] | ['token', endTok, jsonBody, regionStart]
+    var openOpaque = null;
     var st = new State();
     var pieces = [];
     var stack = [];  // [pairId, pieceIndex]
@@ -203,10 +244,31 @@
         kind = k[0]; pairId = k[1]; colorOverride = k[2];
       }
       var esc = escapeHtml(tok);
+      if (openOpaque !== null) {
+        // Inside an argument value: ONLY this region's own terminator ends it. Every
+        // other token is part of the value, so it renders as plain data.
+        var ends;
+        if (openOpaque[0] === 'pair') {
+          ends = (kind === 'close' || kind === 'toggle') && pairId === openOpaque[1];
+        } else {
+          ends = tok === openOpaque[1]
+            && !(openOpaque[2] && inJsonString(text, openOpaque[3], m.index));
+        }
+        if (ends) {
+          openOpaque = null;
+        } else {
+          pieces.push(esc);
+          last = re.lastIndex;
+          continue;
+        }
+      }
       if (kind === null) {
         pieces.push('<span class="tt-orphan">' + esc + '</span>');
       } else if (kind === 'singleton') {
         pieces.push('<span class="' + st.singletonClassFor(pairId) + '">' + esc + '</span>');
+        if (opaque.spans[tok]) {
+          openOpaque = ['token', opaque.spans[tok][0], opaque.spans[tok][1], re.lastIndex];
+        }
       } else if (kind === 'toggle') {
         // Self-paired delimiter: close nearest matching open, else treat as open.
         var matchAtT = findFromTop(stack, pairId);
@@ -220,6 +282,7 @@
         } else {
           pieces.push(esc);
           stack.push([pairId, pieces.length - 1]);
+          if (opaque.pairs[pairId]) { openOpaque = ['pair', pairId, false, 0]; }
         }
       } else if (kind === 'close') {
         var matchAt = findFromTop(stack, pairId);
@@ -238,6 +301,7 @@
       } else {  // open
         pieces.push(esc);
         stack.push([pairId, pieces.length - 1]);
+        if (opaque.pairs[pairId]) { openOpaque = ['pair', pairId, false, 0]; }
       }
       last = re.lastIndex;
     }
@@ -275,6 +339,8 @@
   // so a tag spanning a chunk boundary keeps one color (mirrors colorize_stream_deltas).
   function xmlTokenIntervals(text, family, markersMap) {
     var declared = declaredLookup(family, markersMap);
+    var opaque = declaredOpaque(family, markersMap);
+    var openOpaque = null;
     var st = new State();
     var intervals = [];
     var stack = [];
@@ -286,7 +352,6 @@
         intervals.push({ start: m.index, end: re.lastIndex, cls: NS_CLASS });
         continue;
       }
-      var idx = intervals.length;
       var kind, pairId;
       var hit = declared[tok];
       if (hit != null) {
@@ -295,11 +360,28 @@
         var k = tagKindAndName(tok.slice(1, -1));
         kind = k[0]; pairId = k[1];
       }
+      if (openOpaque !== null) {
+        // Inside an argument value (see declaredOpaque): only this region's own
+        // terminator is markup. Everything else gets NO interval, so it renders as
+        // plain value text.
+        var endsI;
+        if (openOpaque[0] === 'pair') {
+          endsI = (kind === 'close' || kind === 'toggle') && pairId === openOpaque[1];
+        } else {
+          endsI = tok === openOpaque[1]
+            && !(openOpaque[2] && inJsonString(text, openOpaque[3], m.index));
+        }
+        if (endsI) { openOpaque = null; } else { continue; }
+      }
+      var idx = intervals.length;
       intervals.push({ start: m.index, end: re.lastIndex, cls: null });
       if (kind === null) {
         intervals[idx].cls = 'tt-orphan';
       } else if (kind === 'singleton') {
         intervals[idx].cls = st.singletonClassFor(pairId);
+        if (opaque.spans[tok]) {
+          openOpaque = ['token', opaque.spans[tok][0], opaque.spans[tok][1], re.lastIndex];
+        }
       } else if (kind === 'toggle') {
         var matchAtT = findFromTop(stack, pairId);
         if (matchAtT >= 0) {
@@ -310,6 +392,7 @@
           stack.length = matchAtT;
         } else {
           stack.push([pairId, idx]);
+          if (opaque.pairs[pairId]) { openOpaque = ['pair', pairId, false, 0]; }
         }
       } else if (kind === 'close') {
         var matchAt = findFromTop(stack, pairId);
@@ -324,6 +407,7 @@
         }
       } else {  // open
         stack.push([pairId, idx]);
+        if (opaque.pairs[pairId]) { openOpaque = ['pair', pairId, false, 0]; }
       }
     }
     for (var i = 0; i < stack.length; i++) {

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -360,7 +360,10 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
  * The `min-width` floor keeps a column of one-character `–` cells wide enough to
  * scan next to its neighbours. */
 .ttip-chunks { border-collapse: collapse; margin: 3px 0 0 0; font-size: 11px; width: max-content; max-width: 100%; table-layout: auto; }
-.ttip-chunks th:not(:first-child), .ttip-chunks td:not(:first-child) { min-width: 7em; }
+/* No per-column min/max width: `equalizeColumns()` in conformance.js measures each
+ * column's max-content and pins ALL columns to the widest, so they come out equal at
+ * the width where the longest line fits. These rules are only the pre-measure
+ * fallback (and what a no-JS render gets). */
 /* pre-wrap so runs of spaces in emitted text render faithfully — HTML collapsing
    made a whitespace-only divergence (e.g. a double vs single trailing space)
    invisible: two cells LOOKED identical while their compare signatures differed. */

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -349,17 +349,18 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
  * mostly `–` cells rendered just as wide as one full of arguments, so the popup was
  * mostly empty space.
  *
- * Auto layout lets a narrow chart BE narrow. Equal-width columns are recovered
- * approximately by the shared `min-width` below (so columns stay comparable and a
- * one-character `–` column doesn't collapse), while `max-width` stops a long
- * argument from running the table off-screen — it wraps instead. The popup's own
- * `width: max-content` then shrinks around whatever the table actually needs. */
+ * Auto layout lets a narrow chart BE narrow, and `width: max-content` lets it grow
+ * to the width at which every cell fits on ONE line. There is deliberately NO
+ * per-column `max-width`: an emitted `tool_call=get_weather args='{"city":"Paris"}'`
+ * is a single logical line and should read as one, so the only thing that may force
+ * a wrap is genuinely running out of window — the popup's viewport cap, applied via
+ * `max-width: 100%` below. Cells are `white-space: pre-wrap`, so max-content is
+ * exactly "the longest line, unwrapped".
+ *
+ * The `min-width` floor keeps a column of one-character `–` cells wide enough to
+ * scan next to its neighbours. */
 .ttip-chunks { border-collapse: collapse; margin: 3px 0 0 0; font-size: 11px; width: max-content; max-width: 100%; table-layout: auto; }
-/* max-width, not width: the input column may size DOWN when its markers are short. */
-.ttip-chunks th:first-child, .ttip-chunks td:first-child { max-width: 22em; }
-/* Output columns: a floor so they stay scannable side by side, and a ceiling so a
- * long `args='{...}'` wraps rather than widening the whole popup. */
-.ttip-chunks th:not(:first-child), .ttip-chunks td:not(:first-child) { min-width: 7em; max-width: 20em; }
+.ttip-chunks th:not(:first-child), .ttip-chunks td:not(:first-child) { min-width: 7em; }
 /* pre-wrap so runs of spaces in emitted text render faithfully — HTML collapsing
    made a whitespace-only divergence (e.g. a double vs single trailing space)
    invisible: two cells LOOKED identical while their compare signatures differed. */
@@ -369,7 +370,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .ttip-chunks th, .ttip-chunks td { border: 1px solid #475569; padding: 2px 5px; text-align: left; vertical-align: top; white-space: pre-wrap; word-break: break-word; }
 .ttip-chunks th { background: #1e293b; color: #93c5fd; font-weight: 600; }
 .ttip-chunks td { color: #e5e7eb; }
-.ttip-chunks td.cin { color: #cbd5e1; max-width: 22em; word-break: break-word; }
+.ttip-chunks td.cin { color: #cbd5e1; word-break: break-word; }
 .ttip-chunks tr.ttip-final td { border-top: 2px solid #64748b; background: #0b1220; }
 .ttip-chunks tr.ttip-final td.cin { color: #93c5fd; }
 /* A candidate's assembled cell whose output diverges from the golden oracle: red
@@ -379,7 +380,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 /* Baseline column (Dynamo Rust batch): a fixed reference left of the stream columns,
    set off with a thicker right border and a tinted background. */
 .ttip-chunks th.cbase-h { background: #1e293b; color: #fbbf24; border-right: 2px solid #64748b; }
-.ttip-chunks td.cbase { background: #0b1220; border-right: 2px solid #64748b; max-width: 16em; word-break: break-word; vertical-align: bottom; }
+.ttip-chunks td.cbase { background: #0b1220; border-right: 2px solid #64748b; word-break: break-word; vertical-align: bottom; }
 .ttip-chunks .fr { color: #f59e0b; }
 
 /* Per-column GRAMMAR popup: hovering a sub-case header shows that one test case in
@@ -389,22 +390,22 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
  * These rules come AFTER the .ttip-chunks widths above so the narrower family column
  * wins (same specificity, later source order). */
 th.case-sub, th.trow-case { position: relative; cursor: pointer; }
-/* Transposed view: the case moves to a ROW header but carries the same popup. */
-th.trow-case .ttip { min-width: 62em; font-weight: 400; text-align: left; }
-th.case-sub .ttip { min-width: 62em; font-weight: 400; text-align: left; }
-/* The grammar table must AUTO-size: `table-layout: fixed` above exists so the chunk
- * chart's candidate columns come out equal, but here it pinned the model column to a
- * guessed width and long names (`Qwen 3 Coder / Nemotron V3`, `Hermes-3 / Llama
- * variants`) overflowed into the input column. Auto layout sizes it to the longest
- * name and gives the rest to the input. */
-/* Fixed layout so input and EVERY output column come out the SAME width — auto layout
- * sized each column to its own content, so a long header (`Dynamo v2 Rust 0.1.23 ...`)
- * or value made that column wider than its neighbours. Under fixed layout, only the
- * model column is pinned (a modest width that WRAPS long family names like
- * "Qwen 3 Coder / Nemotron V3" instead of clipping — a fixed layout can't auto-size it);
- * input + every output column then share the remaining width equally. */
-.ttip-grammar { table-layout: fixed; width: 100%; }
-.ttip-grammar thead th:first-child, .ttip-grammar td.grf { width: 10em; }
+/* Transposed view: the case moves to a ROW header but carries the same popup.
+ * No `min-width`: this popup used to be pinned at 62em whether or not it had 62em
+ * of content, which is the same wasted-space problem the chunk chart had. It is
+ * `width: max-content` like every other popup, so it sizes to its grammar table. */
+th.trow-case .ttip { font-weight: 400; text-align: left; }
+th.case-sub .ttip { font-weight: 400; text-align: left; }
+/* Same sizing rule as the chunk chart: grow to the width where each row fits on ONE
+ * line, then stop. `table-layout: fixed` + `width: 100%` made every column take an
+ * equal share of a popup that was itself pinned at 62em, so a short grammar row was
+ * padded out to full width while a long one wrapped anyway. Auto layout + max-content
+ * sizes each column to its content and lets the popup shrink; the viewport cap on
+ * `.ttip` is the only thing that forces a wrap. The model column keeps a min-width so
+ * long family names ("Qwen 3 Coder / Nemotron V3") wrap in a readable column rather
+ * than stretching the table. */
+.ttip-grammar { table-layout: auto; width: max-content; max-width: 100%; }
+.ttip-grammar thead th:first-child, .ttip-grammar td.grf { min-width: 10em; }
 .ttip-grammar td.grf { color: #93c5fd; font-weight: 600; white-space: normal; word-break: break-word; }
 /* Parser family under the model name: distinct models can share one grammar
  * (DeepSeek V3 / V3.1 / V3.2), so both facts have to be visible. */

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -287,7 +287,11 @@ td.cell:hover, td.parser:hover, td.cell:focus-within, td.parser:focus-within { z
     font-family: ui-monospace, monospace;
     font-size: 12px;
     line-height: 1.4;
-    max-width: 80vw;
+    /* Ceiling only — `width: max-content` below means a popup that needs less stays
+       narrow. 32px each side matches the `margin` gutter the placement JS clamps to,
+       so on a small screen the popup may grow to the full window minus that padding.
+       (The JS re-sets this inline per-open against the live viewport.) */
+    max-width: calc(100vw - 64px);
     min-width: 280px;
     width: max-content;
     box-shadow: 0 4px 14px rgba(0,0,0,0.35);
@@ -336,13 +340,26 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .ttip-leak { color: #ff6b6b; font-weight: 700; }
 .ttip-pre { margin: 2px 0 0 0; white-space: pre-wrap; word-break: break-word; font-family: inherit; color: #e5e7eb; }
 /* Per-chunk emit chart: input | Dynamo Rust | vLLM Rust | vLLM Python | SGLang, one row per chunk. */
-/* Equal-width output columns. With the default auto layout each candidate column sizes
- * to its own content, so the REF column and the compare-with columns came out different
- * widths and were hard to scan side by side. `table-layout: fixed` gives every column
- * WITHOUT an explicit width an equal share of the leftover space — so only the input
- * column is pinned below, and every output column matches. */
-.ttip-chunks { border-collapse: collapse; margin: 3px 0 0 0; font-size: 11px; width: 100%; table-layout: fixed; }
-.ttip-chunks th:first-child, .ttip-chunks td:first-child { width: 22em; }
+/* Size to CONTENT, capped at the popup width.
+ *
+ * This used to be `width: 100%` + `table-layout: fixed` so that every candidate
+ * column came out the SAME width (auto layout sized each to its own content, which
+ * made the REF and compare columns differ and was hard to scan). The cost was that
+ * the chart always consumed the full popup no matter how little it held: a chart of
+ * mostly `–` cells rendered just as wide as one full of arguments, so the popup was
+ * mostly empty space.
+ *
+ * Auto layout lets a narrow chart BE narrow. Equal-width columns are recovered
+ * approximately by the shared `min-width` below (so columns stay comparable and a
+ * one-character `–` column doesn't collapse), while `max-width` stops a long
+ * argument from running the table off-screen — it wraps instead. The popup's own
+ * `width: max-content` then shrinks around whatever the table actually needs. */
+.ttip-chunks { border-collapse: collapse; margin: 3px 0 0 0; font-size: 11px; width: max-content; max-width: 100%; table-layout: auto; }
+/* max-width, not width: the input column may size DOWN when its markers are short. */
+.ttip-chunks th:first-child, .ttip-chunks td:first-child { max-width: 22em; }
+/* Output columns: a floor so they stay scannable side by side, and a ceiling so a
+ * long `args='{...}'` wraps rather than widening the whole popup. */
+.ttip-chunks th:not(:first-child), .ttip-chunks td:not(:first-child) { min-width: 7em; max-width: 20em; }
 /* pre-wrap so runs of spaces in emitted text render faithfully — HTML collapsing
    made a whitespace-only divergence (e.g. a double vs single trailing space)
    invisible: two cells LOOKED identical while their compare signatures differed. */
@@ -825,6 +842,29 @@ body.cmp-loading .cmp-loading-note { display: block; position: fixed; top: 8px; 
 .expl {
   font-family: -apple-system, system-ui, sans-serif;
 }
+/* Cap the PROSE measure so a long sentence wraps instead of stretching the popup.
+ * The popup is `width: max-content`, which takes the widest child — so one
+ * unwrapped explanatory line (the case description, or the "vLLM diverges too:
+ * ..." footnote) set the popup's width and left the chart floating in a sea of
+ * empty space, even after the chart itself was made to shrink to content. An
+ * element's max-content contribution is clamped by its own max-width, so bounding
+ * the prose hands the width decision back to the chart. ~100 characters is also
+ * about the limit of a comfortable reading measure.
+ *
+ * `.ttip-ref` is excluded below: it is a short `white-space: nowrap` label, not
+ * prose, and must not wrap. */
+.ttip-section,
+.ttip-casedesc,
+.ttip-reason,
+.ttip-note,
+.ttip-pre,
+.ttip-head,
+.expl {
+  max-width: 100ch;
+}
+/* The head carries the case id + an inline description; without this the long
+   description keeps the head on one line and re-widens the popup. */
+.ttip-head { white-space: normal; }
 /* ...and the payload opts back in. `.ttip-code` is the parser input markup, `.ttip-tree`
  * the box-drawing shared-implementation tree; both only read correctly when the glyphs
  * line up in a column. `.ttip-code` sits INSIDE a `.ttip-pre`, so it has to win. */

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -585,14 +585,26 @@
       if (!row || !row.children.length) continue;
       t.style.tableLayout = 'auto';
       t.style.width = 'max-content';
-      let widest = 0;
-      for (const c of row.children) {
-        widest = Math.max(widest, c.getBoundingClientRect().width);
-      }
+      const natural = [];
+      for (const c of row.children) natural.push(c.getBoundingClientRect().width);
+
+      // The grammar popup's first column is only a model name ("qwen3", "kimi_k2"),
+      // so equalizing it just pads every row by a couple hundred pixels. Leave it at
+      // its natural width and equalize only the columns actually being compared. The
+      // chunk chart has no such column — its first column is the input/golden stream,
+      // which belongs in the comparison — so there it stays equal with the rest.
+      const keepFirst = t.classList.contains('ttip-grammar') && natural.length > 1;
+      const compared = keepFirst ? natural.slice(1) : natural;
+      const widest = Math.max.apply(null, compared);
+
       if (widest > 0) {
+        const firstW = keepFirst ? Math.ceil(natural[0]) : 0;
         t.style.tableLayout = 'fixed';
-        t.style.width = Math.ceil(widest * row.children.length) + 'px';
+        t.style.width = Math.ceil(firstW + widest * compared.length) + 'px';
         t.style.maxWidth = '100%';
+        // Under fixed layout the FIRST row's explicit widths pin the columns; the
+        // rest split what is left, which is exactly `widest` each.
+        if (keepFirst) row.children[0].style.width = firstW + 'px';
       }
       t.dataset.eqCols = '1';
     }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -561,9 +561,47 @@
     });
   });
 
+  // Equal columns, sized to what the WIDEST column actually needs.
+  //
+  // Pure CSS gives one or the other, not both: `table-layout: fixed; width: 100%`
+  // makes columns equal but always consumes the whole popup (a chart of `–` cells
+  // took as much room as one full of arguments), while auto layout sizes the table
+  // to its content but leaves every column a different width, which reads as messy
+  // when the point is to compare engines side by side.
+  //
+  // So measure, then pin. Under auto + `max-content` each rendered column width IS
+  // that column's max-content (the width at which its longest line does not wrap);
+  // take the widest, then switch to fixed layout with `width = n * widest`, which
+  // fixed layout divides into n equal columns of exactly that width. If that exceeds
+  // the popup's viewport cap, `max-width: 100%` shrinks it — columns stay equal
+  // because fixed layout keeps dividing evenly.
+  //
+  // Memoized per table: the result only depends on content, which does not change.
+  function equalizeColumns(ttip) {
+    const tables = ttip.querySelectorAll('.ttip-chunks, .ttip-grammar');
+    for (const t of tables) {
+      if (t.dataset.eqCols === '1') continue;
+      const row = t.querySelector('tr');
+      if (!row || !row.children.length) continue;
+      t.style.tableLayout = 'auto';
+      t.style.width = 'max-content';
+      let widest = 0;
+      for (const c of row.children) {
+        widest = Math.max(widest, c.getBoundingClientRect().width);
+      }
+      if (widest > 0) {
+        t.style.tableLayout = 'fixed';
+        t.style.width = Math.ceil(widest * row.children.length) + 'px';
+        t.style.maxWidth = '100%';
+      }
+      t.dataset.eqCols = '1';
+    }
+  }
+
   function place(cell) {
     const ttip = cell.querySelector('.ttip');
     if (!ttip) return;
+    equalizeColumns(ttip);
     ttip.style.visibility = 'hidden';
     ttip.style.opacity = '0';
     ttip.classList.add('ttip-visible');

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -571,12 +571,13 @@
     ttip.style.top = '100%';
     ttip.style.right = 'auto';
     ttip.style.bottom = 'auto';
-    // Cap the width at the viewport MINUS both gutters. 90% alone is not enough: a
-    // tooltip that wide still has to be shifted left to clear the right gutter, and if
-    // the shift then pushes its left edge past `margin` the clamp below cancels it and
-    // the popup ends up flush against an edge. Bounding the width makes both fit.
-    ttip.style.maxWidth = Math.max(240, Math.min(
-      Math.round(window.innerWidth * 0.9), window.innerWidth - 2 * margin)) + 'px';
+    // Cap the width at the viewport MINUS both gutters — that is the most a popup may
+    // use, so on a narrow screen it grows to fill the window while still leaving the
+    // left/right padding. This is only a CEILING: the popup is `width: max-content`, so
+    // a chart that needs less stays narrow rather than padding itself out to the cap.
+    // (The old cap also took 90% of the viewport, which on a small screen threw away a
+    // gutter's worth of usable room on top of the two real gutters.)
+    ttip.style.maxWidth = Math.max(240, window.innerWidth - 2 * margin) + 'px';
     const cellRect = cell.getBoundingClientRect();
     const tipRect = ttip.getBoundingClientRect();
     const vw = window.innerWidth, vh = window.innerHeight;

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -2425,7 +2425,10 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
             tooltip = {
                 "head": f'UNIFIED.{g_num}.{g_sub} ({s}) — {f}',
                 "description": desc,
-                "input": {"kind": "chunks", "text": c["input"], "chunks": chunk_rows, "family": f},
+                # `family` here selects the GRAMMAR the colorizer types markup with,
+                # so it must be the marker-registry family, not the corpus one.
+                "input": {"kind": "chunks", "text": c["input"], "chunks": chunk_rows,
+                          "family": unified_taxonomy.marker_family(f)},
                 "candidates": [
                     {"key": "dynamo", "label": dynamo_label, "impl": "dynamo",
                      "version": None, "parse_mode": "unified", "leak": dverd == "LEAK",

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -2299,7 +2299,9 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
     # column's per-family variant (UnifiedParser for gemma4, CombinedParser otherwise)
     # can't fit one fixed column label, so it's shown per family in the tooltip.
     dynamo_ver_label = _dynamo_v2_version() or "0.1.x"
-    dynamo_label = f"Dynamo v2 Rust {dynamo_ver_label} (stream, orig)"
+    # Per-family mixture now, exactly like vLLM Rust: the native UnifiedParser where
+    # one exists (qwen3), the v1-reasoning + v2-tool split everywhere else.
+    dynamo_label = f"Dynamo v2 Rust {dynamo_ver_label} (stream, Combined & Unified)"
     vllm_label = (f"vLLM Python {vllm_ver_label} (batch, Combined)" if vllm_live
                   else "vLLM Python 0.25.x (expected)")
     vrust_label = f"vLLM Rust {vrust_ver_label} (stream, Combined & Unified)"
@@ -2425,7 +2427,7 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                 "description": desc,
                 "input": {"kind": "chunks", "text": c["input"], "chunks": chunk_rows, "family": f},
                 "candidates": [
-                    {"key": "dynamo", "label": f"{dynamo_label}; v1 reasoning + v2 tool", "impl": "dynamo",
+                    {"key": "dynamo", "label": dynamo_label, "impl": "dynamo",
                      "version": None, "parse_mode": "unified", "leak": dverd == "LEAK",
                      "block": {"events": dyn, "verdict": dverd,
                                "todo": _TODO if dverd != "MATCH" else None}},
@@ -2502,8 +2504,8 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                "detector, Combined)." if sgl_live else "")),
         "toolbar_desc_html": (
             'Reference = <strong>GOLDEN</strong> (authored oracle, best-effort recovery) · '
-            'Compare = <strong>Dynamo v2 Rust (orig)</strong> (v1 reasoning over the whole '
-            'stream, then the v2 tool parser; no unified parser yet), '
+            'Compare = <strong>Dynamo v2 Rust</strong> (native <strong>UnifiedParser</strong> '
+            'for qwen3, v1 reasoning + v2 tool split otherwise), '
             f'<strong>vLLM Python {vllm_ver_label} (Combined)</strong>'
             + (f', and <strong>vLLM Rust {vrust_ver_label}</strong> (native '
                '<strong>UnifiedParser</strong> for gemma4, <strong>CombinedParser</strong> '

--- a/conformance/utils/src/parser_families.yaml
+++ b/conformance/utils/src/parser_families.yaml
@@ -55,6 +55,23 @@ families:
 #   leak:       [s, ...]             extra substrings for the leak detector only —
 #                                    prefixes of parameterized tags (e.g. "<invoke"),
 #                                    tokens the colorizer already handles specially
+#   opaque:     [entry, ...]         regions whose BODY is argument DATA, not markup.
+#                                    Inside one, NOTHING is a control token until that
+#                                    region's own closer — mirroring the parser, which
+#                                    reads a value to its own terminator so a
+#                                    marker-looking substring inside it survives (I7).
+#                                    Without this the colorizer paints an embedded
+#                                    `</tool_call>` in a value as a real close and
+#                                    mis-colors the rest of the value.
+#                                    Two entry forms:
+#                                      "<pair_id>"            region runs from an open
+#                                        (or toggle) to that pair's own closer. A
+#                                        pair_id is the OPEN token of a declared pair,
+#                                        or the tag NAME of a parameterized tag
+#                                        (`<parameter=cmd>` -> `parameter`).
+#                                      {from: TOK, to: TOK}   region opened by a
+#                                        SINGLETON, which has no closer of its own, so
+#                                        the terminator is named explicitly.
 markers:
   deepseek_v3:
     pairs: [["<｜tool▁calls▁begin｜>", "<｜tool▁calls▁end｜>"], ["<｜tool▁call▁begin｜>", "<｜tool▁call▁end｜>"]]
@@ -70,6 +87,9 @@ markers:
     leak: ["<｜DSML｜", "</｜DSML｜"]
   gemma4:
     pairs: [["<|tool_call>", "<tool_call|>"]]
+    # `<|"|>` ... `<|"|>` quotes a raw string value; `__gemma_quote` is the pair id the
+    # colorizer's classifier gives that toggle.
+    opaque: ["__gemma_quote"]
     leak: ['<|"|>']
   glm47:
     pairs: [["<tool_call>", "</tool_call>"], ["<arg_key>", "</arg_key>"], ["<arg_value>", "</arg_value>"]]
@@ -83,6 +103,9 @@ markers:
   kimi_k2:
     pairs: [["<|tool_calls_section_begin|>", "<|tool_calls_section_end|>"], ["<|tool_call_begin|>", "<|tool_call_end|>"]]
     singletons: ["<|tool_call_argument_begin|>"]
+    # The JSON argument blob runs from the singleton to the call close; a marker
+    # inside one of its string values is data.
+    opaque: [{from: "<|tool_call_argument_begin|>", to: "<|tool_call_end|>", json: true}]
   llama3_json:
     singletons: ["<|python_tag|>"]
   minimax_m2:
@@ -108,6 +131,10 @@ markers:
     pairs: [["<tool_call>", "</tool_call>"]]
   qwen3_coder:
     pairs: [["<tool_call>", "</tool_call>"]]
+    # `<parameter=K>` ... `</parameter>` delimits a raw, UNQUOTED value: the grammar
+    # has no escaping, so the value runs to its own closer and anything that looks
+    # like an enclosing marker inside it is data.
+    opaque: ["parameter"]
     leak: ["<function=", "</function", "<parameter=", "</parameter"]
   # Harmony's linear turn tokens pseudo-pair (`<|start|>` closes with `<|end|>` /
   # `<|return|>` / `<|call|>`) — richer than the pairs/singletons schema, so the

--- a/conformance/utils/src/unified_taxonomy.py
+++ b/conformance/utils/src/unified_taxonomy.py
@@ -65,3 +65,17 @@ def numbered_id(scenario):
     'UNIFIED.7.b' (mirrors TOOLCALLING.streamv2.N naming)."""
     g, sub = tax(scenario)
     return f"UNIFIED.{g}.{sub}"
+
+
+# The unified corpus names a family by its MODEL family (`qwen3`); the grammar-token
+# registry in parser_families.yaml names the SAME grammar by its parser family
+# (`qwen3_coder`). The popup colorizer is driven by the registry, so a corpus family
+# has to be translated before it is used to color markup — otherwise the family has no
+# declared markers, the colorizer falls back to heuristics, and its opaque
+# argument-value regions (`opaque:`) are not applied.
+MARKER_FAMILY = {"qwen3": "qwen3_coder"}
+
+
+def marker_family(family):
+    """Corpus family -> the parser_families.yaml `markers:` family that types it."""
+    return MARKER_FAMILY.get(family, family)

--- a/conformance/utils/tests/parity/markup.py
+++ b/conformance/utils/tests/parity/markup.py
@@ -154,6 +154,38 @@ def _declared_lookup(family: str | None) -> dict[str, tuple[str, str]]:
     return table
 
 
+def _declared_opaque(family: str | None) -> tuple[set[str], dict[str, tuple[str, bool]]]:
+    """Regions whose body is argument DATA rather than markup.
+
+    Inside such a region nothing is a control token until the region's OWN
+    terminator — what the parser does when it reads a value to its terminator, so a
+    marker-looking substring in a value survives (`I7`). See `opaque:` in
+    parser_families.yaml.
+
+    Returns `(pair_ids, spans)`:
+      * `pair_ids` — regions opened by a normal open (or toggle) and closed by that
+        pair's own closer: qwen3 `<parameter=K>` .. `</parameter>`, gemma4's
+        `<|"|>` .. `<|"|>` quote toggle.
+      * `spans` — `{from_token: (to_token, json)}`, for regions whose opener is a
+        SINGLETON with no closer of its own, so the terminator must be named: kimi's
+        `<|tool_call_argument_begin|>` .. `<|tool_call_end|>`. With `json: true` the
+        body is a JSON object and a terminator-looking token INSIDE one of its string
+        literals is data — kimi's terminator is the very token that can appear in a
+        value, so position alone cannot disambiguate it. Mirrors the parser, which
+        parses the JSON blob rather than scanning for the marker.
+    """
+    if not family or family not in _FAMILY_MARKERS:
+        return set(), {}
+    pair_ids: set[str] = set()
+    spans: dict[str, tuple[str, bool]] = {}
+    for entry in _FAMILY_MARKERS[family].get("opaque") or []:
+        if isinstance(entry, dict):
+            spans[entry["from"]] = (entry["to"], bool(entry.get("json")))
+        else:
+            pair_ids.add(entry)
+    return pair_ids, spans
+
+
 def declared_markers() -> dict[str, dict[str, list]]:
     """Every family's declared `pairs`/`singletons` (the subset `_declared_lookup`
     consumes), as plain JSON for the JS colorizer. The `leak:` markers are omitted —
@@ -165,6 +197,8 @@ def declared_markers() -> dict[str, dict[str, list]]:
             entry["pairs"] = [list(p) for p in decl["pairs"]]
         if decl.get("singletons"):
             entry["singletons"] = list(decl["singletons"])
+        if decl.get("opaque"):
+            entry["opaque"] = list(decl["opaque"])
         if entry:
             out[family] = entry
     return out
@@ -237,6 +271,21 @@ def _tag_kind_and_name(inner: str) -> tuple[str | None, str, str | None]:
     return ("open", _name_of(inner), None)
 
 
+def _in_json_string(text: str, start: int, pos: int) -> bool:
+    """Is `pos` inside a JSON string literal of the object starting at `start`?"""
+    in_str = False
+    i = start
+    while i < pos:
+        c = text[i]
+        if in_str and c == "\\":
+            i += 2
+            continue
+        if c == '"':
+            in_str = not in_str
+        i += 1
+    return in_str
+
+
 def _colorize_xml(text: str, family: str | None = None) -> str:
     """HTML-escape `text` and wrap each `<...>` token in a span.
     Paired open/close (stack match by tag name) -> class 'tt-paired'.
@@ -253,6 +302,10 @@ def _colorize_xml(text: str, family: str | None = None) -> str:
     surrounding pairs.
     """
     declared = _declared_lookup(family)
+    opaque_pairs, opaque_spans = _declared_opaque(family)
+    # Argument-value region we are inside:
+    #   ("pair", pair_id, False, 0) | ("token", end_token, json_body, region_start)
+    open_opaque: tuple[str, str, bool, int] | None = None
     pieces: list[str] = []
     stack: list[tuple[str, int]] = []
     last = 0
@@ -270,11 +323,30 @@ def _colorize_xml(text: str, family: str | None = None) -> str:
         else:
             kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
         esc = html_lib.escape(tok)
+        if open_opaque is not None:
+            # Inside an argument value: ONLY this region's own terminator ends it.
+            # Every other token is part of the value, so it renders as plain data.
+            mode, want, json_body, region_start = open_opaque
+            if mode == "pair":
+                ends = kind in ("close", "toggle") and pair_id == want
+            else:
+                ends = tok == want and not (
+                    json_body and _in_json_string(text, region_start, m.start())
+                )
+            if ends:
+                open_opaque = None
+            else:
+                pieces.append(esc)
+                last = m.end()
+                continue
         if kind is None:
             pieces.append(f'<span class="tt-orphan">{esc}</span>')
         elif kind == "singleton":
             cls = _singleton_class_for(pair_id)
             pieces.append(f'<span class="{cls}">{esc}</span>')
+            if tok in opaque_spans:
+                end_tok, json_body = opaque_spans[tok]
+                open_opaque = ("token", end_tok, json_body, m.end())
         elif kind == "toggle":
             # Self-paired delimiter: close the nearest matching open if one is
             # on the stack, otherwise treat this as the open. A leftover open
@@ -297,6 +369,8 @@ def _colorize_xml(text: str, family: str | None = None) -> str:
             else:
                 pieces.append(esc)
                 stack.append((pair_id, len(pieces) - 1))
+                if pair_id in opaque_pairs:
+                    open_opaque = ("pair", pair_id, False, 0)
         elif kind == "close":
             match_at = -1
             for i in range(len(stack) - 1, -1, -1):
@@ -324,6 +398,8 @@ def _colorize_xml(text: str, family: str | None = None) -> str:
         else:
             pieces.append(esc)
             stack.append((pair_id, len(pieces) - 1))
+            if pair_id in opaque_pairs:
+                open_opaque = ("pair", pair_id, False, 0)
         last = m.end()
     for _, idx in stack:
         pieces[idx] = f'<span class="tt-orphan">{pieces[idx]}</span>'
@@ -334,6 +410,8 @@ def _colorize_xml(text: str, family: str | None = None) -> str:
 
 def _xml_token_intervals(text: str, family: str | None = None) -> list[dict[str, Any]]:
     declared = _declared_lookup(family)
+    opaque_pairs, opaque_spans = _declared_opaque(family)
+    open_opaque: tuple[str, str, bool, int] | None = None
     intervals: list[dict[str, Any]] = []
     stack: list[tuple[str, int]] = []
     for match in _TAG_RE.finditer(text):
@@ -343,17 +421,35 @@ def _xml_token_intervals(text: str, family: str | None = None) -> list[dict[str,
                 {"start": match.start(), "end": match.end(), "class": _NS_CLASS}
             )
             continue
-        idx = len(intervals)
         hit = declared.get(tok)
         if hit is not None:
             kind, pair_id = hit
         else:
             kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
+        if open_opaque is not None:
+            # Inside an argument value (see _declared_opaque): only this region's own
+            # terminator is markup. Everything else gets NO interval, so it renders as
+            # plain value text.
+            mode, want, json_body, region_start = open_opaque
+            if mode == "pair":
+                ends = kind in ("close", "toggle") and pair_id == want
+            else:
+                ends = tok == want and not (
+                    json_body and _in_json_string(text, region_start, match.start())
+                )
+            if ends:
+                open_opaque = None
+            else:
+                continue
+        idx = len(intervals)
         intervals.append({"start": match.start(), "end": match.end(), "class": None})
         if kind is None:
             intervals[idx]["class"] = "tt-orphan"
         elif kind == "singleton":
             intervals[idx]["class"] = _singleton_class_for(pair_id)
+            if tok in opaque_spans:
+                end_tok, json_body = opaque_spans[tok]
+                open_opaque = ("token", end_tok, json_body, match.end())
         elif kind == "toggle":
             match_at = -1
             for i in range(len(stack) - 1, -1, -1):
@@ -369,6 +465,8 @@ def _xml_token_intervals(text: str, family: str | None = None) -> list[dict[str,
                 del stack[match_at:]
             else:
                 stack.append((pair_id, idx))
+                if pair_id in opaque_pairs:
+                    open_opaque = ("pair", pair_id, False, 0)
         elif kind == "close":
             match_at = -1
             for i in range(len(stack) - 1, -1, -1):
@@ -386,6 +484,8 @@ def _xml_token_intervals(text: str, family: str | None = None) -> list[dict[str,
                 intervals[idx]["class"] = "tt-orphan"
         else:
             stack.append((pair_id, idx))
+            if pair_id in opaque_pairs:
+                open_opaque = ("pair", pair_id, False, 0)
     for _, idx in stack:
         intervals[idx]["class"] = "tt-orphan"
     return intervals

--- a/conformance/utils/tests/parity/test_colorize_parity.py
+++ b/conformance/utils/tests/parity/test_colorize_parity.py
@@ -41,6 +41,46 @@ CASES = [
     ("deepseek_v3", "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>x<｜tool▁sep｜>y<｜tool▁call▁end｜><｜tool▁calls▁end｜>"),
     ("mistral", "[TOOL_CALLS][{\"name\": \"f\"}]"),
     ("hermes", "escape & < > \" ' chars"),
+    # Opaque argument-value regions (parser_families.yaml `opaque:`): a
+    # marker-looking substring INSIDE a value is DATA, so it must not be colored as a
+    # control token and must not steal the real pair. One per region shape.
+    # qwen3: `<parameter=K>` .. `</parameter>`, an unquoted raw value.
+    (
+        "qwen3_coder",
+        "<tool_call>\n<function=run>\n<parameter=cmd>\n"
+        "git log </tool_call> --oneline\n</parameter>\n</function>\n</tool_call>",
+    ),
+    # qwen3: a reasoning marker in a value stays data too (the parser's I7 case).
+    (
+        "qwen3_coder",
+        "<tool_call><function=log><parameter=note><think>reconsider</think>"
+        "</parameter></function></tool_call>",
+    ),
+    # qwen3: two values in one call, and an unterminated value at EOF.
+    (
+        "qwen3_coder",
+        "<tool_call><function=f><parameter=a>1</parameter>"
+        "<parameter=b>2</parameter></function></tool_call>",
+    ),
+    ("qwen3_coder", "<tool_call>\n<function=run>\n<parameter=cmd>unterminated value"),
+    # gemma4: the `<|"|>` quote toggle wraps the value; the `<tool_call|>` inside it
+    # would otherwise close the real `<|tool_call>` and orphan the true closer.
+    ("gemma4", '<|tool_call>call:run{cmd:<|"|>git log }<tool_call|> --oneline<|"|>}<tool_call|>'),
+    ("gemma4", '<|tool_call>call:f{a:<|"|>x<|"|>,b:<|"|>y<|"|>}<tool_call|>'),
+    # kimi: the argument blob is JSON and its terminator is the SAME token that can
+    # appear inside a string value, so only JSON-string awareness separates them.
+    (
+        "kimi_k2",
+        '<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0'
+        '<|tool_call_argument_begin|>{"cmd": "git log <|tool_call_end|> --oneline"}'
+        '<|tool_call_end|><|tool_calls_section_end|>',
+    ),
+    (
+        "kimi_k2",
+        '<|tool_calls_section_begin|><|tool_call_begin|>functions.f:0'
+        '<|tool_call_argument_begin|>{"a": "esc \\" quote <|tool_call_end|>"}'
+        '<|tool_call_end|><|tool_calls_section_end|>',
+    ),
     (None, "no family, plain <tool_call>t</tool_call> & 'text'"),
 ]
 
@@ -51,6 +91,17 @@ STREAM_CASES = [
     ("hermes", [{"delta_text": "<tool_"}, {"delta_text": "call>{\"n"}, {"delta_text": "\":1}</tool_call>"}]),
     ("harmony", [{"delta_text": "<|chan"}, {"delta_text": "nel|>fin"}, {"delta_text": "al<|message|>hi"}]),
     ("hermes", [{"delta_text": "plain "}, {"delta_text": "text & "}, {"delta_text": "more"}]),
+    # An opaque region split across chunk boundaries: the value (and the
+    # marker-looking substring in it) must stay data even though the opener,
+    # the embedded token and the closer arrive in different chunks.
+    (
+        "qwen3_coder",
+        [
+            {"delta_text": "<tool_call><function=run><parameter=cmd>git log "},
+            {"delta_text": "</tool_call> --one"},
+            {"delta_text": "line</parameter></function></tool_call>"},
+        ],
+    ),
 ]
 
 

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -4,6 +4,7 @@
 //! Dynamo parser v2 implementations.
 
 pub mod tool_calling;
+pub mod unified;
 
 pub use tool_calling::debug::{DEBUG_ENV, debug_enabled};
 pub use tool_calling::dsml::DeepSeekV4ToolStreamParser;
@@ -22,3 +23,9 @@ pub use tool_calling::{REGISTERED_FAMILIES, create_tool_parser_for_family};
 // (e.g. `ToolStreamResult::tool_call_chunks`). v2 owns these now — see
 // `tool_calling::v1core`.
 pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType};
+// One state machine per stream owning reasoning + content + tool calls, emitting
+// ONE ordered event stream (see `unified`).
+pub use unified::{
+    Qwen3UnifiedParser, REGISTERED_UNIFIED_FAMILIES, UnifiedDelta, UnifiedEvent, UnifiedParser,
+    assemble, create_unified_parser_for_family,
+};

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -26,6 +26,6 @@ pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType
 // One state machine per stream owning reasoning + content + tool calls, emitting
 // ONE ordered event stream (see `unified`).
 pub use unified::{
-    Qwen3UnifiedParser, REGISTERED_UNIFIED_FAMILIES, UnifiedDelta, UnifiedEvent, UnifiedParser,
-    assemble, create_unified_parser_for_family,
+    REGISTERED_UNIFIED_FAMILIES, UnifiedDelta, UnifiedEvent, UnifiedParser, assemble,
+    create_unified_parser_for_family,
 };

--- a/parsers/v2/src/tool_calling/mod.rs
+++ b/parsers/v2/src/tool_calling/mod.rs
@@ -12,7 +12,9 @@ pub mod kimi_k2;
 pub mod minimax_m2;
 pub mod minimax_m3;
 pub mod qwen3_coder;
-mod scan;
+/// Shared marker-scan core. Crate-visible because `crate::unified` builds on the
+/// same scanner rather than reimplementing marker handling.
+pub(crate) mod scan;
 pub mod traits;
 /// Vendored batch extraction copied from v1 so v2 is standalone (see module docs).
 mod v1core;

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -10,9 +10,9 @@
 //!
 //! The streaming concern (buffering, chunk-split marker safety, normal_text
 //! suppression) is owned by the shared [`scan::WrappedBlockScanner`]. The
-//! per-block value typing is delegated to the v1 batch XML parser
-//! `try_tool_call_parse_xml`, so a streamed call matches exactly what the batch
-//! parser produces (the DIS-2209 bar). Arguments are re-serialized in the
+//! per-block value typing is delegated to the vendored batch XML parser via
+//! `parse_tool_call_block`, so a streamed call matches exactly what the batch
+//! parser produces. Arguments are re-serialized in the
 //! source parameter order because the v1 parser builds them from a `HashMap`
 //! whose key order is non-deterministic; streaming fixtures store the arguments
 //! as an exact JSON string, so order has to be pinned to the model-emitted
@@ -22,7 +22,7 @@ use crate::tool_calling::scan::{
     BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
     reorder_arguments,
 };
-use crate::tool_calling::v1core::{ToolDefinition, XmlParserConfig, try_tool_call_parse_xml};
+use crate::tool_calling::v1core::{ToolDefinition, XmlParserConfig, parse_tool_call_block};
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
 
@@ -54,10 +54,9 @@ fn spec() -> WrappedBlockSpec {
     }
 }
 
-/// Value-typing hook: wraps one complete `<function=...></function>` block in
-/// `<tool_call>` so the v1 parser takes its normal wrapped path, then re-orders
-/// the arguments to source order.
-struct Qwen3Emitter {
+/// Value-typing hook: types one complete `<function=...></function>` block and
+/// re-orders the arguments to source order.
+pub(crate) struct Qwen3Emitter {
     config: XmlParserConfig,
     tools: Vec<ToolDefinition>,
 }
@@ -68,8 +67,14 @@ impl InvokeEmitter for Qwen3Emitter {
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {
-        let wrapped = format!("{BLOCK_START}{invoke}{BLOCK_END}");
-        let (calls, _content) = try_tool_call_parse_xml(&wrapped, &self.config, Some(&self.tools))?;
+        // Type this ONE invoke directly. Wrapping it back in `<tool_call>` and
+        // re-entering `try_tool_call_parse_xml` made the batch parser re-run
+        // block discovery, which cuts the block at the FIRST `</tool_call>` —
+        // so a parameter value that legitimately contains that marker was
+        // truncated (`<parameter=cmd>git log </tool_call> --oneline</parameter>`
+        // typed as `git log </tool_call>`). The scanner has already delimited
+        // the invoke, so re-discovering its bounds could only corrupt them.
+        let calls = parse_tool_call_block(invoke, &self.config, Some(&self.tools))?;
         let Some(call) = calls.into_iter().next() else {
             return Ok(None);
         };
@@ -83,6 +88,22 @@ impl InvokeEmitter for Qwen3Emitter {
     }
 }
 
+/// Build the scan core for the Qwen3 tool grammar.
+///
+/// The single construction site for this grammar. The unified Qwen3 parser
+/// calls it too and layers reasoning on top, so both parsers get the same
+/// block/invoke markers, holdback set, recovery latches and value typing —
+/// there is no second copy to drift.
+pub(crate) fn qwen3_scanner(tools: &[Tool]) -> WrappedBlockScanner<Qwen3Emitter> {
+    WrappedBlockScanner::new(
+        spec(),
+        Qwen3Emitter {
+            config: XmlParserConfig::default(),
+            tools: tools.iter().map(ToolDefinition::from).collect(),
+        },
+    )
+}
+
 /// Stream parser for Qwen3-Coder XML tool calls.
 pub struct Qwen3CoderToolStreamParser {
     scanner: WrappedBlockScanner<Qwen3Emitter>,
@@ -91,13 +112,7 @@ pub struct Qwen3CoderToolStreamParser {
 impl Qwen3CoderToolStreamParser {
     pub fn new(tools: &[Tool]) -> Self {
         Self {
-            scanner: WrappedBlockScanner::new(
-                spec(),
-                Qwen3Emitter {
-                    config: XmlParserConfig::default(),
-                    tools: tools.iter().map(ToolDefinition::from).collect(),
-                },
-            ),
+            scanner: qwen3_scanner(tools),
         }
     }
 }

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -28,10 +28,30 @@
 //! [`WrappedBlockSpec`] fields, not silent copy drift — e.g. MiniMax M2
 //! clears the normal-text suppression latch after a bare-invoke recovery
 //! while M3/qwen3/kimi keep it latched ([`BareRecoveryLatch`]).
+//!
+//! # Ordered output
+//!
+//! The drain loop emits [`UnifiedDelta`]s — text, reasoning and calls in the
+//! order the model produced them. Tool-only parsers project that down to
+//! [`ToolParseResult`] via `push`/`finish` and see no behavior change (that
+//! projection is lossy about order, which is all the tool-only contract ever
+//! promised). Unified parsers take the ordered list through `push_ordered` /
+//! `finish_ordered`. One scan, two views — so reasoning-aware and
+//! reasoning-unaware families cannot drift on marker handling, chunk-boundary
+//! holdback, or recovery.
+//!
+//! Reasoning is opt-in per scanner via [`WrappedBlockScanner::with_reasoning`].
+//! The two nestings are deliberately ASYMMETRIC, because tool structure
+//! dominates: a tool call emitted INSIDE a thought is a real call, so it is
+//! extracted and the thought splits around it; but a reasoning marker inside a
+//! tool argument is argument data (`I7`), because the in-block scan never looks
+//! for one. Burying a nested call would drop it AND leak its markup into the
+//! reasoning payload (`I3`).
 
 use std::collections::HashSet;
 
 use crate::tool_calling::traits::{ToolCallDelta, ToolParseResult};
+use crate::unified::UnifiedDelta;
 
 /// Longest non-empty proper prefix of any `marker` that `text` ends with, so a
 /// marker split across chunk boundaries is held back instead of leaked as
@@ -143,6 +163,20 @@ pub(crate) struct WrappedBlockSpec {
     pub drop_invoke_crossing_block_end: bool,
 }
 
+/// The reasoning channel a unified scanner also owns.
+///
+/// Only meaningful outside tool blocks — see the module docs.
+pub(crate) struct ReasoningSpec {
+    /// Opener, e.g. `<think>`.
+    pub start: String,
+    /// Closer, e.g. `</think>`.
+    pub end: String,
+    /// Stream begins INSIDE reasoning with no opener, because the chat template
+    /// pre-filled it (policy P5). Qwen3 is not one of these; DeepSeek-R1-style
+    /// forced-reasoning templates are.
+    pub forced_start: bool,
+}
+
 /// Per-family hook: parse one complete invoke (opener..closer inclusive) into
 /// a call delta. `None` means the invoke was malformed and is dropped.
 pub(crate) trait InvokeEmitter {
@@ -167,6 +201,35 @@ enum Marker {
     Block(usize),
     /// A bare invoke opener with no block wrapper (recovery path).
     BareInvoke,
+    /// A reasoning opener; carries the matched token length.
+    ReasoningStart(usize),
+}
+
+/// Append `text` as visible content, merging with a trailing text delta so one
+/// drain does not emit a run of adjacent same-kind fragments.
+fn push_text(out: &mut Vec<UnifiedDelta>, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    match out.last_mut() {
+        Some(UnifiedDelta::Text { text: prev }) => prev.push_str(text),
+        _ => out.push(UnifiedDelta::Text {
+            text: text.to_string(),
+        }),
+    }
+}
+
+/// Append `text` as reasoning, merging with a trailing reasoning delta.
+fn push_reasoning(out: &mut Vec<UnifiedDelta>, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    match out.last_mut() {
+        Some(UnifiedDelta::Reasoning { text: prev }) => prev.push_str(text),
+        _ => out.push(UnifiedDelta::Reasoning {
+            text: text.to_string(),
+        }),
+    }
 }
 
 /// The shared buffer-and-scan drain loop for wrapped-invoke grammars.
@@ -181,8 +244,14 @@ enum Marker {
 pub(crate) struct WrappedBlockScanner<E: InvokeEmitter> {
     spec: WrappedBlockSpec,
     emitter: E,
+    reasoning: Option<ReasoningSpec>,
     buffer: String,
     in_block: bool,
+    in_reasoning: bool,
+    /// A tool call opened INSIDE a reasoning span; reasoning resumes when the
+    /// call closes. Without this the tail of the thought would surface as
+    /// visible text instead of reasoning.
+    resume_reasoning: bool,
     suppress_normal_text: bool,
     next_index: usize,
 }
@@ -192,26 +261,156 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         Self {
             spec,
             emitter,
+            reasoning: None,
             buffer: String::new(),
             in_block: false,
+            in_reasoning: false,
+            resume_reasoning: false,
             suppress_normal_text: false,
             next_index: 0,
         }
     }
 
+    /// Also own the reasoning channel, making this scanner unified.
+    ///
+    /// The reasoning markers are registered for chunk-boundary holdback here
+    /// rather than by the caller, so a family cannot add reasoning and forget
+    /// the holdback (which would leak a split `<thi` + `nk>` as visible text).
+    /// The closer additionally joins `orphan_markers`: a stray `</think>` with
+    /// nothing open is malformed markup and is stripped, never leaked (`I3`).
+    pub(crate) fn with_reasoning(mut self, reasoning: ReasoningSpec) -> Self {
+        self.spec.holdback_markers.push(reasoning.start.clone());
+        self.spec.holdback_markers.push(reasoning.end.clone());
+        self.spec.orphan_markers.push(reasoning.end.clone());
+        self.in_reasoning = reasoning.forced_start;
+        self.reasoning = Some(reasoning);
+        self
+    }
+
     pub(crate) fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
+        Ok(ToolParseResult::from_deltas(self.push_ordered(chunk)?))
+    }
+
+    pub(crate) fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
+        Ok(ToolParseResult::from_deltas(self.finish_ordered()?))
+    }
+
+    pub(crate) fn push_ordered(&mut self, chunk: &str) -> anyhow::Result<Vec<UnifiedDelta>> {
         self.buffer.push_str(chunk);
         self.drain(false)
     }
 
-    pub(crate) fn finish(&mut self) -> anyhow::Result<ToolParseResult> {
+    pub(crate) fn finish_ordered(&mut self) -> anyhow::Result<Vec<UnifiedDelta>> {
         self.drain(true)
     }
 
-    fn drain(&mut self, flush: bool) -> anyhow::Result<ToolParseResult> {
-        let mut out = ToolParseResult::default();
+    /// Position and length of the reasoning opener in the buffer, if configured.
+    fn find_reasoning_start(&self) -> Option<(usize, usize)> {
+        let reasoning = self.reasoning.as_ref()?;
+        let pos = self.buffer.find(reasoning.start.as_str())?;
+        Some((pos, reasoning.start.len()))
+    }
+
+    /// Consume buffered reasoning up to its closer, a nested tool opener, or as
+    /// far as is safe.
+    ///
+    /// Returns `true` once the reasoning span yielded (closer seen, tool opener
+    /// reached, or promoted at EOF) and the caller should keep draining; `false`
+    /// means more input is needed.
+    fn drain_reasoning(&mut self, out: &mut Vec<UnifiedDelta>, flush: bool) -> bool {
+        let end = self
+            .reasoning
+            .as_ref()
+            .expect("in_reasoning implies a reasoning spec")
+            .end
+            .clone();
+        let end_pos = self.buffer.find(end.as_str());
+
+        // Tool structure dominates reasoning: a tool call the model emits INSIDE
+        // a thought is still a real call, so it is extracted and the thought
+        // splits around it. Treating reasoning as the innermost scope instead
+        // would bury the call and leak its markup into the reasoning payload,
+        // violating `I3`. (The reverse nesting is NOT symmetric — a reasoning
+        // marker inside a tool argument stays argument data, `I7`, because the
+        // in-block branch never scans for it.)
+        let tool_pos = find_first(&self.buffer, &self.spec.block_starts)
+            .map(|(p, _)| p)
+            .into_iter()
+            .chain(self.buffer.find(self.spec.invoke_start.as_str()))
+            .min();
+
+        if let Some(tool) = tool_pos
+            && end_pos.is_none_or(|e| tool < e)
+        {
+            // Emit the thought up to the call and suspend reasoning; the block
+            // handler resumes it once the call closes.
+            push_reasoning(out, &self.buffer[..tool]);
+            self.buffer.drain(..tool);
+            self.in_reasoning = false;
+            self.resume_reasoning = true;
+            return true;
+        }
+
+        if let Some(pos) = end_pos {
+            push_reasoning(out, &self.buffer[..pos]);
+            self.buffer.drain(..pos + end.len());
+            self.in_reasoning = false;
+            self.resume_reasoning = false;
+            return true;
+        }
+
+        // No closer yet: stream what has arrived, holding back a closer OR a
+        // nested tool opener split across this chunk boundary.
+        let keep = if flush {
+            0
+        } else {
+            marker_prefix_suffix_len(
+                &self.buffer,
+                std::iter::once(end.as_str())
+                    .chain(self.spec.block_starts.iter().map(String::as_str))
+                    .chain(std::iter::once(self.spec.invoke_start.as_str())),
+            )
+        };
+        let emit_len = self.buffer.len().saturating_sub(keep);
+        if emit_len > 0 {
+            push_reasoning(out, &self.buffer[..emit_len]);
+            self.buffer.drain(..emit_len);
+        }
+        if flush {
+            // 4.e: the stream ended mid-thought. The open reasoning is promoted
+            // as reasoning — not dropped, and not leaked as visible text.
+            self.in_reasoning = false;
+            self.resume_reasoning = false;
+            tracing::debug!(
+                why = %format!("{}_reasoning_open_at_eof", self.spec.family),
+                "stream promoted unterminated reasoning at EOF"
+            );
+        }
+        false
+    }
+
+    /// Re-enter reasoning after a tool call that was nested inside a thought.
+    fn resume_reasoning_after_tool(&mut self) {
+        if self.resume_reasoning {
+            self.resume_reasoning = false;
+            self.in_reasoning = true;
+        }
+    }
+
+    fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedDelta>> {
+        let mut out: Vec<UnifiedDelta> = Vec::new();
 
         loop {
+            // Reasoning is the innermost scope: while it is open, ONLY its
+            // closer ends it, so a `<tool_call>` inside a thought stays part of
+            // the thought instead of being executed.
+            if self.in_reasoning {
+                if self.drain_reasoning(&mut out, flush) {
+                    continue;
+                }
+                break;
+            }
+
             if self.in_block {
                 let invoke_start = self.buffer.find(self.spec.invoke_start.as_str());
 
@@ -226,6 +425,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         self.buffer.drain(..end_pos + end_len);
                         self.in_block = false;
                         self.suppress_normal_text = false;
+                        self.resume_reasoning_after_tool();
                         continue;
                     }
                 }
@@ -274,7 +474,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
                 self.buffer.drain(..end + self.spec.invoke_end.len());
                 if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
-                    out.calls.push(delta);
+                    out.push(UnifiedDelta::ToolCall(delta));
                     self.next_index += 1;
                     if self.spec.invoke_latch == InvokeLatch::IfEmitted {
                         self.suppress_normal_text = true;
@@ -296,10 +496,14 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     .map(|(p, _)| p)
                     .into_iter()
                     .chain(self.buffer.find(self.spec.invoke_start.as_str()))
+                    // A reasoning opener counts as an opener here, so the
+                    // matching closer in `<think>a</think>` is not mistaken for
+                    // an orphan and stripped.
+                    .chain(self.find_reasoning_start().map(|(p, _)| p))
                     .min();
                 if next_open.is_none_or(|open| pos < open) {
                     if !self.suppress_normal_text && pos > 0 {
-                        out.normal_text.push_str(&self.buffer[..pos]);
+                        push_text(&mut out, &self.buffer[..pos]);
                     }
                     self.buffer.drain(..pos + len);
                     self.suppress_normal_text = false;
@@ -307,15 +511,19 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 }
             }
 
-            let block = find_first(&self.buffer, &self.spec.block_starts);
-            let bare = self.buffer.find(self.spec.invoke_start.as_str());
-            let next_marker = match (block, bare) {
-                (Some((b, blen)), Some(f)) if b <= f => Some((b, Marker::Block(blen))),
-                (Some(_), Some(f)) => Some((f, Marker::BareInvoke)),
-                (Some((b, blen)), None) => Some((b, Marker::Block(blen))),
-                (None, Some(f)) => Some((f, Marker::BareInvoke)),
-                (None, None) => None,
-            };
+            // Earliest marker wins. Ties resolve in push order (block over bare
+            // invoke), preserving the pre-unified tie-break.
+            let mut candidates: Vec<(usize, Marker)> = Vec::new();
+            if let Some((pos, len)) = find_first(&self.buffer, &self.spec.block_starts) {
+                candidates.push((pos, Marker::Block(len)));
+            }
+            if let Some(pos) = self.buffer.find(self.spec.invoke_start.as_str()) {
+                candidates.push((pos, Marker::BareInvoke));
+            }
+            if let Some((pos, len)) = self.find_reasoning_start() {
+                candidates.push((pos, Marker::ReasoningStart(len)));
+            }
+            let next_marker = candidates.into_iter().min_by_key(|(pos, _)| *pos);
 
             let Some((start, marker)) = next_marker else {
                 // No marker present: emit buffered text, but hold back a trailing
@@ -331,7 +539,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let emit_len = self.buffer.len().saturating_sub(keep);
                 if emit_len > 0 {
                     if !self.suppress_normal_text {
-                        out.normal_text.push_str(&self.buffer[..emit_len]);
+                        push_text(&mut out, &self.buffer[..emit_len]);
                     }
                     self.buffer.drain(..emit_len);
                 }
@@ -340,7 +548,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
             if start > 0 {
                 if !self.suppress_normal_text {
-                    out.normal_text.push_str(&self.buffer[..start]);
+                    push_text(&mut out, &self.buffer[..start]);
                 }
                 self.buffer.drain(..start);
             }
@@ -350,6 +558,15 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     self.buffer.drain(..blen);
                     self.in_block = true;
                     self.suppress_normal_text = true;
+                }
+                Marker::ReasoningStart(rlen) => {
+                    self.buffer.drain(..rlen);
+                    self.in_reasoning = true;
+                    // An explicit reasoning opener is an unambiguous return to
+                    // real content, so it ends any markup-suppression context
+                    // left over from a bare-invoke recovery. Without this a
+                    // thought following a recovered call would be dropped.
+                    self.suppress_normal_text = false;
                 }
                 Marker::BareInvoke => {
                     // A bare invoke (no wrapper) is recovered only once its close
@@ -372,10 +589,16 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                             tool_index = delta.tool_index,
                             "stream recovered a complete bare invoke"
                         );
-                        out.calls.push(delta);
+                        out.push(UnifiedDelta::ToolCall(delta));
                         self.next_index += 1;
                         self.suppress_normal_text =
                             self.spec.bare_recovery_latch == BareRecoveryLatch::Set;
+                    }
+                    // A bare invoke nested in a thought has no block close to
+                    // resume on, so resume here.
+                    if self.resume_reasoning {
+                        self.suppress_normal_text = false;
+                        self.resume_reasoning_after_tool();
                     }
                 }
             }

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -165,12 +165,16 @@ pub(crate) struct WrappedBlockSpec {
 
 /// The reasoning channel a unified scanner also owns.
 ///
-/// Only meaningful outside tool blocks — see the module docs.
+/// Only meaningful outside tool blocks — see the module docs. `Copy` over
+/// `&'static str`: every family's markers are compile-time constants, so
+/// `drain_reasoning` copies two pointers per push instead of allocating two
+/// `String`s on the hot path.
+#[derive(Clone, Copy)]
 pub(crate) struct ReasoningSpec {
     /// Opener, e.g. `<think>`.
-    pub start: String,
+    pub start: &'static str,
     /// Closer, e.g. `</think>`.
-    pub end: String,
+    pub end: &'static str,
     /// Stream begins INSIDE reasoning with no opener, because the chat template
     /// pre-filled it (policy P5). Qwen3 is not one of these; DeepSeek-R1-style
     /// forced-reasoning templates are.
@@ -295,9 +299,9 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// The closer additionally joins `orphan_markers`: a stray `</think>` with
     /// nothing open is malformed markup and is stripped, never leaked (`I3`).
     pub(crate) fn with_reasoning(mut self, reasoning: ReasoningSpec) -> Self {
-        self.spec.holdback_markers.push(reasoning.start.clone());
-        self.spec.holdback_markers.push(reasoning.end.clone());
-        self.spec.orphan_markers.push(reasoning.end.clone());
+        self.spec.holdback_markers.push(reasoning.start.to_string());
+        self.spec.holdback_markers.push(reasoning.end.to_string());
+        self.spec.orphan_markers.push(reasoning.end.to_string());
         self.in_reasoning = reasoning.forced_start;
         self.reasoning = Some(reasoning);
         self
@@ -323,7 +327,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// Position and length of the reasoning opener in the buffer, if configured.
     fn find_reasoning_start(&self) -> Option<(usize, usize)> {
         let reasoning = self.reasoning.as_ref()?;
-        let pos = self.buffer.find(reasoning.start.as_str())?;
+        let pos = self.buffer.find(reasoning.start)?;
         Some((pos, reasoning.start.len()))
     }
 
@@ -333,14 +337,15 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// Returns `true` once the reasoning span yielded (closer seen, tool opener
     /// reached, or promoted at EOF) and the caller should keep draining; `false`
     /// means more input is needed.
-    fn drain_reasoning(&mut self, out: &mut Vec<UnifiedDelta>, flush: bool) -> bool {
-        let (start, end) = {
-            let r = self
-                .reasoning
-                .as_ref()
-                .expect("in_reasoning implies a reasoning spec");
-            (r.start.clone(), r.end.clone())
+    fn drain_reasoning(
+        &mut self,
+        out: &mut Vec<UnifiedDelta>,
+        flush: bool,
+    ) -> anyhow::Result<bool> {
+        let Some(reasoning) = self.reasoning else {
+            anyhow::bail!("reasoning state active without a reasoning spec");
         };
+        let (start, end) = (reasoning.start, reasoning.end);
 
         // Everything that can interrupt an open thought, as (position, meaning).
         // Collecting them into ONE list and taking the earliest keeps the
@@ -362,21 +367,19 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             .into_iter()
             .chain(self.buffer.find(self.spec.invoke_start.as_str()))
             .min();
-        let stray = std::iter::once(start.as_str())
+        let stray = std::iter::once(start)
             .chain(
                 self.spec
                     .orphan_markers
                     .iter()
                     .map(String::as_str)
-                    .filter(|m| *m != end.as_str()),
+                    .filter(|m| *m != end),
             )
             .filter_map(|m| self.buffer.find(m).map(|pos| (pos, m.len())))
             .min_by_key(|(pos, _)| *pos);
 
         if let Some((at, what)) = earliest([
-            self.buffer
-                .find(end.as_str())
-                .map(|pos| (pos, InReasoning::Close)),
+            self.buffer.find(end).map(|pos| (pos, InReasoning::Close)),
             tool_open.map(|pos| (pos, InReasoning::ToolOpen)),
             stray.map(|(pos, len)| (pos, InReasoning::Stray(len))),
         ]) {
@@ -398,7 +401,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     "stream stripped malformed markup inside a reasoning span"
                 );
             }
-            return true;
+            return Ok(true);
         }
 
         // Nothing complete yet: stream what has arrived, holding back ANY marker
@@ -426,7 +429,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 "stream promoted unterminated reasoning at EOF"
             );
         }
-        false
+        Ok(false)
     }
 
     fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedDelta>> {
@@ -438,7 +441,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             // `drain_reasoning`), so a call emitted inside a thought is extracted
             // and the thought resumes after it.
             if self.in_reasoning {
-                if self.drain_reasoning(&mut out, flush) {
+                if self.drain_reasoning(&mut out, flush)? {
                     continue;
                 }
                 break;

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -51,7 +51,7 @@
 use std::collections::HashSet;
 
 use crate::tool_calling::traits::{ToolCallDelta, ToolParseResult};
-use crate::unified::UnifiedDelta;
+use crate::unified::{Kind, UnifiedDelta};
 
 /// Longest non-empty proper prefix of any `marker` that `text` ends with, so a
 /// marker split across chunk boundaries is held back instead of leaked as
@@ -195,6 +195,17 @@ fn find_first(text: &str, markers: &[String]) -> Option<(usize, usize)> {
         .min_by_key(|(p, _)| *p)
 }
 
+/// Earliest `(position, payload)` among the candidates.
+///
+/// Both scan scopes — inside a thought and outside a block — answer the same
+/// question: of everything that could interrupt the current run, which comes
+/// first? One helper keeps that precedence rule in one place, and ties resolve to
+/// the FIRST candidate listed, so each call site states its own priority order
+/// simply by the order it writes them.
+fn earliest<T>(candidates: impl IntoIterator<Item = Option<(usize, T)>>) -> Option<(usize, T)> {
+    candidates.into_iter().flatten().min_by_key(|(pos, _)| *pos)
+}
+
 #[derive(Clone, Copy)]
 enum Marker {
     /// A block opener; carries the matched token length.
@@ -205,29 +216,34 @@ enum Marker {
     ReasoningStart(usize),
 }
 
-/// Append `text` as visible content, merging with a trailing text delta so one
-/// drain does not emit a run of adjacent same-kind fragments.
-fn push_text(out: &mut Vec<UnifiedDelta>, text: &str) {
-    if text.is_empty() {
-        return;
-    }
-    match out.last_mut() {
-        Some(UnifiedDelta::Text { text: prev }) => prev.push_str(text),
-        _ => out.push(UnifiedDelta::Text {
-            text: text.to_string(),
-        }),
-    }
+/// What the earliest marker inside an OPEN reasoning span means.
+enum InReasoning {
+    /// The span's own closer — reasoning ends here.
+    Close,
+    /// A tool opener — suspend the thought, resume after the call closes.
+    ToolOpen,
+    /// Malformed markup to strip, carrying its length.
+    Stray(usize),
 }
 
-/// Append `text` as reasoning, merging with a trailing reasoning delta.
-fn push_reasoning(out: &mut Vec<UnifiedDelta>, text: &str) {
+/// Append a text run, merging into a trailing run of the SAME kind so one drain
+/// never emits a string of adjacent same-kind fragments (`I8`). The or-pattern is
+/// the whole point: text and reasoning coalesce by identical rules, so there is
+/// one implementation to get right instead of two that can drift.
+pub(crate) fn push_run(out: &mut Vec<UnifiedDelta>, kind: Kind, text: &str) {
     if text.is_empty() {
         return;
     }
-    match out.last_mut() {
-        Some(UnifiedDelta::Reasoning { text: prev }) => prev.push_str(text),
-        _ => out.push(UnifiedDelta::Reasoning {
-            text: text.to_string(),
+    match (out.last_mut(), kind) {
+        (Some(UnifiedDelta::Text { text: prev }), Kind::Text)
+        | (Some(UnifiedDelta::Reasoning { text: prev }), Kind::Reasoning) => prev.push_str(text),
+        _ => out.push(match kind {
+            Kind::Text => UnifiedDelta::Text {
+                text: text.to_string(),
+            },
+            Kind::Reasoning => UnifiedDelta::Reasoning {
+                text: text.to_string(),
+            },
         }),
     }
 }
@@ -325,27 +341,28 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 .expect("in_reasoning implies a reasoning spec");
             (r.start.clone(), r.end.clone())
         };
-        let end_pos = self.buffer.find(end.as_str());
 
-        // Tool structure dominates reasoning: a tool call the model emits INSIDE
-        // a thought is still a real call, so it is extracted and the thought
-        // splits around it. Treating reasoning as the innermost scope instead
-        // would bury the call and leak its markup into the reasoning payload,
-        // violating `I3`. (The reverse nesting is NOT symmetric — a reasoning
-        // marker inside a tool argument stays argument data, `I7`, because the
-        // in-block branch never scans for it.)
-        let tool_pos = find_first(&self.buffer, &self.spec.block_starts)
-            .map(|(p, _)| p)
+        // Everything that can interrupt an open thought, as (position, meaning).
+        // Collecting them into ONE list and taking the earliest keeps the
+        // precedence rule in a single place — and makes it visible in a debugger
+        // as a list of candidates rather than three separately-compared Options.
+        // Everything that can interrupt an open thought, in PRECEDENCE order:
+        //  - the span's own closer;
+        //  - a tool opener — tool structure dominates reasoning, so a call emitted
+        //    INSIDE a thought is extracted and the thought splits around it. Burying
+        //    it would drop the call AND leak its markup (`I3`). The reverse nesting
+        //    is NOT symmetric: a reasoning marker inside a tool argument stays
+        //    argument data (`I7`), because the in-block branch never scans for it;
+        //  - malformed markup (duplicate opener / stray tool close) to strip, the
+        //    same rule the orphan handler applies outside reasoning, so being inside
+        //    a thought cannot turn markup into content (`I3`). The closer is excluded
+        //    from this set because it legitimately ends the span.
+        let tool_open = find_first(&self.buffer, &self.spec.block_starts)
+            .map(|(pos, _)| pos)
             .into_iter()
             .chain(self.buffer.find(self.spec.invoke_start.as_str()))
             .min();
-
-        // Malformed markup INSIDE a thought: a duplicate reasoning opener, or a
-        // stray close from the tool grammar. Best-effort recovery STRIPS it, the
-        // same rule the orphan handler applies outside reasoning — otherwise it
-        // leaks into the reasoning payload and violates `I3`. The reasoning
-        // closer is excluded: it legitimately ends the span (handled below).
-        let strip_pos: Option<(usize, usize)> = std::iter::once(start.as_str())
+        let stray = std::iter::once(start.as_str())
             .chain(
                 self.spec
                     .orphan_markers
@@ -353,39 +370,34 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     .map(String::as_str)
                     .filter(|m| *m != end.as_str()),
             )
-            .filter_map(|m| self.buffer.find(m).map(|p| (p, m.len())))
-            .min_by_key(|(p, _)| *p);
+            .filter_map(|m| self.buffer.find(m).map(|pos| (pos, m.len())))
+            .min_by_key(|(pos, _)| *pos);
 
-        // Earliest wins.
-        let first = [end_pos, tool_pos, strip_pos.map(|(p, _)| p)]
-            .into_iter()
-            .flatten()
-            .min();
-
-        if let Some(at) = first {
-            if Some(at) == end_pos {
-                push_reasoning(out, &self.buffer[..at]);
-                self.buffer.drain(..at + end.len());
-                self.in_reasoning = false;
-                self.resume_reasoning = false;
-                return true;
+        if let Some((at, what)) = earliest([
+            self.buffer
+                .find(end.as_str())
+                .map(|pos| (pos, InReasoning::Close)),
+            tool_open.map(|pos| (pos, InReasoning::ToolOpen)),
+            stray.map(|(pos, len)| (pos, InReasoning::Stray(len))),
+        ]) {
+            // One transition table: how many marker bytes to consume, and the state
+            // the span is left in. ToolOpen consumes nothing — the block handler
+            // still needs to see its own opener.
+            let (consume, in_reasoning, resume) = match what {
+                InReasoning::Close => (end.len(), false, false),
+                InReasoning::ToolOpen => (0, false, true),
+                InReasoning::Stray(len) => (len, true, false),
+            };
+            push_run(out, Kind::Reasoning, &self.buffer[..at]);
+            self.buffer.drain(..at + consume);
+            self.in_reasoning = in_reasoning;
+            self.resume_reasoning = resume;
+            if matches!(what, InReasoning::Stray(_)) {
+                tracing::debug!(
+                    why = %format!("{}_stray_marker_in_reasoning", self.spec.family),
+                    "stream stripped malformed markup inside a reasoning span"
+                );
             }
-            if Some(at) == tool_pos {
-                // Emit the thought up to the call and suspend reasoning; the
-                // block handler resumes it once the call closes.
-                push_reasoning(out, &self.buffer[..at]);
-                self.buffer.drain(..at);
-                self.in_reasoning = false;
-                self.resume_reasoning = true;
-                return true;
-            }
-            let (pos, len) = strip_pos.expect("first came from one of the three");
-            push_reasoning(out, &self.buffer[..pos]);
-            self.buffer.drain(..pos + len);
-            tracing::debug!(
-                why = %format!("{}_stray_marker_in_reasoning", self.spec.family),
-                "stream stripped malformed markup inside a reasoning span"
-            );
             return true;
         }
 
@@ -401,7 +413,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         };
         let emit_len = self.buffer.len().saturating_sub(keep);
         if emit_len > 0 {
-            push_reasoning(out, &self.buffer[..emit_len]);
+            push_run(out, Kind::Reasoning, &self.buffer[..emit_len]);
             self.buffer.drain(..emit_len);
         }
         if flush {
@@ -415,14 +427,6 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             );
         }
         false
-    }
-
-    /// Re-enter reasoning after a tool call that was nested inside a thought.
-    fn resume_reasoning_after_tool(&mut self) {
-        if self.resume_reasoning {
-            self.resume_reasoning = false;
-            self.in_reasoning = true;
-        }
     }
 
     fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedDelta>> {
@@ -454,7 +458,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         self.buffer.drain(..end_pos + end_len);
                         self.in_block = false;
                         self.suppress_normal_text = false;
-                        self.resume_reasoning_after_tool();
+                        self.in_reasoning = std::mem::take(&mut self.resume_reasoning);
                         continue;
                     }
                 }
@@ -532,7 +536,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     .min();
                 if next_open.is_none_or(|open| pos < open) {
                     if !self.suppress_normal_text && pos > 0 {
-                        push_text(&mut out, &self.buffer[..pos]);
+                        push_run(&mut out, Kind::Text, &self.buffer[..pos]);
                     }
                     self.buffer.drain(..pos + len);
                     self.suppress_normal_text = false;
@@ -540,19 +544,17 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 }
             }
 
-            // Earliest marker wins. Ties resolve in push order (block over bare
-            // invoke), preserving the pre-unified tie-break.
-            let mut candidates: Vec<(usize, Marker)> = Vec::new();
-            if let Some((pos, len)) = find_first(&self.buffer, &self.spec.block_starts) {
-                candidates.push((pos, Marker::Block(len)));
-            }
-            if let Some(pos) = self.buffer.find(self.spec.invoke_start.as_str()) {
-                candidates.push((pos, Marker::BareInvoke));
-            }
-            if let Some((pos, len)) = self.find_reasoning_start() {
-                candidates.push((pos, Marker::ReasoningStart(len)));
-            }
-            let next_marker = candidates.into_iter().min_by_key(|(pos, _)| *pos);
+            // Block wins a tie with a bare invoke, preserving the pre-unified
+            // tie-break.
+            let next_marker = earliest([
+                find_first(&self.buffer, &self.spec.block_starts)
+                    .map(|(pos, len)| (pos, Marker::Block(len))),
+                self.buffer
+                    .find(self.spec.invoke_start.as_str())
+                    .map(|pos| (pos, Marker::BareInvoke)),
+                self.find_reasoning_start()
+                    .map(|(pos, len)| (pos, Marker::ReasoningStart(len))),
+            ]);
 
             let Some((start, marker)) = next_marker else {
                 // No marker present: emit buffered text, but hold back a trailing
@@ -568,7 +570,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let emit_len = self.buffer.len().saturating_sub(keep);
                 if emit_len > 0 {
                     if !self.suppress_normal_text {
-                        push_text(&mut out, &self.buffer[..emit_len]);
+                        push_run(&mut out, Kind::Text, &self.buffer[..emit_len]);
                     }
                     self.buffer.drain(..emit_len);
                 }
@@ -577,7 +579,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
             if start > 0 {
                 if !self.suppress_normal_text {
-                    push_text(&mut out, &self.buffer[..start]);
+                    push_run(&mut out, Kind::Text, &self.buffer[..start]);
                 }
                 self.buffer.drain(..start);
             }
@@ -627,8 +629,8 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     // resume on, so resume here.
                     if self.resume_reasoning {
                         self.suppress_normal_text = false;
-                        self.resume_reasoning_after_tool();
                     }
+                    self.in_reasoning = std::mem::take(&mut self.resume_reasoning);
                 }
             }
         }

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -318,12 +318,13 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// reached, or promoted at EOF) and the caller should keep draining; `false`
     /// means more input is needed.
     fn drain_reasoning(&mut self, out: &mut Vec<UnifiedDelta>, flush: bool) -> bool {
-        let end = self
-            .reasoning
-            .as_ref()
-            .expect("in_reasoning implies a reasoning spec")
-            .end
-            .clone();
+        let (start, end) = {
+            let r = self
+                .reasoning
+                .as_ref()
+                .expect("in_reasoning implies a reasoning spec");
+            (r.start.clone(), r.end.clone())
+        };
         let end_pos = self.buffer.find(end.as_str());
 
         // Tool structure dominates reasoning: a tool call the model emits INSIDE
@@ -339,36 +340,63 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             .chain(self.buffer.find(self.spec.invoke_start.as_str()))
             .min();
 
-        if let Some(tool) = tool_pos
-            && end_pos.is_none_or(|e| tool < e)
-        {
-            // Emit the thought up to the call and suspend reasoning; the block
-            // handler resumes it once the call closes.
-            push_reasoning(out, &self.buffer[..tool]);
-            self.buffer.drain(..tool);
-            self.in_reasoning = false;
-            self.resume_reasoning = true;
-            return true;
-        }
+        // Malformed markup INSIDE a thought: a duplicate reasoning opener, or a
+        // stray close from the tool grammar. Best-effort recovery STRIPS it, the
+        // same rule the orphan handler applies outside reasoning — otherwise it
+        // leaks into the reasoning payload and violates `I3`. The reasoning
+        // closer is excluded: it legitimately ends the span (handled below).
+        let strip_pos: Option<(usize, usize)> = std::iter::once(start.as_str())
+            .chain(
+                self.spec
+                    .orphan_markers
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|m| *m != end.as_str()),
+            )
+            .filter_map(|m| self.buffer.find(m).map(|p| (p, m.len())))
+            .min_by_key(|(p, _)| *p);
 
-        if let Some(pos) = end_pos {
+        // Earliest wins.
+        let first = [end_pos, tool_pos, strip_pos.map(|(p, _)| p)]
+            .into_iter()
+            .flatten()
+            .min();
+
+        if let Some(at) = first {
+            if Some(at) == end_pos {
+                push_reasoning(out, &self.buffer[..at]);
+                self.buffer.drain(..at + end.len());
+                self.in_reasoning = false;
+                self.resume_reasoning = false;
+                return true;
+            }
+            if Some(at) == tool_pos {
+                // Emit the thought up to the call and suspend reasoning; the
+                // block handler resumes it once the call closes.
+                push_reasoning(out, &self.buffer[..at]);
+                self.buffer.drain(..at);
+                self.in_reasoning = false;
+                self.resume_reasoning = true;
+                return true;
+            }
+            let (pos, len) = strip_pos.expect("first came from one of the three");
             push_reasoning(out, &self.buffer[..pos]);
-            self.buffer.drain(..pos + end.len());
-            self.in_reasoning = false;
-            self.resume_reasoning = false;
+            self.buffer.drain(..pos + len);
+            tracing::debug!(
+                why = %format!("{}_stray_marker_in_reasoning", self.spec.family),
+                "stream stripped malformed markup inside a reasoning span"
+            );
             return true;
         }
 
-        // No closer yet: stream what has arrived, holding back a closer OR a
-        // nested tool opener split across this chunk boundary.
+        // Nothing complete yet: stream what has arrived, holding back ANY marker
+        // this scanner reacts to that is split across the chunk boundary.
         let keep = if flush {
             0
         } else {
             marker_prefix_suffix_len(
                 &self.buffer,
-                std::iter::once(end.as_str())
-                    .chain(self.spec.block_starts.iter().map(String::as_str))
-                    .chain(std::iter::once(self.spec.invoke_start.as_str())),
+                self.spec.holdback_markers.iter().map(String::as_str),
             )
         };
         let emit_len = self.buffer.len().saturating_sub(keep);
@@ -401,9 +429,10 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         let mut out: Vec<UnifiedDelta> = Vec::new();
 
         loop {
-            // Reasoning is the innermost scope: while it is open, ONLY its
-            // closer ends it, so a `<tool_call>` inside a thought stays part of
-            // the thought instead of being executed.
+            // Reasoning yields to tool structure: while a thought is open, its
+            // closer OR a nested tool opener ends the current reasoning run (see
+            // `drain_reasoning`), so a call emitted inside a thought is extracted
+            // and the thought resumes after it.
             if self.in_reasoning {
                 if self.drain_reasoning(&mut out, flush) {
                     continue;

--- a/parsers/v2/src/tool_calling/v1core/mod.rs
+++ b/parsers/v2/src/tool_calling/v1core/mod.rs
@@ -41,6 +41,6 @@ impl From<&crate::tool_calling::traits::Tool> for ToolDefinition {
 pub use config::{Glm47ParserConfig, KimiK2ParserConfig, MiniMaxM3ParserConfig, XmlParserConfig};
 pub use response::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType};
 pub use xml::{
-    try_tool_call_parse_glm47, try_tool_call_parse_kimi_k2, try_tool_call_parse_minimax_m3,
-    try_tool_call_parse_xml,
+    parse_tool_call_block, try_tool_call_parse_glm47, try_tool_call_parse_kimi_k2,
+    try_tool_call_parse_minimax_m3, try_tool_call_parse_xml,
 };

--- a/parsers/v2/src/tool_calling/v1core/xml/mod.rs
+++ b/parsers/v2/src/tool_calling/v1core/xml/mod.rs
@@ -13,4 +13,4 @@ pub use super::response;
 pub use glm47_parser::try_tool_call_parse_glm47;
 pub use kimi_k2_parser::try_tool_call_parse_kimi_k2;
 pub use minimax_m3_parser::try_tool_call_parse_minimax_m3;
-pub use parser::try_tool_call_parse_xml;
+pub use parser::{parse_tool_call_block, try_tool_call_parse_xml};

--- a/parsers/v2/src/tool_calling/v1core/xml/parser.rs
+++ b/parsers/v2/src/tool_calling/v1core/xml/parser.rs
@@ -284,7 +284,13 @@ fn bare_recovery_surrounding_text(
 
 /// Parse a single tool call block
 /// Format: `<tool_call><function=name><parameter=key>value</parameter>...</function></tool_call>`
-fn parse_tool_call_block(
+///
+/// Crate-visible so a streaming scanner that has ALREADY delimited exactly one
+/// invoke can type it directly. Routing such an invoke back through
+/// `try_tool_call_parse_xml` re-runs block discovery, which splits the block at
+/// the FIRST `</tool_call>` — truncating any argument value that legitimately
+/// contains that marker as data (`I7`).
+pub fn parse_tool_call_block(
     block: &str,
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unified parsing: ONE streaming state machine per stream that owns reasoning,
+//! visible content, and tool calls, and emits ONE ordered event stream.
+//!
+//! # Why this exists
+//!
+//! Dynamo serves today by chaining two independent parsers: a reasoning parser
+//! strips `<think>...</think>` over the whole stream into a single assembled
+//! `reasoning_text` field, and a tool parser then scans the leftover content.
+//! That shape cannot represent WHERE reasoning happened. Every thought is
+//! hoisted to the front and merged into one span, so
+//!
+//! ```text
+//! <think>Look it up.</think><tool_call>…</tool_call><think>Now answer.</think>It's 18C.
+//! ```
+//!
+//! serves as `reasoning("Look it up.Now answer.")` → call → `text("It's 18C.")`:
+//! the second thought moved ahead of the call it followed and fused with the
+//! first. A client rendering thoughts inline shows them in the wrong place, and
+//! a client counting reasoning turns sees one where there were two.
+//!
+//! Ordering is not a field the split can add; it is lost at the seam between the
+//! two parsers. So a unified parser owns the whole grammar and emits deltas in
+//! the order the model produced them:
+//!
+//! ```text
+//! reasoning("Look it up.") | tool_call(get_weather, …) | reasoning("Now answer.") | text("It's 18C.")
+//! ```
+//!
+//! # Shape
+//!
+//! [`UnifiedDelta`] is the streaming vocabulary — what one `push` produced, in
+//! order. [`UnifiedEvent`] is the assembled view: adjacent same-kind deltas
+//! coalesced and per-call argument fragments joined into one typed object
+//! (`I8`). [`assemble`] is the single implementation of that fold, so callers
+//! and conformance harnesses never reimplement it and drift.
+//!
+//! Note this is a genuine unified parser, not vLLM's `CombinedParser` shape:
+//! vLLM 0.25.x keeps `extract_tool_calls_streaming` and
+//! `extract_reasoning_streaming` as two chained APIs behind a unified interface
+//! (only gemma4 is natively unified there), which reproduces the same seam.
+
+pub mod qwen3;
+
+use serde::{Deserialize, Serialize};
+
+use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
+
+pub use qwen3::Qwen3UnifiedParser;
+
+/// One ordered update produced while parsing assistant output.
+///
+/// This is the streaming vocabulary shared by the whole crate: the marker-scan
+/// core emits it, tool-only parsers project it down to [`ToolParseResult`], and
+/// unified parsers hand it to the caller as-is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnifiedDelta {
+    /// Private chain-of-thought.
+    Reasoning { text: String },
+    /// User-visible content.
+    Text { text: String },
+    /// A tool-call update. Carries the tool-only [`ToolCallDelta`] verbatim so
+    /// the two surfaces cannot drift in how a call is described.
+    ToolCall(ToolCallDelta),
+}
+
+/// One assembled event: the order-sensitive unit the unified conformance
+/// surface compares. Serializes to the golden-corpus schema
+/// (`{kind: reasoning|text|tool_call, …}`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UnifiedEvent {
+    Reasoning {
+        text: String,
+    },
+    Text {
+        text: String,
+    },
+    ToolCall {
+        name: String,
+        #[serde(default)]
+        arguments: serde_json::Value,
+    },
+}
+
+/// A parser that owns reasoning + content + tool calls for one stream.
+///
+/// Streaming-first, like [`crate::ToolParser`]: `push` per decoded delta,
+/// `finish` once at end of stream. One instance parses exactly one choice of
+/// one request, which is what gives per-stream isolation (`I4`) by construction.
+pub trait UnifiedParser: Send {
+    /// Construct a boxed parser instance for one request stream.
+    fn create(tools: &[Tool]) -> Result<Box<dyn UnifiedParser>>
+    where
+        Self: Sized + 'static;
+
+    /// Return whether decoded output must preserve tokenizer special tokens.
+    fn preserve_special_tokens(&self) -> bool {
+        false
+    }
+
+    /// Feed one decoded text delta; returns the updates it completed, in order.
+    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>>;
+
+    /// Flush buffered partial state at end of stream.
+    ///
+    /// Open reasoning is promoted here rather than dropped or leaked as text,
+    /// and an unrecoverable partial tool call is dropped without erroring
+    /// (policy P2 — best-effort recovery).
+    fn finish(&mut self) -> Result<Vec<UnifiedDelta>>;
+
+    /// Parse complete output through the incremental lifecycle, then assemble.
+    ///
+    /// Routing batch through `push`/`finish` is what makes stream/batch parity
+    /// (`I6`) structural instead of a property two code paths have to agree on.
+    fn parse_complete(&mut self, output: &str) -> Result<Vec<UnifiedEvent>> {
+        let mut deltas = self.push(output)?;
+        deltas.append(&mut self.finish()?);
+        Ok(assemble(&deltas))
+    }
+}
+
+/// Collapse an ordered delta stream into assembled events.
+///
+/// Adjacent same-kind reasoning/text deltas merge (`I8`); tool-call fragments
+/// are joined by `tool_index` and parsed into a typed object, holding each
+/// call's position at its FIRST delta so order survives fragmentation. Empty or
+/// unparseable arguments become `{}` (policy P3) rather than an error, because a
+/// malformed argument payload must not take down the rest of the turn.
+pub fn assemble(deltas: &[UnifiedDelta]) -> Vec<UnifiedEvent> {
+    // Position of each tool_index in `out`, plus its accumulated argument text.
+    let mut slots: Vec<(usize, usize, String)> = Vec::new();
+    let mut out: Vec<UnifiedEvent> = Vec::new();
+
+    for delta in deltas {
+        match delta {
+            UnifiedDelta::Reasoning { text } => {
+                if text.is_empty() {
+                    continue;
+                }
+                match out.last_mut() {
+                    Some(UnifiedEvent::Reasoning { text: prev }) => prev.push_str(text),
+                    _ => out.push(UnifiedEvent::Reasoning { text: text.clone() }),
+                }
+            }
+            UnifiedDelta::Text { text } => {
+                if text.is_empty() {
+                    continue;
+                }
+                match out.last_mut() {
+                    Some(UnifiedEvent::Text { text: prev }) => prev.push_str(text),
+                    _ => out.push(UnifiedEvent::Text { text: text.clone() }),
+                }
+            }
+            UnifiedDelta::ToolCall(call) => {
+                let slot = match slots.iter_mut().find(|(idx, ..)| *idx == call.tool_index) {
+                    Some(slot) => slot,
+                    None => {
+                        out.push(UnifiedEvent::ToolCall {
+                            name: String::new(),
+                            arguments: serde_json::Value::Null,
+                        });
+                        slots.push((call.tool_index, out.len() - 1, String::new()));
+                        slots.last_mut().expect("just pushed")
+                    }
+                };
+                slot.2.push_str(&call.arguments);
+                if let Some(new_name) = &call.name
+                    && let UnifiedEvent::ToolCall { name, .. } = &mut out[slot.1]
+                    && name.is_empty()
+                {
+                    *name = new_name.clone();
+                }
+            }
+        }
+    }
+
+    for (_, pos, raw) in &slots {
+        let parsed = if raw.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(raw).unwrap_or_else(|_| serde_json::json!({}))
+        };
+        if let UnifiedEvent::ToolCall { arguments, .. } = &mut out[*pos] {
+            *arguments = parsed;
+        }
+    }
+
+    out
+}
+
+impl ToolParseResult {
+    /// Project an ordered delta stream down to the tool-only view.
+    ///
+    /// The tool-only contract has no reasoning channel and no text/call
+    /// ordering, so reasoning folds into `normal_text` exactly where it
+    /// occurred — which is what a reasoning-unaware tool parser sees anyway.
+    /// This projection is the ONLY place the two surfaces are bridged, so the
+    /// scan core can emit ordered deltas without changing tool-only behavior.
+    pub fn from_deltas(deltas: Vec<UnifiedDelta>) -> Self {
+        let mut out = Self::default();
+        for delta in deltas {
+            match delta {
+                UnifiedDelta::Reasoning { text } | UnifiedDelta::Text { text } => {
+                    out.normal_text.push_str(&text)
+                }
+                UnifiedDelta::ToolCall(call) => out.calls.push(call),
+            }
+        }
+        out
+    }
+}
+
+/// Every family `create_unified_parser_for_family` accepts, one entry per match
+/// arm. Tests iterate this so a family registered here without conformance
+/// coverage fails the suite instead of silently skipping.
+pub const REGISTERED_UNIFIED_FAMILIES: &[&str] = &["qwen3", "qwen3_coder"];
+
+/// Create the Dynamo unified parser for a conformance family.
+pub fn create_unified_parser_for_family(
+    family: &str,
+    tools: &[Tool],
+) -> Result<Box<dyn UnifiedParser>> {
+    match family {
+        // The conformance corpus calls this family `qwen3`; the tool-only
+        // registry calls the same XML grammar `qwen3_coder`. Accept both so
+        // callers do not have to know which registry they came from.
+        "qwen3" | "qwen3_coder" => Qwen3UnifiedParser::create(tools),
+        other => anyhow::bail!("no Dynamo unified parser for family '{other}'"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedDelta {
+        UnifiedDelta::ToolCall(ToolCallDelta {
+            tool_index,
+            name: name.map(str::to_string),
+            arguments: arguments.to_string(),
+        })
+    }
+
+    #[test]
+    fn registered_families_all_create() {
+        for family in REGISTERED_UNIFIED_FAMILIES {
+            create_unified_parser_for_family(family, &[]).unwrap_or_else(|e| {
+                panic!("REGISTERED_UNIFIED_FAMILIES entry '{family}' does not create: {e}")
+            });
+        }
+    }
+
+    #[test]
+    fn assemble_coalesces_adjacent_same_kind() {
+        let out = assemble(&[
+            UnifiedDelta::Reasoning {
+                text: "think".into(),
+            },
+            UnifiedDelta::Reasoning { text: "ing".into() },
+            UnifiedDelta::Text { text: "he".into() },
+            UnifiedDelta::Text { text: "llo".into() },
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                UnifiedEvent::Reasoning {
+                    text: "thinking".into()
+                },
+                UnifiedEvent::Text {
+                    text: "hello".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn assemble_does_not_coalesce_across_a_call() {
+        // The whole point of the surface: two thoughts separated by a call stay
+        // two thoughts, in position.
+        let out = assemble(&[
+            UnifiedDelta::Reasoning { text: "a".into() },
+            call(0, Some("f"), r#"{"x":"1"}"#),
+            UnifiedDelta::Reasoning { text: "b".into() },
+        ]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], UnifiedEvent::Reasoning { text: "a".into() });
+        assert_eq!(out[2], UnifiedEvent::Reasoning { text: "b".into() });
+    }
+
+    #[test]
+    fn assemble_joins_argument_fragments_at_the_first_position() {
+        let out = assemble(&[
+            call(0, Some("f"), r#"{"x":"#),
+            UnifiedDelta::Text { text: "mid".into() },
+            call(0, None, r#""1"}"#),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                UnifiedEvent::ToolCall {
+                    name: "f".into(),
+                    arguments: serde_json::json!({"x": "1"}),
+                },
+                UnifiedEvent::Text { text: "mid".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn assemble_defaults_unusable_arguments_to_empty_object() {
+        // P3 / best-effort: a malformed payload must not error out the turn.
+        let out = assemble(&[call(0, Some("f"), "not json")]);
+        assert_eq!(
+            out,
+            vec![UnifiedEvent::ToolCall {
+                name: "f".into(),
+                arguments: serde_json::json!({}),
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_only_projection_drops_order_but_not_bytes() {
+        let result = ToolParseResult::from_deltas(vec![
+            UnifiedDelta::Reasoning { text: "a".into() },
+            call(0, Some("f"), "{}"),
+            UnifiedDelta::Text { text: "b".into() },
+        ]);
+        assert_eq!(result.normal_text, "ab");
+        assert_eq!(result.calls.len(), 1);
+    }
+
+    #[test]
+    fn unified_event_matches_the_golden_corpus_schema() {
+        let yaml = "- {kind: reasoning, text: \"a\"}\n\
+                    - {kind: tool_call, name: f, arguments: {x: \"1\"}}\n\
+                    - {kind: text, text: \"b\"}\n";
+        let parsed: Vec<UnifiedEvent> = serde_yaml::from_str(yaml).expect("golden schema");
+        assert_eq!(
+            parsed,
+            vec![
+                UnifiedEvent::Reasoning { text: "a".into() },
+                UnifiedEvent::ToolCall {
+                    name: "f".into(),
+                    arguments: serde_json::json!({"x": "1"}),
+                },
+                UnifiedEvent::Text { text: "b".into() },
+            ]
+        );
+    }
+}

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -44,11 +44,12 @@
 
 pub mod qwen3;
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
+use crate::tool_calling::scan::{InvokeEmitter, WrappedBlockScanner, push_run};
 use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
-
-pub use qwen3::Qwen3UnifiedParser;
 
 /// One ordered update produced while parsing assistant output.
 ///
@@ -91,16 +92,6 @@ pub enum UnifiedEvent {
 /// `finish` once at end of stream. One instance parses exactly one choice of
 /// one request, which is what gives per-stream isolation (`I4`) by construction.
 pub trait UnifiedParser: Send {
-    /// Construct a boxed parser instance for one request stream.
-    fn create(tools: &[Tool]) -> Result<Box<dyn UnifiedParser>>
-    where
-        Self: Sized + 'static;
-
-    /// Return whether decoded output must preserve tokenizer special tokens.
-    fn preserve_special_tokens(&self) -> bool {
-        false
-    }
-
     /// Feed one decoded text delta; returns the updates it completed, in order.
     fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>>;
 
@@ -130,77 +121,71 @@ pub trait UnifiedParser: Send {
 /// unparseable arguments become `{}` (policy P3) rather than an error, because a
 /// malformed argument payload must not take down the rest of the turn.
 pub fn assemble(deltas: &[UnifiedDelta]) -> Vec<UnifiedEvent> {
-    // Position of each tool_index in `out`, plus its accumulated argument text.
-    let mut slots: Vec<(usize, usize, String)> = Vec::new();
-    let mut out: Vec<UnifiedEvent> = Vec::new();
-
+    // Coalesce adjacent same-kind runs with the SAME helper the scan core uses, so
+    // `I8` has exactly ONE implementation instead of one per type.
+    let mut merged: Vec<UnifiedDelta> = Vec::new();
     for delta in deltas {
         match delta {
-            UnifiedDelta::Reasoning { text } => {
-                if text.is_empty() {
-                    continue;
-                }
-                match out.last_mut() {
-                    Some(UnifiedEvent::Reasoning { text: prev }) => prev.push_str(text),
-                    _ => out.push(UnifiedEvent::Reasoning { text: text.clone() }),
-                }
-            }
-            UnifiedDelta::Text { text } => {
-                if text.is_empty() {
-                    continue;
-                }
-                match out.last_mut() {
-                    Some(UnifiedEvent::Text { text: prev }) => prev.push_str(text),
-                    _ => out.push(UnifiedEvent::Text { text: text.clone() }),
-                }
-            }
+            UnifiedDelta::Reasoning { text } => push_run(&mut merged, Kind::Reasoning, text),
+            UnifiedDelta::Text { text } => push_run(&mut merged, Kind::Text, text),
+            call => merged.push(call.clone()),
+        }
+    }
+
+    // Convert, joining each call's argument fragments. Keyed by `tool_index` so
+    // fragments of two interleaved calls cannot merge, and carrying each call's
+    // position so it stays where its FIRST delta landed.
+    let mut out: Vec<UnifiedEvent> = Vec::new();
+    let mut calls: BTreeMap<usize, (usize, String)> = BTreeMap::new();
+    for delta in merged {
+        match delta {
+            UnifiedDelta::Reasoning { text } => out.push(UnifiedEvent::Reasoning { text }),
+            UnifiedDelta::Text { text } => out.push(UnifiedEvent::Text { text }),
             UnifiedDelta::ToolCall(call) => {
-                let slot = match slots.iter_mut().find(|(idx, ..)| *idx == call.tool_index) {
-                    Some(slot) => slot,
-                    None => {
-                        out.push(UnifiedEvent::ToolCall {
-                            name: String::new(),
-                            arguments: serde_json::Value::Null,
-                        });
-                        slots.push((call.tool_index, out.len() - 1, String::new()));
-                        slots.last_mut().expect("just pushed")
-                    }
-                };
-                slot.2.push_str(&call.arguments);
-                if let Some(new_name) = &call.name
-                    && let UnifiedEvent::ToolCall { name, .. } = &mut out[slot.1]
+                let (pos, raw) = calls.entry(call.tool_index).or_insert_with(|| {
+                    out.push(UnifiedEvent::ToolCall {
+                        name: String::new(),
+                        arguments: serde_json::Value::Null,
+                    });
+                    (out.len() - 1, String::new())
+                });
+                raw.push_str(&call.arguments);
+                if let Some(incoming) = call.name
+                    && let UnifiedEvent::ToolCall { name, .. } = &mut out[*pos]
                     && name.is_empty()
                 {
-                    *name = new_name.clone();
+                    *name = incoming;
                 }
             }
         }
     }
 
-    for (_, pos, raw) in &slots {
-        let parsed = if raw.trim().is_empty() {
-            serde_json::json!({})
-        } else {
-            // Best-effort (P3): a malformed payload must not take down the rest of
-            // the turn. But it is NOT discarded silently — a call whose arguments
-            // arrive corrupted is exactly the failure worth seeing in a log, and
-            // `{}` on its own looks indistinguishable from a genuine no-arg call.
-            serde_json::from_str(raw).unwrap_or_else(|e| {
-                tracing::warn!(
-                    why = "unified_unparseable_tool_arguments",
-                    error = %e,
-                    raw = %raw,
-                    "tool-call arguments did not parse as JSON; emitting an empty object instead"
-                );
+    for (pos, raw) in calls.into_values() {
+        if let UnifiedEvent::ToolCall { arguments, .. } = &mut out[pos] {
+            // Best-effort (P3): a malformed payload must not take down the turn, but
+            // it is NOT discarded silently — `{}` alone is indistinguishable from a
+            // genuine no-arg call, so a corrupted argument would look like a clean parse.
+            *arguments = serde_json::from_str(&raw).unwrap_or_else(|e| {
+                if !raw.trim().is_empty() {
+                    tracing::warn!(
+                        why = "unified_unparseable_tool_arguments",
+                        error = %e, raw = %raw,
+                        "tool-call arguments did not parse as JSON; emitting an empty object"
+                    );
+                }
                 serde_json::json!({})
-            })
-        };
-        if let UnifiedEvent::ToolCall { arguments, .. } = &mut out[*pos] {
-            *arguments = parsed;
+            });
         }
     }
-
     out
+}
+
+/// The two payload kinds that carry a text run and coalesce when adjacent (`I8`).
+/// Shared with the scan core, whose `push_run` is the single implementation.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    Reasoning,
+    Text,
 }
 
 impl ToolParseResult {
@@ -225,6 +210,27 @@ impl ToolParseResult {
     }
 }
 
+/// A [`UnifiedParser`] backed by the shared marker scanner.
+///
+/// Any family whose grammar [`WrappedBlockScanner`] already covers becomes a
+/// one-line factory in `create_unified_parser_for_family` — there is no
+/// per-family struct and no per-family trait impl to write, or to forget to keep
+/// in sync when the trait grows. Construction lives in the registry, which is why
+/// the trait itself has no `create`.
+pub(crate) struct ScannerUnified<E: InvokeEmitter> {
+    pub(crate) scanner: WrappedBlockScanner<E>,
+}
+
+impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
+    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>> {
+        self.scanner.push_ordered(chunk)
+    }
+
+    fn finish(&mut self) -> Result<Vec<UnifiedDelta>> {
+        self.scanner.finish_ordered()
+    }
+}
+
 /// Every family `create_unified_parser_for_family` accepts, one entry per match
 /// arm. Tests iterate this so a family registered here without conformance
 /// coverage fails the suite instead of silently skipping.
@@ -239,7 +245,7 @@ pub fn create_unified_parser_for_family(
         // The conformance corpus calls this family `qwen3`; the tool-only
         // registry calls the same XML grammar `qwen3_coder`. Accept both so
         // callers do not have to know which registry they came from.
-        "qwen3" | "qwen3_coder" => Qwen3UnifiedParser::create(tools),
+        "qwen3" | "qwen3_coder" => Ok(qwen3::qwen3_unified(tools)),
         other => anyhow::bail!("no Dynamo unified parser for family '{other}'"),
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -181,7 +181,19 @@ pub fn assemble(deltas: &[UnifiedDelta]) -> Vec<UnifiedEvent> {
         let parsed = if raw.trim().is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(raw).unwrap_or_else(|_| serde_json::json!({}))
+            // Best-effort (P3): a malformed payload must not take down the rest of
+            // the turn. But it is NOT discarded silently — a call whose arguments
+            // arrive corrupted is exactly the failure worth seeing in a log, and
+            // `{}` on its own looks indistinguishable from a genuine no-arg call.
+            serde_json::from_str(raw).unwrap_or_else(|e| {
+                tracing::warn!(
+                    why = "unified_unparseable_tool_arguments",
+                    error = %e,
+                    raw = %raw,
+                    "tool-call arguments did not parse as JSON; emitting an empty object instead"
+                );
+                serde_json::json!({})
+            })
         };
         if let UnifiedEvent::ToolCall { arguments, .. } = &mut out[*pos] {
             *arguments = parsed;

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -41,8 +41,8 @@ const REASONING_END: &str = "</think>";
 pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
     Box::new(ScannerUnified {
         scanner: qwen3_scanner(tools).with_reasoning(ReasoningSpec {
-            start: REASONING_START.to_string(),
-            end: REASONING_END.to_string(),
+            start: REASONING_START,
+            end: REASONING_END,
             // Qwen3 emits its own `<think>`; the template does not pre-fill one,
             // so the stream starts in visible content (policy P5).
             forced_start: false,

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unified streaming parser for the Qwen3 grammar.
+//!
+//! One state machine owns the whole assistant output:
+//!
+//! ```text
+//! reasoning:  <think> … </think>
+//! tool call:  <tool_call><function=NAME><parameter=KEY>VALUE</parameter></function></tool_call>
+//! everything else: visible content
+//! ```
+//!
+//! The scan core ([`WrappedBlockScanner`]) is the same one the tool-only
+//! `Qwen3CoderToolStreamParser` runs on, configured here with the reasoning
+//! channel as well. That is deliberate: block open/close, bare-`<function=>`
+//! recovery, orphan-close stripping, chunk-boundary marker holdback and
+//! EOF-drop behavior stay a single implementation, so the unified path cannot
+//! quietly regress the tool handling that the tool-only conformance suite
+//! already pins. Value typing likewise still delegates to the shared v1 batch
+//! XML parser through [`Qwen3Emitter`], so an argument object streamed here is
+//! byte-identical to the batch one.
+//!
+//! What the unified path adds is ORDER: `<think>` between two calls is a second
+//! thought in its own position instead of being hoisted into the first.
+//!
+//! Nesting is asymmetric, because tool structure dominates. A tool call the
+//! model emits INSIDE a thought is still a real call, so it is extracted and the
+//! thought splits around it (burying it would drop the call and leak its markup
+//! into the reasoning payload, `I3`). A reasoning marker inside a tool ARGUMENT
+//! is data and survives byte-exact (`I7`), because the in-block scan never looks
+//! for one.
+
+use crate::tool_calling::qwen3_coder::{Qwen3Emitter, qwen3_scanner};
+use crate::tool_calling::scan::{ReasoningSpec, WrappedBlockScanner};
+use crate::tool_calling::traits::{Result, Tool};
+use crate::unified::{UnifiedDelta, UnifiedParser};
+
+const REASONING_START: &str = "<think>";
+const REASONING_END: &str = "</think>";
+
+/// Streaming unified parser for Qwen3: reasoning + content + tool calls.
+pub struct Qwen3UnifiedParser {
+    scanner: WrappedBlockScanner<Qwen3Emitter>,
+}
+
+impl Qwen3UnifiedParser {
+    pub fn new(tools: &[Tool]) -> Self {
+        Self {
+            scanner: qwen3_scanner(tools).with_reasoning(ReasoningSpec {
+                start: REASONING_START.to_string(),
+                end: REASONING_END.to_string(),
+                // Qwen3 emits its own `<think>`; the template does not pre-fill
+                // one, so the stream starts in visible content (policy P5).
+                forced_start: false,
+            }),
+        }
+    }
+}
+
+impl UnifiedParser for Qwen3UnifiedParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn UnifiedParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn preserve_special_tokens(&self) -> bool {
+        true
+    }
+
+    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>> {
+        self.scanner.push_ordered(chunk)
+    }
+
+    fn finish(&mut self) -> Result<Vec<UnifiedDelta>> {
+        self.scanner.finish_ordered()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unified::{UnifiedEvent, assemble};
+
+    fn weather_tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "city": { "type": "string" } }
+            }),
+            strict: None,
+        }]
+    }
+
+    fn events(tools: &[Tool], chunks: &[&str]) -> Vec<UnifiedEvent> {
+        let mut parser = Qwen3UnifiedParser::new(tools);
+        let mut deltas = Vec::new();
+        for chunk in chunks {
+            deltas.extend(parser.push(chunk).expect("push"));
+        }
+        deltas.extend(parser.finish().expect("finish"));
+        assemble(&deltas)
+    }
+
+    fn reasoning(text: &str) -> UnifiedEvent {
+        UnifiedEvent::Reasoning { text: text.into() }
+    }
+    fn text(text: &str) -> UnifiedEvent {
+        UnifiedEvent::Text { text: text.into() }
+    }
+    fn call(name: &str, arguments: serde_json::Value) -> UnifiedEvent {
+        UnifiedEvent::ToolCall {
+            name: name.into(),
+            arguments,
+        }
+    }
+
+    #[test]
+    fn reasoning_after_a_call_keeps_its_position() {
+        // The defect the unified parser exists to fix: under the split, both
+        // thoughts merge into one span ahead of the call.
+        let out = events(
+            &weather_tools(),
+            &[
+                "<think>Look it up.</think>",
+                "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
+                "<think>Now answer.</think>It's 18C.",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("Look it up."),
+                call("get_weather", serde_json::json!({"city": "Paris"})),
+                reasoning("Now answer."),
+                text("It's 18C."),
+            ]
+        );
+    }
+
+    #[test]
+    fn content_before_reasoning_is_not_hoisted() {
+        let out = events(
+            &weather_tools(),
+            &["Hello there. <think>let me recall</think>The capital is Paris."],
+        );
+        assert_eq!(
+            out,
+            vec![
+                text("Hello there. "),
+                reasoning("let me recall"),
+                text("The capital is Paris."),
+            ]
+        );
+    }
+
+    #[test]
+    fn unterminated_reasoning_is_promoted_at_finish() {
+        // 4.e: not dropped, and not leaked as visible text.
+        let out = events(&weather_tools(), &["<think>thinking but stream ends"]);
+        assert_eq!(out, vec![reasoning("thinking but stream ends")]);
+    }
+
+    #[test]
+    fn markers_split_across_chunks_never_leak() {
+        // Every marker is cut in half at a chunk boundary.
+        let out = events(
+            &weather_tools(),
+            &[
+                "<thi",
+                "nk>a</thin",
+                "k>go: <tool",
+                "_call><func",
+                "tion=get_weather><parameter=city>Paris</parameter></func",
+                "tion></tool",
+                "_call>done",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("a"),
+                text("go: "),
+                call("get_weather", serde_json::json!({"city": "Paris"})),
+                text("done"),
+            ]
+        );
+    }
+
+    #[test]
+    fn reasoning_marker_inside_an_argument_is_data() {
+        // I7: once a tool block is open, `<think>` is a value, not a control
+        // token, and must survive byte-exact.
+        let tools = vec![Tool {
+            name: "run".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "cmd": { "type": "string" } }
+            }),
+            strict: None,
+        }];
+        let out = events(
+            &tools,
+            &[
+                "<tool_call><function=run><parameter=cmd>echo <think>hi</think></parameter></function></tool_call>",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![call(
+                "run",
+                serde_json::json!({"cmd": "echo <think>hi</think>"})
+            )]
+        );
+    }
+
+    #[test]
+    fn tool_call_inside_reasoning_is_extracted_and_splits_the_thought() {
+        // Tool structure dominates reasoning. A call the model emits inside a
+        // thought is still a real call, so it surfaces as its own event and the
+        // thought splits around it. Burying it would both drop the call and
+        // leak `<tool_call>` markup into the reasoning payload (`I3`).
+        let out = events(
+            &weather_tools(),
+            &[
+                "<think>I should check. <tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call> now answer</think>Done.",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("I should check. "),
+                call("get_weather", serde_json::json!({"city": "Paris"})),
+                reasoning(" now answer"),
+                text("Done."),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_two_nestings_are_not_symmetric() {
+        // Tool-inside-reasoning extracts the call (above), but
+        // reasoning-inside-a-tool-argument stays argument data (`I7`) — the
+        // in-block scan never looks for reasoning markers.
+        let tools = vec![Tool {
+            name: "log".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "note": { "type": "string" } }
+            }),
+            strict: None,
+        }];
+        let out = events(
+            &tools,
+            &[
+                "<tool_call><function=log><parameter=note><think>reconsider</think></parameter></function></tool_call>",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![call(
+                "log",
+                serde_json::json!({"note": "<think>reconsider</think>"})
+            )]
+        );
+    }
+
+    #[test]
+    fn an_argument_value_may_contain_the_block_close_marker() {
+        // I7: the scanner has already delimited the invoke, so typing must not
+        // re-discover its bounds and cut the value at an embedded `</tool_call>`.
+        let tools = vec![Tool {
+            name: "run".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "cmd": { "type": "string" } }
+            }),
+            strict: None,
+        }];
+        let out = events(
+            &tools,
+            &[
+                "<tool_call>\n<function=run>\n<parameter=cmd>\ngit log </tool_call> --oneline\n</parameter>\n</function>\n</tool_call>",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![call(
+                "run",
+                serde_json::json!({"cmd": "git log </tool_call> --oneline"})
+            )]
+        );
+    }
+
+    #[test]
+    fn orphan_reasoning_close_is_stripped_not_leaked() {
+        // I3: a `</think>` with nothing open is malformed markup.
+        let out = events(&weather_tools(), &["Hello </think>world"]);
+        assert_eq!(out, vec![text("Hello world")]);
+    }
+
+    #[test]
+    fn truncated_tool_call_at_eof_keeps_preceding_output() {
+        // P2: drop the unrecoverable partial call, no error, no leaked markup.
+        let out = events(
+            &weather_tools(),
+            &["<think>ok</think>Checking. <tool_call><function=get_weather><parameter=city>Par"],
+        );
+        assert_eq!(out, vec![reasoning("ok"), text("Checking. ")]);
+    }
+
+    #[test]
+    fn empty_arguments_become_an_empty_object() {
+        // P3.
+        let tools = vec![Tool {
+            name: "ping".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type": "object", "properties": {}}),
+            strict: None,
+        }];
+        let out = events(
+            &tools,
+            &["<tool_call><function=ping></function></tool_call>"],
+        );
+        assert_eq!(out, vec![call("ping", serde_json::json!({}))]);
+    }
+
+    #[test]
+    fn batch_and_stream_assemble_identically() {
+        // I6, at the parser level: `parse_complete` routes through the same
+        // push/finish lifecycle, so parity is structural.
+        let input = "<think>a</think>Here you go: <tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call><think>b</think>Done.";
+        let batch = Qwen3UnifiedParser::new(&weather_tools())
+            .parse_complete(input)
+            .expect("parse_complete");
+        assert_eq!(batch, events(&weather_tools(), &[input]));
+        assert_eq!(batch.len(), 5);
+    }
+}

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Unified streaming parser for the Qwen3 grammar.
-//!
-//! One state machine owns the whole assistant output:
+//! Unified parser for the Qwen3 grammar: the Qwen3-Coder tool grammar plus a
+//! `<think>` reasoning channel, in ONE state machine.
 //!
 //! ```text
 //! reasoning:  <think> … </think>
@@ -11,72 +10,44 @@
 //! everything else: visible content
 //! ```
 //!
-//! The scan core ([`WrappedBlockScanner`]) is the same one the tool-only
-//! `Qwen3CoderToolStreamParser` runs on, configured here with the reasoning
-//! channel as well. That is deliberate: block open/close, bare-`<function=>`
-//! recovery, orphan-close stripping, chunk-boundary marker holdback and
-//! EOF-drop behavior stay a single implementation, so the unified path cannot
-//! quietly regress the tool handling that the tool-only conformance suite
-//! already pins. Value typing likewise still delegates to the shared v1 batch
-//! XML parser through [`Qwen3Emitter`], so an argument object streamed here is
-//! byte-identical to the batch one.
+//! This file is only the grammar wiring. The scan core is the same
+//! [`crate::tool_calling::scan::WrappedBlockScanner`] the tool-only
+//! `Qwen3CoderToolStreamParser` runs on — block open/close, bare-`<function=>`
+//! recovery, orphan-close stripping, chunk-boundary holdback and EOF drop stay a
+//! single implementation, so the unified path cannot quietly regress the tool
+//! handling the tool-only suite already pins. Value typing likewise delegates to
+//! the shared batch XML parser, so a streamed argument object matches the batch
+//! one exactly. The `UnifiedParser` impl itself is generic
+//! ([`crate::unified::ScannerUnified`]).
 //!
 //! What the unified path adds is ORDER: `<think>` between two calls is a second
 //! thought in its own position instead of being hoisted into the first.
 //!
-//! Nesting is asymmetric, because tool structure dominates. A tool call the
-//! model emits INSIDE a thought is still a real call, so it is extracted and the
-//! thought splits around it (burying it would drop the call and leak its markup
-//! into the reasoning payload, `I3`). A reasoning marker inside a tool ARGUMENT
-//! is data and survives byte-exact (`I7`), because the in-block scan never looks
-//! for one.
+//! Nesting is asymmetric, because tool structure dominates. A tool call the model
+//! emits INSIDE a thought is still a real call, so it is extracted and the thought
+//! splits around it (burying it would drop the call and leak its markup into the
+//! reasoning payload, `I3`). A reasoning marker inside a tool ARGUMENT is data and
+//! survives byte-exact (`I7`), because the in-block scan never looks for one.
 
-use crate::tool_calling::qwen3_coder::{Qwen3Emitter, qwen3_scanner};
-use crate::tool_calling::scan::{ReasoningSpec, WrappedBlockScanner};
-use crate::tool_calling::traits::{Result, Tool};
-use crate::unified::{UnifiedDelta, UnifiedParser};
+use crate::tool_calling::qwen3_coder::qwen3_scanner;
+use crate::tool_calling::scan::ReasoningSpec;
+use crate::tool_calling::traits::Tool;
+use crate::unified::{ScannerUnified, UnifiedParser};
 
 const REASONING_START: &str = "<think>";
 const REASONING_END: &str = "</think>";
 
-/// Streaming unified parser for Qwen3: reasoning + content + tool calls.
-pub struct Qwen3UnifiedParser {
-    scanner: WrappedBlockScanner<Qwen3Emitter>,
-}
-
-impl Qwen3UnifiedParser {
-    pub fn new(tools: &[Tool]) -> Self {
-        Self {
-            scanner: qwen3_scanner(tools).with_reasoning(ReasoningSpec {
-                start: REASONING_START.to_string(),
-                end: REASONING_END.to_string(),
-                // Qwen3 emits its own `<think>`; the template does not pre-fill
-                // one, so the stream starts in visible content (policy P5).
-                forced_start: false,
-            }),
-        }
-    }
-}
-
-impl UnifiedParser for Qwen3UnifiedParser {
-    fn create(tools: &[Tool]) -> Result<Box<dyn UnifiedParser>>
-    where
-        Self: Sized + 'static,
-    {
-        Ok(Box::new(Self::new(tools)))
-    }
-
-    fn preserve_special_tokens(&self) -> bool {
-        true
-    }
-
-    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>> {
-        self.scanner.push_ordered(chunk)
-    }
-
-    fn finish(&mut self) -> Result<Vec<UnifiedDelta>> {
-        self.scanner.finish_ordered()
-    }
+/// Build the Qwen3 unified parser for one stream.
+pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
+    Box::new(ScannerUnified {
+        scanner: qwen3_scanner(tools).with_reasoning(ReasoningSpec {
+            start: REASONING_START.to_string(),
+            end: REASONING_END.to_string(),
+            // Qwen3 emits its own `<think>`; the template does not pre-fill one,
+            // so the stream starts in visible content (policy P5).
+            forced_start: false,
+        }),
+    })
 }
 
 #[cfg(test)]
@@ -97,7 +68,7 @@ mod tests {
     }
 
     fn events(tools: &[Tool], chunks: &[&str]) -> Vec<UnifiedEvent> {
-        let mut parser = Qwen3UnifiedParser::new(tools);
+        let mut parser = qwen3_unified(tools);
         let mut deltas = Vec::new();
         for chunk in chunks {
             deltas.extend(parser.push(chunk).expect("push"));
@@ -355,7 +326,7 @@ mod tests {
         // I6, at the parser level: `parse_complete` routes through the same
         // push/finish lifecycle, so parity is structural.
         let input = "<think>a</think>Here you go: <tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call><think>b</think>Done.";
-        let batch = Qwen3UnifiedParser::new(&weather_tools())
+        let batch = qwen3_unified(&weather_tools())
             .parse_complete(input)
             .expect("parse_complete");
         assert_eq!(batch, events(&weather_tools(), &[input]));

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -300,6 +300,24 @@ mod tests {
     }
 
     #[test]
+    fn a_duplicate_reasoning_opener_inside_a_thought_is_stripped() {
+        // I3: best-effort recovery strips malformed markup rather than letting it
+        // land in the payload. A second `<think>` while one is already open is a
+        // duplicate opener, not content.
+        let out = events(&weather_tools(), &["<think>a<think>b</think>tail"]);
+        assert_eq!(out, vec![reasoning("ab"), text("tail")]);
+    }
+
+    #[test]
+    fn a_stray_tool_close_inside_a_thought_is_stripped() {
+        // Same rule as the orphan handler applies OUTSIDE reasoning — a stray
+        // `</tool_call>` with nothing open is markup, so it must not leak into the
+        // reasoning payload just because a thought happens to be open.
+        let out = events(&weather_tools(), &["<think>a</tool_call>b</think>tail"]);
+        assert_eq!(out, vec![reasoning("ab"), text("tail")]);
+    }
+
+    #[test]
     fn orphan_reasoning_close_is_stripped_not_leaked() {
         // I3: a `</think>` with nothing open is malformed markup.
         let out = events(&weather_tools(), &["Hello </think>world"]);


### PR DESCRIPTION
#### Overview:

This PR replaces the two-parser chain Dynamo uses for **Qwen3** with one streaming state machine that owns reasoning, visible content and tool calls together, so the three come out in the order the model actually produced them. Today reasoning is parsed first over the whole output and merged into a single field, which silently moves any thought that happened between or after a tool call to the front. Qwen3 only — gemma4 and kimi_k2 keep the current split until their unified parsers land.

#### Example (before → after):

Input: `<think>Look it up.</think><tool_call>…get_weather(city=Paris)…</tool_call><think>Now answer.</think>It's 18C.`

```
before:  reasoning("Look it up.Now answer.")  |  tool_call(get_weather, {"city":"Paris"})  |  text("It's 18C.")
after:   reasoning("Look it up.")  |  tool_call(get_weather, {"city":"Paris"})  |  reasoning("Now answer.")  |  text("It's 18C.")
```

The second thought moved ahead of the call it followed and fused with the first. A client rendering thoughts inline shows them in the wrong place; one counting reasoning turns sees one where the model produced two. Ordering is not a field the split can add — it is gone at the seam between the two parsers.

Two independent bugs this surfaced, both on the **shipping** tool-only `qwen3_coder` parser, not just the unified path:

```
arg truncation   <parameter=cmd>git log </tool_call> --oneline</parameter>
   before:  {"cmd": "git log </tool_call>"}            <- value cut at a marker that was data
   after:   {"cmd": "git log </tool_call> --oneline"}

markup leak      <think>a</tool_call>b</think>
   before:  reasoning("a</tool_call>b")                <- stray markup became content
   after:   reasoning("ab")
```

<img width="1833" height="291" alt="image" src="https://github.com/user-attachments/assets/6746f120-544d-4d5e-a9ea-b481ac9bf594" />


#### Details:

- The existing `WrappedBlockScanner` (which already owns block open/close, bare-`<function=>` recovery, orphan-close stripping, chunk-boundary holdback and EOF drop) now emits ordered deltas, and reasoning is an opt-in channel on it. Tool-only parsers project the same deltas down to `ToolParseResult` and are unchanged. One scan, two views — no second scanner to drift.
- Nesting is deliberately **asymmetric**, because tool structure dominates: a call emitted inside a thought is extracted and the thought splits around it (burying it would drop the call *and* leak its markup, `I3`), while a reasoning marker inside a tool argument stays data (`I7`). Both directions are pinned by the golden corpus (`tool_in_reason`, `reason_markup_in_arg`) and by unit tests.
- The conformance tab is rendered by Python from a **committed capture shard** — it never runs the Rust parsers, so a parser change that is not re-captured leaves the page showing old behavior while every test passes. The capture now uses the unified parser per-family, and `committed_dynamo_capture_matches_the_live_parsers` fails when the shard drifts, naming the stale cases and printing the regenerate commands.
- Popup/highlighter fixes ride along: columns size to content and are equalized, and the colorizer no longer paints markers that live inside an argument value — declared per family in `parser_families.yaml` (`opaque:`), mirrored in both the Python source of truth and its JS port, with byte-parity tests.

- The shared scan core was cleaned up alongside: the `I8` run-merge existed in three copies and is now one helper used by both the scanner and `assemble`; the two "which marker comes first?" sites share one `earliest()`; per-family `UnifiedParser` impls collapse into a generic `ScannerUnified<E>` so a family is a factory rather than a struct plus impl; and `preserve_special_tokens` — declared, stored and plumbed, never called — is deleted. Behavior-preserving, and production code drops 348 -> 333.

#### Verification:

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, the full workspace suite, and `conformance/utils/check.sh ci` are all clean. All **33** qwen3 `UNIFIED.*` cases match the golden oracle, with stream/batch parity and per-stream isolation. Beyond the corpus: an exhaustive **18,623-splitting** chunk sweep over every case found 0 chunk-variance, and an adversarial sweep over **2,196** generated shapes (nested/duplicated openers, strays, empty segments) asserting no marker reaches a payload found 292 problems, all fixed, now 0. The 8 pre-existing tool-only `qwen3_coder` tests and the tool-calling conformance parity suites still pass, so the shared-scanner change is behavior-preserving for the tool-only contract.

Unified tab, Dynamo column vs golden: **qwen3 0 red (was 5)**; gemma4 5 and kimi_k2 13 unchanged (still the split).

#### Known gap (follow-up):

`tool_choice=required` and named functions use guided decoding that emits bare JSON rather than Qwen XML, and Dynamo can prefill the reasoning/content channel so the model never emits its own `<think>`. This parser handles neither, and the corpus has no cases for request modes at all. Tracked separately in [DIS-2544](https://linear.app/nvidia/issue/DIS-2544); PoC in #163.

#### Where should the reviewer start?

`parsers/v2/src/unified/mod.rs`, then `parsers/v2/src/unified/qwen3.rs`, then `parsers/v2/src/tool_calling/scan.rs`, then `conformance/tests/unified_parity.rs`

/coderabbit profile chill

