### PR TITLE
perf(conformance): resolve fixtures in memory, 2m36s render -> 10s — NO PARSER CHANGE

### DIFF
--- a/conformance/utils/check.sh
+++ b/conformance/utils/check.sh
@@ -66,10 +66,12 @@ run_ci() {  # the conformance-table CI gate; fail-fast, also runnable locally
   # The uploaded CI artifact name predates the v1/v2 split; keep it stable.
   \cp -f "$out" "$UTILS/CONFORMITY.html"
   run_coverage
-  python3 -m pytest \
-    "$UTILS/tests/test_model.py" \
-    "$UTILS/tests/test_stream_on_batch.py" \
-    "$UTILS/tests/test_family_coverage.py" -q
+  # The WHOLE tests/ dir, not a hand-maintained file list: the old list named three
+  # files, so the resolver-fold, render-invariant and colorize tests never ran in CI
+  # and a new test file was gated only by remembering to add it here. The browser
+  # tests skip themselves when Selenium isn't installed (CI installs pyyaml/jinja2/
+  # pytest only), so this stays a no-engine, no-browser gate.
+  python3 -m pytest "$UTILS/tests" -q
 }
 
 engine="${1:-}"; shift || true

--- a/conformance/utils/src/_common.sh
+++ b/conformance/utils/src/_common.sh
@@ -76,6 +76,9 @@ _build_stage_base() {
   \cp -f "$TOOLS/model.py" "$STAGE/tests/parity/model.py"
   # markers.py (comparison/facts semantics) + impls.py (identity) are the single
   # source the tables import instead of forking their own comparison copies.
+  # yaml_fast.py is the one place PyYAML gets routed through libyaml; the staged
+  # generator imports it by name, so it has to sit beside it in tests/parity/.
+  \cp -f "$TOOLS/yaml_fast.py" "$STAGE/tests/parity/yaml_fast.py"
   \cp -f "$TOOLS/impls.py" "$STAGE/tests/parity/impls.py"
   \cp -f "$TOOLS/markers.py" "$STAGE/tests/parity/markers.py"
   \cp -f "$TOOLS/unified_taxonomy.py" "$STAGE/tests/parity/unified_taxonomy.py"

--- a/conformance/utils/src/fixture_corpus.py
+++ b/conformance/utils/src/fixture_corpus.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared reading + version-ordering helpers for the three fixture resolvers.
+
+resolve_fixtures.py (batch), resolve_stream_fixtures.py (stream) and
+resolve_reasoning_fixtures.py all walk the same corpus layout —
+
+    <root>/inputs/<family>/*.yaml            shared, version-independent inputs
+    <root>/<impl>-<version>/<family>/*.yaml  per-impl overlays, lowest = full anchor
+
+— and each had grown its own copy of `load`, `version_key` and the "<impl>-<version>"
+splitter. They live here once so a corpus-layout change lands in one place.
+"""
+import re
+from pathlib import Path
+
+import yaml
+import yaml_fast  # noqa: F401 — routes safe_load/safe_dump through libyaml
+
+
+def load(p):
+    return yaml.safe_load(Path(p).read_text())
+
+
+def version_key(ver: str):
+    """Order versions like 0.5.12.post1 < 0.5.14 < 0.24.0 < 3.0.0."""
+    m = re.match(r"(\d+(?:\.\d+)*)(?:[.-]?post(\d+))?", ver)
+    release = tuple(int(x) for x in m.group(1).split(".")) if m else ()
+    post = int(m.group(2)) if m and m.group(2) else 0
+    return (release, post)
+
+
+def split_sel(sel: str):
+    """'vllm_python-0.24.0' -> ('vllm_python', '0.24.0'). An impl key may contain '_',
+    but the version token always starts after the FIRST '-'."""
+    impl, _, ver = sel.partition("-")
+    return impl, ver
+
+
+def load_corpus(root) -> dict[tuple[str, str, str], dict]:
+    """Parse every fixture under <root> ONCE: {(top_dir, family, filename): doc}.
+
+    `top_dir` is "inputs" or an "<impl>-<version>" dir. A caller resolving many version
+    selections out of the same corpus (the generator's version-status maps resolve ~11
+    for stream, ~9 for batch) parses once and reuses the result, instead of re-reading
+    all ~1700 source files per selection.
+    """
+    root = Path(root)
+    return {
+        (fp.parent.parent.name, fp.parent.name, fp.name): yaml.safe_load(fp.read_text())
+        for fp in root.glob("*/*/*.yaml")
+    }

--- a/conformance/utils/src/fixtures.py
+++ b/conformance/utils/src/fixtures.py
@@ -488,7 +488,28 @@ def family_suffix(fam: str, no_vllm: set[str], no_sglang: set[str]) -> str:
 _CAPTURED_WITH_BY_MODE: dict[str, dict[str, str]] = {}
 
 
-def load_all_cases(mode: str) -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
+def _iter_mode_docs(mode: str, docs: dict | None = None):
+    """Yield `(fixture_path, parsed_doc)` for one parser mode.
+
+    `docs` — `{(family_dir, filename): doc}` already resolved in memory, INSTEAD of
+    globbing + parsing FIXTURES. The version-status maps resolve ~20 version
+    selections per render; handing the docs straight over skips writing each staged
+    tree to disk and parsing it back. Paths are still built under FIXTURES so
+    `__fixture_path` names a real staged file.
+    """
+    prefix = f"TOOLCALLING.{mode}"
+    if docs is None:
+        for fp in sorted(FIXTURES.glob(f"*/{prefix}*.yaml")):
+            yield fp, yaml.safe_load(fp.read_text())
+        return
+    for family, name in sorted(docs):
+        if name.startswith(prefix) and name.endswith(".yaml"):
+            yield FIXTURES / family / name, docs[(family, name)]
+
+
+def load_all_cases(
+    mode: str, docs: dict | None = None
+) -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
     """Load every fixture YAML for one parser mode.
 
     Returns `(cases, labels)`:
@@ -498,13 +519,16 @@ def load_all_cases(mode: str) -> tuple[dict[tuple[str, str], dict], dict[str, st
       labels — `{family: model_label}` collected from the fixtures' doc-level
                `model_label:` field. Falls back to the family ID if a fixture
                doesn't declare one.
+
+    `docs` — pre-resolved in-memory docs (see `_iter_mode_docs`). NOTE: the case dicts
+    inside are annotated and rewritten in place, so pass a set of docs that belongs to
+    this call alone (resolve_docs() hands back a fresh copy per selection).
     """
     cases: dict[tuple[str, str], dict] = {}
     labels: dict[str, str] = {}
     captured_with: dict[str, str] = {}
     script_dir = Path(__file__).resolve().parent
-    for fp in sorted(FIXTURES.glob(f"*/TOOLCALLING.{mode}*.yaml")):
-        doc = yaml.safe_load(fp.read_text())
+    for fp, doc in _iter_mode_docs(mode, docs):
         if doc.get("mode") != mode:
             continue
         family = doc["family"]
@@ -530,17 +554,21 @@ def load_all_cases(mode: str) -> tuple[dict[tuple[str, str], dict], dict[str, st
             cases[(family, sub)] = case
     _CAPTURED_WITH_BY_MODE[mode] = captured_with
     if mode == "streamv2":
-        _attach_streamv2_batch_expected(cases)
+        _attach_streamv2_batch_expected(cases, docs)
     return _normalize_split_parent_cases(cases), labels
 
 
-def _attach_streamv2_batch_expected(cases: dict) -> None:
+def _attach_streamv2_batch_expected(cases: dict, docs: dict | None = None) -> None:
     """For each streamv2 case, attach `batch_expected[impl]` from the matching batch
     case (same family + sub), so the stream tab can color each engine's stream
-    against its own batch (streamv2.<sub> mirrors batch.<sub>)."""
+    against its own batch (streamv2.<sub> mirrors batch.<sub>).
+
+    Reads the same source as its caller: with in-memory `docs` from a stream-only
+    resolve there are no batch docs to match, exactly as when the caller staged a
+    stream-only tree on disk."""
     batch_exp: dict[tuple[str, str], dict] = {}
-    for fp in sorted(FIXTURES.glob("*/TOOLCALLING.batch*.yaml")):
-        doc = yaml.safe_load(fp.read_text()) or {}
+    for _fp, doc in _iter_mode_docs("batch", docs):
+        doc = doc or {}
         if doc.get("mode") != "batch":
             continue
         family = doc["family"]

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -64,24 +64,18 @@ import copy
 import datetime
 import functools
 import html as html_lib
+import importlib
 import json
 import os
 import re
 import subprocess
 import sys
-import tempfile
 import zoneinfo
 from pathlib import Path
 from typing import Any
 
 import yaml
-# PERF: this render loads thousands of fixture YAMLs (the stream version-status map
-# re-loads every peer version); PyYAML's pure-Python SafeLoader dominates the wall
-# clock. Route safe_load through libyaml's CSafeLoader (identical result, ~15x faster)
-# when the C extension is present. fixtures.py / markers.py call `yaml.safe_load` at
-# call time, so patching the module here covers them too.
-if hasattr(yaml, "CSafeLoader"):
-    yaml.safe_load = lambda _s, _loader=yaml.CSafeLoader: yaml.load(_s, Loader=_loader)
+import yaml_fast  # noqa: F401 — routes safe_load/safe_dump through libyaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from tables import common
@@ -885,6 +879,26 @@ def _batch_impl_versions() -> dict[str, list[str]]:
     }
 
 
+def _resolver_module(name: str):
+    """Import a fixture resolver from the repo's conformance/utils/src.
+
+    The resolvers are not part of the staged tree, so their directory is APPENDED to
+    sys.path — never prepended — so the staged copies of fixtures/markers/tables keep
+    priority over the repo-side originals sitting beside the resolvers."""
+    src_dir = str(fixtures._RESOLVE_SRC_DIR)
+    if src_dir not in sys.path:
+        sys.path.append(src_dir)
+    return importlib.import_module(name)
+
+
+@functools.lru_cache(maxsize=None)
+def _source_corpus(root_str: str) -> dict:
+    """Parse a versioned fixture corpus ONCE, for every version selection resolved
+    out of it. Each render resolves ~9 batch + ~11 stream selections; re-reading all
+    ~1700 source files per selection was the single largest cost in the render."""
+    return _resolver_module("fixture_corpus").load_corpus(Path(root_str))
+
+
 def _batch_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, str]]]:
     """{(family, sub): {canonical_impl: {version_slug: overview_status}}} for batch.
 
@@ -898,8 +912,9 @@ def _batch_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, str
     src = fixtures._SRC_FIXTURES
     if not resolver.exists() or not src.is_dir():
         return {}
+    resolve_batch = _resolver_module("resolve_fixtures").resolve_docs
+    corpus = _source_corpus(str(src))
     pinned = fixtures._pinned_versions(impl_versions)
-    saved_fixtures = fixtures.FIXTURES
     saved_captured = _CAPTURED_WITH_BY_MODE.get("batch")
     result: dict[tuple[str, str], dict[str, dict[str, str]]] = {}
     try:
@@ -911,18 +926,11 @@ def _batch_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, str
                     f"{other}-{version if other == legacy else pinned[other]}"
                     for other in impl_versions
                 ]
-                # Resolve under the staged fixtures parent so load_all_cases's
-                # `fp.relative_to(script_dir)` stays valid (script_dir = the module
-                # dir, above the fixtures tree).
-                with tempfile.TemporaryDirectory(dir=str(saved_fixtures.parent)) as tmp:
-                    subprocess.run(
-                        [sys.executable, str(resolver),
-                         "--fixtures-root", str(src),
-                         "--out", tmp, "--select", *select],
-                        check=True, capture_output=True,
-                    )
-                    fixtures.FIXTURES = Path(tmp)
-                    cases, _labels = load_all_cases("batch")
+                # Resolve in memory and read the docs directly: this map only needs
+                # each case's status/block/marker, so staging the tree to a tempdir
+                # just to parse it straight back was pure overhead.
+                docs, _folded = resolve_batch(src, select, corpus=corpus)
+                cases, _labels = load_all_cases("batch", docs=docs)
                 for key, case in cases.items():
                     block = _impl_get(case.get("expected") or {}, canon)
                     result.setdefault(key, {}).setdefault(canon, {})[slug] = {
@@ -935,7 +943,7 @@ def _batch_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, str
                         ),
                     }
     finally:
-        fixtures.FIXTURES = saved_fixtures
+        # load_all_cases stamps this per call; put the pinned render's value back.
         if saved_captured is not None:
             _CAPTURED_WITH_BY_MODE["batch"] = saved_captured
     return result
@@ -1228,28 +1236,29 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
     resolver = fixtures._RESOLVE_SRC_DIR / "resolve_stream_fixtures.py"
     if not resolver.exists() or not _STREAM_SRC.is_dir():
         return {}
+    resolve_stream = _resolver_module("resolve_stream_fixtures").resolve_docs
+    corpus = _source_corpus(str(_STREAM_SRC))
     overlaid = {i: vs for i, vs in impl_versions.items() if len(vs) > 1}
     pinned = {i: vs[-1] for i, vs in impl_versions.items()}
-    saved_fixtures = fixtures.FIXTURES
     saved_captured = _CAPTURED_WITH_BY_MODE.get("streamv2")
     result: dict[tuple[str, str], dict[str, dict[str, dict]]] = {}
 
     def _raw_chunk_counts(impl, version):
         """{(family, case_id): n_chunks} straight from the <impl>-<version> dir docs.
         The resolver pads a folded case to the input chunk count, so alignment
-        (did this capture record per-input-chunk timing?) is only visible here."""
+        (did this capture record per-input-chunk timing?) is only visible here.
+        Read out of the shared corpus — these are the same source docs the fold
+        already parsed."""
         counts: dict[tuple[str, str], int] = {}
-        vdir = _STREAM_SRC / f"{impl}-{version}"
-        if vdir.is_dir():
-            for fp in vdir.glob("*/*.yaml"):
-                try:
-                    doc = yaml.safe_load(fp.read_text()) or {}
-                except Exception:
-                    continue
-                fam = doc.get("family") or fp.parent.name
-                for cid, vc in (doc.get("cases") or {}).items():
-                    if isinstance(vc, dict) and isinstance(vc.get("chunks"), list):
-                        counts[(fam, cid)] = len(vc["chunks"])
+        vdir_name = f"{impl}-{version}"
+        for (top, family, _name), doc in corpus.items():
+            if top != vdir_name:
+                continue
+            doc = doc or {}
+            fam = doc.get("family") or family
+            for cid, vc in (doc.get("cases") or {}).items():
+                if isinstance(vc, dict) and isinstance(vc.get("chunks"), list):
+                    counts[(fam, cid)] = len(vc["chunks"])
         return counts
 
     def _record(cases, impl, version):
@@ -1308,17 +1317,12 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
             }
 
     def _resolve_and_load(select):
-        # Resolve under the staged fixtures parent so load_all_cases's
-        # `fp.relative_to(script_dir)` stays valid (script_dir is above the tree).
-        with tempfile.TemporaryDirectory(dir=str(saved_fixtures.parent)) as tmp:
-            subprocess.run(
-                [sys.executable, str(resolver),
-                 "--fixtures-root", str(_STREAM_SRC),
-                 "--out", tmp, "--select", *select],
-                check=True, capture_output=True,
-            )
-            fixtures.FIXTURES = Path(tmp)
-            cases, _labels = load_all_cases("streamv2")
+        # Resolve in memory and read the docs directly. Staging each selection to a
+        # tempdir only to parse it straight back was the bulk of the render's time.
+        # The docs are stream-only, so load_all_cases finds no batch docs to attach
+        # batch_expected from — same as when the staged tree held stream files alone.
+        docs, _folded = resolve_stream(_STREAM_SRC, select, corpus=corpus)
+        cases, _labels = load_all_cases("streamv2", docs=docs)
         return cases
 
     try:
@@ -1336,7 +1340,7 @@ def _stream_version_status_map() -> dict[tuple[str, str], dict[str, dict[str, di
                 cases = _resolve_and_load(select)
                 _record(cases, impl, v)
     finally:
-        fixtures.FIXTURES = saved_fixtures
+        # load_all_cases stamps this per call; put the pinned render's value back.
         if saved_captured is not None:
             _CAPTURED_WITH_BY_MODE["streamv2"] = saved_captured
     return result

--- a/conformance/utils/src/resolve_fixtures.py
+++ b/conformance/utils/src/resolve_fixtures.py
@@ -17,43 +17,35 @@ impl's version dirs in ascending version order up to and including the requested
 merging each case's expected.<impl> block. Default select = latest per impl.
 Readers/renderers consume the flat output unchanged.
 """
-import argparse, re, sys
+import argparse, copy, sys
 from pathlib import Path
 import yaml
-# PERF: route safe_load through libyaml's CSafeLoader (identical result, ~15x faster).
-if hasattr(yaml, "CSafeLoader"):
-    yaml.safe_load = lambda _s, _loader=yaml.CSafeLoader: yaml.load(_s, Loader=_loader)
+import yaml_fast  # noqa: F401 — routes safe_load/safe_dump through libyaml
+# Re-exported: callers import load/version_key/split_sel from this module by name.
+from fixture_corpus import load, load_corpus, split_sel, version_key  # noqa: F401
 
-def load(p): return yaml.safe_load(Path(p).read_text())
+def resolve_docs(fixtures_root, select, corpus=None):
+    """Resolve one version selection entirely in memory.
 
-def version_key(ver: str):
-    """Order versions like 0.5.12.post1 < 0.5.14 < 0.24.0 < 3.0.0."""
-    m = re.match(r"(\d+(?:\.\d+)*)(?:[.-]?post(\d+))?", ver)
-    release = tuple(int(x) for x in m.group(1).split(".")) if m else ()
-    post = int(m.group(2)) if m and m.group(2) else 0
-    return (release, post)
+    Returns `(docs, folded)`: `docs` is {(family, filename): doc} for the whole staged
+    tree, `folded` is the subset of those keys an overlay actually merged into. The
+    fold used to run through the filesystem — load the staged file, merge, dump it
+    back, once per impl per version layer — so each output file was parsed and
+    re-emitted several times per run. Keeping the accumulator in memory does the
+    identical merge with one parse of each source file and at most one dump.
 
-def split_sel(sel: str):
-    """'vllm-0.24.0' -> ('vllm', '0.24.0'); impl names never contain '-'."""
-    impl, _, ver = sel.partition("-")
-    return impl, ver
+    Pass `corpus` (from fixture_corpus.load_corpus) to resolve several selections out
+    of one parse of the source tree."""
+    root = Path(fixtures_root)
+    if corpus is None:
+        corpus = load_corpus(root)
 
-def resolve(fixtures_root, out, select, verbose=False):
-    """Stage inputs/ + the selected per-impl versions into a flat tree at `out`.
-
-    `select` is a list of "<impl>-<version>" targets. Importable for callers that
-    need multiple version snapshots (e.g. the parity table's version radios)."""
-    root = Path(fixtures_root); out = Path(out)
-
-    # 1) copy shared inputs verbatim (preserve text so comments/anchors survive)
-    inputs = root / "inputs"
-    for fp in inputs.glob("*/*.yaml"):
-        dst = out / fp.parent.name / fp.name
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_text(fp.read_text())
+    # 1) shared inputs are the base every impl folds into.
+    docs = {key[1:]: copy.deepcopy(doc) for key, doc in corpus.items() if key[0] == "inputs"}
 
     # 2) for each selected impl, apply its version dirs ascending up to the target,
     #    merging expected.<impl>. Lowest applied dir is the full anchor.
+    folded: set[tuple[str, str]] = set()
     for sel in select:
         impl, target = split_sel(sel)
         target_k = version_key(target)
@@ -66,11 +58,18 @@ def resolve(fixtures_root, out, select, verbose=False):
             print(f"resolve_fixtures: no version dirs for {impl} <= {target}, skipping", file=sys.stderr)
             continue
         for _, vdir in applied:
-            for ofp in vdir.glob("*/*.yaml"):
-                tgt = out / ofp.parent.name / ofp.name
-                if not tgt.exists():
+            for key, src_ov in corpus.items():
+                if key[0] != vdir.name:
                     continue
-                base_doc = load(tgt); ov = load(ofp)
+                base_doc = docs.get(key[1:])
+                if base_doc is None:
+                    continue
+                # deepcopy the WHOLE overlay doc in one call: expected blocks are
+                # grafted into the base by reference, so a shared corpus would
+                # otherwise alias one object into every resolved selection. Copying
+                # the doc (not each value) keeps the object sharing the source file
+                # encodes as YAML anchors, so the re-emitted file is unchanged.
+                ov = copy.deepcopy(src_ov)
                 for cid, oc in (ov.get("cases") or {}).items():
                     bc = (base_doc.get("cases") or {}).get(cid)
                     if bc is None or "expected" not in oc:
@@ -78,7 +77,28 @@ def resolve(fixtures_root, out, select, verbose=False):
                     bc.setdefault("expected", {})
                     for k, val in oc["expected"].items():
                         bc["expected"][k] = val
-                tgt.write_text(yaml.safe_dump(base_doc, sort_keys=False, allow_unicode=True, width=4096))
+                folded.add(key[1:])
+
+    return docs, folded
+
+def resolve(fixtures_root, out, select, verbose=False):
+    """Stage inputs/ + the selected per-impl versions into a flat tree at `out`.
+
+    `select` is a list of "<impl>-<version>" targets. Importable for callers that
+    need multiple version snapshots (e.g. the parity table's version radios)."""
+    root = Path(fixtures_root); out = Path(out)
+    docs, folded = resolve_docs(root, select)
+
+    for (family, name), doc in docs.items():
+        dst = out / family / name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if (family, name) in folded:
+            dst.write_text(yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, width=4096))
+        else:
+            # No overlay touched this one, so it keeps the verbatim inputs/ text
+            # (comments/anchors survive) — same as when the fold ran on disk and
+            # simply never rewrote it.
+            dst.write_text((root / "inputs" / family / name).read_text())
 
     if verbose:
         print(f"resolve_fixtures: staged {len(list(out.glob('*/*.yaml')))} files (select: {select or 'none'})", file=sys.stderr)

