### PR TITLE
fix(renderer): adaptively normalize non-leading system messages

### DIFF
--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -135,6 +135,25 @@ struct JinjaEnvironment {
     env: Environment<'static>,
 }
 
+/// Which message-shape restrictions one chat template enforces, probed once at
+/// load. Each rewrite in `normalize_system_messages` is gated on its own flag:
+/// the restrictions are independent, so a template that rejects a non-leading
+/// `system` (Qwen3.5) but accepts consecutive `user` turns keeps those turns
+/// separate instead of being reshaped for a rule it does not have.
+#[derive(Debug, Default, Clone, Copy)]
+struct SystemNormalization {
+    /// Template raises on a `system` turn that is not first.
+    demote_nonleading_system: bool,
+    /// Template raises on two adjacent `user` turns.
+    coalesce_consecutive_users: bool,
+}
+
+impl SystemNormalization {
+    fn is_required(&self) -> bool {
+        self.demote_nonleading_system || self.coalesce_consecutive_users
+    }
+}
+
 /// Formatter for HuggingFace tokenizer config JSON templates
 ///
 /// Implements chat template rendering based on HuggingFace's tokenizer_config.json format.
@@ -186,13 +205,12 @@ struct HfTokenizerConfigJsonFormatter {
     /// True if the `tool_use` template branches on `tool_call.arguments is string`.
     /// See `default_template_handles_tool_calls_arguments_string` for rationale.
     tool_use_template_handles_tool_calls_arguments_string: bool,
-    /// True if the `default` template rejects a non-leading `system` turn, or
-    /// the consecutive `user` turns demoting one produces. Probed once at load.
-    default_requires_system_normalization: bool,
-    /// True if the `tool_use` template requires the same rewrite.
+    /// Message-shape restrictions the `default` template enforces.
+    default_system_normalization: SystemNormalization,
+    /// Message-shape restrictions the `tool_use` template enforces.
     /// Kept separate because dict-form HF configs may register templates with
-    /// different message-shape constraints.
-    tool_use_requires_system_normalization: bool,
+    /// different constraints.
+    tool_use_system_normalization: SystemNormalization,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -186,6 +186,15 @@ struct HfTokenizerConfigJsonFormatter {
     /// True if the `tool_use` template branches on `tool_call.arguments is string`.
     /// See `default_template_handles_tool_calls_arguments_string` for rationale.
     tool_use_template_handles_tool_calls_arguments_string: bool,
+    /// True if the chat template rejects the message streams that agent clients
+    /// (e.g. Claude Code on `/v1/messages`) produce: a non-leading `system`
+    /// turn, or the consecutive `user` turns an in-place demotion creates.
+    /// Detected once at load time by probing the compiled template. When true,
+    /// `render` normalizes system messages (merge leading run, demote
+    /// non-leading system to `user`, coalesce consecutive users) so the stream
+    /// renders; when false the messages reach the template untouched, so the
+    /// ~76% of templates that accept these streams keep byte-identical output.
+    requires_system_normalization: bool,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -186,9 +186,13 @@ struct HfTokenizerConfigJsonFormatter {
     /// True if the `tool_use` template branches on `tool_call.arguments is string`.
     /// See `default_template_handles_tool_calls_arguments_string` for rationale.
     tool_use_template_handles_tool_calls_arguments_string: bool,
-    /// True if this template rejects a non-leading `system` turn, or the
-    /// consecutive `user` turns demoting one produces. Probed once at load.
-    requires_system_normalization: bool,
+    /// True if the `default` template rejects a non-leading `system` turn, or
+    /// the consecutive `user` turns demoting one produces. Probed once at load.
+    default_requires_system_normalization: bool,
+    /// True if the `tool_use` template requires the same rewrite.
+    /// Kept separate because dict-form HF configs may register templates with
+    /// different message-shape constraints.
+    tool_use_requires_system_normalization: bool,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/renderer/src/template.rs
+++ b/renderer/src/template.rs
@@ -186,14 +186,8 @@ struct HfTokenizerConfigJsonFormatter {
     /// True if the `tool_use` template branches on `tool_call.arguments is string`.
     /// See `default_template_handles_tool_calls_arguments_string` for rationale.
     tool_use_template_handles_tool_calls_arguments_string: bool,
-    /// True if the chat template rejects the message streams that agent clients
-    /// (e.g. Claude Code on `/v1/messages`) produce: a non-leading `system`
-    /// turn, or the consecutive `user` turns an in-place demotion creates.
-    /// Detected once at load time by probing the compiled template. When true,
-    /// `render` normalizes system messages (merge leading run, demote
-    /// non-leading system to `user`, coalesce consecutive users) so the stream
-    /// renders; when false the messages reach the template untouched, so the
-    /// ~76% of templates that accept these streams keep byte-identical output.
+    /// True if this template rejects a non-leading `system` turn, or the
+    /// consecutive `user` turns demoting one produces. Probed once at load.
     requires_system_normalization: bool,
 }
 

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -33,7 +33,12 @@ struct ProbeTokens {
 
 /// Unlike [`render_default_probe`], surfaces the error: a template's
 /// `raise_exception` is the signal that it rejects this message shape.
-fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &ProbeTokens) -> bool {
+fn probe_template_raises(
+    env: &Environment,
+    template_name: &str,
+    messages: serde_json::Value,
+    tok: &ProbeTokens,
+) -> bool {
     let ctx = context! {
         messages => messages,
         add_generation_prompt => false,
@@ -41,7 +46,7 @@ fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &Pr
         eos_token => tok.eos,
         unk_token => tok.unk,
     };
-    match env.get_template("default") {
+    match env.get_template(template_name) {
         Ok(t) => t.render(&ctx).is_err(),
         Err(_) => false,
     }
@@ -52,20 +57,35 @@ fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &Pr
 ///
 /// All three shapes are probed because strict families disagree on which they
 /// reject: Qwen3.5 allows consecutive users, Gemma-3 allows a non-leading system.
-fn detect_requires_system_normalization(env: &Environment, tok: &ProbeTokens) -> bool {
+fn detect_requires_system_normalization(
+    env: &Environment,
+    template_name: &str,
+    tok: &ProbeTokens,
+) -> bool {
     let sys = |c: &str| json!({"role": "system", "content": c});
     let usr = |c: &str| json!({"role": "user", "content": c});
     let asst = |c: &str| json!({"role": "assistant", "content": c});
 
     // A template that can't render even this isn't rejecting shape, it's broken.
-    let baseline_ok = !probe_default_raises(env, json!([sys("s"), usr("u")]), tok);
+    let baseline_ok = !probe_template_raises(env, template_name, json!([sys("s"), usr("u")]), tok);
     if !baseline_ok {
         return false;
     }
-    let nonleading_system = probe_default_raises(env, json!([sys("s0"), usr("u"), sys("s1")]), tok);
-    let consecutive_users = probe_default_raises(env, json!([sys("s"), usr("u0"), usr("u1")]), tok);
-    let mid_after_assistant = probe_default_raises(
+    let nonleading_system = probe_template_raises(
         env,
+        template_name,
+        json!([sys("s0"), usr("u"), sys("s1")]),
+        tok,
+    );
+    let consecutive_users = probe_template_raises(
+        env,
+        template_name,
+        json!([sys("s"), usr("u0"), usr("u1")]),
+        tok,
+    );
+    let mid_after_assistant = probe_template_raises(
+        env,
+        template_name,
         json!([sys("s0"), usr("u"), asst("a"), sys("s1"), usr("u2")]),
         tok,
     );
@@ -545,8 +565,10 @@ impl HfTokenizerConfigJsonFormatter {
             eos: config.eos_tok(),
             unk: config.unk_tok(),
         };
-        let requires_system_normalization =
-            detect_requires_system_normalization(&env, &probe_tokens);
+        let default_requires_system_normalization =
+            detect_requires_system_normalization(&env, "default", &probe_tokens);
+        let tool_use_requires_system_normalization =
+            detect_requires_system_normalization(&env, "tool_use", &probe_tokens);
 
         Ok(HfTokenizerConfigJsonFormatter {
             env,
@@ -560,7 +582,8 @@ impl HfTokenizerConfigJsonFormatter {
             image_placeholder_template,
             default_template_handles_tool_calls_arguments_string,
             tool_use_template_handles_tool_calls_arguments_string,
-            requires_system_normalization,
+            default_requires_system_normalization,
+            tool_use_requires_system_normalization,
         })
     }
 }

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -23,6 +23,67 @@ fn render_default_probe(env: &Environment, messages: serde_json::Value) -> Strin
         .unwrap_or_default()
 }
 
+/// Special tokens supplied to a probe render, so a template that appends
+/// `eos_token`/`bos_token` doesn't raise for a missing-token reason and get
+/// mistaken for a message-shape rejection.
+struct ProbeTokens {
+    bos: Option<String>,
+    eos: Option<String>,
+    unk: Option<String>,
+}
+
+/// Renders the `default` template and returns whether it raised. Unlike
+/// [`render_default_probe`] (which swallows errors), this surfaces the error so
+/// a `raise_exception` in the template — the signal that it rejects a given
+/// message shape — is observable at load time. bos/eos/unk are supplied so only
+/// message-shape raises (not missing-token raises) are detected.
+fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &ProbeTokens) -> bool {
+    let ctx = context! {
+        messages => messages,
+        add_generation_prompt => false,
+        bos_token => tok.bos,
+        eos_token => tok.eos,
+        unk_token => tok.unk,
+    };
+    match env.get_template("default") {
+        Ok(t) => t.render(&ctx).is_err(),
+        // No `default` template compiled: nothing to normalize against.
+        Err(_) => false,
+    }
+}
+
+/// Detects at load time whether this template rejects the message streams agent
+/// clients produce, so `render` can conditionally normalize only when needed.
+///
+/// Different strict families fail on different shapes: Qwen3.5 rejects a
+/// non-leading `system` but accepts consecutive users; Gemma-3 accepts a
+/// non-leading `system` right after the first user yet rejects consecutive
+/// users and a `system` after an assistant turn; Mistral rejects both. So we
+/// probe several shapes and flag the template if ANY that a normalized stream
+/// would fix currently raises — while a plain `[system, user]` baseline still
+/// renders, to avoid flagging a genuinely broken template.
+fn detect_requires_system_normalization(env: &Environment, tok: &ProbeTokens) -> bool {
+    let sys = |c: &str| json!({"role": "system", "content": c});
+    let usr = |c: &str| json!({"role": "user", "content": c});
+    let asst = |c: &str| json!({"role": "assistant", "content": c});
+
+    let baseline_ok = !probe_default_raises(env, json!([sys("s"), usr("u")]), tok);
+    if !baseline_ok {
+        return false;
+    }
+    // Non-leading system, consecutive users, and a system after an assistant
+    // turn: the union catches strict-leading (Qwen3.5), alternation (Gemma,
+    // Mistral) and their combination.
+    let nonleading_system = probe_default_raises(env, json!([sys("s0"), usr("u"), sys("s1")]), tok);
+    let consecutive_users = probe_default_raises(env, json!([sys("s"), usr("u0"), usr("u1")]), tok);
+    let mid_after_assistant = probe_default_raises(
+        env,
+        json!([sys("s0"), usr("u"), asst("a"), sys("s1"), usr("u2")]),
+        tok,
+    );
+    nonleading_system || consecutive_users || mid_after_assistant
+}
+
 /// Detects if a template requires content as arrays (multimodal) vs strings (text-only).
 /// Returns true if the template only works with array format.
 fn detect_content_array_usage(env: &Environment) -> bool {
@@ -491,6 +552,19 @@ impl HfTokenizerConfigJsonFormatter {
         let tool_use_template_handles_tool_calls_arguments_string =
             template_handles_args_string("tool_use");
 
+        // Detect whether this template rejects agent-client message streams
+        // (non-leading system / consecutive users). Only when it does will
+        // `render` normalize; permissive templates render untouched. Supply the
+        // model's special tokens so a missing-token raise isn't misread as a
+        // message-shape rejection.
+        let probe_tokens = ProbeTokens {
+            bos: config.bos_tok(),
+            eos: config.eos_tok(),
+            unk: config.unk_tok(),
+        };
+        let requires_system_normalization =
+            detect_requires_system_normalization(&env, &probe_tokens);
+
         Ok(HfTokenizerConfigJsonFormatter {
             env,
             config,
@@ -503,6 +577,7 @@ impl HfTokenizerConfigJsonFormatter {
             image_placeholder_template,
             default_template_handles_tool_calls_arguments_string,
             tool_use_template_handles_tool_calls_arguments_string,
+            requires_system_normalization,
         })
     }
 }

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -23,20 +23,16 @@ fn render_default_probe(env: &Environment, messages: serde_json::Value) -> Strin
         .unwrap_or_default()
 }
 
-/// Special tokens supplied to a probe render, so a template that appends
-/// `eos_token`/`bos_token` doesn't raise for a missing-token reason and get
-/// mistaken for a message-shape rejection.
+/// Passed to probe renders so a template that appends them doesn't raise for a
+/// missing token, which would read as a message-shape rejection.
 struct ProbeTokens {
     bos: Option<String>,
     eos: Option<String>,
     unk: Option<String>,
 }
 
-/// Renders the `default` template and returns whether it raised. Unlike
-/// [`render_default_probe`] (which swallows errors), this surfaces the error so
-/// a `raise_exception` in the template — the signal that it rejects a given
-/// message shape — is observable at load time. bos/eos/unk are supplied so only
-/// message-shape raises (not missing-token raises) are detected.
+/// Unlike [`render_default_probe`], surfaces the error: a template's
+/// `raise_exception` is the signal that it rejects this message shape.
 fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &ProbeTokens) -> bool {
     let ctx = context! {
         messages => messages,
@@ -47,33 +43,25 @@ fn probe_default_raises(env: &Environment, messages: serde_json::Value, tok: &Pr
     };
     match env.get_template("default") {
         Ok(t) => t.render(&ctx).is_err(),
-        // No `default` template compiled: nothing to normalize against.
         Err(_) => false,
     }
 }
 
-/// Detects at load time whether this template rejects the message streams agent
-/// clients produce, so `render` can conditionally normalize only when needed.
+/// Detects whether this template rejects the message streams agent clients send,
+/// so `render` only rewrites messages for templates that need it.
 ///
-/// Different strict families fail on different shapes: Qwen3.5 rejects a
-/// non-leading `system` but accepts consecutive users; Gemma-3 accepts a
-/// non-leading `system` right after the first user yet rejects consecutive
-/// users and a `system` after an assistant turn; Mistral rejects both. So we
-/// probe several shapes and flag the template if ANY that a normalized stream
-/// would fix currently raises — while a plain `[system, user]` baseline still
-/// renders, to avoid flagging a genuinely broken template.
+/// All three shapes are probed because strict families disagree on which they
+/// reject: Qwen3.5 allows consecutive users, Gemma-3 allows a non-leading system.
 fn detect_requires_system_normalization(env: &Environment, tok: &ProbeTokens) -> bool {
     let sys = |c: &str| json!({"role": "system", "content": c});
     let usr = |c: &str| json!({"role": "user", "content": c});
     let asst = |c: &str| json!({"role": "assistant", "content": c});
 
+    // A template that can't render even this isn't rejecting shape, it's broken.
     let baseline_ok = !probe_default_raises(env, json!([sys("s"), usr("u")]), tok);
     if !baseline_ok {
         return false;
     }
-    // Non-leading system, consecutive users, and a system after an assistant
-    // turn: the union catches strict-leading (Qwen3.5), alternation (Gemma,
-    // Mistral) and their combination.
     let nonleading_system = probe_default_raises(env, json!([sys("s0"), usr("u"), sys("s1")]), tok);
     let consecutive_users = probe_default_raises(env, json!([sys("s"), usr("u0"), usr("u1")]), tok);
     let mid_after_assistant = probe_default_raises(
@@ -552,11 +540,6 @@ impl HfTokenizerConfigJsonFormatter {
         let tool_use_template_handles_tool_calls_arguments_string =
             template_handles_args_string("tool_use");
 
-        // Detect whether this template rejects agent-client message streams
-        // (non-leading system / consecutive users). Only when it does will
-        // `render` normalize; permissive templates render untouched. Supply the
-        // model's special tokens so a missing-token raise isn't misread as a
-        // message-shape rejection.
         let probe_tokens = ProbeTokens {
             bos: config.bos_tok(),
             eos: config.eos_tok(),

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -37,11 +37,13 @@ fn probe_template_raises(
     env: &Environment,
     template_name: &str,
     messages: serde_json::Value,
+    tools: &Option<serde_json::Value>,
     tok: &ProbeTokens,
 ) -> bool {
     let ctx = context! {
         messages => messages,
         add_generation_prompt => false,
+        tools => tools,
         bos_token => tok.bos,
         eos_token => tok.eos,
         unk_token => tok.unk,
@@ -60,6 +62,7 @@ fn probe_template_raises(
 fn detect_requires_system_normalization(
     env: &Environment,
     template_name: &str,
+    tools: &Option<serde_json::Value>,
     tok: &ProbeTokens,
 ) -> bool {
     let sys = |c: &str| json!({"role": "system", "content": c});
@@ -67,7 +70,8 @@ fn detect_requires_system_normalization(
     let asst = |c: &str| json!({"role": "assistant", "content": c});
 
     // A template that can't render even this isn't rejecting shape, it's broken.
-    let baseline_ok = !probe_template_raises(env, template_name, json!([sys("s"), usr("u")]), tok);
+    let baseline_ok =
+        !probe_template_raises(env, template_name, json!([sys("s"), usr("u")]), tools, tok);
     if !baseline_ok {
         return false;
     }
@@ -75,18 +79,21 @@ fn detect_requires_system_normalization(
         env,
         template_name,
         json!([sys("s0"), usr("u"), sys("s1")]),
+        tools,
         tok,
     );
     let consecutive_users = probe_template_raises(
         env,
         template_name,
         json!([sys("s"), usr("u0"), usr("u1")]),
+        tools,
         tok,
     );
     let mid_after_assistant = probe_template_raises(
         env,
         template_name,
         json!([sys("s0"), usr("u"), asst("a"), sys("s1"), usr("u2")]),
+        tools,
         tok,
     );
     nonleading_system || consecutive_users || mid_after_assistant
@@ -565,10 +572,27 @@ impl HfTokenizerConfigJsonFormatter {
             eos: config.eos_tok(),
             unk: config.unk_tok(),
         };
-        let default_requires_system_normalization =
-            detect_requires_system_normalization(&env, "default", &probe_tokens);
-        let tool_use_requires_system_normalization =
-            detect_requires_system_normalization(&env, "tool_use", &probe_tokens);
+        let default_probe_tools = Option::<serde_json::Value>::None;
+        let tool_use_probe_tools = Some(json!([{
+            "type": "function",
+            "function": {
+                "name": "probe",
+                "description": "",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        }]));
+        let default_requires_system_normalization = detect_requires_system_normalization(
+            &env,
+            "default",
+            &default_probe_tools,
+            &probe_tokens,
+        );
+        let tool_use_requires_system_normalization = detect_requires_system_normalization(
+            &env,
+            "tool_use",
+            &tool_use_probe_tools,
+            &probe_tokens,
+        );
 
         Ok(HfTokenizerConfigJsonFormatter {
             env,

--- a/renderer/src/template/formatters.rs
+++ b/renderer/src/template/formatters.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use super::tokcfg::{ChatTemplate, fromjson, raise_exception, strftime_now, tojson};
-use super::{ContextMixins, HfTokenizerConfigJsonFormatter, JinjaEnvironment};
+use super::{ContextMixins, HfTokenizerConfigJsonFormatter, JinjaEnvironment, SystemNormalization};
 use either::Either;
 use minijinja::{Environment, Value, context};
 use serde_json::json;
@@ -54,17 +54,18 @@ fn probe_template_raises(
     }
 }
 
-/// Detects whether this template rejects the message streams agent clients send,
-/// so `render` only rewrites messages for templates that need it.
+/// Detects which message shapes agent clients send that this template rejects,
+/// so `render` applies only the rewrites this template needs.
 ///
-/// All three shapes are probed because strict families disagree on which they
-/// reject: Qwen3.5 allows consecutive users, Gemma-3 allows a non-leading system.
-fn detect_requires_system_normalization(
+/// The non-leading `system` restriction takes two probes because strict families
+/// disagree on where they enforce it: Gemma-3 accepts `[system, user, system]`
+/// but rejects the same turn after an assistant reply.
+fn detect_system_normalization(
     env: &Environment,
     template_name: &str,
     tools: &Option<serde_json::Value>,
     tok: &ProbeTokens,
-) -> bool {
+) -> SystemNormalization {
     let sys = |c: &str| json!({"role": "system", "content": c});
     let usr = |c: &str| json!({"role": "user", "content": c});
     let asst = |c: &str| json!({"role": "assistant", "content": c});
@@ -73,19 +74,12 @@ fn detect_requires_system_normalization(
     let baseline_ok =
         !probe_template_raises(env, template_name, json!([sys("s"), usr("u")]), tools, tok);
     if !baseline_ok {
-        return false;
+        return SystemNormalization::default();
     }
     let nonleading_system = probe_template_raises(
         env,
         template_name,
         json!([sys("s0"), usr("u"), sys("s1")]),
-        tools,
-        tok,
-    );
-    let consecutive_users = probe_template_raises(
-        env,
-        template_name,
-        json!([sys("s"), usr("u0"), usr("u1")]),
         tools,
         tok,
     );
@@ -96,7 +90,17 @@ fn detect_requires_system_normalization(
         tools,
         tok,
     );
-    nonleading_system || consecutive_users || mid_after_assistant
+    let consecutive_users = probe_template_raises(
+        env,
+        template_name,
+        json!([sys("s"), usr("u0"), usr("u1")]),
+        tools,
+        tok,
+    );
+    SystemNormalization {
+        demote_nonleading_system: nonleading_system || mid_after_assistant,
+        coalesce_consecutive_users: consecutive_users,
+    }
 }
 
 /// Detects if a template requires content as arrays (multimodal) vs strings (text-only).
@@ -581,18 +585,10 @@ impl HfTokenizerConfigJsonFormatter {
                 "parameters": {"type": "object", "properties": {}}
             }
         }]));
-        let default_requires_system_normalization = detect_requires_system_normalization(
-            &env,
-            "default",
-            &default_probe_tools,
-            &probe_tokens,
-        );
-        let tool_use_requires_system_normalization = detect_requires_system_normalization(
-            &env,
-            "tool_use",
-            &tool_use_probe_tools,
-            &probe_tokens,
-        );
+        let default_system_normalization =
+            detect_system_normalization(&env, "default", &default_probe_tools, &probe_tokens);
+        let tool_use_system_normalization =
+            detect_system_normalization(&env, "tool_use", &tool_use_probe_tools, &probe_tokens);
 
         Ok(HfTokenizerConfigJsonFormatter {
             env,
@@ -606,8 +602,8 @@ impl HfTokenizerConfigJsonFormatter {
             image_placeholder_template,
             default_template_handles_tool_calls_arguments_string,
             tool_use_template_handles_tool_calls_arguments_string,
-            default_requires_system_normalization,
-            tool_use_requires_system_normalization,
+            default_system_normalization,
+            tool_use_system_normalization,
         })
     }
 }

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -578,16 +578,16 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         let mut messages_for_template: serde_json::Value =
             serde_json::to_value(&messages_canonical).unwrap();
 
+        if requires_system_normalization {
+            normalize_system_messages(&mut messages_for_template);
+        }
+
         messages_for_template = serde_json::to_value(may_be_fix_msg_content(
             messages_for_template,
             self.requires_content_arrays,
             self.image_placeholder_template,
         ))
         .unwrap();
-
-        if requires_system_normalization {
-            normalize_system_messages(&mut messages_for_template);
-        }
 
         // Pre-parse JSON-string `arguments` into objects — but only for templates
         // that unconditionally `| tojson` them. Templates that branch on
@@ -731,6 +731,39 @@ mod tests {
         "{%- set ns.prev = m.role -%}",
         "{%- endfor -%}"
     );
+    // Mirrors templates that only enforce role constraints when a particular
+    // tools shape is present.
+    const DEFAULT_NONE_GATED_TMPL: &str = concat!(
+        "{%- set strict = tools is not none -%}",
+        "{%- for m in messages -%}",
+        "{%- if strict and m.role == 'system' and not loop.first -%}",
+        "{{ raise_exception('System message must be at the beginning.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- endfor -%}"
+    );
+    const TOOL_NONEMPTY_GATED_TMPL: &str = concat!(
+        "{%- set strict = tools|length > 0 -%}",
+        "{%- for m in messages -%}",
+        "{%- if strict and m.role == 'system' and not loop.first -%}",
+        "{{ raise_exception('System message must be at the beginning.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- endfor -%}"
+    );
+    // Ignores string content and only renders text parts from content arrays.
+    const STRICT_ARRAY_TMPL: &str = concat!(
+        "{%- for m in messages -%}",
+        "{%- if m.role == 'system' and not loop.first -%}",
+        "{{ raise_exception('System message must be at the beginning.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n",
+        "{%- if m.content is not string -%}",
+        "{%- for part in m.content -%}{{ part.text }}{%- endfor -%}",
+        "{%- endif -%}",
+        "<|im_end|>\n",
+        "{%- endfor -%}"
+    );
 
     // Claude Code first-turn shape: top-level system + a mid-array system.
     fn claude_shape() -> serde_json::Value {
@@ -790,6 +823,40 @@ mod tests {
         assert!(!f.tool_use_requires_system_normalization);
         let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
         assert!(with_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+    }
+
+    #[test]
+    fn system_normalization_probe_uses_runtime_tools_shape() {
+        let f = formatter_for_templates(DEFAULT_NONE_GATED_TMPL, TOOL_NONEMPTY_GATED_TMPL);
+        assert!(!f.default_requires_system_normalization);
+        assert!(f.tool_use_requires_system_normalization);
+
+        let no_tools = render_shape(&f, claude_shape()).unwrap();
+        assert!(no_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+
+        let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
+        assert_eq!(with_tools.matches("<|im_start|>system").count(), 1);
+        assert!(
+            with_tools.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>")
+        );
+    }
+
+    #[test]
+    fn system_normalization_precedes_required_content_array_conversion() {
+        let f = formatter_for(STRICT_ARRAY_TMPL);
+        assert!(f.requires_content_arrays);
+        assert!(f.default_requires_system_normalization);
+
+        let out = render_shape(
+            &f,
+            json!([
+                {"role": "system", "content": "A"},
+                {"role": "system", "content": "B"},
+                {"role": "user", "content": "hello"},
+            ]),
+        )
+        .unwrap();
+        assert!(out.contains("A\n\nB"));
     }
 
     #[test]

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -433,93 +433,111 @@ impl OAIChatLikeRequest for dynamo_protocols::types::CreateChatCompletionRequest
     }
 }
 
-/// Flattens to text either way, since agent clients send system content as both
-/// a bare string and a content array.
-fn message_content_text(content: &serde_json::Value) -> String {
-    match content {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Array(parts) => parts
-            .iter()
-            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        _ => String::new(),
+/// Joins two message contents without flattening to text: a part array is
+/// spliced part for part, so image parts survive a merge. A string target is
+/// promoted to an array when the source carries parts.
+fn merge_message_content(
+    target: serde_json::Value,
+    source: serde_json::Value,
+) -> serde_json::Value {
+    use serde_json::Value;
+    let text_part = |text: String| json!({"type": "text", "text": text});
+    match (target, source) {
+        (Value::String(mut target), Value::String(source)) => {
+            if !target.is_empty() && !source.is_empty() {
+                target.push_str("\n\n");
+            }
+            target.push_str(&source);
+            Value::String(target)
+        }
+        (Value::Array(mut target), Value::Array(source)) => {
+            target.extend(source);
+            Value::Array(target)
+        }
+        (Value::Array(mut target), Value::String(source)) => {
+            if !source.is_empty() {
+                target.push(text_part(source));
+            }
+            Value::Array(target)
+        }
+        (Value::String(target), Value::Array(source)) => {
+            let mut parts = Vec::with_capacity(source.len() + 1);
+            if !target.is_empty() {
+                parts.push(text_part(target));
+            }
+            parts.extend(source);
+            Value::Array(parts)
+        }
+        (Value::Null, source) => source,
+        // Content is a string or a part array in every shape the schema allows.
+        (target, _) => target,
     }
 }
 
-fn append_message_content_text(message: &mut serde_json::Value, text: String) {
-    let Some(message) = message.as_object_mut() else {
+/// Merges `source` into `target`, leaving every other field on `target` intact.
+fn append_message_content(target: &mut serde_json::Value, source: serde_json::Value) {
+    let Some(target) = target.as_object_mut() else {
         return;
     };
-    match message.get_mut("content") {
-        Some(serde_json::Value::String(content)) => {
-            if !content.is_empty() && !text.is_empty() {
-                content.push_str("\n\n");
-            }
-            content.push_str(&text);
-        }
-        Some(serde_json::Value::Array(parts)) => {
-            if !text.is_empty() {
-                parts.push(json!({"type": "text", "text": text}));
-            }
-        }
-        Some(content) => {
-            *content = serde_json::Value::String(text);
-        }
-        None => {
-            message.insert("content".to_string(), serde_json::Value::String(text));
-        }
-    }
+    let merged = merge_message_content(
+        target.remove("content").unwrap_or(serde_json::Value::Null),
+        source,
+    );
+    target.insert("content".to_string(), merged);
+}
+
+fn take_message_content(message: &mut serde_json::Value) -> serde_json::Value {
+    message
+        .get_mut("content")
+        .map(serde_json::Value::take)
+        .unwrap_or(serde_json::Value::Null)
 }
 
 /// Rewrites an agent-client message stream into a shape strict chat templates
-/// accept. Only called for templates flagged by the load-time probe.
-fn normalize_system_messages(messages: &mut serde_json::Value) {
+/// accept. Each rewrite is gated on the restriction the load-time probe actually
+/// found, so a template is never reshaped for a rule it does not enforce.
+fn normalize_system_messages(messages: &mut serde_json::Value, rules: SystemNormalization) {
     let serde_json::Value::Array(list) = messages else {
         return;
     };
     let role_is =
         |m: &serde_json::Value, r: &str| m.get("role").and_then(|v| v.as_str()) == Some(r);
-    let content_of = |m: &serde_json::Value| {
-        message_content_text(m.get("content").unwrap_or(&serde_json::Value::Null))
-    };
 
-    // Strict templates permit at most one system message, at index 0.
-    let leading = list.iter().take_while(|m| role_is(m, "system")).count();
-    if leading > 1 {
-        let combined = list[..leading]
-            .iter()
-            .map(content_of)
-            .collect::<Vec<_>>()
-            .join("\n\n");
-        list.splice(
-            0..leading,
-            std::iter::once(json!({"role": "system", "content": combined})),
-        );
-    }
+    if rules.demote_nonleading_system {
+        // A template that rejects a system turn away from index 0 rejects a
+        // leading run of them too, so the run collapses into the first.
+        let leading = list.iter().take_while(|m| role_is(m, "system")).count();
+        if leading > 1 {
+            for mut trailing in list.drain(1..leading).collect::<Vec<_>>() {
+                let content = take_message_content(&mut trailing);
+                append_message_content(&mut list[0], content);
+            }
+        }
 
-    // Demoted in place, not folded to the front: a mid-conversation reminder
-    // that toggles would otherwise invalidate the whole KV prefix each turn.
-    let leading = list.iter().take_while(|m| role_is(m, "system")).count();
-    for m in list.iter_mut().skip(leading) {
-        if role_is(m, "system") {
-            *m = json!({"role": "user", "content": content_of(m)});
+        // Demoted in place, not folded to the front: a mid-conversation reminder
+        // that toggles would otherwise invalidate the whole KV prefix each turn.
+        let leading = list.iter().take_while(|m| role_is(m, "system")).count();
+        for m in list.iter_mut().skip(leading) {
+            if role_is(m, "system")
+                && let Some(m) = m.as_object_mut()
+            {
+                m.insert("role".to_string(), json!("user"));
+            }
         }
     }
 
-    // Demotion can leave two user turns adjacent, which alternation-enforcing
-    // templates (Gemma, Mistral) reject.
-    let mut coalesced: Vec<serde_json::Value> = Vec::with_capacity(list.len());
-    for m in list.drain(..) {
-        if role_is(&m, "user") && coalesced.last().is_some_and(|p| role_is(p, "user")) {
-            let cur_text = content_of(&m);
-            let prev = coalesced.last_mut().unwrap();
-            append_message_content_text(prev, cur_text);
-        } else {
-            coalesced.push(m);
+    if rules.coalesce_consecutive_users {
+        let mut coalesced: Vec<serde_json::Value> = Vec::with_capacity(list.len());
+        for mut m in list.drain(..) {
+            if role_is(&m, "user") && coalesced.last().is_some_and(|p| role_is(p, "user")) {
+                let content = take_message_content(&mut m);
+                append_message_content(coalesced.last_mut().unwrap(), content);
+            } else {
+                coalesced.push(m);
+            }
         }
+        *list = coalesced;
     }
-    *list = coalesced;
 }
 
 impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
@@ -557,20 +575,20 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
             template_name,
             template_handles_tool_calls_args_string,
             template_handles_reasoning,
-            requires_system_normalization,
+            system_normalization,
         ) = if has_tools {
             (
                 "tool_use",
                 self.tool_use_template_handles_tool_calls_arguments_string,
                 self.tool_use_template_handles_reasoning,
-                self.tool_use_requires_system_normalization,
+                self.tool_use_system_normalization,
             )
         } else {
             (
                 "default",
                 self.default_template_handles_tool_calls_arguments_string,
                 self.default_template_handles_reasoning,
-                self.default_requires_system_normalization,
+                self.default_system_normalization,
             )
         };
 
@@ -578,8 +596,8 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         let mut messages_for_template: serde_json::Value =
             serde_json::to_value(&messages_canonical).unwrap();
 
-        if requires_system_normalization {
-            normalize_system_messages(&mut messages_for_template);
+        if system_normalization.is_required() {
+            normalize_system_messages(&mut messages_for_template, system_normalization);
         }
 
         messages_for_template = serde_json::to_value(may_be_fix_msg_content(
@@ -720,10 +738,24 @@ mod tests {
         "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
         "{%- endfor -%}"
     );
-    // Rejects consecutive user turns (Gemma/Mistral shape).
+    // Rejects consecutive user turns only; accepts a non-leading system.
     const ALTERNATION_TMPL: &str = concat!(
         "{%- set ns = namespace(prev='') -%}",
         "{%- for m in messages -%}",
+        "{%- if m.role == 'user' and ns.prev == 'user' -%}",
+        "{{ raise_exception('Conversation roles must alternate.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- set ns.prev = m.role -%}",
+        "{%- endfor -%}"
+    );
+    // Rejects both restrictions (Gemma-3 / Mistral shape).
+    const STRICT_BOTH_TMPL: &str = concat!(
+        "{%- set ns = namespace(prev='') -%}",
+        "{%- for m in messages -%}",
+        "{%- if m.role == 'system' and not loop.first -%}",
+        "{{ raise_exception('System message must be at the beginning.') }}",
+        "{%- endif -%}",
         "{%- if m.role == 'user' and ns.prev == 'user' -%}",
         "{{ raise_exception('Conversation roles must alternate.') }}",
         "{%- endif -%}",
@@ -774,53 +806,85 @@ mod tests {
         ])
     }
 
+    fn all_restrictions() -> SystemNormalization {
+        SystemNormalization {
+            demote_nonleading_system: true,
+            coalesce_consecutive_users: true,
+        }
+    }
+
     #[test]
     fn permissive_template_is_not_flagged_and_renders_untouched() {
         let f = formatter_for(PERMISSIVE_TMPL);
-        assert!(!f.default_requires_system_normalization);
-        assert!(!f.tool_use_requires_system_normalization);
+        assert!(!f.default_system_normalization.is_required());
+        assert!(!f.tool_use_system_normalization.is_required());
         let out = render_shape(&f, claude_shape()).unwrap();
         assert!(out.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
     }
 
     #[test]
-    fn strict_leading_template_is_flagged_and_demotes_mid_system() {
+    fn strict_leading_template_demotes_mid_system_but_keeps_user_turns_apart() {
         let f = formatter_for(STRICT_LEADING_TMPL);
-        assert!(f.default_requires_system_normalization);
-        assert!(f.tool_use_requires_system_normalization);
+        assert!(f.default_system_normalization.demote_nonleading_system);
+        // The template accepts consecutive users, so demotion must not merge them.
+        assert!(!f.default_system_normalization.coalesce_consecutive_users);
+
         // This shape returned a 500 before the probe existed.
         let out = render_shape(&f, claude_shape()).unwrap();
-        assert!(out.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>"));
         assert_eq!(out.matches("<|im_start|>system").count(), 1);
+        assert!(out.contains("<|im_start|>user\nhello<|im_end|>"));
+        assert!(out.contains("<|im_start|>user\nmid-conversation reminder<|im_end|>"));
     }
 
     #[test]
-    fn alternation_template_is_flagged_and_coalesces_users() {
+    fn alternation_template_coalesces_users_but_keeps_mid_system() {
         let f = formatter_for(ALTERNATION_TMPL);
-        assert!(f.default_requires_system_normalization);
-        assert!(f.tool_use_requires_system_normalization);
-        // Demotion would create [user, user]; coalescing keeps it valid.
+        assert!(f.default_system_normalization.coalesce_consecutive_users);
+        // The template accepts a non-leading system, so it stays a system turn.
+        assert!(!f.default_system_normalization.demote_nonleading_system);
+
         let out = render_shape(&f, claude_shape()).unwrap();
+        assert!(out.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+
+        let out = render_shape(
+            &f,
+            json!([
+                {"role": "system", "content": "s"},
+                {"role": "user", "content": "hello"},
+                {"role": "user", "content": "again"},
+            ]),
+        )
+        .unwrap();
         assert_eq!(out.matches("<|im_start|>user").count(), 1);
+        assert!(out.contains("<|im_start|>user\nhello\n\nagain<|im_end|>"));
+    }
+
+    #[test]
+    fn strict_both_template_demotes_then_coalesces() {
+        let f = formatter_for(STRICT_BOTH_TMPL);
+        assert!(f.default_system_normalization.demote_nonleading_system);
+        assert!(f.default_system_normalization.coalesce_consecutive_users);
+
+        let out = render_shape(&f, claude_shape()).unwrap();
+        assert_eq!(out.matches("<|im_start|>system").count(), 1);
+        assert!(out.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>"));
     }
 
     #[test]
     fn system_normalization_flag_is_selected_per_template() {
         let f = formatter_for_templates(PERMISSIVE_TMPL, STRICT_LEADING_TMPL);
-        assert!(!f.default_requires_system_normalization);
-        assert!(f.tool_use_requires_system_normalization);
+        assert!(!f.default_system_normalization.is_required());
+        assert!(f.tool_use_system_normalization.is_required());
 
         let no_tools = render_shape(&f, claude_shape()).unwrap();
         assert!(no_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
         let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
         assert_eq!(with_tools.matches("<|im_start|>system").count(), 1);
-        assert!(
-            with_tools.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>")
-        );
+        assert!(with_tools.contains("<|im_start|>user\nmid-conversation reminder<|im_end|>"));
 
         let f = formatter_for_templates(STRICT_LEADING_TMPL, PERMISSIVE_TMPL);
-        assert!(f.default_requires_system_normalization);
-        assert!(!f.tool_use_requires_system_normalization);
+        assert!(f.default_system_normalization.is_required());
+        assert!(!f.tool_use_system_normalization.is_required());
         let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
         assert!(with_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
     }
@@ -828,24 +892,22 @@ mod tests {
     #[test]
     fn system_normalization_probe_uses_runtime_tools_shape() {
         let f = formatter_for_templates(DEFAULT_NONE_GATED_TMPL, TOOL_NONEMPTY_GATED_TMPL);
-        assert!(!f.default_requires_system_normalization);
-        assert!(f.tool_use_requires_system_normalization);
+        assert!(!f.default_system_normalization.is_required());
+        assert!(f.tool_use_system_normalization.is_required());
 
         let no_tools = render_shape(&f, claude_shape()).unwrap();
         assert!(no_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
 
         let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
         assert_eq!(with_tools.matches("<|im_start|>system").count(), 1);
-        assert!(
-            with_tools.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>")
-        );
+        assert!(with_tools.contains("<|im_start|>user\nmid-conversation reminder<|im_end|>"));
     }
 
     #[test]
     fn system_normalization_precedes_required_content_array_conversion() {
         let f = formatter_for(STRICT_ARRAY_TMPL);
         assert!(f.requires_content_arrays);
-        assert!(f.default_requires_system_normalization);
+        assert!(f.default_system_normalization.demote_nonleading_system);
 
         let out = render_shape(
             &f,
@@ -872,7 +934,7 @@ mod tests {
             },
             {"role": "system", "content": "remember"},
         ]);
-        normalize_system_messages(&mut m);
+        normalize_system_messages(&mut m, all_restrictions());
         assert_eq!(
             m,
             json!([{
@@ -887,6 +949,31 @@ mod tests {
         );
     }
 
+    /// The mirror of the case above: the parts belong to the turn being merged
+    /// away, not the one being merged into.
+    #[test]
+    fn coalesce_preserves_multimodal_content_of_the_merged_turn() {
+        let mut m = json!([
+            {"role": "user", "content": "look"},
+            {"role": "user", "content": [
+                {"type": "text", "text": "at this"},
+                {"type": "image_url", "image_url": {"url": "http://img"}},
+            ]},
+        ]);
+        normalize_system_messages(&mut m, all_restrictions());
+        assert_eq!(
+            m,
+            json!([{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "text", "text": "at this"},
+                    {"type": "image_url", "image_url": {"url": "http://img"}},
+                ],
+            }])
+        );
+    }
+
     #[test]
     fn normalize_merges_leading_run_and_coalesces() {
         let mut m = json!([
@@ -895,7 +982,7 @@ mod tests {
             {"role": "user", "content": "hi"},
             {"role": "system", "content": "reminder"},
         ]);
-        normalize_system_messages(&mut m);
+        normalize_system_messages(&mut m, all_restrictions());
         assert_eq!(
             m,
             json!([
@@ -905,15 +992,61 @@ mod tests {
         );
     }
 
+    /// Each restriction drives only its own rewrite, so a template is never
+    /// reshaped for a rule it does not enforce.
     #[test]
-    fn normalize_flattens_array_system_content() {
+    fn each_restriction_applies_only_its_own_rewrite() {
+        let shape = json!([
+            {"role": "system", "content": "A"},
+            {"role": "system", "content": "B"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "reminder"},
+        ]);
+
+        let mut demote_only = shape.clone();
+        normalize_system_messages(
+            &mut demote_only,
+            SystemNormalization {
+                demote_nonleading_system: true,
+                coalesce_consecutive_users: false,
+            },
+        );
+        assert_eq!(
+            demote_only,
+            json!([
+                {"role": "system", "content": "A\n\nB"},
+                {"role": "user", "content": "hi"},
+                {"role": "user", "content": "reminder"},
+            ])
+        );
+
+        let mut coalesce_only = shape.clone();
+        normalize_system_messages(
+            &mut coalesce_only,
+            SystemNormalization {
+                demote_nonleading_system: false,
+                coalesce_consecutive_users: true,
+            },
+        );
+        assert_eq!(coalesce_only, shape);
+    }
+
+    #[test]
+    fn normalize_preserves_array_system_content() {
         let mut m = json!([
             {"role": "user", "content": "hi"},
             {"role": "system", "content": [{"type": "text", "text": "one"},
                                            {"type": "text", "text": "two"}]},
         ]);
-        normalize_system_messages(&mut m);
-        assert_eq!(m, json!([{"role": "user", "content": "hi\n\none\ntwo"}]));
+        normalize_system_messages(&mut m, all_restrictions());
+        assert_eq!(
+            m,
+            json!([{"role": "user", "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "text", "text": "one"},
+                {"type": "text", "text": "two"},
+            ]}])
+        );
     }
 
     /// Renders every agent-client shape through every template in a corpus of
@@ -966,6 +1099,8 @@ mod tests {
 
         let mut total = 0usize;
         let mut flagged = 0usize;
+        let mut demote_only = 0usize;
+        let mut coalesce = 0usize;
         let mut failures: Vec<String> = Vec::new();
         for (file, meta) in manifest.as_object().unwrap() {
             let tmpl = std::fs::read_to_string(format!("{dir}/{file}.jinja")).unwrap();
@@ -986,19 +1121,32 @@ mod tests {
                 continue;
             }
             total += 1;
-            let flag = f.default_requires_system_normalization;
+            let rules = f.default_system_normalization;
+            let flag = rules.is_required();
             if flag {
                 flagged += 1;
+            }
+            if rules.demote_nonleading_system {
+                demote_only += usize::from(!rules.coalesce_consecutive_users);
+            }
+            if rules.coalesce_consecutive_users {
+                coalesce += 1;
             }
             for (name, shape) in &shapes {
                 if render_shape(&f, shape.clone()).is_err() {
                     failures.push(format!("{model} | shape={name} | flag={flag}"));
                 }
             }
-            eprintln!("[ok] flag={flag} {model}");
+            if flag {
+                eprintln!(
+                    "[ok] demote={} coalesce={} {model}",
+                    rules.demote_nonleading_system, rules.coalesce_consecutive_users
+                );
+            }
         }
         eprintln!(
-            "\naudited {total} templates ({flagged} flagged for normalization); {} shape failures",
+            "\naudited {total} templates ({flagged} flagged: {demote_only} demote-only, \
+             {coalesce} coalescing); {} shape failures",
             failures.len()
         );
         for f in &failures {

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -433,9 +433,8 @@ impl OAIChatLikeRequest for dynamo_protocols::types::CreateChatCompletionRequest
     }
 }
 
-/// Text of a message `content`: a string verbatim, or the `text` parts of a
-/// content array joined with `\n`. Used when normalizing system messages, whose
-/// content agent clients send as either shape.
+/// Flattens to text either way, since agent clients send system content as both
+/// a bare string and a content array.
 fn message_content_text(content: &serde_json::Value) -> String {
     match content {
         serde_json::Value::String(s) => s.clone(),
@@ -448,14 +447,8 @@ fn message_content_text(content: &serde_json::Value) -> String {
     }
 }
 
-/// Normalize system messages so a strict chat template accepts an agent-client
-/// stream. Called from `render` only when the template was flagged at load time
-/// (`requires_system_normalization`). Three steps: merge a leading run of
-/// system messages into one; demote any remaining, non-leading system message
-/// to `user` in place (kept in place rather than folded to the front so a
-/// toggling mid-conversation reminder doesn't invalidate the whole KV prefix);
-/// coalesce the consecutive user turns this can produce so alternation-enforcing
-/// templates (Gemma, Mistral) still render.
+/// Rewrites an agent-client message stream into a shape strict chat templates
+/// accept. Only called for templates flagged by the load-time probe.
 fn normalize_system_messages(messages: &mut serde_json::Value) {
     let serde_json::Value::Array(list) = messages else {
         return;
@@ -466,7 +459,7 @@ fn normalize_system_messages(messages: &mut serde_json::Value) {
         message_content_text(m.get("content").unwrap_or(&serde_json::Value::Null))
     };
 
-    // 1. Merge a leading run of system messages into one.
+    // Strict templates permit at most one system message, at index 0.
     let leading = list.iter().take_while(|m| role_is(m, "system")).count();
     if leading > 1 {
         let combined = list[..leading]
@@ -480,7 +473,8 @@ fn normalize_system_messages(messages: &mut serde_json::Value) {
         );
     }
 
-    // 2. Demote any remaining, non-leading system message to `user` in place.
+    // Demoted in place, not folded to the front: a mid-conversation reminder
+    // that toggles would otherwise invalidate the whole KV prefix each turn.
     let leading = list.iter().take_while(|m| role_is(m, "system")).count();
     for m in list.iter_mut().skip(leading) {
         if role_is(m, "system") {
@@ -488,7 +482,8 @@ fn normalize_system_messages(messages: &mut serde_json::Value) {
         }
     }
 
-    // 3. Coalesce consecutive user turns into one.
+    // Demotion can leave two user turns adjacent, which alternation-enforcing
+    // templates (Gemma, Mistral) reject.
     let mut coalesced: Vec<serde_json::Value> = Vec::with_capacity(list.len());
     for m in list.drain(..) {
         if role_is(&m, "user") && coalesced.last().is_some_and(|p| role_is(p, "user")) {
@@ -543,9 +538,6 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         ))
         .unwrap();
 
-        // Normalize system messages for templates that reject agent-client
-        // streams (detected once at load time). No-op for the ~76% of templates
-        // that accept a non-leading system, so their output is unchanged.
         if self.requires_system_normalization {
             normalize_system_messages(&mut messages_for_template);
         }
@@ -633,8 +625,7 @@ mod tests {
     };
 
     fn formatter_for(template: &str) -> SysFormatter {
-        // Supply dummy special tokens so real templates that reference
-        // bos/eos/unk (e.g. Zephyr's `content + eos_token`) render in tests.
+        // Dummy tokens: real templates that append eos/bos won't render without them.
         let ct: SysChatTemplate = serde_json::from_value(json!({
             "chat_template": template,
             "bos_token": "<s>",
@@ -701,7 +692,6 @@ mod tests {
     fn permissive_template_is_not_flagged_and_renders_untouched() {
         let f = formatter_for(PERMISSIVE_TMPL);
         assert!(!f.requires_system_normalization);
-        // The mid system survives verbatim as a `system` turn (no rewrite).
         let out = render_shape(&f, claude_shape()).unwrap();
         assert!(out.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
     }
@@ -710,10 +700,9 @@ mod tests {
     fn strict_leading_template_is_flagged_and_demotes_mid_system() {
         let f = formatter_for(STRICT_LEADING_TMPL);
         assert!(f.requires_system_normalization);
-        // Was a 500 before; now renders, mid system demoted to a user turn.
+        // This shape returned a 500 before the probe existed.
         let out = render_shape(&f, claude_shape()).unwrap();
         assert!(out.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>"));
-        // Exactly one leading system turn survives.
         assert_eq!(out.matches("<|im_start|>system").count(), 1);
     }
 
@@ -755,21 +744,14 @@ mod tests {
         assert_eq!(m, json!([{"role": "user", "content": "hi\n\none\ntwo"}]));
     }
 
-    /// Sufficiency + correctness audit of the shipped probe + normalization
-    /// against a large corpus of REAL model chat templates. Point
-    /// TEMPLATE_CORPUS at a dir of `<name>.jinja` files + `manifest.json`
-    /// mapping each to `{model}` (see experiments/system-probe).
+    /// Renders every agent-client shape through every template in a corpus of
+    /// real models. A failure means the probe missed a strict template, or the
+    /// normalization it triggered was not enough to satisfy one.
     ///
-    /// For every template and every realistic agent-client message shape, it
-    /// calls the *shipped* `render()` (which runs the load-time probe and, only
-    /// when flagged, the normalization) and requires a successful render. A
-    /// failure means one of two real defects: flag=false but a raw agent shape
-    /// raises (probe FALSE NEGATIVE), or flag=true but a normalized shape raises
-    /// (normalization INSUFFICIENT). Either way the audit prints the offending
-    /// (model, shape, flag) and fails.
-    ///
-    /// TEMPLATE_CORPUS=.../experiments/system-probe/templates_big
-    ///   cargo test -p dynamo-renderer adaptive_system_corpus_audit -- --ignored --nocapture
+    /// TEMPLATE_CORPUS points at a dir of `<name>.jinja` files + `manifest.json`
+    /// mapping each to `{model}` (see experiments/system-probe):
+    ///   TEMPLATE_CORPUS=... cargo test -p dynamo-renderer \
+    ///     adaptive_system_corpus_audit -- --ignored --nocapture
     #[test]
     #[ignore]
     fn adaptive_system_corpus_audit() {
@@ -779,10 +761,8 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(format!("{dir}/manifest.json")).unwrap())
                 .unwrap();
 
-        // Realistic agent-client shapes (Claude Code / Codex): non-leading
-        // system in various positions, a toggling tail reminder, consecutive
-        // users, and double-leading systems. Tool-call shapes are covered by
-        // the hermetic tests (they need a matching `tools` payload per family).
+        // Tool-call shapes are omitted: they need a per-family `tools` payload,
+        // and the hermetic tests already cover them.
         let sys = |c: &str| json!({"role": "system", "content": c});
         let usr = |c: &str| json!({"role": "user", "content": c});
         let asst = |c: &str| json!({"role": "assistant", "content": c});
@@ -818,9 +798,8 @@ mod tests {
         for (file, meta) in manifest.as_object().unwrap() {
             let tmpl = std::fs::read_to_string(format!("{dir}/{file}.jinja")).unwrap();
             let model = meta["model"].as_str().unwrap_or(file);
-            // A few templates in the wild don't compile under minijinja for
-            // reasons unrelated to this change (custom tags, etc.); skip those
-            // so the audit measures system-normalization sufficiency only.
+            // Some real templates use custom tags minijinja can't compile,
+            // which says nothing about system normalization.
             let f = match try_formatter_for(&tmpl) {
                 Some(f) => f,
                 None => {
@@ -828,11 +807,8 @@ mod tests {
                     continue;
                 }
             };
-            // Templates that can't render a plain `[system, user]` baseline in
-            // this text-only harness (e.g. vision models needing image inputs)
-            // are out of scope: the probe's baseline guard leaves them
-            // unflagged, and their render failure is unrelated to system
-            // normalization. Skip so the audit measures normalization only.
+            // Vision templates need image inputs, so they can't render text-only
+            // here. The probe's baseline guard leaves them unflagged anyway.
             if render_shape(&f, json!([sys("s"), usr("u")])).is_err() {
                 eprintln!("[skip-baseline] {model}");
                 continue;

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -5,6 +5,7 @@ use super::*;
 
 use crate::{OAIChatLikeRequest, TextInput};
 use minijinja::{context, value::Value};
+use serde_json::json;
 use std::result::Result::Ok;
 
 /// Fix a tool schema that is missing `type`/`properties`. `pub` so consumers
@@ -432,6 +433,76 @@ impl OAIChatLikeRequest for dynamo_protocols::types::CreateChatCompletionRequest
     }
 }
 
+/// Text of a message `content`: a string verbatim, or the `text` parts of a
+/// content array joined with `\n`. Used when normalizing system messages, whose
+/// content agent clients send as either shape.
+fn message_content_text(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(parts) => parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+/// Normalize system messages so a strict chat template accepts an agent-client
+/// stream. Called from `render` only when the template was flagged at load time
+/// (`requires_system_normalization`). Three steps: merge a leading run of
+/// system messages into one; demote any remaining, non-leading system message
+/// to `user` in place (kept in place rather than folded to the front so a
+/// toggling mid-conversation reminder doesn't invalidate the whole KV prefix);
+/// coalesce the consecutive user turns this can produce so alternation-enforcing
+/// templates (Gemma, Mistral) still render.
+fn normalize_system_messages(messages: &mut serde_json::Value) {
+    let serde_json::Value::Array(list) = messages else {
+        return;
+    };
+    let role_is =
+        |m: &serde_json::Value, r: &str| m.get("role").and_then(|v| v.as_str()) == Some(r);
+    let content_of = |m: &serde_json::Value| {
+        message_content_text(m.get("content").unwrap_or(&serde_json::Value::Null))
+    };
+
+    // 1. Merge a leading run of system messages into one.
+    let leading = list.iter().take_while(|m| role_is(m, "system")).count();
+    if leading > 1 {
+        let combined = list[..leading]
+            .iter()
+            .map(content_of)
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        list.splice(
+            0..leading,
+            std::iter::once(json!({"role": "system", "content": combined})),
+        );
+    }
+
+    // 2. Demote any remaining, non-leading system message to `user` in place.
+    let leading = list.iter().take_while(|m| role_is(m, "system")).count();
+    for m in list.iter_mut().skip(leading) {
+        if role_is(m, "system") {
+            *m = json!({"role": "user", "content": content_of(m)});
+        }
+    }
+
+    // 3. Coalesce consecutive user turns into one.
+    let mut coalesced: Vec<serde_json::Value> = Vec::with_capacity(list.len());
+    for m in list.drain(..) {
+        if role_is(&m, "user") && coalesced.last().is_some_and(|p| role_is(p, "user")) {
+            let cur_text = content_of(&m);
+            let prev = coalesced.last_mut().unwrap();
+            let merged = format!("{}\n\n{}", content_of(prev), cur_text);
+            *prev = json!({"role": "user", "content": merged});
+        } else {
+            coalesced.push(m);
+        }
+    }
+    *list = coalesced;
+}
+
 impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
     fn supports_add_generation_prompt(&self) -> bool {
         self.supports_add_generation_prompt
@@ -471,6 +542,13 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
             self.image_placeholder_template,
         ))
         .unwrap();
+
+        // Normalize system messages for templates that reject agent-client
+        // streams (detected once at load time). No-op for the ~76% of templates
+        // that accept a non-leading system, so their output is unchanged.
+        if self.requires_system_normalization {
+            normalize_system_messages(&mut messages_for_template);
+        }
 
         // Pick the concrete template first so the normalization opt-out can be
         // template- and field-specific: only the chosen template's
@@ -546,6 +624,244 @@ mod tests {
     // default `OAIChatLikeRequest` impl above; Dynamo's `Nv*` wrapper lives in lib/llm.
     use dynamo_protocols::types::CreateChatCompletionRequest as NvCreateChatCompletionRequest;
     use minijinja::{Environment, context};
+
+    // --- adaptive system-message normalization (#11762) --------------------
+
+    use super::super::tokcfg::ChatTemplate as SysChatTemplate;
+    use super::super::{
+        ContextMixins as SysMixins, HfTokenizerConfigJsonFormatter as SysFormatter,
+    };
+
+    fn formatter_for(template: &str) -> SysFormatter {
+        // Supply dummy special tokens so real templates that reference
+        // bos/eos/unk (e.g. Zephyr's `content + eos_token`) render in tests.
+        let ct: SysChatTemplate = serde_json::from_value(json!({
+            "chat_template": template,
+            "bos_token": "<s>",
+            "eos_token": "</s>",
+            "unk_token": "<unk>",
+        }))
+        .unwrap();
+        SysFormatter::new(ct, SysMixins::new(&[])).unwrap()
+    }
+
+    fn try_formatter_for(template: &str) -> Option<SysFormatter> {
+        let ct: SysChatTemplate = serde_json::from_value(json!({
+            "chat_template": template,
+            "bos_token": "<s>",
+            "eos_token": "</s>",
+            "unk_token": "<unk>",
+        }))
+        .ok()?;
+        SysFormatter::new(ct, SysMixins::new(&[])).ok()
+    }
+
+    fn render_shape(f: &SysFormatter, messages: serde_json::Value) -> Result<String> {
+        let req: NvCreateChatCompletionRequest =
+            serde_json::from_value(json!({ "model": "test", "messages": messages })).unwrap();
+        f.render(&req)
+    }
+
+    const PERMISSIVE_TMPL: &str = concat!(
+        "{%- for m in messages -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- endfor -%}"
+    );
+    // Rejects a non-leading system (Qwen3.5 shape); accepts consecutive users.
+    const STRICT_LEADING_TMPL: &str = concat!(
+        "{%- for m in messages -%}",
+        "{%- if m.role == 'system' and not loop.first -%}",
+        "{{ raise_exception('System message must be at the beginning.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- endfor -%}"
+    );
+    // Rejects consecutive user turns (Gemma/Mistral shape).
+    const ALTERNATION_TMPL: &str = concat!(
+        "{%- set ns = namespace(prev='') -%}",
+        "{%- for m in messages -%}",
+        "{%- if m.role == 'user' and ns.prev == 'user' -%}",
+        "{{ raise_exception('Conversation roles must alternate.') }}",
+        "{%- endif -%}",
+        "<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n",
+        "{%- set ns.prev = m.role -%}",
+        "{%- endfor -%}"
+    );
+
+    // Claude Code first-turn shape: top-level system + a mid-array system.
+    fn claude_shape() -> serde_json::Value {
+        json!([
+            {"role": "system", "content": "You are Claude Code."},
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "mid-conversation reminder"},
+        ])
+    }
+
+    #[test]
+    fn permissive_template_is_not_flagged_and_renders_untouched() {
+        let f = formatter_for(PERMISSIVE_TMPL);
+        assert!(!f.requires_system_normalization);
+        // The mid system survives verbatim as a `system` turn (no rewrite).
+        let out = render_shape(&f, claude_shape()).unwrap();
+        assert!(out.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+    }
+
+    #[test]
+    fn strict_leading_template_is_flagged_and_demotes_mid_system() {
+        let f = formatter_for(STRICT_LEADING_TMPL);
+        assert!(f.requires_system_normalization);
+        // Was a 500 before; now renders, mid system demoted to a user turn.
+        let out = render_shape(&f, claude_shape()).unwrap();
+        assert!(out.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>"));
+        // Exactly one leading system turn survives.
+        assert_eq!(out.matches("<|im_start|>system").count(), 1);
+    }
+
+    #[test]
+    fn alternation_template_is_flagged_and_coalesces_users() {
+        let f = formatter_for(ALTERNATION_TMPL);
+        assert!(f.requires_system_normalization);
+        // Demotion would create [user, user]; coalescing keeps it valid.
+        let out = render_shape(&f, claude_shape()).unwrap();
+        assert_eq!(out.matches("<|im_start|>user").count(), 1);
+    }
+
+    #[test]
+    fn normalize_merges_leading_run_and_coalesces() {
+        let mut m = json!([
+            {"role": "system", "content": "A"},
+            {"role": "system", "content": "B"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "reminder"},
+        ]);
+        normalize_system_messages(&mut m);
+        assert_eq!(
+            m,
+            json!([
+                {"role": "system", "content": "A\n\nB"},
+                {"role": "user", "content": "hi\n\nreminder"},
+            ])
+        );
+    }
+
+    #[test]
+    fn normalize_flattens_array_system_content() {
+        let mut m = json!([
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": [{"type": "text", "text": "one"},
+                                           {"type": "text", "text": "two"}]},
+        ]);
+        normalize_system_messages(&mut m);
+        assert_eq!(m, json!([{"role": "user", "content": "hi\n\none\ntwo"}]));
+    }
+
+    /// Sufficiency + correctness audit of the shipped probe + normalization
+    /// against a large corpus of REAL model chat templates. Point
+    /// TEMPLATE_CORPUS at a dir of `<name>.jinja` files + `manifest.json`
+    /// mapping each to `{model}` (see experiments/system-probe).
+    ///
+    /// For every template and every realistic agent-client message shape, it
+    /// calls the *shipped* `render()` (which runs the load-time probe and, only
+    /// when flagged, the normalization) and requires a successful render. A
+    /// failure means one of two real defects: flag=false but a raw agent shape
+    /// raises (probe FALSE NEGATIVE), or flag=true but a normalized shape raises
+    /// (normalization INSUFFICIENT). Either way the audit prints the offending
+    /// (model, shape, flag) and fails.
+    ///
+    /// TEMPLATE_CORPUS=.../experiments/system-probe/templates_big
+    ///   cargo test -p dynamo-renderer adaptive_system_corpus_audit -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn adaptive_system_corpus_audit() {
+        let dir =
+            std::env::var("TEMPLATE_CORPUS").expect("set TEMPLATE_CORPUS to the templates dir");
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(format!("{dir}/manifest.json")).unwrap())
+                .unwrap();
+
+        // Realistic agent-client shapes (Claude Code / Codex): non-leading
+        // system in various positions, a toggling tail reminder, consecutive
+        // users, and double-leading systems. Tool-call shapes are covered by
+        // the hermetic tests (they need a matching `tools` payload per family).
+        let sys = |c: &str| json!({"role": "system", "content": c});
+        let usr = |c: &str| json!({"role": "user", "content": c});
+        let asst = |c: &str| json!({"role": "assistant", "content": c});
+        let shapes: Vec<(&str, serde_json::Value)> = vec![
+            ("turn1", json!([sys("s"), usr("u"), sys("mid")])),
+            (
+                "multiturn",
+                json!([sys("s"), usr("u"), sys("mid"), asst("a"), usr("u2")]),
+            ),
+            (
+                "mid_after_asst",
+                json!([sys("s"), usr("u"), asst("a"), sys("mid"), usr("u2")]),
+            ),
+            ("double_leading", json!([sys("s0"), sys("s1"), usr("u")])),
+            ("consec_user", json!([sys("s"), usr("u0"), usr("u1")])),
+            (
+                "tail_reminder",
+                json!([
+                    sys("s"),
+                    usr("u"),
+                    asst("a"),
+                    usr("u2"),
+                    sys("mid"),
+                    usr("u3")
+                ]),
+            ),
+            ("leading_only_baseline", json!([sys("s"), usr("u")])),
+        ];
+
+        let mut total = 0usize;
+        let mut flagged = 0usize;
+        let mut failures: Vec<String> = Vec::new();
+        for (file, meta) in manifest.as_object().unwrap() {
+            let tmpl = std::fs::read_to_string(format!("{dir}/{file}.jinja")).unwrap();
+            let model = meta["model"].as_str().unwrap_or(file);
+            // A few templates in the wild don't compile under minijinja for
+            // reasons unrelated to this change (custom tags, etc.); skip those
+            // so the audit measures system-normalization sufficiency only.
+            let f = match try_formatter_for(&tmpl) {
+                Some(f) => f,
+                None => {
+                    eprintln!("[skip-compile] {model}");
+                    continue;
+                }
+            };
+            // Templates that can't render a plain `[system, user]` baseline in
+            // this text-only harness (e.g. vision models needing image inputs)
+            // are out of scope: the probe's baseline guard leaves them
+            // unflagged, and their render failure is unrelated to system
+            // normalization. Skip so the audit measures normalization only.
+            if render_shape(&f, json!([sys("s"), usr("u")])).is_err() {
+                eprintln!("[skip-baseline] {model}");
+                continue;
+            }
+            total += 1;
+            let flag = f.requires_system_normalization;
+            if flag {
+                flagged += 1;
+            }
+            for (name, shape) in &shapes {
+                if render_shape(&f, shape.clone()).is_err() {
+                    failures.push(format!("{model} | shape={name} | flag={flag}"));
+                }
+            }
+            eprintln!("[ok] flag={flag} {model}");
+        }
+        eprintln!(
+            "\naudited {total} templates ({flagged} flagged for normalization); {} shape failures",
+            failures.len()
+        );
+        for f in &failures {
+            eprintln!("  FAIL {f}");
+        }
+        assert!(
+            failures.is_empty(),
+            "{} template/shape combinations did not render (probe insufficient or normalization insufficient)",
+            failures.len()
+        );
+    }
 
     /// End-to-end guard for the minijinja stack-overflow fix, exercised through
     /// Dynamo's real chat-template render path. A template that accumulates

--- a/renderer/src/template/oai.rs
+++ b/renderer/src/template/oai.rs
@@ -447,6 +447,31 @@ fn message_content_text(content: &serde_json::Value) -> String {
     }
 }
 
+fn append_message_content_text(message: &mut serde_json::Value, text: String) {
+    let Some(message) = message.as_object_mut() else {
+        return;
+    };
+    match message.get_mut("content") {
+        Some(serde_json::Value::String(content)) => {
+            if !content.is_empty() && !text.is_empty() {
+                content.push_str("\n\n");
+            }
+            content.push_str(&text);
+        }
+        Some(serde_json::Value::Array(parts)) => {
+            if !text.is_empty() {
+                parts.push(json!({"type": "text", "text": text}));
+            }
+        }
+        Some(content) => {
+            *content = serde_json::Value::String(text);
+        }
+        None => {
+            message.insert("content".to_string(), serde_json::Value::String(text));
+        }
+    }
+}
+
 /// Rewrites an agent-client message stream into a shape strict chat templates
 /// accept. Only called for templates flagged by the load-time probe.
 fn normalize_system_messages(messages: &mut serde_json::Value) {
@@ -489,8 +514,7 @@ fn normalize_system_messages(messages: &mut serde_json::Value) {
         if role_is(&m, "user") && coalesced.last().is_some_and(|p| role_is(p, "user")) {
             let cur_text = content_of(&m);
             let prev = coalesced.last_mut().unwrap();
-            let merged = format!("{}\n\n{}", content_of(prev), cur_text);
-            *prev = json!({"role": "user", "content": merged});
+            append_message_content_text(prev, cur_text);
         } else {
             coalesced.push(m);
         }
@@ -527,6 +551,29 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
             add_generation_prompt
         );
 
+        // Pick the concrete template before applying any template-specific
+        // message rewrites or field normalization.
+        let (
+            template_name,
+            template_handles_tool_calls_args_string,
+            template_handles_reasoning,
+            requires_system_normalization,
+        ) = if has_tools {
+            (
+                "tool_use",
+                self.tool_use_template_handles_tool_calls_arguments_string,
+                self.tool_use_template_handles_reasoning,
+                self.tool_use_requires_system_normalization,
+            )
+        } else {
+            (
+                "default",
+                self.default_template_handles_tool_calls_arguments_string,
+                self.default_template_handles_reasoning,
+                self.default_requires_system_normalization,
+            )
+        };
+
         let messages_canonical = req.messages();
         let mut messages_for_template: serde_json::Value =
             serde_json::to_value(&messages_canonical).unwrap();
@@ -538,30 +585,9 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         ))
         .unwrap();
 
-        if self.requires_system_normalization {
+        if requires_system_normalization {
             normalize_system_messages(&mut messages_for_template);
         }
-
-        // Pick the concrete template first so the normalization opt-out can be
-        // template- and field-specific: only the chosen template's
-        // `tool_call.arguments is string` flag should suppress normalization,
-        // and only for the `tool_calls[].function.arguments` field. Legacy
-        // `function_call.arguments` lives outside that branch and is always
-        // normalized.
-        let (template_name, template_handles_tool_calls_args_string, template_handles_reasoning) =
-            if has_tools {
-                (
-                    "tool_use",
-                    self.tool_use_template_handles_tool_calls_arguments_string,
-                    self.tool_use_template_handles_reasoning,
-                )
-            } else {
-                (
-                    "default",
-                    self.default_template_handles_tool_calls_arguments_string,
-                    self.default_template_handles_reasoning,
-                )
-            };
 
         // Pre-parse JSON-string `arguments` into objects — but only for templates
         // that unconditionally `| tojson` them. Templates that branch on
@@ -636,6 +662,20 @@ mod tests {
         SysFormatter::new(ct, SysMixins::new(&[])).unwrap()
     }
 
+    fn formatter_for_templates(default: &str, tool_use: &str) -> SysFormatter {
+        let ct: SysChatTemplate = serde_json::from_value(json!({
+            "chat_template": [
+                {"default": default},
+                {"tool_use": tool_use},
+            ],
+            "bos_token": "<s>",
+            "eos_token": "</s>",
+            "unk_token": "<unk>",
+        }))
+        .unwrap();
+        SysFormatter::new(ct, SysMixins::new(&[])).unwrap()
+    }
+
     fn try_formatter_for(template: &str) -> Option<SysFormatter> {
         let ct: SysChatTemplate = serde_json::from_value(json!({
             "chat_template": template,
@@ -650,6 +690,19 @@ mod tests {
     fn render_shape(f: &SysFormatter, messages: serde_json::Value) -> Result<String> {
         let req: NvCreateChatCompletionRequest =
             serde_json::from_value(json!({ "model": "test", "messages": messages })).unwrap();
+        f.render(&req)
+    }
+
+    fn render_shape_with_tools(f: &SysFormatter, messages: serde_json::Value) -> Result<String> {
+        let req: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test",
+            "messages": messages,
+            "tools": [{
+                "type": "function",
+                "function": {"name": "noop", "parameters": {}}
+            }]
+        }))
+        .unwrap();
         f.render(&req)
     }
 
@@ -691,7 +744,8 @@ mod tests {
     #[test]
     fn permissive_template_is_not_flagged_and_renders_untouched() {
         let f = formatter_for(PERMISSIVE_TMPL);
-        assert!(!f.requires_system_normalization);
+        assert!(!f.default_requires_system_normalization);
+        assert!(!f.tool_use_requires_system_normalization);
         let out = render_shape(&f, claude_shape()).unwrap();
         assert!(out.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
     }
@@ -699,7 +753,8 @@ mod tests {
     #[test]
     fn strict_leading_template_is_flagged_and_demotes_mid_system() {
         let f = formatter_for(STRICT_LEADING_TMPL);
-        assert!(f.requires_system_normalization);
+        assert!(f.default_requires_system_normalization);
+        assert!(f.tool_use_requires_system_normalization);
         // This shape returned a 500 before the probe existed.
         let out = render_shape(&f, claude_shape()).unwrap();
         assert!(out.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>"));
@@ -709,10 +764,60 @@ mod tests {
     #[test]
     fn alternation_template_is_flagged_and_coalesces_users() {
         let f = formatter_for(ALTERNATION_TMPL);
-        assert!(f.requires_system_normalization);
+        assert!(f.default_requires_system_normalization);
+        assert!(f.tool_use_requires_system_normalization);
         // Demotion would create [user, user]; coalescing keeps it valid.
         let out = render_shape(&f, claude_shape()).unwrap();
         assert_eq!(out.matches("<|im_start|>user").count(), 1);
+    }
+
+    #[test]
+    fn system_normalization_flag_is_selected_per_template() {
+        let f = formatter_for_templates(PERMISSIVE_TMPL, STRICT_LEADING_TMPL);
+        assert!(!f.default_requires_system_normalization);
+        assert!(f.tool_use_requires_system_normalization);
+
+        let no_tools = render_shape(&f, claude_shape()).unwrap();
+        assert!(no_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+        let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
+        assert_eq!(with_tools.matches("<|im_start|>system").count(), 1);
+        assert!(
+            with_tools.contains("<|im_start|>user\nhello\n\nmid-conversation reminder<|im_end|>")
+        );
+
+        let f = formatter_for_templates(STRICT_LEADING_TMPL, PERMISSIVE_TMPL);
+        assert!(f.default_requires_system_normalization);
+        assert!(!f.tool_use_requires_system_normalization);
+        let with_tools = render_shape_with_tools(&f, claude_shape()).unwrap();
+        assert!(with_tools.contains("<|im_start|>system\nmid-conversation reminder<|im_end|>"));
+    }
+
+    #[test]
+    fn normalize_preserves_multimodal_user_content_and_fields() {
+        let mut m = json!([
+            {
+                "role": "user",
+                "name": "kept",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image"},
+                ],
+            },
+            {"role": "system", "content": "remember"},
+        ]);
+        normalize_system_messages(&mut m);
+        assert_eq!(
+            m,
+            json!([{
+                "role": "user",
+                "name": "kept",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image"},
+                    {"type": "text", "text": "remember"},
+                ],
+            }])
+        );
     }
 
     #[test]
@@ -814,7 +919,7 @@ mod tests {
                 continue;
             }
             total += 1;
-            let flag = f.requires_system_normalization;
+            let flag = f.default_requires_system_normalization;
             if flag {
                 flagged += 1;
             }


### PR DESCRIPTION
#### Overview

Agent clients (Claude Code on `/v1/messages`, Codex on `/v1/responses`) send `role:"system"` turns mid-conversation. Strict chat templates reject a system message that is not first and raise, so the frontend returns HTTP 500 on every request. See ai-dynamo/dynamo#11762.

Rather than unconditionally rewriting messages for every model, this detects at model load time whether the template actually rejects these streams, and normalizes only when it does. Permissive templates, which are the large majority, render byte for byte as they do today.

Before: `System message must be at the beginning.` -> HTTP 500.
After: renders normally. Permissive models are unchanged.

#### Details

`formatters.rs`: `detect_requires_system_normalization` runs inside the formatter constructor, alongside the existing `detect_content_array_usage` and `detect_passthrough_template` probes. It renders three message shapes through the compiled template (non-leading system, consecutive users, and a system after an assistant turn) with the model's own bos/eos/unk supplied, and flags the template if any raise while a plain `[system, user]` baseline still renders. The result is cached as `requires_system_normalization` on the formatter.

`oai.rs`: in `render()`, gated on that flag, `normalize_system_messages` merges a leading run of system messages into one, demotes any non-leading system to `user` in place, then coalesces the consecutive user turns that can produce.

Two details worth calling out for review:

- The demotion is in place rather than folded to the front. Folding changes the leading block whenever a mid-conversation reminder toggles, which invalidates the whole prefix; keeping it in place only shifts a block deeper in. Measured over 100 x 20-turn conversations with a toggling reminder, folding cost about 2.5x more prefill recompute (KV hit 0.78 vs 0.91 overall, 0.47 vs 0.91 on toggle turns).
- The coalescing step is not cosmetic. Demoting alone produces two consecutive `user` turns, which alternation-enforcing templates (Gemma 3, Mistral, Llama-2) reject with `Conversation roles must alternate`, trading one 500 for another.

#### Where should the reviewer start?

`detect_requires_system_normalization` in `renderer/src/template/formatters.rs` (the probe and why those shapes), then `normalize_system_messages` in `renderer/src/template/oai.rs` (the three-step transform).

#### Validation

- `cargo test -p dynamo-renderer`: 109 passed. Five new hermetic tests cover permissive-untouched, strict-leading demotion, alternation coalescing, and the transform itself.
- Real-template audit (`adaptive_system_corpus_audit`, ignored by default): 126 chat templates pulled from popular served models, each rendered through the shipped probe across 7 agent-client message shapes. 11 templates flagged, 0 shape failures. Every unflagged template renders all shapes untouched (no probe false negatives) and every flagged template renders after normalization (normalization sufficient).
- Flagged families: Qwen3.5 and Qwen3.6-NVFP4 (reject a non-leading system), Gemma 3, Mistral 7B / Small / Nemo, and Ornith-1.0 (also reject consecutive users).
- End to end through Dynamo: loading Qwen3-0.6B with a strict template via `--custom-jinja-template` renders a mid-conversation-system request instead of returning 500, and the same request against the stock permissive template is unchanged.
- `cargo clippy --all-targets -D warnings` clean.

Two probe details were driven by the corpus rather than by design: no single "non-leading system" shape detects Gemma 3 (it accepts `[system, user, system]` but rejects `[system, user, assistant, system, user]`), and the probe must supply bos/eos or templates like Falcon3 and Zephyr false-flag on a missing-token raise.

The experiment scripts and the template corpus are not in this PR to keep it focused, and are available on request.

#### Related Issues

Addresses ai-dynamo/dynamo#11762. Generalizes the leading-system merge from ai-dynamo/dynamo#10283: that merge now happens here for strict templates, conditionally, and covers `/v1/messages`, `/v1/responses`, and `/v1/chat/completions` in one place.
