### PR TITLE
feat(tokenizers): add basetenkenizer backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,6 @@ dependencies = [
  "chrono",
  "daachorse",
  "fancy-regex 0.17.0",
- "hf-hub",
  "icu_normalizer",
  "icu_properties",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basetenkenizer"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55524e9467214686afafb60b7cedf28549f0ce964457658842999f6ef7ccbae7"
+dependencies = [
+ "chrono",
+ "daachorse",
+ "fancy-regex 0.17.0",
+ "hf-hub",
+ "icu_normalizer",
+ "icu_properties",
+ "memchr",
+ "minijinja",
+ "minijinja-contrib",
+ "pcre2",
+ "rayon",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1023,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "base64 0.22.1",
+ "basetenkenizer",
  "blake3",
  "fastokens",
  "moka",
@@ -2093,7 +2117,9 @@ version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
+ "indexmap 2.14.0",
  "memo-map",
+ "percent-encoding",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-openai = { version = "0.41", default-features = false }
 async-stream = "0.3"
 axum = "0.8"
 base64 = "0.22"
-basetenkenizer = "0.2.8"
+basetenkenizer = { version = "0.2.8", default-features = false }
 blake3 = "1"
 chrono = { version = "0.4", default-features = false, features = [
     "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ async-openai = { version = "0.41", default-features = false }
 async-stream = "0.3"
 axum = "0.8"
 base64 = "0.22"
+basetenkenizer = "0.2.8"
 blake3 = "1"
 chrono = { version = "0.4", default-features = false, features = [
     "alloc",

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -6,7 +6,7 @@ name = "dynamo-tokenizers"
 readme = "README.md"
 version = "1.5.4"
 edition.workspace = true
-description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
+description = "Standalone HuggingFace, tiktoken, fastokens, and Baseten tokenizer implementations for LLM inference serving."
 authors.workspace = true
 license = "Apache-2.0"
 homepage.workspace = true
@@ -17,6 +17,7 @@ include = ["src/**/*", "Cargo.toml", "README.md"]
 [dependencies]
 aho-corasick.workspace = true
 anyhow.workspace = true
+basetenkenizer.workspace = true
 blake3.workspace = true
 moka = { workspace = true, features = ["sync"] }
 fastokens.workspace = true

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -20,7 +20,7 @@ remain distinct:
 
 ```rust
 use dynamo_tokenizers::{
-    BasetenTokenizer, EncodeSegment, SegmentEncodingOptions,
+    BasetenTokenizer, EncodeSegment,
     traits::Encoder,
 };
 
@@ -30,13 +30,11 @@ let segments = [
     EncodeSegment::new(user_message, false),
     EncodeSegment::new("<|close|>message<|sep|><|end_of_msg|>", true),
 ];
-let encoding =
-    tokenizer.encode_segments(&segments, SegmentEncodingOptions::default())?;
+let encoding = tokenizer.encode_segments(&segments)?;
 ```
 
-The default segmented mode preserves legacy tiktoken chunk boundaries for
-long-input ID parity. Set `tiktoken_safe: false` only when those artificial
-boundaries are not required.
+Segmented encoding preserves legacy tiktoken chunk boundaries for long-input
+token-ID parity, as required by Kimi K3.
 
 ## Quick start
 

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -1,13 +1,42 @@
 # dynamo-tokenizers
 
-Efficient, versatile tokenization for LLM inference. Wraps HuggingFace and TikToken tokenizers (plus a FastTokenizer hybrid mode) behind a small encode/decode/sequence API designed for streaming detokenization.
+Efficient, versatile tokenization for LLM inference. Wraps Hugging Face,
+TikToken, fastokens, and Baseten Tokenizer backends behind a small
+encode/decode/sequence API designed for streaming detokenization.
 
 ## Features
 
-- **Multiple backends.** HuggingFace `tokenizers`, OpenAI `tiktoken`, and a FastTokenizer hybrid behind one trait.
+- **Multiple backends.** Hugging Face `tokenizers`, OpenAI `tiktoken`,
+  `fastokens`, and `basetenkenizer` behind one trait.
 - **Streaming-friendly.** `Sequence` tracks incremental token-id appends and emits text deltas without re-decoding the full prefix.
 - **Prefix caching.** `CachedTokenizer` records prefix tokenizations at special-token boundaries; repeated prompts that share a system prefix re-encode only the trailing suffix, turning O(N) work into O(suffix_len).
 - **Hash verification.** Detect tokenizer drift across model versions.
+
+## Segmented prompts
+
+`BasetenTokenizer` supports segmented encoding for renderers such as Kimi K3's
+XTML renderer, where trusted control tokens and untrusted message content must
+remain distinct:
+
+```rust
+use dynamo_tokenizers::{
+    BasetenTokenizer, EncodeSegment, SegmentEncodingOptions,
+    traits::Encoder,
+};
+
+let tokenizer = BasetenTokenizer::from_file("/path/to/tokenizer.json")?;
+let segments = [
+    EncodeSegment::new("<|open|>message role=\"user\"<|sep|>", true),
+    EncodeSegment::new(user_message, false),
+    EncodeSegment::new("<|close|>message<|sep|><|end_of_msg|>", true),
+];
+let encoding =
+    tokenizer.encode_segments(&segments, SegmentEncodingOptions::default())?;
+```
+
+The default segmented mode preserves legacy tiktoken chunk boundaries for
+long-input ID parity. Set `tiktoken_safe: false` only when those artificial
+boundaries are not required.
 
 ## Quick start
 

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -18,6 +18,12 @@ encode/decode/sequence API designed for streaming detokenization.
 XTML renderer, where trusted control tokens and untrusted message content must
 remain distinct:
 
+Many Kimi model repositories ship tiktoken assets rather than a directly
+loadable `tokenizer.json`. Baseten publishes compatible `tokenizer.json`
+artifacts for these models; for Kimi K3, use
+[`baseten/kimi-k3-tokenizer`](https://huggingface.co/baseten/kimi-k3-tokenizer).
+Download the file and pass its path to `BasetenTokenizer::from_file`.
+
 ```rust
 use dynamo_tokenizers::{
     BasetenTokenizer, EncodeSegment,

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use super::{
-    EncodeSegment, Encoding, Error, Result, SegmentEncodingOptions, TokenIdType, TokenizerOptions,
+    EncodeSegment, Encoding, Error, Result, TokenIdType, TokenizerOptions,
     traits::{DecodeResult, Decoder, Encoder, Tokenizer},
 };
 
@@ -44,22 +44,14 @@ impl Encoder for BasetenTokenizer {
             .map_err(|e| Error::msg(format!("Baseten tokenizer batch encode error: {e}")))
     }
 
-    fn encode_segments(
-        &self,
-        segments: &[EncodeSegment<'_>],
-        options: SegmentEncodingOptions,
-    ) -> Result<Encoding> {
+    fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
         let segments = segments
             .iter()
             .map(|segment| (segment.text, segment.allow_special));
-        let ids = if options.tiktoken_safe {
-            self.tokenizer
-                .encode_segments_tiktoken_safe(segments, self.options.add_special_tokens)
-        } else {
-            self.tokenizer
-                .encode_segments(segments, self.options.add_special_tokens)
-        }
-        .map_err(|e| Error::msg(format!("Baseten tokenizer segment encode error: {e}")))?;
+        let ids = self
+            .tokenizer
+            .encode_segments_tiktoken_safe(segments, self.options.add_special_tokens)
+            .map_err(|e| Error::msg(format!("Baseten tokenizer segment encode error: {e}")))?;
         Ok(Encoding::Sp(ids))
     }
 }
@@ -204,9 +196,7 @@ mod tests {
             EncodeSegment::new(" world!", true),
         ];
 
-        let segmented = tokenizer
-            .encode_segments(&segments, SegmentEncodingOptions::default())
-            .unwrap();
+        let segmented = tokenizer.encode_segments(&segments).unwrap();
         let flattened = tokenizer.encode("Hello<ctl> world!").unwrap();
 
         assert_ne!(
@@ -254,7 +244,7 @@ mod tests {
 
         let plain = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
         let plain_ids = plain
-            .encode_segments(&segments, SegmentEncodingOptions::default())
+            .encode_segments(&segments)
             .unwrap()
             .token_ids()
             .to_vec();
@@ -265,10 +255,7 @@ mod tests {
                 add_special_tokens: true,
             });
         assert_eq!(
-            with_bos
-                .encode_segments(&segments, SegmentEncodingOptions::default())
-                .unwrap()
-                .token_ids(),
+            with_bos.encode_segments(&segments).unwrap().token_ids(),
             [&[23], plain_ids.as_slice()].concat()
         );
     }

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Baseten Tokenizer backend for high-performance BPE encoding and decoding.
+
+use std::path::Path;
+
+use super::{
+    EncodeSegment, Encoding, Error, Result, SegmentEncodingOptions, TokenIdType, TokenizerOptions,
+    traits::{DecodeResult, Decoder, Encoder, Tokenizer},
+};
+
+/// Tokenizer backed by the `basetenkenizer` crate.
+pub struct BasetenTokenizer {
+    tokenizer: basetenkenizer::Tokenizer,
+    options: TokenizerOptions,
+}
+
+impl BasetenTokenizer {
+    /// Load a tokenizer from a Hugging Face `tokenizer.json` file.
+    pub fn from_file(path: &str) -> Result<Self> {
+        let tokenizer = basetenkenizer::Tokenizer::from_file(Path::new(path))
+            .map_err(|e| Error::msg(format!("Error loading Baseten tokenizer: {e}")))?;
+        Ok(Self {
+            tokenizer,
+            options: TokenizerOptions::default(),
+        })
+    }
+}
+
+impl Encoder for BasetenTokenizer {
+    fn encode(&self, input: &str) -> Result<Encoding> {
+        let ids = self
+            .tokenizer
+            .encode_with_special_tokens(input, self.options.add_special_tokens)
+            .map_err(|e| Error::msg(format!("Baseten tokenizer encode error: {e}")))?;
+        Ok(Encoding::Sp(ids))
+    }
+
+    fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+        self.tokenizer
+            .encode_batch(inputs, self.options.add_special_tokens)
+            .map(|ids| ids.into_iter().map(Encoding::Sp).collect())
+            .map_err(|e| Error::msg(format!("Baseten tokenizer batch encode error: {e}")))
+    }
+
+    fn encode_segments(
+        &self,
+        segments: &[EncodeSegment<'_>],
+        options: SegmentEncodingOptions,
+    ) -> Result<Encoding> {
+        let segments = segments
+            .iter()
+            .map(|segment| (segment.text, segment.allow_special));
+        let ids = if options.tiktoken_safe {
+            self.tokenizer
+                .encode_segments_tiktoken_safe(segments, self.options.add_special_tokens)
+        } else {
+            self.tokenizer
+                .encode_segments(segments, self.options.add_special_tokens)
+        }
+        .map_err(|e| Error::msg(format!("Baseten tokenizer segment encode error: {e}")))?;
+        Ok(Encoding::Sp(ids))
+    }
+}
+
+impl Decoder for BasetenTokenizer {
+    fn decode(&self, token_ids: &[TokenIdType], skip_special_tokens: bool) -> Result<DecodeResult> {
+        self.tokenizer
+            .decode(token_ids, skip_special_tokens)
+            .map(DecodeResult::from)
+            .map_err(|e| Error::msg(format!("Baseten tokenizer decode error: {e}")))
+    }
+}
+
+impl Tokenizer for BasetenTokenizer {
+    fn validate_prefix_cache(&self) -> Result<()> {
+        if self.options.add_special_tokens {
+            return Err(Error::msg(
+                "Baseten tokenizers configured with add_special_tokens=true must remain uncached",
+            ));
+        }
+        Ok(())
+    }
+
+    fn with_options(mut self, options: TokenizerOptions) -> Self {
+        self.options = options;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        HuggingFaceTokenizer, Tokenizer as TokenizerWrapper, traits::Tokenizer as TokenizerTrait,
+    };
+
+    const TOKENIZER_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/minimal-bpe/tokenizer.json"
+    );
+
+    #[test]
+    fn encode_matches_hugging_face() {
+        let baseten = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        let hf = HuggingFaceTokenizer::from_file(TOKENIZER_PATH).unwrap();
+
+        for text in ["Hello, world!", "Hello", " world", "He llo"] {
+            let baseten_ids = baseten.encode(text).unwrap();
+            let hf_ids = hf.encode(text).unwrap();
+            assert_eq!(
+                baseten_ids.token_ids(),
+                hf_ids.token_ids(),
+                "Baseten and Hugging Face must produce identical token IDs for '{text}'"
+            );
+        }
+    }
+
+    #[test]
+    fn batch_encode_matches_sequential_encode() {
+        let tokenizer = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        let inputs = ["Hello", " world", "Hello, world!"];
+        let batch = tokenizer.encode_batch(&inputs).unwrap();
+
+        for (encoding, input) in batch.iter().zip(inputs) {
+            let sequential = tokenizer.encode(input).unwrap();
+            assert_eq!(encoding.token_ids(), sequential.token_ids());
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let tokenizer = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        let encoding = tokenizer.encode("Hello, world!").unwrap();
+        let decoded = tokenizer.decode(encoding.token_ids(), true).unwrap();
+
+        assert_eq!(decoded.as_str(), "Hello, world!");
+    }
+
+    #[test]
+    fn works_with_decode_stream() {
+        let tokenizer = Arc::new(BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap());
+        let wrapper = TokenizerWrapper::from(tokenizer);
+        let prompt_ids = wrapper.encode("Hello").unwrap().token_ids().to_vec();
+        let continuation_ids = wrapper.encode(", world!").unwrap().token_ids().to_vec();
+        let mut stream = wrapper.decode_stream(&prompt_ids, true);
+        let mut accumulated = String::new();
+
+        for id in &continuation_ids {
+            if let Some(chunk) = stream.step(*id).unwrap() {
+                accumulated.push_str(&chunk);
+            }
+        }
+
+        let mut all_ids = prompt_ids.clone();
+        all_ids.extend_from_slice(&continuation_ids);
+        let full_text: String = wrapper.decode(&all_ids, true).unwrap().into();
+        let prompt_text: String = wrapper.decode(&prompt_ids, true).unwrap().into();
+        assert_eq!(accumulated, full_text[prompt_text.len()..]);
+    }
+
+    #[test]
+    fn prefix_cache_rejects_special_token_post_processing() {
+        let plain = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        assert!(plain.validate_prefix_cache().is_ok());
+
+        let with_special_tokens = BasetenTokenizer::from_file(TOKENIZER_PATH)
+            .unwrap()
+            .with_options(TokenizerOptions {
+                add_special_tokens: true,
+            });
+        assert!(with_special_tokens.validate_prefix_cache().is_err());
+    }
+
+    #[test]
+    fn segments_preserve_special_token_trust_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("tokenizer.json");
+        let mut json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        let vocab = json["model"]["vocab"].as_object_mut().unwrap();
+        vocab.insert("<".to_string(), serde_json::json!(23));
+        vocab.insert(">".to_string(), serde_json::json!(24));
+        vocab.insert("c".to_string(), serde_json::json!(25));
+        json["added_tokens"] = serde_json::json!([{
+            "id": 26,
+            "content": "<ctl>",
+            "single_word": false,
+            "lstrip": false,
+            "rstrip": false,
+            "normalized": false,
+            "special": true
+        }]);
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        let tokenizer = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        let segments = [
+            EncodeSegment::new("Hello", true),
+            EncodeSegment::new("<ctl>", false),
+            EncodeSegment::new(" world!", true),
+        ];
+
+        let segmented = tokenizer
+            .encode_segments(&segments, SegmentEncodingOptions::default())
+            .unwrap();
+        let flattened = tokenizer.encode("Hello<ctl> world!").unwrap();
+
+        assert_ne!(
+            segmented.token_ids(),
+            flattened.token_ids(),
+            "untrusted control-token-looking text must not become an added token"
+        );
+        assert!(flattened.token_ids().contains(&26));
+        assert!(!segmented.token_ids().contains(&26));
+    }
+}

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Baseten Tokenizer backend for high-performance BPE encoding and decoding.
+//!
+//! Some Kimi repositories ship tiktoken assets without a directly loadable
+//! `tokenizer.json`. Baseten publishes compatible tokenizer artifacts,
+//! including [`baseten/kimi-k3-tokenizer`](https://huggingface.co/baseten/kimi-k3-tokenizer).
 
 use std::path::Path;
 

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -23,12 +23,99 @@ pub struct BasetenTokenizer {
 impl BasetenTokenizer {
     /// Load a tokenizer from a Hugging Face `tokenizer.json` file.
     pub fn from_file(path: &str) -> Result<Self> {
-        let tokenizer = basetenkenizer::Tokenizer::from_file(Path::new(path))
+        let path = Path::new(path);
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| Error::msg(format!("Error reading Baseten tokenizer: {e}")))?;
+        let mut json: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| Error::msg(format!("Error parsing Baseten tokenizer: {e}")))?;
+        if let Some(parent) = path.parent() {
+            merge_special_tokens_from_config(&mut json, parent);
+        }
+        let tokenizer = basetenkenizer::Tokenizer::from_json(json)
             .map_err(|e| Error::msg(format!("Error loading Baseten tokenizer: {e}")))?;
         Ok(Self {
             tokenizer,
             options: TokenizerOptions::default(),
         })
+    }
+}
+
+fn merge_special_tokens_from_config(json: &mut serde_json::Value, model_dir: &Path) {
+    let config_path = model_dir.join("tokenizer_config.json");
+    let Ok(raw) = std::fs::read_to_string(&config_path) else {
+        return;
+    };
+    let config: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::debug!(
+                target: "tokenizer",
+                path = %config_path.display(),
+                error = %error,
+                "tokenizer_config.json parse failed; skipping special-token merge"
+            );
+            return;
+        }
+    };
+    let Some(decoder) = config
+        .get("added_tokens_decoder")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return;
+    };
+
+    if json.get("added_tokens").is_none() {
+        json["added_tokens"] = serde_json::json!([]);
+    }
+    let Some(added_tokens) = json
+        .get_mut("added_tokens")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for (id, spec) in decoder {
+        let Some(id) = id.parse::<u32>().ok() else {
+            continue;
+        };
+        let Some(spec) = spec.as_object() else {
+            continue;
+        };
+        if spec.get("special").and_then(serde_json::Value::as_bool) != Some(true) {
+            continue;
+        }
+        let Some(content) = spec
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .filter(|content| !content.is_empty())
+        else {
+            continue;
+        };
+
+        if let Some(existing) = added_tokens
+            .iter_mut()
+            .find(|token| token.get("content").and_then(serde_json::Value::as_str) == Some(content))
+        {
+            existing["special"] = serde_json::Value::Bool(true);
+            continue;
+        }
+
+        let mut token = serde_json::Map::from_iter([
+            ("id".to_string(), serde_json::json!(id)),
+            ("content".to_string(), serde_json::json!(content)),
+            ("special".to_string(), serde_json::Value::Bool(true)),
+        ]);
+        for field in ["single_word", "lstrip", "rstrip", "normalized"] {
+            token.insert(
+                field.to_string(),
+                serde_json::Value::Bool(
+                    spec.get(field)
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false),
+                ),
+            );
+        }
+        added_tokens.push(serde_json::Value::Object(token));
     }
 }
 
@@ -262,5 +349,35 @@ mod tests {
             with_bos.encode_segments(&segments).unwrap().token_ids(),
             [&[23], plain_ids.as_slice()].concat()
         );
+    }
+
+    #[test]
+    fn merges_config_only_special_tokens() {
+        let temp = tempfile::tempdir().unwrap();
+        let tokenizer_path = temp.path().join("tokenizer.json");
+        std::fs::copy(TOKENIZER_PATH, &tokenizer_path).unwrap();
+        std::fs::write(
+            temp.path().join("tokenizer_config.json"),
+            serde_json::json!({
+                "added_tokens_decoder": {
+                    "23": {
+                        "content": "<ctl>",
+                        "special": true,
+                        "single_word": false,
+                        "lstrip": false,
+                        "rstrip": false,
+                        "normalized": false
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let tokenizer = BasetenTokenizer::from_file(tokenizer_path.to_str().unwrap()).unwrap();
+        let encoding = tokenizer.encode("<ctl>").unwrap();
+        assert_eq!(encoding.token_ids(), &[23]);
+        assert_eq!(tokenizer.decode(&[23], false).unwrap().as_str(), "<ctl>");
+        assert_eq!(tokenizer.decode(&[23], true).unwrap().as_str(), "");
     }
 }

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -196,7 +196,8 @@ mod tests {
         }]);
         std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
 
-        let tokenizer = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        let tokenizer: Arc<dyn TokenizerTrait> =
+            Arc::new(BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap());
         let segments = [
             EncodeSegment::new("Hello", true),
             EncodeSegment::new("<ctl>", false),
@@ -215,5 +216,60 @@ mod tests {
         );
         assert!(flattened.token_ids().contains(&26));
         assert!(!segmented.token_ids().contains(&26));
+    }
+
+    #[test]
+    fn segments_honor_add_special_tokens_option() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("tokenizer.json");
+        let mut json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        json["model"]["vocab"]["<bos>"] = serde_json::json!(23);
+        json["added_tokens"] = serde_json::json!([{
+            "id": 23,
+            "content": "<bos>",
+            "single_word": false,
+            "lstrip": false,
+            "rstrip": false,
+            "normalized": false,
+            "special": true
+        }]);
+        json["post_processor"] = serde_json::json!({
+            "type": "TemplateProcessing",
+            "single": [
+                {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                {"Sequence": {"id": "A", "type_id": 0}}
+            ],
+            "pair": [
+                {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                {"Sequence": {"id": "A", "type_id": 0}},
+                {"Sequence": {"id": "B", "type_id": 0}}
+            ],
+            "special_tokens": {
+                "<bos>": {"id": "<bos>", "ids": [23], "tokens": ["<bos>"]}
+            }
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+        let segments = [EncodeSegment::new("Hello", false)];
+
+        let plain = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        let plain_ids = plain
+            .encode_segments(&segments, SegmentEncodingOptions::default())
+            .unwrap()
+            .token_ids()
+            .to_vec();
+
+        let with_bos = BasetenTokenizer::from_file(path.to_str().unwrap())
+            .unwrap()
+            .with_options(TokenizerOptions {
+                add_special_tokens: true,
+            });
+        assert_eq!(
+            with_bos
+                .encode_segments(&segments, SegmentEncodingOptions::default())
+                .unwrap()
+                .token_ids(),
+            [&[23], plain_ids.as_slice()].concat()
+        );
     }
 }

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -41,6 +41,9 @@
 //!   An empty list disables L1: `encode`/`encode_batch` short-circuit straight
 //!   to the inner tokenizer with no lookup, no miss-counter bump, and no
 //!   insert attempt.
+//! - `encode_segments` always passes through to the inner tokenizer without
+//!   caching. Flattening segments for L1 would discard their special-token
+//!   trust boundaries.
 //! - `max_memory_bytes` — L1 byte budget; entries evicted via approximate LRU.
 //!
 //! # Provenance
@@ -57,7 +60,7 @@ use std::sync::Arc;
 pub use l1::{CacheEventFn, L1Cache, L1CacheStats};
 
 use crate::{
-    Encoding, Result, TokenIdType,
+    EncodeSegment, Encoding, Result, TokenIdType,
     traits::{DecodeResult, Decoder, Encoder, Tokenizer},
 };
 
@@ -248,6 +251,13 @@ impl Encoder for CachedTokenizer {
         // belongs here, not inside `encode`.
         inputs.iter().map(|&i| self.encode(i)).collect()
     }
+
+    fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
+        // L1 indexes flattened string offsets and cannot preserve each
+        // segment's allow_special boundary. Keep the operation correct by
+        // delegating without populating or consulting the cache.
+        self.inner.encode_segments(segments)
+    }
 }
 
 impl Decoder for CachedTokenizer {
@@ -266,6 +276,42 @@ mod tests {
     use std::sync::{Mutex, atomic::AtomicU64, atomic::Ordering};
 
     struct FailingTokenizer;
+
+    struct SegmentTokenizer;
+
+    impl Encoder for SegmentTokenizer {
+        fn encode(&self, input: &str) -> Result<Encoding> {
+            Ok(Encoding::Sp(vec![input.len() as u32]))
+        }
+
+        fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+            inputs.iter().map(|input| self.encode(input)).collect()
+        }
+
+        fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
+            let ids = segments
+                .iter()
+                .flat_map(|segment| [segment.allow_special as u32, segment.text.len() as u32])
+                .collect();
+            Ok(Encoding::Sp(ids))
+        }
+    }
+
+    impl Decoder for SegmentTokenizer {
+        fn decode(
+            &self,
+            _token_ids: &[TokenIdType],
+            _skip_special_tokens: bool,
+        ) -> Result<DecodeResult> {
+            Ok(DecodeResult::Complete(String::new()))
+        }
+    }
+
+    impl Tokenizer for SegmentTokenizer {
+        fn validate_prefix_cache(&self) -> Result<()> {
+            Ok(())
+        }
+    }
 
     impl Encoder for FailingTokenizer {
         fn encode(&self, _input: &str) -> Result<Encoding> {
@@ -360,6 +406,28 @@ mod tests {
             events.lock().unwrap().is_empty(),
             "empty specials must not emit token usage"
         );
+    }
+
+    #[test]
+    fn segmented_encoding_passes_through_without_caching() {
+        let inner: Arc<dyn Tokenizer> = Arc::new(SegmentTokenizer);
+        let segments = [
+            EncodeSegment::new("<ctl>", true),
+            EncodeSegment::new("user content", false),
+        ];
+        let expected = inner.encode_segments(&segments).unwrap();
+
+        for special_tokens in [Vec::new(), vec!["<ctl>".to_string()]] {
+            let cached = CachedTokenizer::new(inner.clone(), special_tokens, 4096)
+                .expect("test tokenizer supports prefix caching");
+            let actual = cached.encode_segments(&segments).unwrap();
+
+            assert_eq!(actual.token_ids(), expected.token_ids());
+            let stats = cached.cache_stats();
+            assert_eq!(stats.entries, 0);
+            assert_eq!(stats.hits, 0);
+            assert_eq!(stats.misses, 0);
+        }
     }
 
     #[test]

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -256,7 +256,11 @@ impl Encoder for CachedTokenizer {
         // L1 indexes flattened string offsets and cannot preserve each
         // segment's allow_special boundary. Keep the operation correct by
         // delegating without populating or consulting the cache.
-        self.inner.encode_segments(segments)
+        let encoding = self.inner.encode_segments(segments)?;
+        if self.l1_enabled {
+            self.observe_token_usage(0, encoding.token_ids().len());
+        }
+        Ok(encoding)
     }
 }
 
@@ -418,8 +422,11 @@ mod tests {
         let expected = inner.encode_segments(&segments).unwrap();
 
         for special_tokens in [Vec::new(), vec!["<ctl>".to_string()]] {
-            let cached = CachedTokenizer::new(inner.clone(), special_tokens, 4096)
-                .expect("test tokenizer supports prefix caching");
+            let l1_enabled = !special_tokens.is_empty();
+            let (cached, events) = collect_token_usage(
+                CachedTokenizer::new(inner.clone(), special_tokens, 4096)
+                    .expect("test tokenizer supports prefix caching"),
+            );
             let actual = cached.encode_segments(&segments).unwrap();
 
             assert_eq!(actual.token_ids(), expected.token_ids());
@@ -427,6 +434,18 @@ mod tests {
             assert_eq!(stats.entries, 0);
             assert_eq!(stats.hits, 0);
             assert_eq!(stats.misses, 0);
+            let events = events.lock().unwrap();
+            if l1_enabled {
+                assert_eq!(
+                    events.as_slice(),
+                    &[CacheTokenUsage {
+                        cached_tokens: 0,
+                        uncached_tokens: expected.token_ids().len(),
+                    }]
+                );
+            } else {
+                assert!(events.is_empty());
+            }
         }
     }
 

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -287,10 +287,11 @@ impl Encoding {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TokenizerOptions {
     /// Ask the tokenizer to add its declared special tokens (e.g. BOS/EOS via
-    /// the HuggingFace post-processor) during `encode`/`encode_batch`.
+    /// its post-processor) during `encode`, `encode_batch`, and supported
+    /// `encode_segments` calls.
     /// Defaults to `false`, the historical behavior.
     ///
-    /// Only applicable to HuggingFace tokenizers.
+    /// Applicable to Hugging Face and Baseten tokenizers.
     pub add_special_tokens: bool,
 }
 

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod basetenkenizer;
 pub mod cache;
 pub mod fastokens;
 pub mod hf;
@@ -17,6 +18,7 @@ use std::{fs::File, io::BufReader, ops::Deref, path::Path};
 use anyhow::Context as _;
 pub use anyhow::{Error, Result};
 
+pub use basetenkenizer::BasetenTokenizer;
 pub use cache::{CacheTokenUsage, CacheTokenUsageFn, CachedTokenizer, L1CacheStats};
 pub use fastokens::FastTokenizer;
 pub use hf::HuggingFaceTokenizer;
@@ -24,6 +26,41 @@ pub use tiktoken::TikTokenTokenizer;
 pub use traits::DecodeResult;
 
 pub type TokenIdType = u32;
+
+/// A rendered prompt segment with an explicit trust boundary for special tokens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodeSegment<'a> {
+    pub text: &'a str,
+    /// Recognize added/control tokens in this trusted renderer output.
+    ///
+    /// Set this to `false` for user, tool, and attribute content so text that
+    /// resembles a control token is encoded as ordinary text.
+    pub allow_special: bool,
+}
+
+impl<'a> EncodeSegment<'a> {
+    pub const fn new(text: &'a str, allow_special: bool) -> Self {
+        Self {
+            text,
+            allow_special,
+        }
+    }
+}
+
+/// Options for encoding an already-rendered segmented prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SegmentEncodingOptions {
+    /// Preserve legacy tiktoken chunk boundaries on very long inputs.
+    pub tiktoken_safe: bool,
+}
+
+impl Default for SegmentEncodingOptions {
+    fn default() -> Self {
+        Self {
+            tiktoken_safe: true,
+        }
+    }
+}
 
 /// Represents the type of tokenizer being used
 #[derive(Debug)]
@@ -65,6 +102,21 @@ pub mod traits {
     pub trait Encoder: Send + Sync {
         fn encode(&self, input: &str) -> Result<Encoding>;
         fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>>;
+
+        /// Encode renderer output while preserving trusted-control and
+        /// untrusted-content boundaries.
+        ///
+        /// Backends must not implement this by concatenating the segments:
+        /// doing so lets control-token-looking user content become structural.
+        fn encode_segments(
+            &self,
+            _segments: &[EncodeSegment<'_>],
+            _options: SegmentEncodingOptions,
+        ) -> Result<Encoding> {
+            Err(Error::msg(
+                "tokenizer backend does not support segmented encoding",
+            ))
+        }
     }
 
     /// Result of decoding token IDs to text.

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -88,11 +88,23 @@ pub mod traits {
         fn encode(&self, input: &str) -> Result<Encoding>;
         fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>>;
 
-        /// Encode renderer output while preserving trusted-control and
-        /// untrusted-content boundaries.
+        /// Encode Kimi K3-style renderer segments while preserving trusted
+        /// control-token and untrusted content boundaries.
         ///
-        /// Backends must not implement this by concatenating the segments:
-        /// doing so lets control-token-looking user content become structural.
+        /// Each segment controls whether added/control tokens are recognized
+        /// through [`EncodeSegment::allow_special`]. This prevents text in user,
+        /// tool, or attribute content from becoming structural when it happens
+        /// to resemble a control token.
+        ///
+        /// The Baseten backend preserves legacy tiktoken behavior by splitting
+        /// each segment into chunks of at most 400,000 characters and splitting
+        /// whitespace/non-whitespace runs at 25,000 characters. Independent
+        /// chunks are encoded through the Rayon thread pool, then concatenated
+        /// in input order. Tokenizer post-processing is applied once after all
+        /// segment IDs have been joined.
+        ///
+        /// Backends must not implement this by flattening the segments first,
+        /// because that discards the special-token trust boundary.
         fn encode_segments(&self, _segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
             Err(Error::msg(
                 "tokenizer backend does not support segmented encoding",

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -47,21 +47,6 @@ impl<'a> EncodeSegment<'a> {
     }
 }
 
-/// Options for encoding an already-rendered segmented prompt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SegmentEncodingOptions {
-    /// Preserve legacy tiktoken chunk boundaries on very long inputs.
-    pub tiktoken_safe: bool,
-}
-
-impl Default for SegmentEncodingOptions {
-    fn default() -> Self {
-        Self {
-            tiktoken_safe: true,
-        }
-    }
-}
-
 /// Represents the type of tokenizer being used
 #[derive(Debug)]
 pub enum TokenizerType {
@@ -108,11 +93,7 @@ pub mod traits {
         ///
         /// Backends must not implement this by concatenating the segments:
         /// doing so lets control-token-looking user content become structural.
-        fn encode_segments(
-            &self,
-            _segments: &[EncodeSegment<'_>],
-            _options: SegmentEncodingOptions,
-        ) -> Result<Encoding> {
+        fn encode_segments(&self, _segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
             Err(Error::msg(
                 "tokenizer backend does not support segmented encoding",
             ))


### PR DESCRIPTION
## Summary

- add `basetenkenizer` 0.2.8 as a native `dynamo-tokenizers` backend for encode, batch encode, decode, and incremental decode
- add object-safe segmented encoding to preserve trusted renderer control tokens separately from untrusted user/tool content
- keep segmented encoding tiktoken-safe for Kimi K3 long-input token-ID parity
- honor existing tokenizer construction options and prefix-cache safety requirements
- disable the unused `hf-hub` feature for the local-file adapter

## Motivation

The existing `FastTokenizer` integration provides a faster encoder but falls back to Hugging Face for decoding and only accepts flattened strings. Newer model renderers, notably Kimi K2.7 Code and Kimi K3 XTML, produce segments carrying an `allow_special` trust boundary. Concatenating those segments before encoding can turn control-token-looking user content into structural tokens.

This PR makes segmented encoding part of the object-safe `Encoder` interface. Unsupported backends return an explicit error instead of flattening segments unsafely. `BasetenTokenizer` implements the capability using `basetenkenizer::Tokenizer::encode_segments_tiktoken_safe`; the frontend does not expose a non-tiktoken-safe segmented mode.

This intentionally does not change the default `.json` tokenizer factory, preserving current backend selection and model coverage. A native Kimi K3 XTML renderer can be added independently in `dynamo-renderer` and pass its segments through this API.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-tokenizers --all-targets --locked`
- `cargo clippy -p dynamo-tokenizers --all-targets --all-features --locked -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- `cargo package -p dynamo-tokenizers --allow-dirty --no-verify`
- `git diff --check`
- local crates.io `basetenkenizer` smoke probe against the vendored Kimi K3 tokenizer: load, raw encode/decode, and segmented XTML encode

`cargo deny` was not available in the local environment.