--- a/conformance/utils/src/resolve_reasoning_fixtures.py
+++ b/conformance/utils/src/resolve_reasoning_fixtures.py
@@ -15,30 +15,12 @@ in ascending order up to and including the selected version, patching expected.<
 Default select = latest available per impl. Readers (reasoning/table.py) consume the flat
 output unchanged.
 """
-import argparse, re, sys
+import argparse, sys
 from pathlib import Path
 import yaml
-# PERF: route safe_load through libyaml's CSafeLoader (identical result, ~15x faster).
-if hasattr(yaml, "CSafeLoader"):
-    yaml.safe_load = lambda _s, _loader=yaml.CSafeLoader: yaml.load(_s, Loader=_loader)
-
-
-def load(p):
-    return yaml.safe_load(Path(p).read_text())
-
-
-def version_key(ver: str):
-    """Order versions like 0.5.12.post1 < 0.5.14 < 0.24.0 < 3.0.0."""
-    m = re.match(r"(\d+(?:\.\d+)*)(?:[.-]?post(\d+))?", ver)
-    release = tuple(int(x) for x in m.group(1).split(".")) if m else ()
-    post = int(m.group(2)) if m and m.group(2) else 0
-    return (release, post)
-
-
-def split_impl_ver(dirname: str):
-    """'vllm-0.23.0' -> ('vllm', '0.23.0'); impl names never contain '-'."""
-    impl, _, ver = dirname.partition("-")
-    return impl, ver
+import yaml_fast  # noqa: F401 — routes safe_load/safe_dump through libyaml
+from fixture_corpus import load, version_key  # noqa: F401 — re-exported
+from fixture_corpus import split_sel as split_impl_ver
 
 
 # The captured_with key each impl records its engine version under.

--- a/conformance/utils/src/resolve_stream_fixtures.py
+++ b/conformance/utils/src/resolve_stream_fixtures.py
@@ -23,34 +23,15 @@ single-version impl (vllm_rust, dynamo_v2) needs no explicit select.
 Readers (load_all_cases("streamv2")) consume the flat output unchanged.
 """
 import argparse
