### PR TITLE
feat(protocols): preserve Codex agent messages

### DIFF
--- a/protocols/CLAUDE.md
+++ b/protocols/CLAUDE.md
@@ -72,7 +72,7 @@ CreateResponse
             └── ... upstream variants (FunctionCall, Reasoning, etc.)
 ```
 
-`Item` mirrors upstream variant-for-variant except for Codex's `agent_message` extension, which is represented losslessly as `Item::AgentMessage` and converted by the server-side Responses translation layer. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
+`Item` mirrors upstream variant-for-variant because it's a `#[serde(tag = "type")]` enum — we can't inherit variants. `InputItem` separately accepts Codex's `agent_message` extension and normalizes its plaintext content to the existing simplified user-message shape, rejecting encrypted content without adding a public enum variant or prompt metadata. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
 
 The output chain (`Response`, `OutputItem`, `OutputMessage`, streaming events, etc.) is fully upstream. We mint valid id/status on output, so there's no lenience needed and no reason to own it.
 

--- a/protocols/CLAUDE.md
+++ b/protocols/CLAUDE.md
@@ -72,7 +72,7 @@ CreateResponse
             └── ... upstream variants (FunctionCall, Reasoning, etc.)
 ```
 
-`Item` mirrors upstream variant-for-variant because it's a `#[serde(tag = "type")]` enum — we can't inherit variants. `InputItem` separately accepts Codex's `agent_message` extension and reuses the existing simplified user-message shape for its plaintext task, without injecting author or recipient metadata, avoiding a public enum variant in a patch release. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
+`Item` mirrors upstream variant-for-variant except for Codex's `agent_message` extension, which is represented losslessly as `Item::AgentMessage` and converted by the server-side Responses translation layer. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
 
 The output chain (`Response`, `OutputItem`, `OutputMessage`, streaming events, etc.) is fully upstream. We mint valid id/status on output, so there's no lenience needed and no reason to own it.
 

--- a/protocols/CLAUDE.md
+++ b/protocols/CLAUDE.md
@@ -69,10 +69,10 @@ CreateResponse
             │   └── Output(InputOutputMessage)  (NEW NAME — relaxed)
             │       └── content: Vec<InputOutputMessageContent>  (NEW NAME)
             │           └── OutputText(InputOutputTextContent)   (NEW NAME — relaxed)
-            └── ... 19 other upstream variants (FunctionCall, Reasoning, etc.)
+            └── ... upstream variants (FunctionCall, Reasoning, etc.)
 ```
 
-`Item` mirrors upstream variant-for-variant because it's a `#[serde(tag = "type")]` enum — we can't inherit variants. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
+`Item` mirrors upstream variant-for-variant because it's a `#[serde(tag = "type")]` enum — we can't inherit variants. `InputItem` separately accepts Codex's `agent_message` extension and reuses the existing simplified user-message shape for its plaintext task, without injecting author or recipient metadata, avoiding a public enum variant in a patch release. If upstream adds a new variant to their `Item`, we must add it here too, or payloads carrying that type will fail to deserialize. This is the one place where upstream drift bites us; accept it as the cost of owning the chain.
 
 The output chain (`Response`, `OutputItem`, `OutputMessage`, streaming events, etc.) is fully upstream. We mint valid id/status on output, so there's no lenience needed and no reason to own it.
 

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize, de};
+use serde::{Deserialize, Serialize};
 
 // Re-export all upstream response types (shared structures like ResponseUsage,
 // tool-call item types, streaming events, etc.). The types we own below
@@ -336,28 +336,25 @@ pub struct InputReasoningItem {
     pub status: Option<OutputStatus>,
 }
 
