### PR TITLE
feat(tokenizers): support segmented encoding with fastokens 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,17 +1145,19 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796a262ed47d1458a4b40d0ed831c927e6f54d5b9c1de2683bb4ac9b04f4c7cc"
+checksum = "5f1f336629cfa807210f0b68de9b27ec7699cedf32d57b125bd4d73f87f6e92b"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",
  "hf-hub",
  "icu_normalizer",
+ "libc",
  "memchr",
  "pcre2",
  "rayon",
+ "regex-syntax",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1f336629cfa807210f0b68de9b27ec7699cedf32d57b125bd4d73f87f6e92b"
+checksum = "35ff8cf975d8f772e7d4c3be439659b0b23b1ae1086ebee7204573807053ff7f"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",
@@ -1162,6 +1162,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ dynamo-protocols = { path = "protocols", version = "5.1.0" }
 dynamo-renderer = { path = "renderer", version = "5.0.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.7.0" }
 either = { version = "1.13", features = ["serde"] }
-fastokens = "0.2.0"
+fastokens = "0.3.0"
 futures = "0.3"
 hf-hub = { version = "0.4", default-features = false }
 minijinja = { version = "2.21.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ dynamo-protocols = { path = "protocols", version = "5.1.0" }
 dynamo-renderer = { path = "renderer", version = "5.0.0" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.7.0" }
 either = { version = "1.13", features = ["serde"] }
-fastokens = "0.3.0"
+fastokens = "0.3.1"
 futures = "0.3"
 hf-hub = { version = "0.4", default-features = false }
 minijinja = { version = "2.21.0" }

--- a/tokenizers/src/fastokens.rs
+++ b/tokenizers/src/fastokens.rs
@@ -3,16 +3,16 @@
 
 //! Fastokens backend using the `fastokens` crate for high-performance BPE encoding.
 //!
-//! `fastokens` only supports encoding, so this module provides a hybrid tokenizer that
-//! uses `fastokens` for encoding and falls back to `HuggingFaceTokenizer` for decoding.
-//! Both are loaded from the same `tokenizer.json` file.
+//! This module preserves the existing hybrid behavior: `fastokens` handles encoding and
+//! `HuggingFaceTokenizer` handles decoding. Both are loaded from the same `tokenizer.json`
+//! file.
 
 use std::path::Path;
 
 use rayon::prelude::*;
 
 use super::{
-    Encoding, Error, Result, TokenIdType,
+    EncodeSegment, Encoding, Error, Result, TokenIdType,
     hf::HuggingFaceTokenizer,
     traits::{DecodeResult, Decoder, Encoder, Tokenizer},
 };
@@ -49,6 +49,21 @@ impl Encoder for FastTokenizer {
     fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
         inputs.par_iter().map(|input| self.encode(input)).collect()
     }
+
+    fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Encoding> {
+        let segments: Vec<fastokens::EncodeSegment<'_>> = segments
+            .iter()
+            .map(|segment| fastokens::EncodeSegment {
+                text: segment.text,
+                allow_special: segment.allow_special,
+            })
+            .collect();
+        let ids = self
+            .fast_encoder
+            .encode_segments(&segments)
+            .map_err(|e| Error::msg(format!("Fastokens segmented encode error: {e}")))?;
+        Ok(Encoding::Sp(ids))
+    }
 }
 
 impl Decoder for FastTokenizer {
@@ -73,6 +88,10 @@ mod tests {
     const TOKENIZER_PATH: &str = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/tests/data/minimal-bpe/tokenizer.json"
+    );
+    const SEGMENTED_TOKENIZER_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/sample-models/TinyLlama_v1.1/tokenizer.json"
     );
 
     #[test]
@@ -124,6 +143,55 @@ mod tests {
                 "encoding for '{input}' must be non-empty"
             );
         }
+    }
+
+    #[test]
+    fn test_fast_segmented_encoding_preserves_trust_boundaries() {
+        let tokenizer = FastTokenizer::from_file(SEGMENTED_TOKENIZER_PATH).unwrap();
+        let upstream =
+            fastokens::Tokenizer::from_file(std::path::Path::new(SEGMENTED_TOKENIZER_PATH))
+                .unwrap();
+        let marker = "<s>";
+
+        let trusted = tokenizer
+            .encode_segments(&[EncodeSegment::control(marker)])
+            .unwrap();
+        assert_eq!(
+            trusted.token_ids(),
+            &[upstream.token_to_id(marker).unwrap()],
+            "trusted renderer output must recognize the control token"
+        );
+
+        let ordinary = tokenizer
+            .encode_segments(&[EncodeSegment::ordinary(marker)])
+            .unwrap();
+        assert_ne!(
+            ordinary.token_ids(),
+            trusted.token_ids(),
+            "untrusted content must encode the control-token spelling as ordinary text"
+        );
+
+        let segments = [
+            EncodeSegment::ordinary("hello "),
+            EncodeSegment::control(marker),
+            EncodeSegment::ordinary(marker),
+        ];
+        let upstream_segments = [
+            fastokens::EncodeSegment::ordinary("hello "),
+            fastokens::EncodeSegment::special(marker),
+            fastokens::EncodeSegment::ordinary(marker),
+        ];
+        let actual = tokenizer.encode_segments(&segments).unwrap();
+        let expected = upstream.encode_segments(&upstream_segments).unwrap();
+        assert_eq!(actual.token_ids(), expected);
+
+        assert!(
+            tokenizer
+                .encode_segments(&[])
+                .unwrap()
+                .token_ids()
+                .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- upgrade the workspace `fastokens` dependency from 0.2.0 to 0.3.1
- implement `FastTokenizer::encode_segments` by forwarding Dynamo segment trust boundaries to fastokens 0.3.1
- preserve the existing Hugging Face decoder, batch behavior, and segmented L1-cache bypass
- keep native tiktoken model loading out of scope

## Validation

- `cargo metadata --locked --format-version=1 --no-deps`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --locked`
- `cargo test --workspace --doc --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check`