-import re
+import copy
 import sys
 from pathlib import Path
 
 import yaml
-# PERF: this resolver loads every peer fixture to merge overlays; route safe_load
-# through libyaml's CSafeLoader (identical result, ~15x faster) when available.
-if hasattr(yaml, "CSafeLoader"):
-    yaml.safe_load = lambda _s, _loader=yaml.CSafeLoader: yaml.load(_s, Loader=_loader)
-
-
-def load(p):
-    return yaml.safe_load(Path(p).read_text())
-
-
-def version_key(ver: str):
-    """Order versions like 0.5.12.post1 < 0.5.14 < 0.24.0 < 3.0.0."""
-    m = re.match(r"(\d+(?:\.\d+)*)(?:[.-]?post(\d+))?", ver)
-    release = tuple(int(x) for x in m.group(1).split(".")) if m else ()
-    post = int(m.group(2)) if m and m.group(2) else 0
-    return (release, post)
-
-
-def split_sel(sel: str):
-    """'vllm_python-0.24.0' -> ('vllm_python', '0.24.0'). Impl keys may contain '_'
-    but the version token starts after the first '-'."""
-    impl, _, ver = sel.partition("-")
-    return impl, ver
+import yaml_fast  # noqa: F401 — routes safe_load/safe_dump through libyaml
+# Re-exported: test_render_invariants.py and the generator import version_key/load
+# from this module by name.
+from fixture_corpus import load, load_corpus, split_sel, version_key  # noqa: F401
 
 
 def _impl_version_dirs(root: Path) -> dict[str, list[tuple]]:
@@ -114,16 +95,22 @@ def _merge_impl(base_doc, vdoc, impl):
                 bchunks[i]["normal_text"].pop(impl, None)
 
 
-def resolve(sv2_root, out, select, verbose=False):
-    root = Path(sv2_root)
-    out = Path(out)
+def resolve_docs(sv2_root, select, corpus=None):
+    """Resolve one version selection entirely in memory.
 
-    # 1) copy the shared inputs tree verbatim (the base every impl folds into).
-    inputs = root / "inputs"
-    for fp in inputs.glob("*/*.yaml"):
-        dst = out / fp.parent.name / fp.name
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_text(fp.read_text())
+    Returns `(docs, folded)`: `docs` is {(family, filename): doc} for the whole staged
+    tree, `folded` is the subset of those keys an impl overlay actually merged into.
+    The fold used to run through the filesystem — load the staged file, merge, dump it
+    back, once per impl per version layer — which meant every output file was parsed
+    and re-emitted several times per run. Keeping the accumulator in memory does the
+    identical merge with one parse of each source file and at most one dump.
+    """
+    root = Path(sv2_root)
+    if corpus is None:
+        corpus = load_corpus(root)
+
+    # 1) the shared inputs tree is the base every impl folds into.
+    docs = {key[1:]: copy.deepcopy(doc) for key, doc in corpus.items() if key[0] == "inputs"}
 
     # 2) per-impl target: default = that impl's lowest version; --select bumps it.
     dirs = _impl_version_dirs(root)