-/// Private Codex wire shape, normalized to an existing user message.
-#[derive(Deserialize)]
-struct AgentMessage {
-    #[serde(rename = "author")]
-    _author: String,
-    #[serde(rename = "recipient")]
-    _recipient: String,
-    content: Vec<AgentMessageInputContent>,
+/// Codex's agent-to-agent input item.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AgentMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub author: String,
+    pub recipient: String,
+    pub content: Vec<AgentMessageInputContent>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum AgentMessageInputContent {
+pub enum AgentMessageInputContent {
     InputText(InputTextContent),
-    EncryptedContent {
-        #[serde(rename = "encrypted_content")]
-        _encrypted_content: String,
-    },
+    EncryptedContent { encrypted_content: String },
 }
 
 /// Structured input/output item, discriminated by `type`. Mirrors upstream
-/// `Item` variant-for-variant; only `Message` and `Reasoning` use owned types.
+/// except for the Codex-only `AgentMessage` input extension.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Item {
@@ -386,10 +383,11 @@ pub enum Item {
     McpCall(MCPToolCall),
     CustomToolCallOutput(CustomToolCallOutput),
     CustomToolCall(CustomToolCall),
+    AgentMessage(AgentMessage),
 }
 
 /// Single input item. Untagged; order matters (most specific first).
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputItem {
     ItemReference(ItemReference),
@@ -397,104 +395,12 @@ pub enum InputItem {
     EasyMessage(EasyInputMessage),
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum InputItemWire {
-    ItemReference(ItemReference),
-    Item(Item),
-    EasyMessage(EasyInputMessage),
-}
-
-impl<'de> Deserialize<'de> for InputItem {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = serde_json::Value::deserialize(deserializer)?;
-        if matches!(
-            value.get("type").and_then(serde_json::Value::as_str),
-            Some("agent_message")
-        ) {
-            let message = AgentMessage::deserialize(value).map_err(de::Error::custom)?;
-            return normalize_agent_message(message).map_err(de::Error::custom);
-        }
-
-        match InputItemWire::deserialize(value).map_err(de::Error::custom)? {
-            InputItemWire::ItemReference(item) => Ok(Self::ItemReference(item)),
-            InputItemWire::Item(item) => Ok(Self::Item(item)),
-            InputItemWire::EasyMessage(message) => Ok(Self::EasyMessage(message)),
-        }
-    }
-}
-
-fn normalize_agent_message(message: AgentMessage) -> Result<InputItem, &'static str> {
-    let mut text = Vec::with_capacity(message.content.len());
-    for part in message.content {
-        match part {
-            AgentMessageInputContent::InputText(part) => text.push(part.text),
-            AgentMessageInputContent::EncryptedContent { .. } => {
-                return Err("Codex agent_message with encrypted content is unsupported");
-            }
-        }
-    }
-    Ok(InputItem::EasyMessage(EasyInputMessage {
-        r#type: MessageType::Message,
-        role: Role::User,
-        content: EasyInputContent::Text(text.join("\n")),
-        phase: None,
-    }))
-}
-
 /// Input to a `POST /v1/responses` request.
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputParam {
     Text(String),
     Items(Vec<InputItem>),
-}
-
-struct InputParamVisitor;
-
-impl<'de> de::Visitor<'de> for InputParamVisitor {
-    type Value = InputParam;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a string or an array of input items")
-    }
-
-    fn visit_str<E>(self, text: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(InputParam::Text(text.to_owned()))
-    }
-
-    fn visit_string<E>(self, text: String) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(InputParam::Text(text))
-    }
-
-    fn visit_seq<A>(self, mut items: A) -> Result<Self::Value, A::Error>
-    where
-        A: de::SeqAccess<'de>,
-    {
-        let mut input = Vec::with_capacity(items.size_hint().unwrap_or(0));
-        while let Some(item) = items.next_element()? {
-            input.push(item);
-        }
-        Ok(InputParam::Items(input))
-    }
-}
-
-impl<'de> Deserialize<'de> for InputParam {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_any(InputParamVisitor)
-    }
 }
 
 impl Default for InputParam {
@@ -696,96 +602,34 @@ mod tests {
     }
 
     #[test]
-    fn codex_agent_message_normalizes_to_user_message() {
-        let req: CreateResponse = serde_json::from_value(serde_json::json!({
-            "input": [{
-                "type": "agent_message",
-                "author": "/root",
-                "recipient": "/root/worker",
-                "content": [{"type": "input_text", "text": "Return exactly OK."}],
-            }],
-        }))
-        .expect("Codex agent message should deserialize");
+    fn codex_agent_message_round_trips_losslessly() {
+        let json = serde_json::json!({
+            "type": "agent_message",
+            "id": "agm_1",
+            "author": "/root",
+            "recipient": "/root/worker",
+            "content": [
+                {"type": "input_text", "text": "First."},
+                {"type": "encrypted_content", "encrypted_content": "AB=="},
+            ],
+        });
+        let item: InputItem =
+            serde_json::from_value(json.clone()).expect("Codex agent message should deserialize");
 
-        let InputParam::Items(items) = req.input else {
-            panic!("expected items");
+        let InputItem::Item(Item::AgentMessage(message)) = &item else {
+            panic!("expected Item::AgentMessage");
         };
-        let InputItem::EasyMessage(message) = &items[0] else {
-            panic!("expected normalized user message");
-        };
-        assert_eq!(message.role, Role::User);
-        assert!(
-            matches!(message.content, EasyInputContent::Text(ref text) if text == "Return exactly OK.")
-        );
-    }
-
-    #[test]
-    fn codex_agent_message_joins_plaintext_parts_with_newlines() {
-        let req: CreateResponse = serde_json::from_value(serde_json::json!({
-            "input": [{
-                "type": "agent_message",
-                "author": "/root",
-                "recipient": "/root/worker",
-                "content": [
-                    {"type": "input_text", "text": "First."},
-                    {"type": "input_text", "text": "Second."},
-                ],
-            }],
-        }))
-        .expect("Codex agent message should deserialize");
-
-        let InputParam::Items(items) = req.input else {
-            panic!("expected items");
-        };
+        assert_eq!(message.id.as_deref(), Some("agm_1"));
+        assert_eq!(message.author, "/root");
+        assert_eq!(message.recipient, "/root/worker");
         assert!(matches!(
-            &items[0],
-            InputItem::EasyMessage(EasyInputMessage {
-                content: EasyInputContent::Text(text),
-                ..
-            }) if text == "First.\nSecond."
+            message.content.as_slice(),
+            [
+                AgentMessageInputContent::InputText(first),
+                AgentMessageInputContent::EncryptedContent { encrypted_content },
+            ] if first.text == "First." && encrypted_content == "AB=="
         ));
-    }
-
-    #[test]
-    fn codex_agent_message_rejects_encrypted_content() {
-        let error = serde_json::from_value::<CreateResponse>(serde_json::json!({
-            "input": [{
-                "type": "agent_message",
-                "author": "/root",
-                "recipient": "/root/worker",
-                "content": [{"type": "encrypted_content", "encrypted_content": "AB=="}],
-            }],
-        }));
-        assert!(
-            error
-                .expect_err("encrypted agent messages must not be accepted")
-                .to_string()
-                .contains("encrypted content is unsupported")
-        );
-    }
-
-    #[test]
-    fn codex_agent_message_preserves_empty_text() {
-        let req: CreateResponse = serde_json::from_value(serde_json::json!({
-            "input": [{
-                "type": "agent_message",
-                "author": "/root",
-                "recipient": "/root/worker",
-                "content": [],
-            }],
-        }))
-        .expect("empty Codex agent message should deserialize");
-
-        let InputParam::Items(items) = req.input else {
-            panic!("expected items");
-        };
-        assert!(matches!(
-            &items[0],
-            InputItem::EasyMessage(EasyInputMessage {
-                content: EasyInputContent::Text(text),
-                ..
-            }) if text.is_empty()
-        ));
+        assert_eq!(serde_json::to_value(item).unwrap(), json);
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -343,6 +343,7 @@ pub struct AgentMessage {
     pub id: Option<String>,
     pub author: String,
     pub recipient: String,
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
     pub content: Vec<AgentMessageInputContent>,
 }
 
@@ -630,6 +631,22 @@ mod tests {
             ] if first.text == "First." && encrypted_content == "AB=="
         ));
         assert_eq!(serde_json::to_value(item).unwrap(), json);
+    }
+
+    #[test]
+    fn codex_agent_message_null_content_defaults_empty() {
+        let item: InputItem = serde_json::from_value(serde_json::json!({
+            "type": "agent_message",
+            "author": "/root",
+            "recipient": "/root/worker",
+            "content": null,
+        }))
+        .expect("Codex agent message with null content should deserialize");
+
+        let InputItem::Item(Item::AgentMessage(message)) = item else {
+            panic!("expected Item::AgentMessage");
+        };
+        assert!(message.content.is_empty());
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 
 // Re-export all upstream response types (shared structures like ResponseUsage,
 // tool-call item types, streaming events, etc.). The types we own below
@@ -336,26 +336,32 @@ pub struct InputReasoningItem {
     pub status: Option<OutputStatus>,
 }
 
-/// Codex's agent-to-agent input item.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct AgentMessage {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    pub author: String,
-    pub recipient: String,
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub content: Vec<AgentMessageInputContent>,
+/// Private Codex wire shape, normalized to an existing user message.
+#[derive(Deserialize)]
+struct CodexAgentMessage {
+    #[serde(default)]
+    content: Option<CodexAgentMessageContent>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CodexAgentMessageContent {
+    Text(String),
+    Parts(Vec<CodexAgentMessageInputContent>),
+}
+
+#[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum AgentMessageInputContent {
+enum CodexAgentMessageInputContent {
     InputText(InputTextContent),
-    EncryptedContent { encrypted_content: String },
+    EncryptedContent {
+        #[serde(rename = "encrypted_content")]
+        _encrypted_content: String,
+    },
 }
 
 /// Structured input/output item, discriminated by `type`. Mirrors upstream
-/// except for the Codex-only `AgentMessage` input extension.
+/// variant-for-variant; only `Message` and `Reasoning` use owned types.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Item {
@@ -384,11 +390,10 @@ pub enum Item {
     McpCall(MCPToolCall),
     CustomToolCallOutput(CustomToolCallOutput),
     CustomToolCall(CustomToolCall),
-    AgentMessage(AgentMessage),
 }
 
 /// Single input item. Untagged; order matters (most specific first).
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputItem {
     ItemReference(ItemReference),
@@ -396,12 +401,81 @@ pub enum InputItem {
     EasyMessage(EasyInputMessage),
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum InputItemWire {
+    ItemReference(ItemReference),
+    Item(Item),
+    EasyMessage(EasyInputMessage),
+}
+
+impl<'de> Deserialize<'de> for InputItem {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("type").and_then(serde_json::Value::as_str) == Some("agent_message") {
+            let message = CodexAgentMessage::deserialize(value).map_err(de::Error::custom)?;
+            return normalize_codex_agent_message(message).map_err(de::Error::custom);
+        }
+
+        match InputItemWire::deserialize(value).map_err(de::Error::custom)? {
+            InputItemWire::ItemReference(item) => Ok(Self::ItemReference(item)),
+            InputItemWire::Item(item) => Ok(Self::Item(item)),
+            InputItemWire::EasyMessage(message) => Ok(Self::EasyMessage(message)),
+        }
+    }
+}
+
+fn normalize_codex_agent_message(message: CodexAgentMessage) -> Result<InputItem, &'static str> {
+    let content = match message.content {
+        None => String::new(),
+        Some(CodexAgentMessageContent::Text(text)) => text,
+        Some(CodexAgentMessageContent::Parts(parts)) => parts
+            .into_iter()
+            .map(|part| match part {
+                CodexAgentMessageInputContent::InputText(part) => Ok(part.text),
+                CodexAgentMessageInputContent::EncryptedContent { .. } => {
+                    Err("Codex agent_message with encrypted content is unsupported")
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .join("\n"),
+    };
+    Ok(InputItem::EasyMessage(EasyInputMessage {
+        r#type: MessageType::Message,
+        role: Role::User,
+        content: EasyInputContent::Text(content),
+        phase: None,
+    }))
+}
+
 /// Input to a `POST /v1/responses` request.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputParam {
     Text(String),
     Items(Vec<InputItem>),
+}
+
+impl<'de> Deserialize<'de> for InputParam {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match serde_json::Value::deserialize(deserializer)? {
+            serde_json::Value::String(text) => Ok(Self::Text(text)),
+            serde_json::Value::Array(items) => {
+                serde_json::from_value(serde_json::Value::Array(items))
+                    .map(Self::Items)
+                    .map_err(de::Error::custom)
+            }
+            _ => Err(de::Error::custom(
+                "input must be a string or an array of input items",
+            )),
+        }
+    }
 }
 
 impl Default for InputParam {
@@ -603,38 +677,87 @@ mod tests {
     }
 
     #[test]
-    fn codex_agent_message_round_trips_losslessly() {
-        let json = serde_json::json!({
-            "type": "agent_message",
-            "id": "agm_1",
-            "author": "/root",
-            "recipient": "/root/worker",
-            "content": [
-                {"type": "input_text", "text": "First."},
-                {"type": "encrypted_content", "encrypted_content": "AB=="},
-            ],
-        });
-        let item: InputItem =
-            serde_json::from_value(json.clone()).expect("Codex agent message should deserialize");
+    fn codex_agent_message_normalizes_to_user_message() {
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "author": "/root",
+                "recipient": "/root/worker",
+                "content": [
+                    {"type": "input_text", "text": "First."},
+                    {"type": "input_text", "text": "Second."},
+                ],
+            }],
+        }))
+        .expect("Codex agent message should deserialize");
 
-        let InputItem::Item(Item::AgentMessage(message)) = &item else {
-            panic!("expected Item::AgentMessage");
+        let InputParam::Items(items) = req.input else {
+            panic!("expected items");
         };
-        assert_eq!(message.id.as_deref(), Some("agm_1"));
-        assert_eq!(message.author, "/root");
-        assert_eq!(message.recipient, "/root/worker");
         assert!(matches!(
-            message.content.as_slice(),
-            [
-                AgentMessageInputContent::InputText(first),
-                AgentMessageInputContent::EncryptedContent { encrypted_content },
-            ] if first.text == "First." && encrypted_content == "AB=="
+            &items[0],
+            InputItem::EasyMessage(EasyInputMessage {
+                role: Role::User,
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text == "First.\nSecond."
         ));
-        assert_eq!(serde_json::to_value(item).unwrap(), json);
     }
 
     #[test]
-    fn codex_agent_message_null_content_defaults_empty() {
+    fn codex_agent_message_string_content_normalizes_to_user_message() {
+        let item: InputItem = serde_json::from_value(serde_json::json!({
+            "type": "agent_message",
+            "author": "/root",
+            "recipient": "/root/worker",
+            "content": "Return exactly OK.",
+        }))
+        .expect("Codex agent message with string content should deserialize");
+
+        assert!(matches!(
+            item,
+            InputItem::EasyMessage(EasyInputMessage {
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text == "Return exactly OK."
+        ));
+    }
+
+    #[test]
+    fn codex_agent_message_rejects_encrypted_content() {
+        let error = serde_json::from_value::<CreateResponse>(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "content": [{"type": "encrypted_content", "encrypted_content": "AB=="}],
+            }],
+        }))
+        .expect_err("encrypted agent messages must not be accepted");
+        assert!(
+            error
+                .to_string()
+                .contains("encrypted content is unsupported")
+        );
+    }
+
+    #[test]
+    fn codex_agent_message_missing_content_normalizes_empty() {
+        let item: InputItem = serde_json::from_value(serde_json::json!({
+            "type": "agent_message",
+            "author": "/root",
+            "recipient": "/root/worker",
+        }))
+        .expect("Codex agent message without content should deserialize");
+        assert!(matches!(
+            item,
+            InputItem::EasyMessage(EasyInputMessage {
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text.is_empty()
+        ));
+    }
+
+    #[test]
+    fn codex_agent_message_null_content_normalizes_empty() {
         let item: InputItem = serde_json::from_value(serde_json::json!({
             "type": "agent_message",
             "author": "/root",
@@ -642,26 +765,13 @@ mod tests {
             "content": null,
         }))
         .expect("Codex agent message with null content should deserialize");
-
-        let InputItem::Item(Item::AgentMessage(message)) = item else {
-            panic!("expected Item::AgentMessage");
-        };
-        assert!(message.content.is_empty());
-    }
-
-    #[test]
-    fn codex_agent_message_missing_content_defaults_empty() {
-        let item: InputItem = serde_json::from_value(serde_json::json!({
-            "type": "agent_message",
-            "author": "/root",
-            "recipient": "/root/worker",
-        }))
-        .expect("Codex agent message without content should deserialize");
-
-        let InputItem::Item(Item::AgentMessage(message)) = item else {
-            panic!("expected Item::AgentMessage");
-        };
-        assert!(message.content.is_empty());
+        assert!(matches!(
+            item,
+            InputItem::EasyMessage(EasyInputMessage {
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text.is_empty()
+        ));
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 
 // Re-export all upstream response types (shared structures like ResponseUsage,
 // tool-call item types, streaming events, etc.). The types we own below
@@ -336,6 +336,26 @@ pub struct InputReasoningItem {
     pub status: Option<OutputStatus>,
 }
 
+/// Private Codex wire shape, normalized to an existing user message.
+#[derive(Deserialize)]
+struct AgentMessage {
+    #[serde(rename = "author")]
+    _author: String,
+    #[serde(rename = "recipient")]
+    _recipient: String,
+    content: Vec<AgentMessageInputContent>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AgentMessageInputContent {
+    InputText(InputTextContent),
+    EncryptedContent {
+        #[serde(rename = "encrypted_content")]
+        _encrypted_content: String,
+    },
+}
+
 /// Structured input/output item, discriminated by `type`. Mirrors upstream
 /// `Item` variant-for-variant; only `Message` and `Reasoning` use owned types.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -369,7 +389,7 @@ pub enum Item {
 }
 
 /// Single input item. Untagged; order matters (most specific first).
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputItem {
     ItemReference(ItemReference),
@@ -377,12 +397,104 @@ pub enum InputItem {
     EasyMessage(EasyInputMessage),
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum InputItemWire {
+    ItemReference(ItemReference),
+    Item(Item),
+    EasyMessage(EasyInputMessage),
+}
+
+impl<'de> Deserialize<'de> for InputItem {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if matches!(
+            value.get("type").and_then(serde_json::Value::as_str),
+            Some("agent_message")
+        ) {
+            let message = AgentMessage::deserialize(value).map_err(de::Error::custom)?;
+            return normalize_agent_message(message).map_err(de::Error::custom);
+        }
+
+        match InputItemWire::deserialize(value).map_err(de::Error::custom)? {
+            InputItemWire::ItemReference(item) => Ok(Self::ItemReference(item)),
+            InputItemWire::Item(item) => Ok(Self::Item(item)),
+            InputItemWire::EasyMessage(message) => Ok(Self::EasyMessage(message)),
+        }
+    }
+}
+
+fn normalize_agent_message(message: AgentMessage) -> Result<InputItem, &'static str> {
+    let mut text = Vec::with_capacity(message.content.len());
+    for part in message.content {
+        match part {
+            AgentMessageInputContent::InputText(part) => text.push(part.text),
+            AgentMessageInputContent::EncryptedContent { .. } => {
+                return Err("Codex agent_message with encrypted content is unsupported");
+            }
+        }
+    }
+    Ok(InputItem::EasyMessage(EasyInputMessage {
+        r#type: MessageType::Message,
+        role: Role::User,
+        content: EasyInputContent::Text(text.join("\n")),
+        phase: None,
+    }))
+}
+
 /// Input to a `POST /v1/responses` request.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InputParam {
     Text(String),
     Items(Vec<InputItem>),
+}
+
+struct InputParamVisitor;
+
+impl<'de> de::Visitor<'de> for InputParamVisitor {
+    type Value = InputParam;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a string or an array of input items")
+    }
+
+    fn visit_str<E>(self, text: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(InputParam::Text(text.to_owned()))
+    }
+
+    fn visit_string<E>(self, text: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(InputParam::Text(text))
+    }
+
+    fn visit_seq<A>(self, mut items: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut input = Vec::with_capacity(items.size_hint().unwrap_or(0));
+        while let Some(item) = items.next_element()? {
+            input.push(item);
+        }
+        Ok(InputParam::Items(input))
+    }
+}
+
+impl<'de> Deserialize<'de> for InputParam {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(InputParamVisitor)
+    }
 }
 
 impl Default for InputParam {
@@ -581,6 +693,99 @@ mod tests {
             req.is_ok(),
             "idless reasoning input should deserialize: {req:?}"
         );
+    }
+
+    #[test]
+    fn codex_agent_message_normalizes_to_user_message() {
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "author": "/root",
+                "recipient": "/root/worker",
+                "content": [{"type": "input_text", "text": "Return exactly OK."}],
+            }],
+        }))
+        .expect("Codex agent message should deserialize");
+
+        let InputParam::Items(items) = req.input else {
+            panic!("expected items");
+        };
+        let InputItem::EasyMessage(message) = &items[0] else {
+            panic!("expected normalized user message");
+        };
+        assert_eq!(message.role, Role::User);
+        assert!(
+            matches!(message.content, EasyInputContent::Text(ref text) if text == "Return exactly OK.")
+        );
+    }
+
+    #[test]
+    fn codex_agent_message_joins_plaintext_parts_with_newlines() {
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "author": "/root",
+                "recipient": "/root/worker",
+                "content": [
+                    {"type": "input_text", "text": "First."},
+                    {"type": "input_text", "text": "Second."},
+                ],
+            }],
+        }))
+        .expect("Codex agent message should deserialize");
+
+        let InputParam::Items(items) = req.input else {
+            panic!("expected items");
+        };
+        assert!(matches!(
+            &items[0],
+            InputItem::EasyMessage(EasyInputMessage {
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text == "First.\nSecond."
+        ));
+    }
+
+    #[test]
+    fn codex_agent_message_rejects_encrypted_content() {
+        let error = serde_json::from_value::<CreateResponse>(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "author": "/root",
+                "recipient": "/root/worker",
+                "content": [{"type": "encrypted_content", "encrypted_content": "AB=="}],
+            }],
+        }));
+        assert!(
+            error
+                .expect_err("encrypted agent messages must not be accepted")
+                .to_string()
+                .contains("encrypted content is unsupported")
+        );
+    }
+
+    #[test]
+    fn codex_agent_message_preserves_empty_text() {
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "input": [{
+                "type": "agent_message",
+                "author": "/root",
+                "recipient": "/root/worker",
+                "content": [],
+            }],
+        }))
+        .expect("empty Codex agent message should deserialize");
+
+        let InputParam::Items(items) = req.input else {
+            panic!("expected items");
+        };
+        assert!(matches!(
+            &items[0],
+            InputItem::EasyMessage(EasyInputMessage {
+                content: EasyInputContent::Text(text),
+                ..
+            }) if text.is_empty()
+        ));
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -650,6 +650,21 @@ mod tests {
     }
 
     #[test]
