### PR TITLE
fix(GUI): backfill all the results for 5.1.x

### DIFF
--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -1167,15 +1167,28 @@ def _stream_divergence_note(family: str, case_id: str, impl: str) -> str | None:
 
 
 def _stream_version_families(impl: str, version: str) -> set[str] | None:
-    """Families the `<impl>-<version>` stream fixture dir actually holds — the
-    authoritative coverage for that parser build. `None` if the dir is absent (don't
-    gate). Used to mark the Dynamo v2 stream candidate `na` on families its parser
-    doesn't implement, since the dir only contains the families it produced output
-    for (dynamo_v2-0.1.11 = the v2-supported handful; dynamo_v1-3.0.0 = all)."""
-    d = _STREAM_SRC / f"{impl}-{version}"
-    if not d.is_dir():
+    """Families covered after resolving `<impl>` through `version`.
+
+    The lowest version is the full anchor; higher directories may contain only
+    changed cases. Coverage therefore accumulates through the selected version just
+    as `resolve_stream_fixtures.py` accumulates their outputs. `None` means no version
+    directory was found, so callers should not gate the candidate.
+    """
+    prefix = f"{impl}-"
+    target = fixtures._version_sort_key(version)
+    found = False
+    families: set[str] = set()
+    if not _STREAM_SRC.is_dir():
         return None
-    return {p.name for p in d.iterdir() if p.is_dir()}
+    for directory in _STREAM_SRC.iterdir():
+        if not directory.is_dir() or not directory.name.startswith(prefix):
+            continue
+        candidate_version = directory.name[len(prefix) :]
+        if fixtures._version_sort_key(candidate_version) > target:
+            continue
+        found = True
+        families.update(path.name for path in directory.iterdir() if path.is_dir())
+    return families if found else None
 
 
 def _parser_ni_map() -> dict:

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -833,6 +833,20 @@ def test_every_stream_family_has_registry_row_and_fixtures() -> None:
             assert list((inputs_root / fam).glob("*.yaml")), f"dynamo_v2 family {fam} has no stream fixtures"
 
 
+def test_stream_version_families_include_inherited_anchor_coverage(
+    tmp_path, monkeypatch
+) -> None:
+    """A changed-only version directory inherits families from earlier versions."""
+    (tmp_path / "dynamo_v1-3.0.0" / "deepseek_v3").mkdir(parents=True)
+    (tmp_path / "dynamo_v1-5.1.2" / "inkling").mkdir(parents=True)
+    monkeypatch.setattr(g, "_STREAM_SRC", tmp_path)
+
+    assert g._stream_version_families("dynamo_v1", "5.1.2") == {
+        "deepseek_v3",
+        "inkling",
+    }
+
+
 def test_impl_spec_is_single_identity_source() -> None:
     """D5: ImplSpec is the one identity table; the generator's derived dicts match
     it, every spec is complete, markers/displays are unique, and vLLM Rust has no


### PR DESCRIPTION
#### Overview:

UI change only — no parser code is touched. This PR fixes Dynamo v1 stream conformance rows so changed-only version overlays retain inherited parser-family coverage.

#### Example (before → after):

Input: select Dynamo v1 5.1.2 on Tool Calling (stream data)

```
before: available=30,  n/a=616
after:  available=615, n/a=31 (Harmony token-ID only)
```

Before:
<img width="1562" height="769" alt="image" src="https://github.com/user-attachments/assets/dadb51c9-5b5d-49e5-8110-75c359d93672" />

After:
<img width="1556" height="769" alt="image" src="https://github.com/user-attachments/assets/f3a146f1-1905-42f5-83f6-99370e1e685e" />


#### Details:

- Accumulate family coverage through the selected version, matching fixture resolver semantics.
- Add a regression for a 3.0.0 anchor plus a 5.1.2 Inkling-only overlay.

#### Verification:

44 tests passed; Python compilation and rendered HTML/browser verification passed with zero missing 5.1.2 cells.

#### Where should the reviewer start?

`conformance/utils/src/generate_conformance_table.py`, then `conformance/utils/tests/test_stream_on_batch.py`

/coderabbit profile chill