@@ -134,20 +121,43 @@ def resolve(sv2_root, out, select, verbose=False):
             targets[impl] = ver
 
     # 3) fold each impl's version dirs ascending up to its target into the base tree.
+    folded: set[tuple[str, str]] = set()
     for impl, target in targets.items():
         tk = version_key(target)
-        applied = [(k, d) for k, _v, d in dirs[impl] if k <= tk]
-        for _k, vdir in applied:
-            for vfp in vdir.glob("*/*.yaml"):
-                tgt = out / vfp.parent.name / vfp.name
-                if not tgt.exists():
+        for k, _v, vdir in dirs[impl]:
+            if k > tk:
+                continue
+            for key, vdoc in corpus.items():
+                if key[0] != vdir.name:
                     continue
-                base_doc = load(tgt)
-                _merge_impl(base_doc, load(vfp), impl)
-                base_doc.setdefault("captured_with", {})[impl] = target
-                tgt.write_text(
-                    yaml.safe_dump(base_doc, sort_keys=False, allow_unicode=True, width=4096)
-                )
+                doc = docs.get(key[1:])
+                if doc is None:
+                    continue
+                # deepcopy: _merge_impl grafts the overlay's own lists/dicts into the
+                # base doc by reference, and with a shared corpus that would alias the
+                # same objects into every resolved selection.
+                _merge_impl(doc, copy.deepcopy(vdoc), impl)
+                doc.setdefault("captured_with", {})[impl] = target
+                folded.add(key[1:])
+    return docs, folded
+
+
+def resolve(sv2_root, out, select, verbose=False):
+    root = Path(sv2_root)
+    out = Path(out)
+    docs, folded = resolve_docs(root, select)
+
+    for (family, name), doc in docs.items():
+        dst = out / family / name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if (family, name) in folded:
+            dst.write_text(
+                yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, width=4096)
+            )
+        else:
+            # No overlay touched this one, so it stays the verbatim inputs/ text —
+            # same as when the fold ran on disk and simply never rewrote it.
+            dst.write_text((root / "inputs" / family / name).read_text())
 
     if verbose:
         n = len(list(out.glob("*/TOOLCALLING.streamv2.*.yaml")))