+    fn codex_agent_message_missing_content_defaults_empty() {
+        let item: InputItem = serde_json::from_value(serde_json::json!({
+            "type": "agent_message",
+            "author": "/root",
+            "recipient": "/root/worker",
+        }))
+        .expect("Codex agent message without content should deserialize");
+
+        let InputItem::Item(Item::AgentMessage(message)) = item else {
+            panic!("expected Item::AgentMessage");
+        };
+        assert!(message.content.is_empty());
+    }
+
+    #[test]
     fn relaxed_assistant_message_without_id_or_status() {
         let json = serde_json::json!({
             "type": "message",


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Accept Codex `agent_message` records through a private deserializer that normalizes plaintext to the existing user-message input shape. This accepts Codex traffic without changing the public `Item` enum or composing prompts in the protocol crate.

### How This Was Implemented

- Detect the Codex discriminator in `InputItem` deserialization and convert plaintext content to an existing `EasyInputMessage`.
- Preserve plaintext string and multipart content exactly, joining multipart text with newlines.
- Treat missing or `null` content as empty and reject encrypted content with a concrete error.

<details>
<summary>Walkthrough</summary>

`agent_message` is a Codex input extension, not a new protocol type Dynamo needs to expose. Deserialization converts it to the existing user-message shape, which Dynamo's Responses-to-Chat conversion already handles.

Encrypted content remains a hard error until Dynamo has a decryption contract; it is never flattened or dropped. Agent lineage continues to use the request headers, not prompt text.

The public Responses API remains source compatible, so the next release is a minor version bump.

</details>

### Validation

- `cargo test -p dynamo-protocols --lib` (87 passed)
- `cargo clippy -p dynamo-protocols --lib --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
<!-- codex-pr-description:end -->
