### PR TITLE
feat(protocols): include token ids in chat logprobs

### DIFF
--- a/parsers/v1/src/tool_calling/jail/mod.rs
+++ b/parsers/v1/src/tool_calling/jail/mod.rs
@@ -2437,6 +2437,7 @@ mod tests {
                         |(i, c)| dynamo_protocols::types::ChatCompletionTokenLogprob {
                             token: c.to_string(),
                             logprob: -(i as f32 + 1.0) * 0.1,
+                            token_id: None,
                             bytes: Some(c.to_string().into_bytes()),
                             top_logprobs: vec![],
                         },

--- a/protocols/src/types/chat.rs
+++ b/protocols/src/types/chat.rs
@@ -22,7 +22,6 @@ use crate::error::OpenAIError;
 // Consumers should use them via `dynamo_protocols::types::*` as before.
 
 pub use async_openai::types::chat::{
-    ChatChoiceLogprobs,
     ChatCompletionAudio,
     ChatCompletionAudioFormat,
     ChatCompletionAudioVoice,
@@ -46,7 +45,6 @@ pub use async_openai::types::chat::{
     ChatCompletionRequestSystemMessageContent,
     ChatCompletionRequestSystemMessageContentPart,
     ChatCompletionResponseMessageAudio,
-    ChatCompletionTokenLogprob,
     Choice,
     CompletionFinishReason,
     CompletionTokensDetails,
@@ -378,6 +376,30 @@ impl From<String> for ChatCompletionRequestToolMessageContent {
 pub struct ChatCompletionRequestToolMessage {
     pub content: ChatCompletionRequestToolMessageContent,
     pub tool_call_id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ChatChoiceLogprobs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<Vec<ChatCompletionTokenLogprob>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<Vec<ChatCompletionTokenLogprob>>,
+}
+
+/// Token logprob entry with optional backend token ID.
+///
+/// Some inference backends can report both the rendered token string and its
+/// vocabulary ID. Keeping this optional preserves the upstream OpenAI shape
+/// when token IDs are unavailable.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ChatCompletionTokenLogprob {
+    pub token: String,
+    pub logprob: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<Vec<u8>>,
+    pub top_logprobs: Vec<TopLogprobs>,
 }
 
 #[derive(Clone, Serialize, Default, Debug, Deserialize, PartialEq)]
@@ -1466,5 +1488,20 @@ mod tests {
             parts[3],
             ChatCompletionRequestToolMessageContentPart::AudioUrl(_)
         ));
+    }
+
+    #[test]
+    fn chat_logprob_serializes_token_id_when_present() {
+        let logprob = ChatCompletionTokenLogprob {
+            token: " hello".into(),
+            logprob: -0.12,
+            token_id: Some(123),
+            bytes: Some(vec![32, 104, 101, 108, 108, 111]),
+            top_logprobs: vec![],
+        };
+
+        let json = serde_json::to_value(logprob).unwrap();
+
+        assert_eq!(json["token_id"], 123);
     }
 }

--- a/protocols/src/types/chat.rs
+++ b/protocols/src/types/chat.rs
@@ -1503,6 +1503,31 @@ mod tests {
     }
 
     #[test]
+    fn chat_logprob_deserializes_optional_fields() {
+        let choice_logprobs: ChatChoiceLogprobs = serde_json::from_value(serde_json::json!({
+            "content": [{
+                "token": " hello",
+                "logprob": -0.12,
+                "top_logprobs": []
+            }]
+        }))
+        .unwrap();
+        let token_logprob: ChatCompletionTokenLogprob = serde_json::from_value(serde_json::json!({
+            "token": " hello",
+            "logprob": -0.12,
+            "token_id": 123,
+            "bytes": [32, 104, 101, 108, 108, 111],
+            "top_logprobs": []
+        }))
+        .unwrap();
+
+        assert_eq!(choice_logprobs.content.as_ref().unwrap()[0].token_id, None);
+        assert!(choice_logprobs.refusal.is_none());
+        assert_eq!(token_logprob.token_id, Some(123));
+        assert_eq!(token_logprob.bytes, Some(vec![32, 104, 101, 108, 108, 111]));
+    }
+
+    #[test]
     fn chat_logprob_preserves_nullable_fields() {
         let choice_logprobs = ChatChoiceLogprobs {
             content: None,

--- a/protocols/src/types/chat.rs
+++ b/protocols/src/types/chat.rs
@@ -380,9 +380,7 @@ pub struct ChatCompletionRequestToolMessage {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ChatChoiceLogprobs {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Vec<ChatCompletionTokenLogprob>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub refusal: Option<Vec<ChatCompletionTokenLogprob>>,
 }
 
@@ -397,7 +395,6 @@ pub struct ChatCompletionTokenLogprob {
     pub logprob: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_id: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes: Option<Vec<u8>>,
     pub top_logprobs: Vec<TopLogprobs>,
 }
@@ -1503,5 +1500,28 @@ mod tests {
         let json = serde_json::to_value(logprob).unwrap();
 
         assert_eq!(json["token_id"], 123);
+    }
+
+    #[test]
+    fn chat_logprob_preserves_nullable_fields() {
+        let choice_logprobs = ChatChoiceLogprobs {
+            content: None,
+            refusal: None,
+        };
+        let token_logprob = ChatCompletionTokenLogprob {
+            token: " hello".into(),
+            logprob: -0.12,
+            token_id: None,
+            bytes: None,
+            top_logprobs: vec![],
+        };
+
+        let choice_json = serde_json::to_value(choice_logprobs).unwrap();
+        let token_json = serde_json::to_value(token_logprob).unwrap();
+
+        assert_eq!(choice_json["content"], serde_json::Value::Null);
+        assert_eq!(choice_json["refusal"], serde_json::Value::Null);
+        assert!(token_json.get("token_id").is_none());
+        assert_eq!(token_json["bytes"], serde_json::Value::Null);
     }
 }


### PR DESCRIPTION
## Summary

- Own `ChatChoiceLogprobs` and `ChatCompletionTokenLogprob` in `dynamo-protocols`.
- Add optional `token_id` to chat logprob entries when the backend provides token IDs.
- Keep `token_id` omitted when absent.

Fixes #156.

## Validation

- `cargo fmt --check`
- `cargo test -p dynamo-protocols`

The regression test uses only synthetic dummy token data.