--- a/conformance/utils/src/yaml_fast.py
+++ b/conformance/utils/src/yaml_fast.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Route PyYAML through libyaml's C parser/emitter. Import for the side effect.
+
+The conformance render is dominated by YAML: the resolvers parse the whole fixture
+corpus and re-emit every staged file, and the generator re-loads it per peer version.
+PyYAML's pure-Python SafeLoader/SafeDumper are what that time is actually spent in —
+in one resolver run the emitter alone was 72% of tottime. CSafeLoader/CSafeDumper
+produce identical documents (verified byte-identical across the staged corpus), so
+this patches `yaml.safe_load` / `yaml.safe_dump` at module level ONCE.
+
+Patching the module rather than each call site is deliberate: fixtures.py, markers.py,
+and the tables package call `yaml.safe_load` directly at call time, so one import here
+covers them without a copy of the shim in each file. Every module that reads or writes
+fixture YAML on the render path imports this instead of rolling its own.
+"""
+import yaml
+
+if hasattr(yaml, "CSafeLoader"):
+
+    def _fast_load(stream, _loader=yaml.CSafeLoader):
+        return yaml.load(stream, Loader=_loader)
+
+    yaml.safe_load = _fast_load
+
+if hasattr(yaml, "CSafeDumper"):
+
+    def _fast_dump(data, stream=None, _dumper=yaml.CSafeDumper, **kwargs):
+        return yaml.dump(data, stream, Dumper=_dumper, **kwargs)
+
+    yaml.safe_dump = _fast_dump

--- a/conformance/utils/tests/conftest.py
+++ b/conformance/utils/tests/conftest.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Shared fixtures: one real render per test session, reused by the output-invariant
-and browser tests (rendering takes ~1-2 min; per-module renders would multiply that)."""
+"""Shared fixtures: ONE real render per test session, reused by every browser test.
+
+Both browser modules must take the page from here. test_browser_smoke.py used to
+declare its own module-scoped copy of this fixture, so a full run rendered the table
+twice — and the two renders were the bulk of the suite's wall clock."""
 import subprocess
 from pathlib import Path
 

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -12,9 +12,7 @@ Skips when Selenium or headless Chrome aren't available, so it adds no hard test
 dependency — it runs where a browser exists and is a no-op otherwise.
 """
 import shutil
-import subprocess
 import time
-from pathlib import Path
 
 import pytest
 
@@ -22,23 +20,10 @@ selenium = pytest.importorskip("selenium")
 from selenium import webdriver  # noqa: E402
 from selenium.webdriver.chrome.options import Options  # noqa: E402
 
-UTILS = Path(__file__).resolve().parents[1]
-REPO = UTILS.parents[1]
-
 pytestmark = pytest.mark.skipif(
     not any(shutil.which(b) for b in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser")),
     reason="no headless Chrome available",
 )
-
-
-@pytest.fixture(scope="module")
-def rendered(tmp_path_factory):
-    out = tmp_path_factory.mktemp("d4") / "table.html"
-    subprocess.run(
-        [str(UTILS / "render_table_v2.sh"), "--output", str(out)],
-        check=True, cwd=REPO, capture_output=True, text=True,
-    )
-    return out
 
 
 # Headless Chrome reports `(hover: hover)` as FALSE, so conformance.js takes its touch
@@ -60,7 +45,7 @@ window.matchMedia = function (q) {
 
 
 @pytest.fixture(scope="module")
-def driver(rendered):
+def driver(rendered_page):
     opts = Options()
     for a in ("--headless=new", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--window-size=1600,1200"):
         opts.add_argument(a)
@@ -69,7 +54,7 @@ def driver(rendered):
     except Exception as exc:  # noqa: BLE001 — environment without a usable driver
         pytest.skip(f"could not start Chrome webdriver: {exc}")
     d.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {"source": _FORCE_HOVER_JS})
-    d.get(f"file://{rendered}")
+    d.get(f"file://{rendered_page}")
     d.implicitly_wait(2)
     yield d
     d.quit()

--- a/conformance/utils/tests/test_resolve_corpus_reuse.py
+++ b/conformance/utils/tests/test_resolve_corpus_reuse.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract for resolving many version selections out of ONE parsed corpus.
+
+The fold used to run through the filesystem: load the staged file, merge one impl's
+overlay, dump it back, repeat per version layer. It now folds in memory, and the
+generator resolves ~20 version selections from a single `load_corpus()` parse. Two
+things have to hold for that to be a pure speedup:
+
+1. A resolved doc must not alias objects owned by the shared corpus. Overlay blocks
+   are grafted into the base BY REFERENCE, so without a copy, selection A and
+   selection B would hand back the same mutable objects and a reader that touched
+   one would corrupt the other.
+2. The copy must preserve object sharing WITHIN a source doc. Fixture files use YAML
+   anchors (`&id002` / `*id002`) for repeated expected blocks; deep-copying each
+   grafted value separately silently expanded every alias, so the staged file grew
+   and stopped matching what the on-disk fold produced. Copying the doc in one call
+   keeps the sharing — and the anchors — intact.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import resolve_fixtures  # noqa: E402
+import resolve_stream_fixtures  # noqa: E402
+from fixture_corpus import load_corpus  # noqa: E402
+
+FAMILY = "famx"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _batch_tree(root: Path) -> None:
+    """Batch corpus whose overlay shares ONE expected block across two cases via a
+    YAML anchor — the shape whose aliases the per-value copy expanded."""
+    _write(root / "inputs" / FAMILY / "TOOLCALLING.batch.yaml", (
+        "family: famx\n"
+        "mode: batch\n"
+        "cases:\n"
+        "  TOOLCALLING.batch.1:\n"
+        "    model_text: a\n"
+        "  TOOLCALLING.batch.2:\n"
+        "    model_text: b\n"
+    ))
+    for ver in ("0.23.0", "0.24.0"):
+        _write(root / f"vllm_python-{ver}" / FAMILY / "TOOLCALLING.batch.yaml", (
+            "family: famx\n"
+            "mode: batch\n"
+            "cases:\n"
+            "  TOOLCALLING.batch.1:\n"
+            "    expected:\n"
+            "      vllm_python: &shared\n"
+            "        calls: []\n"
+            f"        normal_text: 'v{ver}'\n"
+            "  TOOLCALLING.batch.2:\n"
+            "    expected:\n"
+            "      vllm_python: *shared\n"
+        ))
+
+
+def _stream_tree(root: Path) -> None:
+    _write(root / "inputs" / FAMILY / "TOOLCALLING.streamv2.1.yaml", (
+        "family: famx\n"
+        "mode: streamv2\n"
+        "cases:\n"
+        "  TOOLCALLING.streamv2.1:\n"
+        "    chunks:\n"
+        "    - delta_text: 'x'\n"
+        "    - delta_text: 'y'\n"
+    ))
+    for ver in ("0.1.11", "0.1.22"):
+        _write(root / f"dynamo_v2-{ver}" / FAMILY / "TOOLCALLING.streamv2.1.yaml", (
+            "family: famx\n"
+            "mode: streamv2\n"
+            "cases:\n"
+            "  TOOLCALLING.streamv2.1:\n"
+            "    chunks:\n"
+            "    - expected: &shared\n"
+            "      - index: 0\n"
+            f"        name: 'v{ver}'\n"
+            "    - expected: *shared\n"
+        ))
+
+
+RESOLVERS = {
+    "batch": (resolve_fixtures, _batch_tree, "TOOLCALLING.batch.yaml",
+              ["vllm_python-0.23.0"], ["vllm_python-0.24.0"]),
+    "stream": (resolve_stream_fixtures, _stream_tree, "TOOLCALLING.streamv2.1.yaml",
+               ["dynamo_v2-0.1.11"], ["dynamo_v2-0.1.22"]),
+}
+
+
+@pytest.mark.parametrize("kind", sorted(RESOLVERS))
+def test_shared_corpus_matches_a_fresh_parse(tmp_path, kind):
+    """resolve_docs(corpus=<shared>) == resolve_docs(corpus=None), for every selection."""
+    mod, make_tree, name, sel_a, sel_b = RESOLVERS[kind]
+    root = tmp_path / kind
+    make_tree(root)
+    corpus = load_corpus(root)
+
+    for select in (sel_a, sel_b):
+        shared, _ = mod.resolve_docs(root, select, corpus=corpus)
+        fresh, _ = mod.resolve_docs(root, select)
+        assert shared == fresh, f"{kind} {select}: shared-corpus resolve diverged"
+
+
+@pytest.mark.parametrize("kind", sorted(RESOLVERS))
+def test_selections_do_not_alias_each_other(tmp_path, kind):
+    """Mutating one resolved selection must not reach another, or the corpus."""
+    mod, make_tree, name, sel_a, sel_b = RESOLVERS[kind]
+    root = tmp_path / kind
+    make_tree(root)
+    corpus = load_corpus(root)
+
+    docs_a, _ = mod.resolve_docs(root, sel_a, corpus=corpus)
+    docs_b, _ = mod.resolve_docs(root, sel_b, corpus=corpus)
+    before_b = yaml.safe_dump(docs_b[(FAMILY, name)], sort_keys=False)
+    before_corpus = yaml.safe_dump(
+        {"/".join(k): v for k, v in sorted(corpus.items())}, sort_keys=False
+    )
+
+    # Reach into A and scribble on every mutable leaf a reader could touch.
+    doc_a = docs_a[(FAMILY, name)]
+    for case in (doc_a.get("cases") or {}).values():
+        for blk in (case.get("expected") or {}).values():
+            if isinstance(blk, dict):
+                blk["normal_text"] = "SCRIBBLED"
+        for ch in case.get("chunks") or []:
+            for deltas in (ch.get("expected") or {}).values():
+                if isinstance(deltas, list):
+                    deltas.append({"index": 99, "name": "SCRIBBLED"})
+
+    assert yaml.safe_dump(docs_b[(FAMILY, name)], sort_keys=False) == before_b, (
+        f"{kind}: mutating one selection leaked into another"
+    )
+    assert yaml.safe_dump(
+        {"/".join(k): v for k, v in sorted(corpus.items())}, sort_keys=False
+    ) == before_corpus, f"{kind}: mutating a resolved selection leaked into the corpus"
+
+
+@pytest.mark.parametrize("kind", sorted(RESOLVERS))
+def test_source_anchors_survive_the_fold(tmp_path, kind):
+    """Two cases sharing one object in the source must still share it after resolving,
+    so the staged file re-emits the alias instead of expanding it."""
+    mod, make_tree, name, sel_a, _sel_b = RESOLVERS[kind]
+    root = tmp_path / kind
+    out = tmp_path / f"{kind}-out"
+    make_tree(root)
+
+    mod.resolve(root, out, select=sel_a)
+    text = (out / FAMILY / name).read_text()
+    staged = yaml.safe_load(text)
+
+    blocks = []
+    for case in staged["cases"].values():
+        for blk in (case.get("expected") or {}).values():
+            blocks.append(blk)
+        for ch in case.get("chunks") or []:
+            for deltas in (ch.get("expected") or {}).values():
+                blocks.append(deltas)
+    assert len(blocks) == 2, f"{kind}: expected 2 shared blocks, got {len(blocks)}"
+    assert blocks[0] is blocks[1], (
+        f"{kind}: the source's shared block was expanded into two copies; the staged "
+        f"file no longer matches the on-disk fold's output:\n{text}"
+    )


### PR DESCRIPTION
## Overview

The conformance render took 2m35.8s and the pytest suite 5m13s. Both spent their time redoing the same work: the fixture resolver ran 20 times per render, each run re-parsing all 1732 source YAMLs and round-tripping every output file through YAML on every version layer. The render was 97% one core on a 32-core box.

| | before | after |
|---|---|---|
| `render_table_v2.sh` | 2m35.8s | 9.5-12.7s |
| `python3 -m pytest tests` | 313.9s | 40-44s |
| `check.sh ci` (this PR's CI gate) | ~2m50s | 16.0s |

No parallelism was used — this is redundant work removed, so that lever is still free if it is ever needed.

## Details

- **`yaml_fast.py` (new)** routes `yaml.safe_load` **and** `safe_dump` through libyaml. Four files had each grown their own copy of the CSafeLoader shim and none patched the dump side, so the pure-Python emitter was 72% of a resolver run.
- **`fixture_corpus.py` (new)** is the shared parent for `load` / `version_key` / the `<impl>-<version>` splitter — one copy each in the three resolvers — plus the new `load_corpus`.
- **`resolve_docs()`** keeps the fold's accumulator in memory instead of on disk, so each source file is parsed once and each output dumped at most once (was: load staged file, merge, dump, write — per file per version layer).
- **The 20 `subprocess.run` resolves are gone.** `load_all_cases(mode, docs=...)` takes the resolved docs directly, so a selection is no longer staged to a tempdir just to be parsed straight back.
- **`test_browser_smoke.py`** dropped its module-scoped render fixture, a duplicate of conftest's session-scoped one, so the suite renders once instead of twice.
- **`check.sh ci`** runs the whole `tests/` dir rather than a three-file list that silently excluded the resolver, render-invariant and colorize tests: 77 -> 95 tests in CI. Browser tests skip themselves without Selenium, which CI does not install.

## Verification

Byte-identical output, not just "it still renders":

- The rendered HTML matches the pre-change output once the render timestamp is normalised, and the parsed JSON page model compares equal.
- The three resolvers produce identical staged trees — `diff -r` clean over 2188 files across 5 batch + 4 stream selections plus reasoning.
- `check.sh ci` re-run in a fresh venv with only `pyyaml jinja2 pytest` (what CI installs): rc=0, 95 passed + 2 skipped.

Deep-copying each grafted value separately expanded the YAML anchors the fixtures use for repeated `expected` blocks; copying the overlay doc in one `deepcopy` call preserves the sharing via the memo. `test_resolve_corpus_reuse.py` pins that plus the no-aliasing-between-selections property, and both were mutation-tested — reintroducing either defect fails the suite.

## Where

`conformance/utils/src/{yaml_fast,fixture_corpus,resolve_fixtures,resolve_stream_fixtures,resolve_reasoning_fixtures,fixtures,generate_conformance_table}.py`, `conformance/utils/{check.sh,src/_common.sh}`, `conformance/utils/tests/{conftest,test_browser_smoke,test_resolve_corpus_reuse}.py`

## Notes for the reviewer

- `_raw_chunk_counts` used to swallow YAML parse errors with a blanket `except Exception: continue`. Parsing now happens up front in `load_corpus`, so a malformed fixture fails the render instead of silently dropping its chunk counts. Intended direction, but it is a behavior change.
- `test_browser_smoke.py::test_every_wired_element_stays_pinned[normal]` fails in a full-suite run and passes in isolation. It fails the same way on untouched `main`, so it is pre-existing and untouched here.
