### PR TITLE
chore(conformance): label captures per change, compare Dynamo versions on one page — NO PARSER CHANGE

### DIFF
--- a/conformance/tests/capture_cross_version.rs
+++ b/conformance/tests/capture_cross_version.rs
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Run an OLDER build's unified parser against the CURRENT corpus.
+//!
+//! Every committed `dynamo_v2-<ver>/` shard holds only the cases that existed when it
+//! was taken, so a case added later shows "no data" on the older column and the table
+//! cannot say what the old parser WOULD have done with it. That is the interesting
+//! question for a behavior change: not "did the old build pass the old tests" but
+//! "what does the old build do with the new ones".
+//!
+//! Usage — check this file out into a worktree at the OLD commit, then run it there
+//! pointed at the CURRENT corpus:
+//!
+//! ```text
+//! git worktree add --detach /tmp/old <old-sha>
+//! cp conformance/tests/capture_cross_version.rs /tmp/old/conformance/tests/
+//! cd /tmp/old && \
+//!   XVER_INPUTS=<repo>/conformance/unified/inputs \
+//!   XVER_OUT=<repo>/conformance/unified/dynamo_v2-<label> \
+//!   XVER_LABEL=<label> \
+//!   cargo test -p dynamo-conformance-fixtures-v2 --test capture_cross_version -- --nocapture
+//! ```
+//!
+//! Pick `<label>` as `<version>+<tag>` (e.g. `0.1.24+pre163`). The table sorts a `+tag`
+//! capture BEFORE the plain release it qualifies, so the released build stays the
+//! reference and the tagged one is the historical column.
+//!
+//! It deliberately uses only `push`/`finish` — the smallest surface every build of the
+//! trait has had — so it compiles against old trees whose parser has no `initialize` or
+//! output-mode API. A build lacking those APIs runs every case in its only mode, and
+//! that IS the finding for a request-mode case.
+//!
+//! No-op unless `XVER_INPUTS` is set, so it costs nothing in a normal test run.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use dynamo_parsers::{ReasoningParser, ReasoningParserType};
+use dynamo_parsers_v2::{
+    Tool, UnifiedEvent, assemble, create_tool_parser_for_family, create_unified_parser_for_family,
+};
+use serde_json::{Value, json};
+
+/// Corpus family -> (v1 reasoning parser, v2 tool parser) for the SPLIT path.
+/// Mirrors `unified_render::parsers_for`.
+fn parsers_for(family: &str) -> Option<(&'static str, &'static str)> {
+    match family {
+        "gemma4" => Some(("gemma4", "gemma4")),
+        "qwen3" => Some(("qwen3", "qwen3_coder")),
+        "kimi_k2" => Some(("kimi_k25", "kimi_k2")),
+        // Unknown to this build: reported, not guessed.
+        _ => None,
+    }
+}
+
+fn tool_deltas(res: &dynamo_parsers_v2::ToolParseResult, out: &mut Vec<Value>) {
+    if !res.normal_text.is_empty() {
+        out.push(json!({"kind": "text", "text": res.normal_text}));
+    }
+    for c in &res.calls {
+        out.push(json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments}));
+    }
+}
+
+/// The SPLIT path: v1 reasoning over the whole stream, then the v2 tool parser on the
+/// leftover. This is what Dynamo still serves for families with no native unified
+/// parser, and what `unified_render::dynamo_chunks` records for them — so a
+/// cross-version capture has to reproduce it or those rows come out empty and the
+/// table reads "this build produced nothing" for gemma4/kimi_k2.
+fn split_path_chunks(family: &str, input: &str) -> Option<Vec<Vec<Value>>> {
+    let (reasoning_name, tool_family) = parsers_for(family)?;
+    let mut rp = ReasoningParserType::get_reasoning_parser_from_name(reasoning_name);
+    let mut tp = create_tool_parser_for_family(tool_family, &tools()).ok()?;
+
+    let mut rows = Vec::new();
+    for chunk in chunk_input(input) {
+        let mut deltas: Vec<Value> = Vec::new();
+        let rr = rp.parse_reasoning_streaming_incremental(&chunk, &[]);
+        if !rr.reasoning_text.is_empty() {
+            deltas.push(json!({"kind": "reasoning", "text": rr.reasoning_text}));
+        }
+        if !rr.normal_text.is_empty() {
+            let tr = tp.push(&rr.normal_text).unwrap_or_default();
+            tool_deltas(&tr, &mut deltas);
+        }
+        rows.push(deltas);
+    }
+    // Flush in the same order the live harness uses: reasoning tail -> tool -> finish.
+    let mut tail: Vec<Value> = Vec::new();
+    let rf = rp.finish_reasoning_stream();
+    if !rf.reasoning_text.is_empty() {
+        tail.push(json!({"kind": "reasoning", "text": rf.reasoning_text}));
+    }
+    if !rf.normal_text.is_empty() {
+        let tr = tp.push(&rf.normal_text).unwrap_or_default();
+        tool_deltas(&tr, &mut tail);
+    }
+    tool_deltas(&tp.finish().unwrap_or_default(), &mut tail);
+    if !tail.is_empty() {
+        rows.push(tail);
+    }
+    Some(rows)
+}
+
+/// Marker-aligned chunking, byte-for-byte `unified_render::chunk_input`. The per-chunk
+/// rows are compared across columns, so a different split would surface as a parser
+/// difference that is really a harness difference.
+fn chunk_input(input: &str) -> Vec<String> {
+    let bytes = input.as_bytes();
+    let mut chunks = Vec::new();
+    let mut i = 0;
+    let mut text_start = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if text_start < i {
+                chunks.push(input[text_start..i].to_string());
+            }
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] != b'>' {
+                j += 1;
+            }
+            let end = (j + 1).min(bytes.len());
+            chunks.push(input[i..end].to_string());
+            i = end;
+            text_start = i;
+        } else {
+            i += 1;
+        }
+    }
+    if text_start < bytes.len() {
+        chunks.push(input[text_start..].to_string());
+    }
+    chunks
+}
+
+/// Identical to `unified_render::tools()`. The tool list is a parser INPUT — it is baked
+/// into the emitter at construction — so a different list here would read as a version
+/// difference.
+fn tools() -> Vec<Tool> {
+    let mk = |name: &str, key: &str| Tool {
+        name: name.to_string(),
+        description: None,
+        parameters: serde_json::json!({"type":"object","properties":{key:{"type":"string"}}}),
+        strict: None,
+    };
+    vec![
+        mk("get_weather", "city"),
+        mk("f", "x"),
+        mk("g", "y"),
+        mk("run", "cmd"),
+    ]
+}
+
+fn ev_to_yaml(ev: &UnifiedEvent) -> serde_yaml::Value {
+    serde_yaml::to_value(ev).expect("event serializes")
+}
+
+/// Fold per-chunk deltas into assembled events, mirroring the page's `_assemble_stream`:
+/// consecutive same-kind text/reasoning runs concatenate, and a tool_call delta carrying
+/// a name opens a call while later nameless fragments append to its argument string.
+fn fold_chunks(rows: &[Vec<Value>]) -> Vec<serde_yaml::Value> {
+    let mut out: Vec<Value> = Vec::new();
+    let mut raw: Vec<String> = Vec::new(); // argument text per open call, by position in `out`
+    for row in rows {
+        for d in row {
+            let kind = d.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+            let text = d.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            match kind {
+                "reasoning" | "text" => {
+                    let same = out
+                        .last()
+                        .and_then(|l| l.get("kind"))
+                        .and_then(|k| k.as_str())
+                        == Some(kind);
+                    if same {
+                        let last = out.last_mut().unwrap();
+                        let joined = format!("{}{}", last["text"].as_str().unwrap_or(""), text);
+                        last["text"] = Value::String(joined);
+                    } else {
+                        out.push(json!({"kind": kind, "text": text}));
+                        raw.push(String::new());
+                    }
+                }
+                "tool_call" => {
+                    let name = d.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    let args = d.get("arguments").and_then(|a| a.as_str()).unwrap_or("");
+                    let open_last = out
+                        .last()
+                        .and_then(|l| l.get("kind"))
+                        .and_then(|k| k.as_str())
+                        == Some("tool_call")
+                        && name.is_empty();
+                    if !open_last {
+                        out.push(json!({"kind": "tool_call", "name": name, "arguments": ""}));
+                        raw.push(String::new());
+                    }
+                    if let Some(r) = raw.last_mut() {
+                        r.push_str(args);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    // Argument text is a JSON fragment stream; parse once at the end, and keep it as a
+    // string when it never became valid JSON rather than dropping what the parser said.
+    for (i, ev) in out.iter_mut().enumerate() {
+        if ev.get("kind").and_then(|k| k.as_str()) == Some("tool_call") {
+            let r = raw.get(i).map(String::as_str).unwrap_or("");
+            ev["arguments"] = if r.trim().is_empty() {
+                json!({})
+            } else {
+                serde_json::from_str(r).unwrap_or_else(|_| Value::String(r.to_string()))
+            };
+        }
+    }
+    out.into_iter()
+        .map(|v| serde_yaml::to_value(v).expect("event"))
+        .collect()
+}
+
+/// Per-chunk rows record RAW deltas, not assembled events — `arguments` stays the
+/// literal fragment the parser emitted. Mirrors `unified_render::unified_delta_json`.
+/// (Assembling per chunk instead produces a mapping and makes every case look changed.)
+fn delta_to_yaml(d: &dynamo_parsers_v2::UnifiedDelta) -> serde_yaml::Value {
+    let v = match d {
+        dynamo_parsers_v2::UnifiedDelta::Reasoning { text } => {
+            serde_json::json!({"kind": "reasoning", "text": text})
+        }
+        dynamo_parsers_v2::UnifiedDelta::Text { text } => {
+            serde_json::json!({"kind": "text", "text": text})
+        }
+        dynamo_parsers_v2::UnifiedDelta::ToolCall(c) => {
+            serde_json::json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
+        }
+    };
+    serde_yaml::to_value(v).expect("delta serializes")
+}
+
+#[test]
+fn capture_this_build_against_the_current_corpus() {
+    let Ok(inputs_root) = std::env::var("XVER_INPUTS") else {
+        return; // not a cross-version run
+    };
+    let out_root = PathBuf::from(std::env::var("XVER_OUT").expect("XVER_OUT"));
+    let label = std::env::var("XVER_LABEL").expect("XVER_LABEL");
+
+    let mut families: Vec<PathBuf> = std::fs::read_dir(Path::new(&inputs_root))
+        .expect("inputs dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir())
+        .collect();
+    families.sort();
+
+    let mut total = 0usize;
+    let mut skipped_families = Vec::new();
+    for fam_dir in families {
+        let family = fam_dir.file_name().unwrap().to_string_lossy().to_string();
+        // Native unified parser if this build has one, else the SPLIT path — the same
+        // per-family mixture the live harness records. A family with neither is
+        // reported, not written as an empty dir: "no parser here" and "parser emitted
+        // nothing" must not look alike on the page.
+        let native = create_unified_parser_for_family(&family, &tools()).is_ok();
+        if !native && parsers_for(&family).is_none() {
+            skipped_families.push(family);
+            continue;
+        }
+        let mut cases: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&fam_dir)
+            .expect("family dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "yaml"))
+            .collect();
+        files.sort();
+        for fp in files {
+            let doc: serde_yaml::Value =
+                serde_yaml::from_str(&std::fs::read_to_string(&fp).expect("read")).expect("yaml");
+            let Some(case_map) = doc.get("cases").and_then(|c| c.as_mapping()) else {
+                continue;
+            };
+            for (cid, cdoc) in case_map {
+                let cid = cid.as_str().unwrap_or_default().to_string();
+                let input = cdoc.get("input").and_then(|v| v.as_str()).unwrap_or("");
+
+                let (per_chunk, assembled): (Vec<Vec<serde_yaml::Value>>, Vec<serde_yaml::Value>) =
+                    if native {
+                        let mut parser = create_unified_parser_for_family(&family, &tools())
+                            .expect("registered");
+                        let mut deltas = Vec::new();
+                        let mut rows = Vec::new();
+                        for ch in chunk_input(input) {
+                            // A push error is this build's honest answer for that chunk;
+                            // record no deltas rather than aborting the whole capture.
+                            let d = parser.push(&ch).unwrap_or_default();
+                            rows.push(d.iter().map(delta_to_yaml).collect::<Vec<_>>());
+                            deltas.extend(d);
+                        }
+                        let tail = parser.finish().unwrap_or_default();
+                        if !tail.is_empty() {
+                            // Its own row, as `dynamo_chunks` records it.
+                            rows.push(tail.iter().map(delta_to_yaml).collect::<Vec<_>>());
+                            deltas.extend(tail);
+                        }
+                        (rows, assemble(&deltas).iter().map(ev_to_yaml).collect())
+                    } else {
+                        let rows = split_path_chunks(&family, input).expect("split path");
+                        // The page assembles the Dynamo column from the per-chunk deltas
+                        // (`_assemble_stream`), not from this field, so folding the same
+                        // rows keeps the two consistent by construction.
+                        let assembled = fold_chunks(&rows);
+                        let rows = rows
+                            .into_iter()
+                            .map(|r| {
+                                r.into_iter()
+                                    .map(|v| serde_yaml::to_value(v).expect("delta"))
+                                    .collect::<Vec<_>>()
+                            })
+                            .collect();
+                        (rows, assembled)
+                    };
+
+                let chunk_rows: Vec<serde_yaml::Value> = per_chunk
+                    .into_iter()
+                    .map(|expected| {
+                        let mut m = serde_yaml::Mapping::new();
+                        m.insert("expected".into(), serde_yaml::Value::Sequence(expected));
+                        serde_yaml::Value::Mapping(m)
+                    })
+                    .collect();
+                let mut cm = serde_yaml::Mapping::new();
+                cm.insert("assembled".into(), serde_yaml::Value::Sequence(assembled));
+                cm.insert("chunks".into(), serde_yaml::Value::Sequence(chunk_rows));
+                cases.insert(cid, serde_yaml::Value::Mapping(cm));
+            }
+        }
+        let fam_out = out_root.join(&family);
+        std::fs::create_dir_all(&fam_out).expect("mkdir");
+        for (cid, case) in &cases {
+            let mut cw = serde_yaml::Mapping::new();
+            cw.insert("dynamo_v2".into(), label.clone().into());
+            let mut one = serde_yaml::Mapping::new();
+            one.insert(cid.clone().into(), case.clone());
+            let mut doc = serde_yaml::Mapping::new();
+            doc.insert("family".into(), family.clone().into());
+            doc.insert("mode".into(), "unified".into());
+            doc.insert("captured_with".into(), serde_yaml::Value::Mapping(cw));
+            doc.insert("cases".into(), serde_yaml::Value::Mapping(one));
+            std::fs::write(
+                fam_out.join(format!("{cid}.yaml")),
+                serde_yaml::to_string(&serde_yaml::Value::Mapping(doc)).expect("emit"),
+            )
+            .expect("write");
+            total += 1;
+        }
+        println!("[xver] {family}: {} cases", cases.len());
+    }
+    println!("[xver] wrote {total} case files to {}", out_root.display());
+    if !skipped_families.is_empty() {
+        println!("[xver] no unified parser in this build for: {skipped_families:?}");
+    }
+    assert!(total > 0, "captured nothing — check XVER_INPUTS layout");
+}

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -135,7 +135,14 @@ pub fn version_dirs_ascending(root: &Path, prefix: &str) -> Vec<PathBuf> {
                     // rendered under the 0.1.11 column in HTML). They are NOT the current
                     // parser, so they must never join this "latest capture wins" fold —
                     // otherwise a stale old-binary result can shadow the real latest.
-                    n.starts_with(prefix) && !n.contains(".patch")
+                    //
+                    // `<ver>+<tag>` dirs are the same kind of thing for the same reason:
+                    // a change-scoped capture, an older build run over the current corpus
+                    // (see `capture_cross_version.rs`). Excluded HERE rather than at each
+                    // call site because the version key below splits on non-digits, so
+                    // `0.1.24+pre163` folds to [0,1,24,163] and would sort ABOVE the real
+                    // 0.1.24 — letting a historical snapshot win "latest capture".
+                    n.starts_with(prefix) && !n.contains(".patch") && !n.contains('+')
                 })
         })
         .map(|p| {

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -762,15 +762,14 @@ fn committed_dynamo_capture_matches_the_live_parsers() {
             root.display()
         );
     }
-    let capture_dir = std::fs::read_dir(&root)
-        .unwrap()
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .find(|p| {
-            p.is_dir()
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n.starts_with("dynamo_v2-"))
-        })
+    // THIS build's capture: the newest version dir, via the shared helper so the
+    // "which capture is current" rule lives in ONE place. The helper already drops
+    // `.patchN` overlays and `+tag` change-scoped captures, both of which are older
+    // parsers and must never be mistaken for the live one. Resolving by readdir order
+    // instead made this guard nondeterministic — the same commit could pass against one
+    // shard and report parser drift against another purely on directory listing order.
+    let capture_dir = common::version_dirs_ascending(&root, "dynamo_v2-")
+        .pop()
         .expect("no committed dynamo_v2-<ver> capture dir");
 
     // key -> (family, scenario, input), from the inputs shard.

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -821,10 +821,14 @@ body.cmp-loading .cmp-loading-note { display: block; position: fixed; top: 8px; 
 
 /* Dark-mode compare colors: #76b884 / #db7777 were picked for a white page and glare on
  * a dark one. Same hues, dropped in luminance so the grid reads without shouting. */
-:root[data-theme="dark"] td.cell.cmp-eq { background: #2f5d3d !important; }
-:root[data-theme="dark"] td.cell.cmp-leak { background: #6e2f2f !important; }
-:root[data-theme="dark"] body.view-overview td.cell.cmp-eq { color: #2f5d3d; }
-:root[data-theme="dark"] body.view-overview td.cell.cmp-leak { color: #6e2f2f; }
+/* Dark theme verdict colors. These were dark enough that a green cell read as
+   near-black against the page and the green/red distinction only showed up on close
+   inspection. Lifted well above the surface luminance; the marker text flips dark so it
+   still carries on the brighter fill. */
+:root[data-theme="dark"] td.cell.cmp-eq { background: #4fc27d !important; color: #08240f; }
+:root[data-theme="dark"] td.cell.cmp-leak { background: #f5736f !important; color: #2b0606; }
+:root[data-theme="dark"] body.view-overview td.cell.cmp-eq { color: #4fc27d; }
+:root[data-theme="dark"] body.view-overview td.cell.cmp-leak { color: #f5736f; }
 :root[data-theme="dark"] td.cell.ok { color: #5aa06e; }
 :root[data-theme="dark"] td.cell.research,
 :root[data-theme="dark"] td.cell.leak,

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -202,6 +202,13 @@
       }
       // Unavailable candidates never count toward the diff; still shown in tooltip.
       const avail = shown.map(function (k) { return cmp[k]; }).filter(function (o) { return o && o.na !== 1; });
+      // ...but they must not be SILENT either. A compare candidate that has no data for
+      // this case (an older capture taken before the case existed) is not agreement, and
+      // folding it into "=" claims the two builds produced the same output when one of
+      // them never ran it. Counted separately so the glyph can say "no data" instead.
+      const naShown = shown.filter(function (k) {
+        return k !== base && cmp[k] && cmp[k].na === 1;
+      }).length;
       // NΔ counts shown COMPARE engines that diverge from GOLDEN (the fixed reference),
       // independent of which engine is starred. When there is no golden (other tabs), fall
       // back to the selected reference. `avail` excludes the base (the starred REF).
@@ -222,11 +229,15 @@
       const leaked = leak;  // the REF's own leak drives ↯, same as every other tab
       // Marker: ✗ when the REF diverges (the red signal); otherwise NΔ = how many Compare
       // engines diverge from golden (informational, stays green), "=" when all agree.
+      // "=" is only honest when every shown candidate actually produced output. When a
+      // selected compare candidate has no capture for this case, say so ("?") rather
+      // than reporting agreement it cannot support. A real divergence still wins.
+      const eqTxt = naShown > 0 ? '?' : '=';
       let txt;
       if (redOnDiff) {
-        txt = refDiverges ? '✗' : (diffs > 0 ? String(diffs) + 'Δ' : '=');
+        txt = refDiverges ? '✗' : (diffs > 0 ? String(diffs) + 'Δ' : eqTxt);
       } else {
-        txt = donly ? '' : (diffs === 0 ? '=' : String(diffs) + 'Δ');
+        txt = donly ? '' : (diffs === 0 ? eqTxt : String(diffs) + 'Δ');
       }
       if (marker) { marker.textContent = (leaked ? '↯' : '') + txt; }
       const problem = redOnDiff ? refDiverges : leaked;

--- a/conformance/utils/src/dynamo_version.py
+++ b/conformance/utils/src/dynamo_version.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The ONE label a Dynamo capture is filed under.
+
+A capture is stored as `dynamo_v2-<label>/` and stamped `captured_with:
+{dynamo_v2: <label>}`. Every writer in the pipeline must agree on that string:
+`refresh_dynamo_captures` creates the dir, `explode_unified_fixtures` re-derives
+it to place exploded cases, and a mismatch produces a capture dir the table
+cannot find. They used to compute it separately — regex vs tomllib, with
+different failure modes — so this is the shared parent.
+
+The label defaults to the live `parsers/v2` crate version, which gives RELEASE
+granularity. Releases are explicit `chore: release` commits, so several merges
+can share one version and a release can contain no parser change at all. To
+compare a single change instead, override the label:
+
+    CONFORMANCE_DYNAMO_V2_LABEL=0.1.24+pr163 ...
+    refresh_dynamo_captures.py --label 0.1.24+pr163
+
+That writes an ADDITIONAL `dynamo_v2-0.1.24+pr163/` dir beside the released one
+rather than replacing it. Version dirs are capture HISTORY (see
+`conformance/tests/common/mod.rs`) — never rewrite one; only add.
+"""
+
+import os
+import re
+from pathlib import Path
+
+ENV_OVERRIDE = "CONFORMANCE_DYNAMO_V2_LABEL"
+
+# `0.1.24`, and the PR/SHA-qualified forms that make a capture attributable to
+# one change: `0.1.24+pr163`, `0.1.24+g06bc1f2`. Kept strict so a typo becomes a
+# missing-column error at capture time, not a mystery dir nobody reads.
+_LABEL_RE = re.compile(r"^\d+\.\d+\.\d+(?:[.\w-]*)?(?:\+[0-9A-Za-z._-]+)?$")
+
+
+def crate_version(cargo_toml: Path) -> str:
+    """The `version = "..."` from a Cargo.toml. Raises if absent — a capture filed
+    under a guessed version is worse than a failed capture."""
+    m = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml.read_text(), re.MULTILINE)
+    if not m:
+        raise ValueError(f"no [package] version in {cargo_toml}")
+    return m.group(1)
+
+
+def dynamo_v2_label(repo_root: Path, override: str | None = None) -> str:
+    """Label to file this Dynamo v2 capture under.
+
+    Precedence: explicit `override` (a `--label` flag) > `$CONFORMANCE_DYNAMO_V2_LABEL`
+    > the live parsers/v2 crate version.
+    """
+    # An explicitly-supplied-but-blank override is an error, not a request for the
+    # default: `--label ""` / `CONFORMANCE_DYNAMO_V2_LABEL=` means the caller meant
+    # to name this capture and the name got lost. Falling back would silently file
+    # it under the released version and overwrite that comparison point.
+    for supplied in (override, os.environ.get(ENV_OVERRIDE)):
+        if supplied is None:
+            continue
+        if not supplied.strip():
+            raise ValueError("empty Dynamo v2 capture label; omit the override to use the crate version")
+        label = supplied.strip()
+        break
+    else:
+        label = crate_version(repo_root / "parsers" / "v2" / "Cargo.toml").strip()
+    if not _LABEL_RE.match(label):
+        raise ValueError(
+            f"bad Dynamo v2 capture label {label!r}: expected <version>[+<tag>], "
+            "e.g. 0.1.24 or 0.1.24+pr163"
+        )
+    return label

--- a/conformance/utils/src/explode_unified_fixtures.py
+++ b/conformance/utils/src/explode_unified_fixtures.py
@@ -144,16 +144,11 @@ def main():
 
 
 def _dynamo_v2_version():
-    # Mirror generate_conformance_table._dynamo_v2_version without importing the whole module.
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib
-    cargo = REPO / "parsers" / "v2" / "Cargo.toml"
-    try:
-        return tomllib.loads(cargo.read_text())["package"]["version"]
-    except Exception:
-        return "0.1.x"
+    # Shared with refresh_dynamo_captures so the dir this writes is the dir that
+    # one created. No fallback: a guessed label files cases under a version that
+    # was never captured.
+    from dynamo_version import dynamo_v2_label
+    return dynamo_v2_label(REPO)
 
 
 if __name__ == "__main__":

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -1125,6 +1125,9 @@ def _stream_candidate_items() -> list[dict[str, str]]:
             if impl == BASELINE_STREAM_IMPL and v == latest.get(impl):
                 bucket = "A"
             else:
+                # Older captures stay SELECTABLE but unchecked. Auto-comparing every
+                # version turns on a wall of columns the moment Detailed is pressed;
+                # the reader picks the one build they want to diff against.
                 bucket = "C"
             out.append({
                 "key": f"{impl}-{slug}",
@@ -2167,14 +2170,33 @@ def _load_unified_fixtures(base: Path):
 
     inputs = _read_dir("inputs")
     golden = _read_dir("golden")
-    engine_dirs = {}  # impl -> (dirname, version)
+    # impl -> [(version, dirname)] ascending. Dynamo keeps EVERY capture so the tab can
+    # compare one parser build against another; a dict keyed by impl silently dropped
+    # all but the last dir, which is why only one Dynamo column could ever render.
+    # `sorted()` alone is lexicographic (0.1.9 > 0.1.10), so sort on the version key.
+    engine_versions: dict[str, list[tuple[str, str]]] = {}
     for d in sorted(base.iterdir()):
         if not d.is_dir() or d.name in ("inputs", "golden"):
             continue
         m = re.match(r"^([a-z0-9_]+)-(\d.*)$", d.name)
         if m:
-            engine_dirs[m.group(1)] = (d.name, m.group(2))
+            engine_versions.setdefault(m.group(1), []).append((m.group(2), d.name))
+    for impl in engine_versions:
+        # `_version_sort_key` reads only the leading digits, so `0.1.24+pre163` ties with
+        # `0.1.24`. Break the tie so a `+tag` capture sorts BEFORE the plain release it
+        # qualifies: the tag marks a code state within that version (a pre-merge branch
+        # point), while the unadorned version is the released build. Without this the
+        # tagged capture wins the tie and becomes the reference, which would star the OLD
+        # parser and quietly measure everything against it.
+        engine_versions[impl].sort(
+            key=lambda vd: (fixtures._version_sort_key(vd[0]), "+" not in vd[0])
+        )
+    # Peers still resolve to their single latest dir; only Dynamo fans out per version.
+    engine_dirs = {impl: (vs[-1][1], vs[-1][0]) for impl, vs in engine_versions.items()}
     engine_cases = {impl: _read_dir(dirname) for impl, (dirname, _v) in engine_dirs.items()}
+    dynamo_by_ver = {
+        ver: _read_dir(dirname) for ver, dirname in engine_versions.get("dynamo_v2", [])
+    }
 
     cases = []
     caps = {"vllm_python": {}, "vllm_rust": {}, "sglang_python": {}}
@@ -2192,6 +2214,18 @@ def _load_unified_fixtures(base: Path):
             "input": inp.get("input", ""),
             "golden": gdoc.get("assembled") or [],
             "dynamo": ddoc.get("assembled") or [],
+            # Per-capture payloads, latest included. A version that never recorded this
+            # case is ABSENT here rather than empty: an older capture predating the case
+            # has no opinion about it, and scoring [] against golden would invent a
+            # divergence the parser never produced.
+            "dynamo_by_ver": {
+                ver: {
+                    "assembled": (vdoc.get("assembled") or []),
+                    "chunks": [c.get("expected") or [] for c in (vdoc.get("chunks") or [])],
+                }
+                for ver, vcases in dynamo_by_ver.items()
+                if (vdoc := vcases.get((fam, key))) is not None
+            },
             "dynamo_verdict": None, "vllm_verdict": None, "vllm_note": None,
             "chunks": [
                 {"delta_text": ic.get("delta_text", ""),
@@ -2212,6 +2246,8 @@ def _load_unified_fixtures(base: Path):
                     "parser": edoc.get("parser"),
                 }
     versions = {impl: v for impl, (_d, v) in engine_dirs.items()}
+    # Ascending; the tab makes the last one the reference and the rest compare-on.
+    versions["dynamo_v2_all"] = [v for v, _d in engine_versions.get("dynamo_v2", [])]
     return cases, caps, versions
 
 
@@ -2296,7 +2332,12 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
     # Names follow the convention <Engine> [version] (<parser/mode>). The vLLM Rust
     # column's per-family variant (UnifiedParser for gemma4, CombinedParser otherwise)
     # can't fit one fixed column label, so it's shown per family in the tooltip.
-    dynamo_ver_label = _dynamo_v2_version() or "0.1.x"
+    # THIS tab's own capture version. It used to borrow _dynamo_v2_version(), which reads
+    # the STREAM tree (toolcalling/fixtures-stream-v2) — a different tree on a different
+    # release cadence — so the column was labelled with a version that did not produce
+    # these rows (0.1.23 on 0.1.24 data).
+    dynamo_all_vers = _vers.get("dynamo_v2_all") or []
+    dynamo_ver_label = (dynamo_all_vers[-1] if dynamo_all_vers else None) or "0.1.x"
     # Per-family mixture now, exactly like vLLM Rust: the native UnifiedParser where
     # one exists (qwen3), the v1-reasoning + v2-tool split everywhere else.
     dynamo_label = f"Dynamo v2 Rust {dynamo_ver_label} (stream, Combined & Unified)"
@@ -2310,17 +2351,29 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
         # green. See conformance_view.compareBarHtml (golden's hidden ref radio is dropped
         # when an engine is the default REF).
         _cand("dynamo", dynamo_label, "A"),  # Reference (default, starred)
-        _cand("golden", "GOLDEN (oracle)", "B"),  # fixed NΔ baseline, not the base
-        _cand("vllm", vllm_label, "B"),  # Compare-on by default
+        # Only the Reference is on by default — same rule as the stream and batch tabs.
+        # Reset reloads at these defaults, so anything B here comes back checked every
+        # time the reader clears the board, which reads as the page re-selecting itself.
+        _cand("golden", "GOLDEN (oracle)", "C"),  # fixed NΔ baseline, not the base
+        _cand("vllm", vllm_label, "C"),
     ]
+    # Older Dynamo captures, newest-first, each its own clickable column — UNCHECKED,
+    # so pressing Detailed does not switch on every historical build at once. The point
+    # is that the version is THERE to click, not that it is compared by default.
+    # impl="dynamo" groups them under the one Dynamo engine block of the compare bar.
+    for v in reversed(dynamo_all_vers[:-1]):
+        pc = _cand(f"dynamo@{v}", f"Dynamo v2 Rust {v} (stream, Combined & Unified)", "C")
+        pc["impl"] = "dynamo"
+        pc["version"] = v
+        candidates.append(pc)
     if vrust_live:
         # impl="vllm" groups it under the vLLM engine column of the compare bar (a second
         # row next to vLLM Python); key stays "vllm_rust" for the cmp/chunk/chart lookups.
-        rc = _cand("vllm_rust", vrust_label, "B")
+        rc = _cand("vllm_rust", vrust_label, "C")
         rc["impl"] = "vllm"
         candidates.append(rc)
     if sgl_live:
-        candidates.append(_cand("sglang", f"SGLang Python {sgl_ver_label} (stream, Combined)", "B"))
+        candidates.append(_cand("sglang", f"SGLang Python {sgl_ver_label} (stream, Combined)", "C"))
     _TODO = ("TODO: adopt a unified parser for this family (Dynamo v2 is moving to a "
              "per-family mixture — native unified where available, split elsewhere). "
              "Today's split parses ALL reasoning first, so reasoning between/after tool "
@@ -2390,17 +2443,37 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                 cmp["vllm_rust"] = {"sig": rsig, "leak": 1 if rverd == "LEAK" else 0, "na": 0}
             if sgl_events is not None:
                 cmp["sglang"] = {"sig": ssig, "leak": 1 if sverd == "LEAK" else 0, "na": 0}
+            # Older Dynamo builds, scored against GOLDEN exactly like the latest one, so a
+            # cell that changed between builds shows a real NΔ instead of a styling hint.
+            prev_by_ver = c.get("dynamo_by_ver") or {}
+            prev_chunks_by_ver = {}
+            for pv in dynamo_all_vers[:-1]:
+                pdoc = prev_by_ver.get(pv)
+                if pdoc is None:
+                    # Capture predates this case: n/a, not a divergence.
+                    cmp[f"dynamo@{pv}"] = {"sig": 0, "leak": 0, "na": 1}
+                    prev_chunks_by_ver[pv] = []
+                    continue
+                pchunks = pdoc.get("chunks") or []
+                pevents = _assemble_stream(pchunks)
+                pverd = _unified_classify(f, gold, pevents)
+                cmp[f"dynamo@{pv}"] = {
+                    "sig": _sig(pevents), "leak": 1 if pverd == "LEAK" else 0, "na": 0,
+                }
+                prev_chunks_by_ver[pv] = pchunks
             desc = c["description"]
             if c.get("policy_tags"):
                 desc = f"{desc}  [policy: {', '.join(c['policy_tags'])}]"
-            chunk_rows = [
-                {"delta_text": ch["delta_text"], "finish_reason": None,
-                 "expected": {"dynamo": ch.get("dynamo") or [],
-                              "vllm": (vllm_chunks[i] if i < len(vllm_chunks) else []),
-                              "vllm_rust": (vrust_chunks[i] if i < len(vrust_chunks) else []),
-                              "sglang": (sgl_chunks[i] if i < len(sgl_chunks) else [])}}
-                for i, ch in enumerate(c.get("chunks") or [])
-            ]
+            chunk_rows = []
+            for i, ch in enumerate(c.get("chunks") or []):
+                expected = {"dynamo": ch.get("dynamo") or [],
+                            "vllm": (vllm_chunks[i] if i < len(vllm_chunks) else []),
+                            "vllm_rust": (vrust_chunks[i] if i < len(vrust_chunks) else []),
+                            "sglang": (sgl_chunks[i] if i < len(sgl_chunks) else [])}
+                for pv, pchunks in prev_chunks_by_ver.items():
+                    expected[f"dynamo@{pv}"] = pchunks[i] if i < len(pchunks) else []
+                chunk_rows.append({"delta_text": ch["delta_text"],
+                                   "finish_reason": None, "expected": expected})
             reasons = []
             if dverd in ("MERGE", "ORDER"):
                 reasons.append({
@@ -2455,7 +2528,22 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                      "leak": sverd == "LEAK",
                      "block": ({"error": sgl_err} if sgl_err else
                                {"events": sgl_events, "verdict": sverd})},
-                ] if sgl_events is not None else []),
+                ] if sgl_events is not None else []) + [
+                    # One popup column per older Dynamo capture, newest-first. A version
+                    # that never recorded this case says so instead of showing an empty
+                    # event list that reads like the parser produced nothing.
+                    {"key": f"dynamo@{pv}",
+                     "label": f"Dynamo v2 Rust {pv} (stream, Combined & Unified)",
+                     "impl": "dynamo", "version": pv, "parse_mode": "unified",
+                     "leak": bool(cmp.get(f"dynamo@{pv}", {}).get("leak")),
+                     "block": ({"unavailable": f"not captured at {pv} — this case postdates that build"}
+                               if (prev_by_ver.get(pv) is None)
+                               else {"events": _assemble_stream(prev_chunks_by_ver.get(pv) or []),
+                                     "verdict": _unified_classify(
+                                         f, gold,
+                                         _assemble_stream(prev_chunks_by_ver.get(pv) or []))})}
+                    for pv in reversed(dynamo_all_vers[:-1])
+                ],
                 "baseline": None, "reasons": reasons, "dynamo_notes": [], "refs": [],
                 "leak_note": None, "na_note": None,
             }

--- a/conformance/utils/src/refresh_dynamo_captures.py
+++ b/conformance/utils/src/refresh_dynamo_captures.py
@@ -40,6 +40,8 @@ from pathlib import Path
 
 import yaml
 
+from dynamo_version import crate_version, dynamo_v2_label
+
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent.parent.parent  # conformance/utils/src -> repo root
 TREE = ROOT / "conformance" / "toolcalling"
@@ -54,13 +56,6 @@ _FAMILIES = yaml.safe_load((HERE / "parser_families.yaml").read_text())["familie
 # Families the Dynamo v2 stream parser implements (the registry's single source
 # of truth) — these get stream + batch-on-stream captures.
 V2_FAMILIES = sorted(f for f, s in _FAMILIES.items() if s.get("dynamo_v2"))
-
-
-def crate_version(cargo_toml: Path) -> str:
-    m = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml.read_text(), re.MULTILINE)
-    if not m:
-        raise SystemExit(f"no version in {cargo_toml}")
-    return m.group(1)
 
 
 def cache_root() -> Path:
@@ -339,11 +334,17 @@ def main() -> int:
         "modes", nargs="*", choices=[[], "batch", "stream", "batch-on-stream"],
         help="subset of captures to refresh (default: all)",
     )
+    ap.add_argument(
+        "--label", default=None,
+        help="file the Dynamo v2 capture under this label instead of the crate "
+             "version (e.g. 0.1.24+pr163). Writes an ADDITIONAL version dir; it "
+             "never replaces an existing one.",
+    )
     args = ap.parse_args()
     modes = args.modes or ["batch", "stream", "batch-on-stream"]
 
     v1_ver = crate_version(ROOT / "parsers" / "v1" / "Cargo.toml")
-    v2_ver = crate_version(ROOT / "parsers" / "v2" / "Cargo.toml")
+    v2_ver = dynamo_v2_label(ROOT, args.label)
     print(f"[refresh] dynamo-parsers {v1_ver}, dynamo-parsers-v2 {v2_ver}")
 
     if "batch" in modes:

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -118,7 +118,11 @@ def _peer_versions(tree: str) -> dict[str, set[str]]:
     return out
 
 
-_VER_PAREN = re.compile(r"\b\d[\w.]*\s+\([^)]+\)\s*$")
+# A version token then a parenthesized mode, e.g. "0.1.24 (stream)". `+` is allowed in
+# the token because a capture can be filed under a change-scoped label ("0.1.24+pr163")
+# to compare one code state against another within a single release — see
+# conformance/utils/src/dynamo_version.py.
+_VER_PAREN = re.compile(r"\b\d[\w.+-]*\s+\([^)]+\)\s*$")
 
 # ---- schema + shape -----------------------------------------------------------
 


### PR DESCRIPTION
#### Overview:

**NO PARSER CHANGE.** Every file is under `conformance/` (a `publish = false` test crate); zero files under `parsers/`. The two `.rs` files are the capture harness and the drift guard — they call the parsers to record what they already do, and cannot alter a byte a parser emits. If a Dynamo cell on the table moves after this merges, that is a bug in THIS PR.

This PR makes a conformance capture attributable to ONE change instead of one release, and makes the Unified tab show every captured Dynamo version as its own column. Affects the conformance harness and the rendered table only — no parser code is touched (zero `.rs` under `parsers/`).

A capture is filed under `dynamo_v2-<crate version>/`, which is RELEASE granularity. Version bumps are explicit `chore: release` commits, so several merges can share one version (#80 landed between 0.1.23 and 0.1.24 with no bump) and a release can contain no parser change at all (0.1.25 had none since 0.1.24). There was no way to capture "before this change" against "after this change".

<img width="1835" height="374" alt="image" src="https://github.com/user-attachments/assets/1cc77dfe-df6d-4440-a0be-9e9b2e0acd9c" />

#### Example (before → after):

Input: two committed captures present, `dynamo_v2-0.1.23/` and `dynamo_v2-0.1.25/`

```
before:  Unified tab renders ONE Dynamo column, labelled 0.1.23, showing 0.1.25 data
         (the loader keyed engine dirs in a dict, so 0.1.23 was read then overwritten;
          the label came from the STREAM tree, a different tree on a different cadence)
after:   two columns, each labelled with the version that produced its rows
```

```
before:  a case the older capture never ran renders "="   ← claims the two builds agree
after:   the same cell renders "?"                        ← says there is no data
```

#### Details:

- `dynamo_version.py` is the one source for a capture label, with a `--label` / `CONFORMANCE_DYNAMO_V2_LABEL` override. It replaces two derivations that had to agree and did not — a regex that raised, and a tomllib read that silently fell back to `"0.1.x"` — where a disagreement files exploded cases under a dir the table cannot find. A blank override is an error, not a silent fall-back.
- `capture_cross_version.rs` runs an OLDER build against the CURRENT corpus, so an older column can say what that parser would have done with cases added after it. Uses only push/finish plus the v1-reasoning/v2-tool split path, so it compiles against trees whose parser has no `initialize`; no-op unless `XVER_INPUTS` is set.
- The drift guard resolved "which capture is current" by `read_dir` order, so the same commit could pass against one shard and report parser drift against another purely on directory listing order. It now uses the existing `common::version_dirs_ascending`, and that helper learned to skip `+tag` captures alongside the `.patchN` overlays it already skipped — its version key splits on non-digits, so `0.1.24+pre163` folds to `[0,1,24,163]` and would otherwise sort ABOVE the real `0.1.24` and win "latest". Fixed in the shared helper so every reader gets it, rather than at the call site.

#### Verification:

109 python and 16 rust tests pass on this branch alone, with a single capture dir present — the loader and guard changes had to stay correct in that shape to land ahead of the corpus that exercises them.

#### Where should the reviewer start?

`conformance/utils/src/dynamo_version.py`, then `conformance/tests/capture_cross_version.rs`, then the `_load_unified_fixtures` / `_stream_candidate_items` changes in `conformance/utils/src/generate_conformance_table.py`

/coderabbit profile chill


