### PR TITLE
feat(parsers): add Qwen3 unified request modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,9 +1,9 @@
 {
-  "snapshot": "20260807_193005",
-  "created_pt": "2026-08-07 19:30:05 America/Los_Angeles",
+  "snapshot": "20260814_105421",
+  "created_pt": "2026-08-14 10:54:21 America/Los_Angeles",
   "crates": {
-    "dynamo-parsers": "7.1.0",
-    "dynamo-parsers-v2": "0.1.27"
+    "dynamo-parsers": "7.1.1",
+    "dynamo-parsers-v2": "0.2.0"
   },
   "peers": {
     "vllm": "0.26.0",
@@ -171,19 +171,39 @@
       "size": 4308
     },
     {
+      "path": "unified/dynamo_v2-0.1.22.tar.gz",
+      "sha256": "a7e7f1d161719e8f6caaa1f3fb07f169718308cc13f6a687916975c0ab144de3",
+      "size": 10008
+    },
+    {
       "path": "unified/dynamo_v2-0.1.23.tar.gz",
-      "sha256": "7d8ec2aa4fd17b47afb2107bb3b90ad8461031eac575e88424c811845ef651b3",
-      "size": 5130
+      "sha256": "69dd3be5a0f3a108e513c34a8b3669b405b521061872bfab5b1fb9885ac76880",
+      "size": 10164
+    },
+    {
+      "path": "unified/dynamo_v2-0.1.25.tar.gz",
+      "sha256": "c3113143c757e206d719538092213268cdfbae1f6df0954ac73a72b6da55a5a1",
+      "size": 9660
+    },
+    {
+      "path": "unified/dynamo_v2-0.1.27.tar.gz",
+      "sha256": "64c76851f11dae7c3aeda35f746f64355e535b6c81c77b60f70c214f367dfa8c",
+      "size": 9785
+    },
+    {
+      "path": "unified/dynamo_v2-0.2.0.tar.gz",
+      "sha256": "3e0f153218785fc1a4285d90f19a7a54cc69066462848ba5eda61e25a522772e",
+      "size": 10039
     },
     {
       "path": "unified/golden.tar.gz",
-      "sha256": "43db28380b26c57e01ca90d1d63cf6674c27d41eed0f4603ac4ddda05f6ec8a4",
-      "size": 3644
+      "sha256": "fef673ea851d87236f33e8a989dfe22f1d73d7a1f2c7710bb31583bba71c21ba",
+      "size": 7074
     },
     {
       "path": "unified/inputs.tar.gz",
-      "sha256": "70fda09d7e2f2b2add94b075d3c64207ea0bde7513d426940ff570e35422a1b1",
-      "size": 12937
+      "sha256": "b074f0fe37564cbfb659f958a90c9d4ae45b38a161f6037cd8026ec94d2cf47c",
+      "size": 34876
     },
     {
       "path": "unified/sglang_python-0.5.14.tar.gz",
@@ -191,14 +211,19 @@
       "size": 4363
     },
     {
+      "path": "unified/sglang_python-0.5.16.tar.gz",
+      "sha256": "68b20e272da148503f2626342fbe7977ac259a0a391c5fc4b902ce59c9584d35",
+      "size": 8409
+    },
+    {
       "path": "unified/vllm_python-0.25.1.tar.gz",
-      "sha256": "001076878fe7649be3ff0ae44352c45112b5e7cbba86399afa9d8cf3993540ad",
-      "size": 4742
+      "sha256": "ac45a91593eb85a694321e86216eceeeb6134108a0aed7e352231910c930aa2a",
+      "size": 9365
     },
     {
       "path": "unified/vllm_rust-0.25.1.tar.gz",
-      "sha256": "6c0a80957217c5246e6a7269dfe22e4c7f018ac42b625d30cb1f3502eaca8fdd",
-      "size": 5367
+      "sha256": "0ef327ee87ac8df71dd8bee069ba33561cd4fc06486acb99298e73f1cac8ff9a",
+      "size": 10472
     }
   ]
 }

--- a/conformance/fixtures/unified/README.md
+++ b/conformance/fixtures/unified/README.md
@@ -22,6 +22,35 @@ Every fixture ships as a per-version LFS shard here, same convention as the tool
 - `../utils/lib/parsers/UNIFIED_CASES.md` — schema, invariants, policies, divergence classes, case taxonomy.
 - `../tests/unified_schema_roundtrip.rs` — proves every authored golden case parses and round-trips through the event schema.
 
+### Pre-unified columns (`dynamo_v2-0.1.22`, `dynamo_v2-0.1.23`)
+
+`0.1.23` is the last release with NO `unified` module at all — the unified parser first shipped in `0.1.24`, verified with `git ls-tree -d <tag> parsers/v2/src/unified` across `0.1.22`..`0.1.26`. **BOTH `0.1.22` and `0.1.23`** are therefore the SPLIT path by definition (v1 reasoning + v2 tool), and they are what show the argument-integrity divergences the unified parser fixes (`UNIFIED.12.a`, `UNIFIED.7.b`). (An earlier revision of this file said unified shipped in `0.1.23` and scoped this section to `0.1.22` alone; both were wrong.)
+
+Some released capture rows retain legacy `parser_path` metadata, but the capture producer does not own that field consistently and the renderer does not treat it as authoritative. `unified_parser_path()` derives the label from the tested release boundary: `0.1.22` and `0.1.23` map to `split`, while `0.1.24` and later map to `unified`; `test_unified_parser_path_uses_the_release_boundary_not_fixture_metadata` pins that mapping. The table labels the older columns `SPLIT ONLY — no unified parser in this build`. That label is not cosmetic: an empty result under a `Combined & Unified` heading reads as "the unified parser returned nothing", when in fact there was never a unified parser to run. On a native case `0.1.22` returns a real `tool_call`; on the guided cases it returns nothing at all, and THAT is the finding.
+
+**Reading the diff counts.** The cross-version harness drives `push`/`finish` only — it has to compile against builds with no `initialize` / output-mode API — so it cannot apply a case's `init:`. Every case therefore runs in that build's ONLY mode. For a pre-request-mode build that is not a mis-measurement (it has one mode, so "what it does" is "what it would have done"), but it does mean part of any diff count against a modern column is missing capability rather than changed behaviour in a comparable mode. The group 30/31/40/41/50/51 cases are the affected ones.
+
+`capture_cross_version.rs` cannot be used unmodified against them: that harness falls back to the split path when a family has no native unified parser, but it still needs `UnifiedDelta`/`assemble` to EXIST at compile time. To re-capture, copy it into the old worktree, drop the unified imports, delete the `native` branch and its `ev_to_yaml`/`delta_to_yaml` helpers, and pin `let native = false`.
+
+### Back-capturing a NEW case into the older columns (MUST, every time)
+
+Adding a corpus case only writes the CURRENT build's column. Every older shard holds just the cases that existed when it was taken, so a new case renders `not captured at <ver> — this case postdates that build` on every historical column. **A row with data in exactly one column shows NO difference, and the difference is the entire point of this table** — a reviewer cannot tell a fixed regression from a case nobody ever ran. Back-capture in the SAME change:
+
+```bash
+git worktree add --detach /tmp/old-<ver> dynamo-parsers-v2-v<ver>
+# pre-unified (<= 0.1.23): apply the split-only edits above before running
+cp conformance/tests/capture_cross_version.rs /tmp/old-<ver>/conformance/tests/
+cd /tmp/old-<ver> && \
+  XVER_INPUTS=<repo>/conformance/unified/inputs \
+  XVER_FAMILIES=<repo>/conformance/utils/src/parser_families.yaml \
+  XVER_OUT=/tmp/xver-<ver> XVER_LABEL=<ver> \
+  cargo test -p dynamo-conformance-fixtures-v2 --test capture_cross_version -- --nocapture
+```
+
+Then merge **only files absent from the released tarball** into `conformance/unified/dynamo_v2-<ver>/` — never overwrite a shipped entry, that is the rewrite this file forbids — and run `package_fixtures.py`, `extract_fixtures.py`, `render_table_v2.sh`.
+
+**Done means the whole chain, in every worktree that has the corpus.** A stacked PR and its base are two separate renders, and their `inputs/` can legitimately differ, so each needs its OWN capture — never copy one branch's shards into the other. Verify per worktree: every `dynamo_v2-*` dir has the same case count as `inputs/`, and the rendered HTML greps **0** for `postdates that build`.
+
 ## Golden case file format (authored spec, `conformance/unified/golden_spec/<family>.yaml`)
 
 ```yaml

--- a/conformance/fixtures/unified/dynamo_v2-0.1.22.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.1.22.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7e7f1d161719e8f6caaa1f3fb07f169718308cc13f6a687916975c0ab144de3
+size 10008

--- a/conformance/fixtures/unified/dynamo_v2-0.1.23.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.1.23.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d8ec2aa4fd17b47afb2107bb3b90ad8461031eac575e88424c811845ef651b3
-size 5130
+oid sha256:69dd3be5a0f3a108e513c34a8b3669b405b521061872bfab5b1fb9885ac76880
+size 10164

--- a/conformance/fixtures/unified/dynamo_v2-0.1.25.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.1.25.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3113143c757e206d719538092213268cdfbae1f6df0954ac73a72b6da55a5a1
+size 9660

--- a/conformance/fixtures/unified/dynamo_v2-0.1.27.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.1.27.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64c76851f11dae7c3aeda35f746f64355e535b6c81c77b60f70c214f367dfa8c
+size 9785

--- a/conformance/fixtures/unified/dynamo_v2-0.2.0.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.2.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e0f153218785fc1a4285d90f19a7a54cc69066462848ba5eda61e25a522772e
+size 10039

--- a/conformance/fixtures/unified/golden.tar.gz
+++ b/conformance/fixtures/unified/golden.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43db28380b26c57e01ca90d1d63cf6674c27d41eed0f4603ac4ddda05f6ec8a4
-size 3644
+oid sha256:fef673ea851d87236f33e8a989dfe22f1d73d7a1f2c7710bb31583bba71c21ba
+size 7074

--- a/conformance/fixtures/unified/inputs.tar.gz
+++ b/conformance/fixtures/unified/inputs.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:70fda09d7e2f2b2add94b075d3c64207ea0bde7513d426940ff570e35422a1b1
-size 12937
+oid sha256:b074f0fe37564cbfb659f958a90c9d4ae45b38a161f6037cd8026ec94d2cf47c
+size 34876

--- a/conformance/fixtures/unified/sglang_python-0.5.16.tar.gz
+++ b/conformance/fixtures/unified/sglang_python-0.5.16.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b20e272da148503f2626342fbe7977ac259a0a391c5fc4b902ce59c9584d35
+size 8409

--- a/conformance/fixtures/unified/vllm_python-0.25.1.tar.gz
+++ b/conformance/fixtures/unified/vllm_python-0.25.1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:001076878fe7649be3ff0ae44352c45112b5e7cbba86399afa9d8cf3993540ad
-size 4742
+oid sha256:ac45a91593eb85a694321e86216eceeeb6134108a0aed7e352231910c930aa2a
+size 9365

--- a/conformance/fixtures/unified/vllm_rust-0.25.1.tar.gz
+++ b/conformance/fixtures/unified/vllm_rust-0.25.1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c0a80957217c5246e6a7269dfe22e4c7f018ac42b625d30cb1f3502eaca8fdd
-size 5367
+oid sha256:0ef327ee87ac8df71dd8bee069ba33561cd4fc06486acb99298e73f1cac8ff9a
+size 10472

--- a/conformance/tests/capture_cross_version.rs
+++ b/conformance/tests/capture_cross_version.rs
@@ -89,10 +89,13 @@ fn tool_deltas(res: &dynamo_parsers_v2::ToolParseResult, out: &mut Vec<Value>) {
 /// parser, and what `unified_render::dynamo_chunks` records for them — so a
 /// cross-version capture has to reproduce it or those rows come out empty and the
 /// table reads "this build produced nothing" for gemma4/kimi_k2.
-fn split_path_chunks(family: &str, input: &str) -> Option<Vec<Vec<Value>>> {
-    let (reasoning_name, tool_family) = parsers_for(family)?;
-    let mut rp = ReasoningParserType::get_reasoning_parser_from_name(&reasoning_name);
-    let mut tp = create_tool_parser_for_family(&tool_family, &tools()).ok()?;
+fn split_path_chunks_with_parsers(
+    reasoning_name: &str,
+    tool_family: &str,
+    input: &str,
+) -> Option<Vec<Vec<Value>>> {
+    let mut rp = ReasoningParserType::get_reasoning_parser_from_name(reasoning_name);
+    let mut tp = create_tool_parser_for_family(tool_family, &tools()).ok()?;
 
     let mut rows = Vec::new();
     for chunk in chunk_input(input) {
@@ -241,6 +244,72 @@ fn fold_chunks(rows: &[Vec<Value>]) -> Vec<serde_yaml::Value> {
         .collect()
 }
 
+fn split_path_capture_with_parsers(
+    reasoning_name: &str,
+    tool_family: &str,
+    input: &str,
+) -> Option<(Vec<Vec<Value>>, Vec<serde_yaml::Value>)> {
+    let rows = split_path_chunks_with_parsers(reasoning_name, tool_family, input)?;
+
+    // The split serving path assembles reasoning over the WHOLE input before it
+    // streams the leftover through the tool parser. Its raw chunk evidence comes
+    // from the incremental APIs, but folding those rows invents interleaving the
+    // assembled contract cannot represent and rewrites released capture behavior.
+    let mut rp = ReasoningParserType::get_reasoning_parser_from_name(reasoning_name);
+    let split = rp.detect_and_parse_reasoning(input, &[]);
+    let mut assembled_rows = Vec::new();
+    if !split.reasoning_text.is_empty() {
+        assembled_rows.push(vec![json!({
+            "kind": "reasoning",
+            "text": split.reasoning_text,
+        })]);
+    }
+    let mut tp = create_tool_parser_for_family(tool_family, &tools()).ok()?;
+    for ch in split.normal_text.chars() {
+        let mut buf = [0u8; 4];
+        let mut deltas = Vec::new();
+        tool_deltas(
+            &tp.push(ch.encode_utf8(&mut buf)).unwrap_or_default(),
+            &mut deltas,
+        );
+        if !deltas.is_empty() {
+            assembled_rows.push(deltas);
+        }
+    }
+    let mut tail = Vec::new();
+    tool_deltas(&tp.finish().unwrap_or_default(), &mut tail);
+    if !tail.is_empty() {
+        assembled_rows.push(tail);
+    }
+    let assembled = fold_chunks(&assembled_rows);
+    Some((rows, assembled))
+}
+
+fn split_path_capture(
+    family: &str,
+    input: &str,
+) -> Option<(Vec<Vec<Value>>, Vec<serde_yaml::Value>)> {
+    let (reasoning_name, tool_family) = parsers_for(family)?;
+    split_path_capture_with_parsers(&reasoning_name, &tool_family, input)
+}
+
+#[test]
+fn split_capture_assembles_reasoning_over_the_whole_input() {
+    let input = "<|channel>thought\nLook it up.<channel|><|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|><|channel>thought\nNow answer.<channel|>It's 18C.";
+    let (_, assembled) =
+        split_path_capture_with_parsers("gemma4", "gemma4", input).expect("split path");
+    let want = vec![
+        serde_yaml::to_value(json!({"kind": "reasoning", "text": "Look it up.Now answer."}))
+            .expect("reasoning"),
+        serde_yaml::to_value(
+            json!({"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}),
+        )
+        .expect("tool call"),
+        serde_yaml::to_value(json!({"kind": "text", "text": "It's 18C."})).expect("text"),
+    ];
+    assert_eq!(assembled, want);
+}
+
 /// Per-chunk rows record RAW deltas, not assembled events — `arguments` stays the
 /// literal fragment the parser emitted. Mirrors `unified_render::unified_delta_json`.
 /// (Assembling per chunk instead produces a mapping and makes every case look changed.)
@@ -325,11 +394,8 @@ fn capture_this_build_against_the_current_corpus() {
                         }
                         (rows, assemble(&deltas).iter().map(ev_to_yaml).collect())
                     } else {
-                        let rows = split_path_chunks(&family, input).expect("split path");
-                        // The page assembles the Dynamo column from the per-chunk deltas
-                        // (`_assemble_stream`), not from this field, so folding the same
-                        // rows keeps the two consistent by construction.
-                        let assembled = fold_chunks(&rows);
+                        let (rows, assembled) =
+                            split_path_capture(&family, input).expect("split path");
                         let rows = rows
                             .into_iter()
                             .map(|r| {

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -226,3 +226,75 @@ pub fn unified_family(corpus_name: &str) -> UnifiedFamily {
         )
     })
 }
+
+/// The request-scoped parser configuration a unified case declares.
+///
+/// Read from the case's `init:` block and passed to the parser verbatim, by BOTH
+/// unified harnesses (`unified_render` draws the tab, `unified_parity` gates CI). It
+/// lives here so there is exactly one answer to "how is a case's parser configured":
+/// each harness previously carried its own copy that INFERRED the config by sniffing
+/// the input text, and the copies could disagree with each other and with the `init:`
+/// the popup displayed — a case could declare `tool_output_mode=GuidedJson` and be
+/// parsed as `Native` because its input did not happen to start with `[`.
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+pub struct Init {
+    #[serde(default)]
+    pub starting_state: String,
+    #[serde(default)]
+    pub tool_output_mode: String,
+    #[serde(default)]
+    pub named_tool: Option<String>,
+}
+
+impl Init {
+    /// An unknown value is a spec bug, not something to paper over with a default:
+    /// silently falling back to `None`/`Native` is exactly the failure this replaced.
+    pub fn starting_state(&self) -> dynamo_parsers_v2::UnifiedParserStartingState {
+        use dynamo_parsers_v2::UnifiedParserStartingState as P;
+        match self.starting_state.as_str() {
+            "" | "None" => P::None,
+            "Reasoning" => P::Reasoning,
+            "Response" => P::Response,
+            other => panic!("unknown init.starting_state `{other}` (None|Reasoning|Response)"),
+        }
+    }
+
+    pub fn output_mode(&self) -> dynamo_parsers_v2::UnifiedToolOutputMode {
+        use dynamo_parsers_v2::UnifiedToolOutputMode as O;
+        match self.tool_output_mode.as_str() {
+            "" | "Native" => O::Native,
+            "GuidedJson" => O::GuidedJson {
+                named_tool: self.named_tool.clone(),
+            },
+            other => panic!("unknown init.tool_output_mode `{other}` (Native|GuidedJson)"),
+        }
+    }
+
+    /// Apply this configuration to a freshly created parser.
+    pub fn apply(&self, parser: &mut Box<dyn dynamo_parsers_v2::UnifiedParser>, what: &str) {
+        use dynamo_parsers_v2::{InvalidGuidedPayloadPolicy, UnifiedParserInit};
+        parser
+            .initialize_request(UnifiedParserInit {
+                starting_state: self.starting_state(),
+                tool_output_mode: self.output_mode(),
+                invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+                ..UnifiedParserInit::default()
+            })
+            .unwrap_or_else(|e| panic!("{what}: initialize_request {self:?}: {e}"));
+    }
+
+    /// The config as APPLIED, not as written — an omitted field is reported as the
+    /// value the parser actually received, so what the popup shows and what the
+    /// parser ran under are the same object by construction.
+    pub fn applied(&self) -> serde_json::Value {
+        use dynamo_parsers_v2::UnifiedToolOutputMode as O;
+        serde_json::json!({
+            "starting_state": format!("{:?}", self.starting_state()),
+            "tool_output_mode": match self.output_mode() {
+                O::Native => "Native",
+                O::GuidedJson { .. } => "GuidedJson",
+            },
+            "named_tool": self.named_tool,
+        })
+    }
+}

--- a/conformance/tests/unified_parity.rs
+++ b/conformance/tests/unified_parity.rs
@@ -17,6 +17,8 @@
 
 mod common;
 
+use common::Init;
+
 use std::collections::BTreeMap;
 
 use dynamo_parsers_v2::{
@@ -36,6 +38,11 @@ struct GoldenFile {
 struct GoldenCase {
     input: String,
     golden: Vec<UnifiedEvent>,
+    /// Request-scoped parser configuration, declared by the case. Shared with
+    /// `unified_render` via `common::Init` so both harnesses configure a case
+    /// identically; see that type for why it is declared and not inferred.
+    #[serde(default)]
+    init: Init,
 }
 
 /// Tool schemas the corpus is written against (string params, so a value like
@@ -53,6 +60,7 @@ fn tools() -> Vec<Tool> {
         mk("f", "x"),
         mk("g", "y"),
         mk("run", "cmd"),
+        mk("sum_values", "values"),
         mk("log", "note"),
     ]
 }
@@ -78,9 +86,11 @@ fn has_unified_parser(family: &str) -> bool {
     create_unified_parser_for_family(family, &[]).is_ok()
 }
 
-fn events(family: &str, chunks: &[String]) -> Vec<UnifiedEvent> {
+fn events(family: &str, chunks: &[String], init: &Init) -> Vec<UnifiedEvent> {
     let mut parser = create_unified_parser_for_family(family, &tools())
         .unwrap_or_else(|e| panic!("create unified parser for `{family}`: {e}"));
+    init.apply(&mut parser, family);
+
     let mut deltas = Vec::new();
     for chunk in chunks {
         deltas.extend(parser.push(chunk).unwrap_or_else(|e| panic!("push: {e}")));
@@ -167,7 +177,7 @@ fn unified_parser_matches_the_golden_oracle() {
     for file in &covered {
         for (id, case) in &file.cases {
             checked += 1;
-            let got = events(&file.family, &chunk_markers(&case.input));
+            let got = events(&file.family, &chunk_markers(&case.input), &case.init);
             if got != case.golden {
                 failures.push(format!(
                     "{id}\n     input: {:?}\n    golden: {}\n   unified: {}",
@@ -197,9 +207,9 @@ fn unified_parser_is_chunk_invariant() {
         .filter(|f| has_unified_parser(&f.family))
     {
         for (id, case) in &file.cases {
-            let baseline = events(&file.family, std::slice::from_ref(&case.input));
+            let baseline = events(&file.family, std::slice::from_ref(&case.input), &case.init);
             for (label, chunks) in splittings(&case.input) {
-                let got = events(&file.family, &chunks);
+                let got = events(&file.family, &chunks, &case.init);
                 if got != baseline {
                     failures.push(format!(
                         "{id} [{label}, {} chunks]\n  whole: {}\n    got: {}",
@@ -227,8 +237,10 @@ fn unified_parser_has_stream_batch_parity() {
         .filter(|f| has_unified_parser(&f.family))
     {
         for (id, case) in &file.cases {
-            let streamed = events(&file.family, &chunk_markers(&case.input));
+            let streamed = events(&file.family, &chunk_markers(&case.input), &case.init);
             let mut parser = create_unified_parser_for_family(&file.family, &tools()).unwrap();
+            case.init.apply(&mut parser, id);
+
             let batch = parser
                 .parse_complete(&case.input)
                 .unwrap_or_else(|e| panic!("{id}: parse_complete: {e}"));
@@ -257,11 +269,14 @@ fn unified_parsers_are_isolated_per_stream() {
                 continue;
             };
             let (ca, cb) = (chunk_markers(&a.input), chunk_markers(&b.input));
-            let solo_a = events(&file.family, &ca);
-            let solo_b = events(&file.family, &cb);
+            let solo_a = events(&file.family, &ca, &a.init);
+            let solo_b = events(&file.family, &cb, &b.init);
 
             let mut pa = create_unified_parser_for_family(&file.family, &tools()).unwrap();
             let mut pb = create_unified_parser_for_family(&file.family, &tools()).unwrap();
+            a.init.apply(&mut pa, id_a);
+            b.init.apply(&mut pb, id_b);
+
             let (mut da, mut db) = (Vec::new(), Vec::new());
             for i in 0..ca.len().max(cb.len()) {
                 if let Some(c) = ca.get(i) {
@@ -271,8 +286,8 @@ fn unified_parsers_are_isolated_per_stream() {
                     db.extend(pb.push(c).unwrap());
                 }
             }
-            da.extend(pa.finish().unwrap());
-            db.extend(pb.finish().unwrap());
+            da.extend(pa.finish().unwrap().events);
+            db.extend(pb.finish().unwrap().events);
 
             assert_eq!(
                 assemble(&da),

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -31,6 +31,8 @@ use serde_json::{Value, json};
 
 mod common;
 
+use common::Init;
+
 #[derive(Deserialize)]
 struct GoldenFile {
     family: String,
@@ -42,6 +44,10 @@ struct GoldenCase {
     description: String,
     #[serde(default)]
     policy: Vec<String>,
+    #[serde(default)]
+    init: Init,
+    #[serde(default)]
+    finish_reason: Option<String>,
     input: String,
     golden: Vec<Ev>,
     expect: BTreeMap<String, Expect>,
@@ -103,6 +109,8 @@ fn tools() -> Vec<Tool> {
         mk("f", "x"),
         mk("g", "y"),
         mk("run", "cmd"),
+        mk("log", "note"),
+        mk("sum_values", "values"),
     ]
 }
 
@@ -179,8 +187,10 @@ fn unified_delta_json(d: &dynamo_parsers_v2::UnifiedParserEvent) -> Value {
 ///
 /// Both paths are driven from the SAME chunking as `dynamo_chunks`, so the
 /// assembled row and the per-chunk rows in the popup describe one run.
-fn dynamo_events(family: &str, input: &str) -> Vec<Ev> {
+fn dynamo_events(family: &str, input: &str, init: &Init) -> Vec<Ev> {
     if let Ok(mut parser) = create_unified_parser_for_family(family, &tools()) {
+        init.apply(&mut parser, family);
+
         let mut deltas = Vec::new();
         for chunk in chunk_input(input) {
             deltas.extend(
@@ -292,9 +302,11 @@ fn tool_deltas(res: &dynamo_parsers_v2::ToolParseResult, out: &mut Vec<Value>) {
 /// Stream `input` through Dynamo's split pipeline CHUNK BY CHUNK, recording the
 /// real per-chunk emitted deltas (v1 reasoning streaming incremental -> v2 tool
 /// streaming push on the leftover content).
-fn dynamo_chunks(family: &str, input: &str) -> Vec<ChunkRow> {
+fn dynamo_chunks(family: &str, input: &str, init: &Init) -> Vec<ChunkRow> {
     // Unified families: ONE parser, so a chunk's deltas are simply what it emitted.
     if let Ok(mut parser) = create_unified_parser_for_family(family, &tools()) {
+        init.apply(&mut parser, family);
+
         let mut rows = Vec::new();
         for chunk in chunk_input(input) {
             let deltas = parser.push(&chunk).unwrap_or_default();
@@ -309,12 +321,10 @@ fn dynamo_chunks(family: &str, input: &str) -> Vec<ChunkRow> {
             .iter()
             .map(unified_delta_json)
             .collect();
-        if !tail.is_empty() {
-            rows.push(ChunkRow {
-                delta_text: "‹finish›".to_string(),
-                deltas: tail,
-            });
-        }
+        rows.push(ChunkRow {
+            delta_text: "‹finish›".to_string(),
+            deltas: tail,
+        });
         return rows;
     }
 
@@ -350,13 +360,22 @@ fn dynamo_chunks(family: &str, input: &str) -> Vec<ChunkRow> {
         tool_deltas(&tr, &mut tail);
     }
     tool_deltas(&tp.finish().unwrap_or_default(), &mut tail);
-    if !tail.is_empty() {
-        rows.push(ChunkRow {
-            delta_text: "‹finish›".to_string(),
-            deltas: tail,
-        });
-    }
+    rows.push(ChunkRow {
+        delta_text: "‹finish›".to_string(),
+        deltas: tail,
+    });
     rows
+}
+
+#[test]
+fn finish_is_part_of_the_stream_schedule_even_when_it_emits_nothing() {
+    let rows = dynamo_chunks("qwen3", "plain response", &Init::default());
+    let finish = rows.last().expect("finish row");
+    assert_eq!(finish.delta_text, "‹finish›");
+    assert!(
+        finish.deltas.is_empty(),
+        "fixture must exercise an empty finish"
+    );
 }
 
 /// Classify a Dynamo divergence from the golden.
@@ -496,6 +515,44 @@ fn cell(
 
 #[test]
 fn render_unified_conformance_html() {
+    // The vLLM column is LIVE, not an expectation. `capture_vllm_rust_unified.py`
+    // records the `vllm-parser` crate against this same corpus; reading it here is
+    // what makes the column evidence instead of a claim.
+    let vllm_live: BTreeMap<(String, String), Vec<Ev>> = {
+        let froot = common::ensure_fixtures().join("unified");
+        let mut m = BTreeMap::new();
+        // Shards key by TAXONOMY id (`UNIFIED.30.a`); the golden keys by SCENARIO
+        // (`UNIFIED.guided_json_named_tool.qwen3`). The inputs shard carries both, so
+        // it is the bridge — without it every cell reads NO-DATA while the capture
+        // sits right there, which is how this first went wrong.
+        let mut by_tax: BTreeMap<(String, String), String> = BTreeMap::new();
+        for entry in glob_yaml(&froot.join("inputs")) {
+            if let Ok(doc) = serde_yaml::from_str::<InputDoc>(
+                &std::fs::read_to_string(&entry).unwrap_or_default(),
+            ) {
+                for (cid, c) in doc.cases {
+                    by_tax.insert((doc.family.clone(), cid), c.scenario);
+                }
+            }
+        }
+        if let Some(d) = common::version_dirs_ascending(&froot, "vllm_rust-").pop() {
+            for entry in glob_yaml(&d) {
+                if let Ok(doc) = serde_yaml::from_str::<CaptureDoc>(
+                    &std::fs::read_to_string(&entry).unwrap_or_default(),
+                ) {
+                    for (cid, c) in doc.cases {
+                        if let Some(sc) = by_tax.get(&(doc.family.clone(), cid)) {
+                            m.insert(
+                                (doc.family.clone(), format!("UNIFIED.{sc}.{}", doc.family)),
+                                c.assembled,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        m
+    };
     let dir = common::ensure_unified_golden();
     let mut files: Vec<GoldenFile> = Vec::new();
     for entry in std::fs::read_dir(&dir).unwrap() {
@@ -528,13 +585,13 @@ fn render_unified_conformance_html() {
             total += 1;
 
             // Dynamo: live.
-            let got = dynamo_events(&file.family, &case.input);
+            let got = dynamo_events(&file.family, &case.input, &case.init);
             let dclass = classify(&file.family, &case.golden, &got);
             eprintln!(
                 "{id:44} dynamo={dclass:6} :: {}",
                 got.iter().map(Ev::render).collect::<Vec<_>>().join("  |  ")
             );
-            let chunk_feed: Vec<Value> = dynamo_chunks(&file.family, &case.input)
+            let chunk_feed: Vec<Value> = dynamo_chunks(&file.family, &case.input, &case.init)
                 .into_iter()
                 .map(|r| json!({"delta_text": r.delta_text, "dynamo": r.deltas}))
                 .collect();
@@ -550,6 +607,8 @@ fn render_unified_conformance_html() {
                 "scenario": scenario,
                 "description": case.description,
                 "policy": case.policy,
+                "init": case.init.applied(),
+                "finish_reason": case.finish_reason.clone().unwrap_or_else(|| "stop".to_string()),
                 "input": case.input,
                 "golden": case.golden,
                 "dynamo": got,
@@ -602,13 +661,36 @@ fn render_unified_conformance_html() {
                 .note
                 .map(|n| format!("<hr><div class=note>{}</div>", esc(&n)))
                 .unwrap_or_default();
+            let vlive = vllm_live.get(&(file.family.clone(), id.clone()));
+            let (vgot_html, vverdict, vclass_final) = match vlive {
+                Some(ev) => {
+                    let matches = ev == &case.golden;
+                    (
+                        events_html(ev),
+                        if matches { "match" } else { "diverge" },
+                        if matches {
+                            "MATCH".to_string()
+                        } else {
+                            "DIVERGE".to_string()
+                        },
+                    )
+                }
+                // No capture for this case: say so. Do NOT fall back to the authored
+                // expectation dressed up as a result — that is how this column spent
+                // its life claiming MATCH with nothing behind it.
+                None => (
+                    "<i>(no vLLM capture for this case)</i>".to_string(),
+                    "diverge",
+                    "NO-DATA".to_string(),
+                ),
+            };
             let vcell = cell(
-                "vLLM 0.25.x (expected)",
+                "vLLM Rust 0.25.1 (LIVE)",
                 &case.input,
                 &case.golden,
-                "<i>(live capture pending — U1)</i>",
-                &vx.verdict,
-                &vclass,
+                &vgot_html,
+                vverdict,
+                &vclass_final,
                 &vnote,
             );
 
@@ -733,6 +815,11 @@ struct InputCase {
     scenario: String,
     #[serde(default)]
     input: String,
+    /// The guard must re-run each case under the SAME configuration the shard was
+    /// captured with; re-running everything under the default would report false
+    /// drift for every prefilled / guided-JSON case.
+    #[serde(default)]
+    init: Init,
 }
 
 /// GUARD: the COMMITTED Dynamo capture must equal what the parsers produce NOW.
@@ -763,13 +850,16 @@ fn committed_dynamo_capture_matches_the_live_parsers() {
         .pop()
         .expect("no committed dynamo_v2-<ver> capture dir");
 
-    // key -> (family, scenario, input), from the inputs shard.
-    let mut meta: BTreeMap<(String, String), (String, String)> = BTreeMap::new();
+    // key -> (family, scenario, input, init), from the inputs shard.
+    let mut meta: BTreeMap<(String, String), (String, String, Init)> = BTreeMap::new();
     for entry in glob_yaml(&root.join("inputs")) {
         let doc: InputDoc = serde_yaml::from_str(&std::fs::read_to_string(&entry).unwrap())
             .unwrap_or_else(|e| panic!("{}: {e}", entry.display()));
         for (key, case) in doc.cases {
-            meta.insert((doc.family.clone(), key), (case.scenario, case.input));
+            meta.insert(
+                (doc.family.clone(), key),
+                (case.scenario, case.input, case.init),
+            );
         }
     }
 
@@ -779,13 +869,13 @@ fn committed_dynamo_capture_matches_the_live_parsers() {
         let doc: CaptureDoc = serde_yaml::from_str(&std::fs::read_to_string(&entry).unwrap())
             .unwrap_or_else(|e| panic!("{}: {e}", entry.display()));
         for (key, committed) in doc.cases {
-            let Some((scenario, input)) = meta.get(&(doc.family.clone(), key.clone())) else {
+            let Some((scenario, input, init)) = meta.get(&(doc.family.clone(), key.clone())) else {
                 continue;
             };
             checked += 1;
             let id = format!("UNIFIED.{scenario}.{}", doc.family);
 
-            let live_assembled = dynamo_events(&doc.family, input);
+            let live_assembled = dynamo_events(&doc.family, input, init);
             if live_assembled != committed.assembled {
                 stale.push(format!(
                     "{id} [{key}] assembled\n    committed: {}\n         live: {}",
@@ -805,7 +895,7 @@ fn committed_dynamo_capture_matches_the_live_parsers() {
             }
             // The page assembles the Dynamo column from these per-chunk deltas, so
             // they have to be current too — not just the assembled list.
-            let live_chunks: Vec<Vec<Value>> = dynamo_chunks(&doc.family, input)
+            let live_chunks: Vec<Vec<Value>> = dynamo_chunks(&doc.family, input, init)
                 .into_iter()
                 .map(|r| r.deltas)
                 .collect();

--- a/conformance/tests/unified_schema_roundtrip.rs
+++ b/conformance/tests/unified_schema_roundtrip.rs
@@ -27,11 +27,16 @@ struct GoldenFile {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct GoldenCase {
     description: String,
     /// Policy decisions (P1/P2/...) this case's correctness depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     policy: Vec<String>,
+    #[serde(default)]
+    init: common::Init,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    finish_reason: Option<String>,
     /// Raw streamed model text.
     input: String,
     /// Spec-derived correct event list — the oracle.
@@ -120,10 +125,29 @@ fn every_case_is_well_formed() {
                 file.family
             );
             assert!(!case.input.is_empty(), "{path}: `{id}` has empty input");
-            assert!(
-                !case.golden.is_empty(),
-                "{path}: `{id}` has empty golden event list"
-            );
+            // An EMPTY golden is legitimate: a turn made only of control markup must
+            // emit nothing at all, and forbidding it is why no row ever pinned that.
+            // A golden forgotten by mistake is still caught — `unified_parity` compares
+            // every case against the live parser, so an empty golden passes only when
+            // the parser genuinely produces no events. Require the description to SAY
+            // so, else a reader cannot tell a deliberate no-op from a missing one.
+            if case.golden.is_empty() {
+                assert!(
+                    case.description
+                        .to_ascii_lowercase()
+                        .contains("emits nothing")
+                        || case
+                            .description
+                            .to_ascii_lowercase()
+                            .contains("nothing is emitted")
+                        || case
+                            .description
+                            .to_ascii_lowercase()
+                            .contains("emits no events"),
+                    "{path}: `{id}` has an empty golden but its description does not say \
+                     the turn emits nothing"
+                );
+            }
             assert!(
                 !case.description.is_empty(),
                 "{path}: `{id}` has empty description"

--- a/conformance/utils/lib/parsers/UNIFIED_CASES.md
+++ b/conformance/utils/lib/parsers/UNIFIED_CASES.md
@@ -2,7 +2,7 @@
 
 Reference taxonomy for the **unified** conformance surface: one parser owns the whole assistant-output grammar and emits ONE ordered event stream. Sibling stage docs: `REASONING_CASES.md` (reasoning only), `TOOLCALLING_CASES.md` / `TOOLCALLING_STREAMING_V2_CASES.md` (tool calls only). This surface is what those two cannot express — the ORDER between reasoning and tool calls, and reasoning that occurs *between* or *after* tool calls.
 
-The golden corpus is authored by `conformance/utils/src/gen_unified_golden.py` (one scenario spec -> `conformance/unified/golden_spec/<family>.yaml` in the gitignored build tree); the committed, versioned `conformance/fixtures/unified/golden.tar.gz` shard is derived from it. The surface overview is `conformance/unified/README.md`.
+The golden corpus is authored by `conformance/utils/src/gen_unified_golden.py` (one scenario spec -> `conformance/unified/golden_spec/<family>.yaml` in the gitignored build tree); the committed, versioned `conformance/fixtures/unified/golden.tar.gz` shard is derived from it.
 
 ## The oracle: GOLDEN is authored, not captured
 
@@ -34,12 +34,12 @@ Comparison is ORDER-SENSITIVE on the ASSEMBLED list. Streaming delta granularity
 
 ## Governing principle: best-effort error recovery
 
-The parser recovers everything it can and NEVER drops valid text, leaks markup, or hard-errors on malformed/truncated input. Documented contract: `conformance/README.md` (v2 "preserves surrounding/inter-call prose... recovers bare calls v1 drops"; "dropping text, leaking markup, corrupting args" is a regression to FIX, not paper over) and `TOOLCALLING_CASES.md` batch.5.e / 5.g (drop only the unrecoverable partial call while earlier output stays recoverable; strip orphan close markers; do not leak). This principle resolves the policy calls below.
+The parser recovers everything it can and NEVER drops valid text, leaks markup, or hard-errors on malformed/truncated input. Documented contract: `conformance/README.md` (v2 "preserves surrounding/inter-call prose... recovers bare calls v1 drops"; "dropping text, leaking markup, corrupting args" is a regression to FIX, not paper over) and `TOOLCALLING_CASES.md` TOOLCALLING.batch.5.e / TOOLCALLING.batch.5.g (drop only the unrecoverable partial call while earlier output stays recoverable; strip orphan close markers; do not leak). This principle resolves the policy calls below.
 
 ## Policy decisions
 
 - **P1 Trailing text after the last tool call** -> emit as `text`. RESOLVED by best-effort recovery: trailing prose is arbitrary visible content and must be preserved (dropping it is a regression). vLLM's kimi config suppresses it -> vLLM red (LOSS).
-- **P2 Truncated tool call at EOF** -> DROP the unrecoverable partial call, emit preceding reasoning/text cleanly, no error, no leaked markup. RESOLVED by best-effort recovery (TOOLCALLING batch.5.e). Dynamo drops -> correct. The two vLLM implementations fail differently, both confirmed by live 0.25.1 capture: the native Rust `Gemma4UnifiedParser` returns `ParsingFailed { "incomplete Gemma4 tool call" }` -> red (ERROR), while the Python parser DISPATCHES the partial call with its truncated arguments (`{city: "Par"}`) — worse for a side-effecting action, since the client executes a call the parser never finished reading.
+- **P2 Truncated tool call at EOF** -> DROP the unrecoverable partial call, emit preceding reasoning/text cleanly, no error, no leaked markup. RESOLVED by best-effort recovery (TOOLCALLING.batch.5.e). Dynamo drops -> correct. The two vLLM implementations fail differently, both confirmed by live 0.25.1 capture: the native Rust `Gemma4UnifiedParser` returns `ParsingFailed { "incomplete Gemma4 tool call" }` -> red (ERROR), while the Python parser DISPATCHES the partial call with its truncated arguments (`{city: "Par"}`) — worse for a side-effecting action, since the client executes a call the parser never finished reading.
 - **P3 Empty arguments** -> `{}`.
 - **P4 Structural whitespace** -> strip only tokenizer-structural whitespace bound to the marker grammar (e.g. gemma4 `thought\n`), preserve model-authored whitespace. RESOLVED for gemma4 by `ReasoningSpec::start_label`: the role label is consumed when present and TOLERATED when absent, so `<|channel>thoughtful musing<channel|>` keeps its first word and a bare `<|channel>` still opens a thought instead of leaking as text. Folding the label into the opener would have passed this corpus and broken both.
 - **P5 Implicit reasoning start** -> prompt-conditioned per family (forced-reasoning models start in reasoning with no `<think>`).
@@ -54,45 +54,45 @@ The parser recovers everything it can and NEVER drops valid text, leaks markup, 
 
 `MATCH` (green) · `ORDER` / `MERGE` / `LOSS` (the unification gap) · `LEAK` (markup in text, `↯`) · `ARG_MISMATCH` / `WHITESPACE` (version drift) · `ERROR` (engine hard-errored where the spec expects graceful output).
 
-The Dynamo column is a per-family MIXTURE: `gemma4` and `qwen3` run the native `UnifiedParser` (green across all 52 scenarios each), `kimi_k2` still runs the v1-reasoning + v2-tool split and carries the gap. Every remaining red Dynamo cell in this tab is a split-path cell.
+The Dynamo column is a per-family MIXTURE: only `qwen3` runs the native `UnifiedParser` (the sole entry in `unified_registry!`); `gemma4` and `kimi_k2` still run the v1-reasoning + v2-tool split and carry the gap. Every remaining red Dynamo cell in this tab is a split-path cell.
 
 ## Quick reference — numbered taxonomy (`UNIFIED.<group>.<sub>`)
 
-Case IDs use short `group.sub` labels (`1.a`, `2.b`, …) like the other suites; the scenario slug (the golden filename key) is shown in parentheses. **Groups 1–9 mirror the tool-calling STREAM taxonomy** (`TOOLCALLING.streamv2.N`) as reasoning-free unified cases — this surface subsumes STREAM. **Group 10** is the reasoning axis (`REASONING.*`). **Group 11 is UNIQUE to unified**: reasoning↔tool ORDER that neither STREAM (no reasoning) nor REASONING (no ordered tool events) can express. **Group 12** is adversarial nesting — a marker of one channel inside another (P7). **Groups 30+ are REQUEST-SCOPED modes** — what the serving layer told the parser about this request, rather than what the model emitted; they use PAIRED TENS, `X0` for a mode's happy path and `X1` for its malformed counterpart, so a recovery case never sorts next to the baseline it contrasts with. 52 scenarios × 3 families (gemma4 / qwen3 / kimi_k2) = 156 cases.
+Case IDs use short `group.sub` labels (`1.a`, `2.b`, …) like the other suites; the scenario slug (the golden filename key) is shown in parentheses. **Groups 1–9 mirror the tool-calling STREAM taxonomy** (`TOOLCALLING.streamv2.N`) as reasoning-free unified cases — this surface subsumes STREAM. **Group 10** is the reasoning axis (`REASONING.*`). **Group 11 is UNIQUE to unified**: reasoning↔tool ORDER that neither STREAM (no reasoning) nor REASONING (no ordered tool events) can express. **Group 12** is adversarial nesting — a marker of one channel inside another (P7). **Groups 30+ are REQUEST-SCOPED modes** — what the serving layer told the parser about this request, rather than what the model emitted; they use PAIRED TENS, `X0` for a mode's happy path and `X1` for its malformed counterpart, so a recovery case never sorts next to the baseline it contrasts with. 80 scenarios × 3 families (gemma4 / qwen3 / kimi_k2) = 240 cases. These counts come from the generator's `CLEAN + EDGE` lists, not from the taxonomy map — the map reserves names the generator does not emit, which is how a stale denominator survived here before.
 
 ### Group 1 — TC Single call
 - **`1.a`** (`tool_only`) One tool call, no reasoning, no surrounding text. The tool suite's baseline.
 
-### Group 2 — TC Multiple calls (streamv2.2)
-- **`2.a`** (`two_calls`) Two distinct calls back-to-back, order preserved.
-- **`2.b`** (`two_calls_same_name`) Two calls to the SAME function, different args — must not dedup or merge.
+### Group 2 — TC Multiple calls (TOOLCALLING.streamv2.2)
+- **`2.a`** (`two_calls`) Two distinct calls back-to-back, order preserved. This is also covered in: TOOLCALLING.streamv2.2.a.
+- **`2.b`** (`two_calls_same_name`) Two calls to the SAME function, different args — must not dedup or merge. This is also covered in: TOOLCALLING.streamv2.2.d.
 
-### Group 3 — TC No call (streamv2.3)
-- **`3.a`** (`text_only`) Plain content, zero tool structure. No spurious call.
+### Group 3 — TC No call (TOOLCALLING.streamv2.3)
+- **`3.a`** (`text_only`) Plain content, zero tool structure. No spurious call. This is also covered in: TOOLCALLING.streamv2.3. No e2e case has this shape: Qwen3.6 always emits a reasoning span, so the plain-content case is corpus-only.
 
-### Group 5 — TC Truncation / recovery (streamv2.5)
+### Group 5 — TC Truncation / recovery (TOOLCALLING.streamv2.5)
 - **`5.a`** (`truncated_tool_eof`) EOF mid-call. Golden drops the partial, keeps preceding output (P2); vLLM Rust hard-errors (`ParsingFailed`). Class ERROR.
-- **`5.b`** (`tool_no_close`) Complete call body but the close marker never arrives. Golden recovers the call at finish; vLLM Rust hard-errors. Class ERROR.
+- **`5.b`** (`tool_no_close`) Complete call body but the close marker never arrives. Golden recovers the call at finish; vLLM Rust hard-errors. Class ERROR. This is also covered in: TOOLCALLING.streamv2.5.a.
 - **`5.c`** (`orphan_close_after_prose`) Orphan close marker after prose. Golden strips it; engines may leak. Class LEAK.
 
-### Group 6 — TC Empty body (streamv2.6)
-- **`6.a`** (`empty_args`) Call with `{}` arguments. Must emit the call with an empty object, not drop it.
+### Group 6 — TC Empty body (TOOLCALLING.streamv2.6)
+- **`6.a`** (`empty_args`) Call with `{}` arguments. Must emit the call with an empty object, not drop it. This is also covered in: TOOLCALLING.streamv2.6.a.
 
-### Group 7 — TC Argument fidelity (streamv2.7)
-- **`7.a`** (`arg_unicode`) Non-ASCII argument value round-trips byte-exact (I7).
+### Group 7 — TC Argument fidelity (TOOLCALLING.streamv2.7)
+- **`7.a`** (`arg_unicode`) Non-ASCII argument value round-trips byte-exact (I7). This is also covered in: TOOLCALLING.streamv2.7.b.
 - **`7.b`** (`arg_marker_in_string`) A close-marker substring INSIDE a string arg is data, preserved exactly (I7). vLLM Rust truncates. Class ARG_MISMATCH.
 
-### Group 8 — TC Content / narration position (streamv2.8)
-- **`8.a`** (`text_before_tool`) Visible narration precedes the call.
+### Group 8 — TC Content / narration position (TOOLCALLING.streamv2.8)
+- **`8.a`** (`text_before_tool`) Visible narration precedes the call. This is also covered in: TOOLCALLING.streamv2.8.a.
 - **`8.b`** (`trailing_text_after_tool`) Arbitrary prose AFTER the tool section (P1). vLLM suppresses it. Class LOSS.
-- **`8.c`** (`text_sandwich`) text → call → text; both text spans survive in order.
-- **`8.d`** (`text_between_calls`) call → text → call; the inter-call prose survives (v2 recovers what v1 drops).
+- **`8.c`** (`text_sandwich`) text → call → text; both text spans survive in order. This is also covered in: TOOLCALLING.streamv2.8.c.
+- **`8.d`** (`text_between_calls`) call → text → call; the inter-call prose survives (v2 recovers what v1 drops). This is also covered in: TOOLCALLING.streamv2.8.d.
 - **`8.e`** (`narrated_calls`) Multiple calls with narration between each — `tool_call → text → tool_call → text → tool_call`. The agentic call/narrate/call pattern; every call and inter-call text span is its own ordered event.
 
 ### Group 10 — Reasoning span (`REASONING.*`)
-- **`10.a`** (`reason_only`) Reasoning span, nothing else.
-- **`10.b`** (`reason_then_content`) Reasoning then visible content, no call.
-- **`10.c`** (`two_reason_spans`) Two reasoning spans separated by content. Batch reasoning merges them → Class MERGE.
+- **`10.a`** (`reason_only`) Reasoning span, nothing else. This is also covered in: REASONING.batch.2.a.
+- **`10.b`** (`reason_then_content`) Reasoning then visible content, no call. This is also covered in: e2e case-0001-chinese_arithmetic__non-stream-budget_capped.json (+ 42 more: every `reasoning/core`, `reasoning/complex` and `reasoning/history` case, `tool_none_arithmetic__*`, and the SECOND step of both `lifecycle_*` — each with its `-budget_unlimited` pair).
+- **`10.c`** (`two_reason_spans`) Two reasoning spans separated by content. Batch reasoning merges them → Class MERGE. This is also covered in: REASONING.batch.6.a.
 - **`10.d`** (`reason_unterminated`) Stream ends inside reasoning; open reasoning promoted at finish.
 
 ### Group 11 — Reasoning ↔ tool interleaving (UNIQUE to unified; the unification gap)
@@ -113,24 +113,162 @@ Case IDs use short `group.sub` labels (`1.a`, `2.b`, …) like the other suites;
 - **`12.c`** (`reason_markup_in_arg_with_text`) 12.a WITH visible narration before and after — all three channels at once (text / tool-call-with-markup-arg / text). Golden keeps text as text, the call clean, the markup byte-exact in the arg. Class ARG_MISMATCH / MERGE.
 - **`12.d`** (`tool_in_reason_with_text`) 12.b WITH visible narration before and after — text → reason → call → reason → text. Golden breaks out and keeps the surrounding text; engines leak the nested markup. Class LEAK.
 
+## End-to-end test cases (`End-to-end:` tags)
+
+Cases tagged `End-to-end:` name the corresponding end-to-end test case(s) in the Qwen3.6 run captured for PR #163 (`qwen36_pr163_test_cases.html` — 49 distinct cases, each run under two thinking-budget variants, at worker stream intervals 20 and 1). The two surfaces answer different questions and neither replaces the other:
+
+- **This corpus** is authored and hermetic. It feeds an exact byte string to the parser and asserts the exact event list, so a regression names the grammar construct that broke. It cannot tell you whether a real model ever emits that string.
+- **The e2e cases** are captured. They send real requests to a real worker and only check the final response, so they prove the path works end to end — but a failure there implicates the whole stack, and it only covers shapes the model happened to produce.
+
+So an `End-to-end:` tag means "a real model exercised this construct", and its ABSENCE is the interesting signal: it marks a construct this corpus pins that no e2e case reaches. Groups 31, 41 and 51 are entirely untagged by design — malformed guided output, redundant openers and truncated prefills are what a backend produces when something goes wrong, and a healthy worker will not produce them on demand.
+
+Known gaps in the other direction — end-to-end test cases with no corpus analogue:
+
+- `lifecycle_*` are 2-step: the tool result is fed back and the model called again. Multi-turn is a frontend/templating concern; a single-stream parser corpus cannot express it.
+- `history_*` cover conversation-history handling, likewise above this layer.
+- The `reasoning/core` and `reasoning/complex` cases (32 of the 49) vary the PROMPT, not the output grammar. They exercise the reasoning parser end to end but map onto the same handful of reasoning-span constructs, so tagging each one would add noise, not coverage.
+
+### Artifact index
+
+An `End-to-end:` tag names the end-to-end test case and its artifact index. Each index is TWO JSON artifacts — the same case run under both thinking-budget variants — so `e2e case-0047` means both `end-to-end case-0047-*` files below. The report embeds every case inline in `const REPORT`, so the JSON files are provenance labels, not inputs; they live with whoever ran the harness, not in this repo.
+
+| Case | e2e case | Artifact JSON file |
+|---|---|---|
+| `10.b` | `chinese_arithmetic__non-stream` | `end-to-end case-0001-chinese_arithmetic__non-stream-budget_capped.json` |
+| `10.b` | `chinese_arithmetic__non-stream` | `end-to-end case-0001-chinese_arithmetic__non-stream-budget_unlimited.json` |
+| `10.b` | `chinese_arithmetic__stream` | `end-to-end case-0002-chinese_arithmetic__stream-budget_capped.json` |
+| `10.b` | `chinese_arithmetic__stream` | `end-to-end case-0002-chinese_arithmetic__stream-budget_unlimited.json` |
+| `10.b` | `compare_fractions__non-stream` | `end-to-end case-0003-compare_fractions__non-stream-budget_capped.json` |
+| `10.b` | `compare_fractions__non-stream` | `end-to-end case-0003-compare_fractions__non-stream-budget_unlimited.json` |
+| `10.b` | `compare_fractions__stream` | `end-to-end case-0004-compare_fractions__stream-budget_capped.json` |
+| `10.b` | `compare_fractions__stream` | `end-to-end case-0004-compare_fractions__stream-budget_unlimited.json` |
+| `10.b` | `history_not_preserved__non-stream` | `end-to-end case-0013-history_not_preserved__non-stream-budget_capped.json` |
+| `10.b` | `history_not_preserved__non-stream` | `end-to-end case-0013-history_not_preserved__non-stream-budget_unlimited.json` |
+| `10.b` | `history_not_preserved__stream` | `end-to-end case-0014-history_not_preserved__stream-budget_capped.json` |
+| `10.b` | `history_not_preserved__stream` | `end-to-end case-0014-history_not_preserved__stream-budget_unlimited.json` |
+| `10.b` | `history_preserved_addition__non-stream` | `end-to-end case-0015-history_preserved_addition__non-stream-budget_capped.json` |
+| `10.b` | `history_preserved_addition__non-stream` | `end-to-end case-0015-history_preserved_addition__non-stream-budget_unlimited.json` |
+| `10.b` | `history_preserved_addition__stream` | `end-to-end case-0016-history_preserved_addition__stream-budget_capped.json` |
+| `10.b` | `history_preserved_addition__stream` | `end-to-end case-0016-history_preserved_addition__stream-budget_unlimited.json` |
+| `10.b` | `history_preserved_codeword__non-stream` | `end-to-end case-0017-history_preserved_codeword__non-stream-budget_capped.json` |
+| `10.b` | `history_preserved_codeword__non-stream` | `end-to-end case-0017-history_preserved_codeword__non-stream-budget_unlimited.json` |
+| `10.b` | `history_preserved_codeword__stream` | `end-to-end case-0018-history_preserved_codeword__stream-budget_capped.json` |
+| `10.b` | `history_preserved_codeword__stream` | `end-to-end case-0018-history_preserved_codeword__stream-budget_unlimited.json` |
+| `10.b` | `history_unicode__non-stream` | `end-to-end case-0019-history_unicode__non-stream-budget_capped.json` |
+| `10.b` | `history_unicode__non-stream` | `end-to-end case-0019-history_unicode__non-stream-budget_unlimited.json` |
+| `10.b` | `history_unicode__stream` | `end-to-end case-0020-history_unicode__stream-budget_capped.json` |
+| `10.b` | `history_unicode__stream` | `end-to-end case-0020-history_unicode__stream-budget_unlimited.json` |
+| `10.b` | `logic_syllogism__non-stream` | `end-to-end case-0021-logic_syllogism__non-stream-budget_capped.json` |
+| `10.b` | `logic_syllogism__non-stream` | `end-to-end case-0021-logic_syllogism__non-stream-budget_unlimited.json` |
+| `10.b` | `logic_syllogism__stream` | `end-to-end case-0022-logic_syllogism__stream-budget_capped.json` |
+| `10.b` | `logic_syllogism__stream` | `end-to-end case-0022-logic_syllogism__stream-budget_unlimited.json` |
+| `10.b` | `long_context_retrieval__non-stream` | `end-to-end case-0023-long_context_retrieval__non-stream-budget_capped.json` |
+| `10.b` | `long_context_retrieval__non-stream` | `end-to-end case-0023-long_context_retrieval__non-stream-budget_unlimited.json` |
+| `10.b` | `long_context_retrieval__stream` | `end-to-end case-0024-long_context_retrieval__stream-budget_capped.json` |
+| `10.b` | `long_context_retrieval__stream` | `end-to-end case-0024-long_context_retrieval__stream-budget_unlimited.json` |
+| `10.b` | `minutes_to_seconds__non-stream` | `end-to-end case-0025-minutes_to_seconds__non-stream-budget_capped.json` |
+| `10.b` | `minutes_to_seconds__non-stream` | `end-to-end case-0025-minutes_to_seconds__non-stream-budget_unlimited.json` |
+| `10.b` | `minutes_to_seconds__stream` | `end-to-end case-0026-minutes_to_seconds__stream-budget_capped.json` |
+| `10.b` | `minutes_to_seconds__stream` | `end-to-end case-0026-minutes_to_seconds__stream-budget_unlimited.json` |
+| `10.b` | `multiline_checksum__non-stream` | `end-to-end case-0027-multiline_checksum__non-stream-budget_capped.json` |
+| `10.b` | `multiline_checksum__non-stream` | `end-to-end case-0027-multiline_checksum__non-stream-budget_unlimited.json` |
+| `10.b` | `multiline_checksum__stream` | `end-to-end case-0028-multiline_checksum__stream-budget_capped.json` |
+| `10.b` | `multiline_checksum__stream` | `end-to-end case-0028-multiline_checksum__stream-budget_unlimited.json` |
+| `10.b` | `multiply_17_19__non-stream` | `end-to-end case-0029-multiply_17_19__non-stream-budget_capped.json` |
+| `10.b` | `multiply_17_19__non-stream` | `end-to-end case-0029-multiply_17_19__non-stream-budget_unlimited.json` |
+| `10.b` | `multiply_17_19__stream` | `end-to-end case-0030-multiply_17_19__stream-budget_capped.json` |
+| `10.b` | `multiply_17_19__stream` | `end-to-end case-0030-multiply_17_19__stream-budget_unlimited.json` |
+| `10.b` | `parity_expression__non-stream` | `end-to-end case-0031-parity_expression__non-stream-budget_capped.json` |
+| `10.b` | `parity_expression__non-stream` | `end-to-end case-0031-parity_expression__non-stream-budget_unlimited.json` |
+| `10.b` | `parity_expression__stream` | `end-to-end case-0032-parity_expression__stream-budget_capped.json` |
+| `10.b` | `parity_expression__stream` | `end-to-end case-0032-parity_expression__stream-budget_unlimited.json` |
+| `10.b` | `python_loop_trace__non-stream` | `end-to-end case-0033-python_loop_trace__non-stream-budget_capped.json` |
+| `10.b` | `python_loop_trace__non-stream` | `end-to-end case-0033-python_loop_trace__non-stream-budget_unlimited.json` |
+| `10.b` | `python_loop_trace__stream` | `end-to-end case-0034-python_loop_trace__stream-budget_capped.json` |
+| `10.b` | `python_loop_trace__stream` | `end-to-end case-0034-python_loop_trace__stream-budget_unlimited.json` |
+| `10.b` | `sequence_next__non-stream` | `end-to-end case-0035-sequence_next__non-stream-budget_capped.json` |
+| `10.b` | `sequence_next__non-stream` | `end-to-end case-0035-sequence_next__non-stream-budget_unlimited.json` |
+| `10.b` | `sequence_next__stream` | `end-to-end case-0036-sequence_next__stream-budget_capped.json` |
+| `10.b` | `sequence_next__stream` | `end-to-end case-0036-sequence_next__stream-budget_unlimited.json` |
+| `10.b` | `set_intersection__non-stream` | `end-to-end case-0037-set_intersection__non-stream-budget_capped.json` |
+| `10.b` | `set_intersection__non-stream` | `end-to-end case-0037-set_intersection__non-stream-budget_unlimited.json` |
+| `10.b` | `set_intersection__stream` | `end-to-end case-0038-set_intersection__stream-budget_capped.json` |
+| `10.b` | `set_intersection__stream` | `end-to-end case-0038-set_intersection__stream-budget_unlimited.json` |
+| `10.b` | `sort_integers__non-stream` | `end-to-end case-0039-sort_integers__non-stream-budget_capped.json` |
+| `10.b` | `sort_integers__non-stream` | `end-to-end case-0039-sort_integers__non-stream-budget_unlimited.json` |
+| `10.b` | `sort_integers__stream` | `end-to-end case-0040-sort_integers__stream-budget_capped.json` |
+| `10.b` | `sort_integers__stream` | `end-to-end case-0040-sort_integers__stream-budget_unlimited.json` |
+| `10.b` | `spanish_logic__non-stream` | `end-to-end case-0041-spanish_logic__non-stream-budget_capped.json` |
+| `10.b` | `spanish_logic__non-stream` | `end-to-end case-0041-spanish_logic__non-stream-budget_unlimited.json` |
+| `10.b` | `spanish_logic__stream` | `end-to-end case-0042-spanish_logic__stream-budget_capped.json` |
+| `10.b` | `spanish_logic__stream` | `end-to-end case-0042-spanish_logic__stream-budget_unlimited.json` |
+| `10.b` | `structured_json__non-stream` | `end-to-end case-0043-structured_json__non-stream-budget_capped.json` |
+| `10.b` | `structured_json__non-stream` | `end-to-end case-0043-structured_json__non-stream-budget_unlimited.json` |
+| `10.b` | `structured_json__stream` | `end-to-end case-0044-structured_json__stream-budget_capped.json` |
+| `10.b` | `structured_json__stream` | `end-to-end case-0044-structured_json__stream-budget_unlimited.json` |
+| `10.b` | `system_instruction__non-stream` | `end-to-end case-0045-system_instruction__non-stream-budget_capped.json` |
+| `10.b` | `system_instruction__non-stream` | `end-to-end case-0045-system_instruction__non-stream-budget_unlimited.json` |
+| `10.b` | `system_instruction__stream` | `end-to-end case-0046-system_instruction__stream-budget_capped.json` |
+| `10.b` | `system_instruction__stream` | `end-to-end case-0046-system_instruction__stream-budget_unlimited.json` |
+| `10.b` | `tool_none_arithmetic__non-stream` | `end-to-end case-0051-tool_none_arithmetic__non-stream-budget_capped.json` |
+| `10.b` | `tool_none_arithmetic__non-stream` | `end-to-end case-0051-tool_none_arithmetic__non-stream-budget_unlimited.json` |
+| `10.b` | `tool_none_arithmetic__stream` | `end-to-end case-0052-tool_none_arithmetic__stream-budget_capped.json` |
+| `10.b` | `tool_none_arithmetic__stream` | `end-to-end case-0052-tool_none_arithmetic__stream-budget_unlimited.json` |
+| `10.b` | `unicode_symbol_math__non-stream` | `end-to-end case-0067-unicode_symbol_math__non-stream-budget_capped.json` |
+| `10.b` | `unicode_symbol_math__non-stream` | `end-to-end case-0067-unicode_symbol_math__non-stream-budget_unlimited.json` |
+| `10.b` | `unicode_symbol_math__stream` | `end-to-end case-0068-unicode_symbol_math__stream-budget_capped.json` |
+| `10.b` | `unicode_symbol_math__stream` | `end-to-end case-0068-unicode_symbol_math__stream-budget_unlimited.json` |
+| `10.b` | `lifecycle_single_result__stream` | `end-to-end case-0129-lifecycle_single_result__stream-budget_capped.json` |
+| `10.b` | `lifecycle_single_result__stream` | `end-to-end case-0129-lifecycle_single_result__stream-budget_unlimited.json` |
+| `30.a` | `tool_add_named__non-stream` | `end-to-end case-0047-tool_add_named__non-stream-budget_capped.json` |
+| `30.a` | `tool_add_named__non-stream` | `end-to-end case-0047-tool_add_named__non-stream-budget_unlimited.json` |
+| `30.a` | `tool_add_named__stream` | `end-to-end case-0048-tool_add_named__stream-budget_capped.json` |
+| `30.a` | `tool_add_named__stream` | `end-to-end case-0048-tool_add_named__stream-budget_unlimited.json` |
+| `30.a` | `tool_translate_named__stream` | `end-to-end case-0054-tool_translate_named__stream-budget_capped.json` |
+| `30.a` | `tool_translate_named__stream` | `end-to-end case-0054-tool_translate_named__stream-budget_unlimited.json` |
+| `30.b` | `lifecycle_single_result__stream` | `end-to-end case-0129-lifecycle_single_result__stream-budget_capped.json` |
+| `30.b` | `lifecycle_single_result__stream` | `end-to-end case-0129-lifecycle_single_result__stream-budget_unlimited.json` |
+| `30.b` | `lifecycle_chained_calculation__stream` | `end-to-end case-0145-lifecycle_chained_calculation__stream-budget_capped.json` |
+| `30.b` | `lifecycle_chained_calculation__stream` | `end-to-end case-0145-lifecycle_chained_calculation__stream-budget_unlimited.json` |
+| `30.d` | `schema_escaped_unicode_string__non-stream` | `end-to-end case-0105-schema_escaped_unicode_string__non-stream-budget_capped.json` |
+| `30.d` | `schema_escaped_unicode_string__non-stream` | `end-to-end case-0105-schema_escaped_unicode_string__non-stream-budget_unlimited.json` |
+| `30.e` | `schema_array__stream` | `end-to-end case-0108-schema_array__stream-budget_capped.json` |
+| `30.e` | `schema_array__stream` | `end-to-end case-0108-schema_array__stream-budget_unlimited.json` |
+
 ## Request-scoped modes (groups 30+)
 
-Groups 1–12 vary the model OUTPUT. Groups 30+ vary the request: what the serving layer passed to `UnifiedParser::initialize_with_output_mode(prefill, tool_output_mode)` before any output arrived. The pairing is `X0` happy / `X1` malformed, and a new mode takes the next ten.
+Groups 1–12 vary the model OUTPUT. Groups 30+ vary the request: the resolved `UnifiedParserInit` the serving layer passed to `UnifiedParser::initialize_request` before any output arrived. The pairing is `X0` happy / `X1` malformed, and a new mode takes the next ten.
 
-`prefill` says which channel the rendered prompt already opened, so the model never emits that opener: `None` (it opens its own), `Reasoning` (the stream begins INSIDE a thought), `Response` (visible content is already open, so there is no reasoning channel at all and reasoning markers are ordinary text). `tool_output_mode` says whether the backend constrained decoding: `Native` (model markup) or `GuidedJson` (bare JSON — a NAMED choice sends that tool's arguments alone, a REQUIRED choice sends one call object or an array of them).
+`starting_state` says which channel the rendered prompt already opened, so the model never emits that opener: `None` (it opens its own), `Reasoning` (the stream begins INSIDE a thought), `Response` (visible content is already open, so there is no reasoning channel at all and reasoning markers are ordinary text). `tool_output_mode` says whether the backend constrained decoding: `Native` (model markup) or `GuidedJson` (bare JSON — a NAMED choice sends that tool's arguments alone, a REQUIRED choice sends one call object or an array of them).
 
 ### Group 30 — Guided decoding, happy
-- **`30.a`** (`guided_json_named_tool`) `tool_choice` names a tool; the payload is that tool's arguments and the name comes from the request.
-- **`30.b`** (`guided_json_required_tool`) Required choice; the payload is an array of call objects.
+- **`30.a`** (`guided_json_named_tool`) `tool_choice` names a tool; the payload is that tool's arguments and the name comes from the request. This is also covered in: e2e case-0047-tool_add_named__non-stream-budget_capped.json, e2e case-0048-tool_add_named__stream-budget_capped.json, e2e case-0054-tool_translate_named__stream-budget_capped.json (each with its `-budget_unlimited` pair).
+- **`30.b`** (`guided_json_required_tool`) Required choice; the payload is an array of call objects. This is also covered in: e2e case-0129-lifecycle_single_result__stream-budget_capped.json, e2e case-0145-lifecycle_chained_calculation__stream-budget_capped.json (FIRST step of each; both with their `-budget_unlimited` pair).
 - **`30.c`** (`guided_json_two_calls`) Two DIFFERENT tools in one array. Multi-call is the array's ordinary shape, not an edge case.
+- **`30.d`** (`guided_json_escaped_string_args`) An argument value carrying non-ASCII, escaped quotes and Windows backslashes. Native mode covers the same value in `7.*`, but there the value is raw text between markers and no escaping is involved — the escaping is only the parser's problem on this path. This is also covered in: e2e case-0105-schema_escaped_unicode_string__non-stream-budget_capped.json (and its `-budget_unlimited` pair).
+- **`30.e`** (`guided_json_array_argument`) An argument VALUE that is an array, not a scalar. Distinct from `30.b`/`30.c`, where the array is the list OF CALLS one level up. A list arriving as its string rendering is a silently wrong call, not a failed one. This is also covered in: e2e case-0108-schema_array__stream-budget_capped.json (and its `-budget_unlimited` pair).
+- **`30.f`** (`guided_json_after_reasoning`) A normal thought, THEN the constrained payload. Every other guided case starts at the payload, so nothing pinned the ordinary shape where the model reasons first and the backend constrains only the call. This is the baseline group 31's surroundings cases contrast with.
+- **`30.g`** (`guided_json_marker_inside_argument`) A control marker of the family's OWN grammar inside a guided argument VALUE. Once the payload has opened, a marker is argument DATA and must survive byte-exact (`I7`); re-reading it as a channel token corrupts the call the tool receives while still looking like a successful dispatch. The golden argument is the family's own marker, not a placeholder — a stand-in would pass whatever the parser did.
 
-### Group 31 — Guided decoding, malformed
-- **`31.a`** (`guided_json_invalid_call`) Valid JSON that is not a call (no `name`). Surfaces as text (P2); no call dispatched.
+### Group 31 — Guided decoding, malformed / recovery
+- **`31.a`** (`guided_json_invalid_call`) Valid JSON that is not a call (no `name`). Surfaces as text under the guided malformed-payload policy; no call dispatched.
 - **`31.b`** (`guided_json_malformed_json`) JSON that does not parse — a truncated object, what a constrained decode looks like when the budget runs out.
 - **`31.c`** (`guided_json_partial_calls`) The array parses but one element is not a call.
 - **`31.d`** (`guided_json_list_with_broken_element`) `[<valid call>, <broken JSON>]` — the array itself does not parse, so per-element recovery never runs.
+- **`31.e`** (`guided_json_tool_open_before_payload`) A native tool OPENER precedes the payload. Guided decoding delivers the call as JSON, so leading markup is stray: strip it, or it enters the payload buffer, breaks the parse and costs the call.
+- **`31.f`** (`guided_json_tool_close_after_payload`) A native tool CLOSER follows the payload. Markers can BRACKET a payload, not only precede it — once the opening brace latches visible-only, every later byte is appended verbatim.
+- **`31.g`** (`guided_json_wrapped_in_tool_markup`) Opener AND closer, the shape a template emits when guided decoding is applied INSIDE a tool block. Handling one end only still loses the call.
+- **`31.h`** (`guided_json_narrated_invoke_in_reasoning`) The model NARRATES a tool opener while thinking, then the real call arrives as JSON. The reasoning channel is unconstrained under guided decoding, so that markup is prose; treating it as structure ends the turn and discards the payload.
+- **`31.i`** (`guided_json_prose_before_reasoning`) Visible prose, then a thought, then the payload. Every other guided case opens its thought at byte 0; with prose first the run can latch the payload buffer and surface the model's private thinking to the user as the answer.
+- **`31.j`** (`guided_json_orphan_reason_close_before_payload`) An orphan reasoning CLOSER with nothing open. The native scanner strips a stray closer wherever it appears before an opener; guided must agree or the same bytes read differently by request mode (`I3`).
+- **`31.k`** (`guided_json_orphan_tool_close_before_payload`) An orphan tool CLOSER. Paired with `31.e`: while the closer was stripped and the opener beside it was not, which marker leaked depended on which one the model happened to emit.
+- **`31.w`** (`guided_json_native_markup_only`) Guided mode receives one complete native tool call instead of bare JSON. The turn is control markup and emits no events; every stream split must match the whole-input result instead of leaking the parameter body as visible text.
 
-`31.c` and `31.d` pin **all-or-nothing**: one bad element voids the whole array and the payload goes out as text, taking the valid call with it. That is deliberate. A tool call is a side effect, so dispatching one extracted from a document that failed validation fails OPEN. Text loses nothing — the raw payload stays visible. Every case in this group also emits `tracing::warn!(why = "unified_guided_json_not_a_tool_call")`: the events alone are indistinguishable from a model that chose to answer in prose, so the log is the only signal the backend's guided decoding failed.
+`31.c` and `31.d` pin **all-or-nothing**: one bad element voids the whole array and the payload goes out as text, taking the valid call with it. That is deliberate. A tool call is a side effect, so dispatching one extracted from a document that failed validation fails OPEN. Text loses nothing — the raw payload stays visible. `31.a`–`31.d` each also emit `tracing::warn!(why = "unified_guided_json_not_a_tool_call")`: the events alone are indistinguishable from a model that chose to answer in prose, so the log is the only signal the backend's guided decoding failed.
+
+`31.a`–`31.d` are malformed PAYLOADS. `31.e`–`31.k` are well-formed payloads in malformed SURROUNDINGS: they recover the markers, the payload then parses, and the call dispatches — so neither the all-or-nothing rule nor that warning applies to them.
+
+**Peer-engine value here is intentionally limited.** vLLM does not emit guided JSON in the base capture, and the families with no native unified parser cannot honour `init` at all, so those columns are structurally `UNSUPPORTED` rather than a comparison. What these rows do pin: the authored golden contract, the current native parsers' recovery, and the split-family result where 0.1.25 captured it. The `dynamo_v2-0.1.22` column was back-captured through the prior 237-case corpus; cases added later are explicitly missing from that historical capture rather than inferred.
 
 ### Group 40 — Prefilled reasoning, happy
 - **`40.a`** (`prefilled_reasoning_with_tool`) Stream begins inside a thought, closes it, calls a tool.
@@ -146,7 +284,7 @@ Groups 1–12 vary the model OUTPUT. Groups 30+ vary the request: what the servi
 - **`50.a`** (`prefilled_response_with_tool`) Leading visible content, then a native call.
 - **`50.b`** (`prefilled_response_with_guided_json`) Guided payload with the response channel already open.
 - **`50.c`** (`prefilled_response_guided_json_two_calls`) Two different tools; enters guided mode visible-only rather than outside-reasoning.
-- **`50.d`** (`prefilled_response_reasoning_markers_literal`) **The only case where `prefill=Response` is observable.** `<think>literal</think>` must reach the user as TEXT, markers and all, because this stream has no reasoning channel. Every other 50/51 case has no reasoning markers in its input and therefore parses identically under `prefill=None` — 50.a matches 8.a, 50.b matches 30.b, 50.c matches 30.c, 51.b matches 31.c.
+- **`50.d`** (`prefilled_response_reasoning_markers_literal`) **The only case where `starting_state=Response` is observable.** `<think>literal</think>` must reach the user as TEXT, markers and all, because this stream has no reasoning channel. Every other 50/51 case has no reasoning markers in its input and therefore parses identically under `starting_state=None` — 50.a matches 8.a, 50.b matches 30.b, 50.c matches 30.c, 51.b matches 31.c.
 
 ### Group 51 — Prefilled response, malformed
 - **`51.a`** (`prefilled_response_truncated`) Budget runs out mid-call; the prose already emitted survives.
@@ -158,7 +296,7 @@ Every rule here exists because a case was added that could not fail for the reas
 
 1. **Is it distinguishable from an existing case?** Compare `init` AND input against the corpus. If some existing case has the same configuration and the same input shape, the new case tests nothing. Three groups were deleted for exactly this: a whole axis whose 51/52/53 cases had the same config and inputs as `1.a`, differing only in a label the parser cannot read.
 2. **Can it fail for the stated reason?** Write down what would have to break for the case to go red, then confirm the parser can even SEE that input. `finish_reason` cannot: `finish()` takes no argument, in Dynamo and in vLLM alike, so a case that varies only the finish reason varies nothing. If the axis is invisible to the parser, express it as an input shape instead — `length` becomes a TRUNCATED input, which is observable.
-3. **Does the field already exist under another name?** A per-case `input_mode` was added that was a 1:1 alias of `init.prefill` across every row, and could not diverge, because "where the stream starts" IS what prefill encodes. Grep the case dict before adding a key.
+3. **Does the field already exist under another name?** A per-case `input_mode` was added that was a 1:1 alias of `init.starting_state` across every row, and could not diverge, because "where the stream starts" IS what the starting state encodes. Grep the case dict before adding a key.
 4. **Measure the behavior, do not predict it.** Author the case, run the harness, read what the parser actually emitted, and THEN write the golden and the description around it. The all-or-nothing array semantics were found this way; predicting them would have produced a wrong golden that looked authoritative.
 5. **A near-duplicate that survives must say what it duplicates.** If a case is kept because it exercises a different code path despite the same shape, name the sibling in its description (`50.b` says it matches `30.b`), so the next reader does not re-derive the question.
 6. **The input must be a shape the declared `init` can actually produce.** Six guided-decoding scenarios rendered NATIVE model markup for gemma4 and kimi_k2 while declaring `tool_output_mode=GuidedJson` — a mode that constrains the model to bare JSON, so that markup is the one input it can never emit. They rendered green for a year because neither family had a unified parser to run them; the moment gemma4 got one, all six failed. Guided payloads are grammar-independent and are now written ONCE for every family (`every_family` in `gen_unified_golden.py`); only the reasoning envelope around them is per family.
@@ -177,3 +315,13 @@ The model blob and the rendered page are different things. A cell can carry corr
 ## Deferred (not in the U0 seed set)
 
 - **n>1 interleave** (`UNIFIED.interleave_n2.*`, the Example-B n>1 LOSS case) needs a multi-choice interleaved driver (extends PR #135's tool-only lanes to carry reasoning state). Its golden is per-choice, a different shape than the single-stream cases here. Author with the n>1 lane.
+
+## A defect the corpus missed owes the corpus a case
+
+Every bug found by a reviewer, another agent, or a probe — that the existing cases did NOT catch — is evidence of a missing case, and the fix is not complete until that case exists here. Prefer a taxonomy scenario over a unit test: a scenario runs for every family and every delivery schedule the harness drives, a unit test runs once for one family. Fall back to a unit test only when the schema cannot express the property, and say why in its doc comment.
+
+Name the missing DIMENSION, not the example. `guided_json_stray_prefix_before_reasoning` and `guided_json_narrated_prefix_inside_reasoning` were added after a stray `<function=` header borrowed its `>` from a following thought opener and emitted the model's private reasoning as visible text. The example was one input; the untested axis was **which control marker owns a terminator when two compete** — and nothing in the corpus had ever asked that question.
+
+The check is the count: if a review round produced N defects the corpus missed and the scenario count did not move, the holes are still open.
+
+**A duplicate is worse than a gap.** Before adding, normalize `(input, init, golden)` across the corpus and drop any crossing that already exists. A generated product once recreated three hand-authored scenarios — 9 cases across families — inflating the count while testing nothing new, and leaving two names for one behaviour to drift apart. `test_no_two_scenarios_have_identical_behaviour` now enforces this.

--- a/conformance/utils/src/assets/conformance_view.js
+++ b/conformance/utils/src/assets/conformance_view.js
@@ -473,7 +473,7 @@
   // `None` and `Native` are real `#[default]` variants, NOT absent values — the gloss
   // says so, because "None" otherwise reads as null/unset.
   var CONFIG_GLOSS = {
-    prefill: {
+    starting_state: {
       'None': 'prompt opened no channel; the model emits its own markers (enum default)',
       'Reasoning': 'prompt opened reasoning, so the stream begins INSIDE a thought',
       'Response': 'prompt opened the visible response channel'
@@ -485,7 +485,7 @@
   };
 
   var CONFIG_KEYS = [
-    { key: 'prefill', dflt: 'None', values: ['None', 'Reasoning', 'Response'] },
+    { key: 'starting_state', dflt: 'None', values: ['None', 'Reasoning', 'Response'] },
     { key: 'tool_output_mode', dflt: 'Native', values: ['Native', 'GuidedJson'] },
     {
       key: 'named_tool',

--- a/conformance/utils/src/e2e_cases.json
+++ b/conformance/utils/src/e2e_cases.json
@@ -1,0 +1,656 @@
+{
+  "_comment": [
+    "Derived SNAPSHOT of the end-to-end test cases, generated from the Qwen3.6 report",
+    "(qwen36_pr163_test_cases.html). That report and its per-case JSON artifacts live OUTSIDE",
+    "this repo, so this file is the only thing CI can check against \u2014 regenerate it when the",
+    "report changes. `unified` lists the UNIFIED case(s) whose output SHAPE covers this e2e",
+    "case; UNIFIED may be a superset (more channels, more text) as long as the shape matches.",
+    "An empty `unified` is a FAILURE, not a default: see test_unified_taxonomy_covers_corpus.py."
+  ],
+  "source_report": "qwen36_pr163_test_cases.html",
+  "source_commit": "4ba15bbcd84bdd8fe3958435506870a569d0f93f",
+  "model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+  "distinct_cases": 49,
+  "logical_cases": 98,
+  "cases": {
+    "chinese_arithmetic__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0001-chinese_arithmetic__non-stream-budget_capped.json",
+        "case-0001-chinese_arithmetic__non-stream-budget_unlimited.json"
+      ]
+    },
+    "chinese_arithmetic__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0002-chinese_arithmetic__stream-budget_capped.json",
+        "case-0002-chinese_arithmetic__stream-budget_unlimited.json"
+      ]
+    },
+    "compare_fractions__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0003-compare_fractions__non-stream-budget_capped.json",
+        "case-0003-compare_fractions__non-stream-budget_unlimited.json"
+      ]
+    },
+    "compare_fractions__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0004-compare_fractions__stream-budget_capped.json",
+        "case-0004-compare_fractions__stream-budget_unlimited.json"
+      ]
+    },
+    "history_not_preserved__non-stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0013-history_not_preserved__non-stream-budget_capped.json",
+        "case-0013-history_not_preserved__non-stream-budget_unlimited.json"
+      ]
+    },
+    "history_not_preserved__stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0014-history_not_preserved__stream-budget_capped.json",
+        "case-0014-history_not_preserved__stream-budget_unlimited.json"
+      ]
+    },
+    "history_preserved_addition__non-stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0015-history_preserved_addition__non-stream-budget_capped.json",
+        "case-0015-history_preserved_addition__non-stream-budget_unlimited.json"
+      ]
+    },
+    "history_preserved_addition__stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0016-history_preserved_addition__stream-budget_capped.json",
+        "case-0016-history_preserved_addition__stream-budget_unlimited.json"
+      ]
+    },
+    "history_preserved_codeword__non-stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0017-history_preserved_codeword__non-stream-budget_capped.json",
+        "case-0017-history_preserved_codeword__non-stream-budget_unlimited.json"
+      ]
+    },
+    "history_preserved_codeword__stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0018-history_preserved_codeword__stream-budget_capped.json",
+        "case-0018-history_preserved_codeword__stream-budget_unlimited.json"
+      ]
+    },
+    "history_unicode__non-stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0019-history_unicode__non-stream-budget_capped.json",
+        "case-0019-history_unicode__non-stream-budget_unlimited.json"
+      ]
+    },
+    "history_unicode__stream": {
+      "suite": "reasoning",
+      "category": "history",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0020-history_unicode__stream-budget_capped.json",
+        "case-0020-history_unicode__stream-budget_unlimited.json"
+      ]
+    },
+    "lifecycle_chained_calculation__stream": {
+      "suite": "tool_calling",
+      "category": "parallel_lifecycle",
+      "mode": "stream",
+      "steps": 2,
+      "unified": [
+        "10.b",
+        "30.b"
+      ],
+      "artifacts": [
+        "case-0145-lifecycle_chained_calculation__stream-budget_capped.json",
+        "case-0145-lifecycle_chained_calculation__stream-budget_unlimited.json"
+      ]
+    },
+    "lifecycle_single_result__stream": {
+      "suite": "tool_calling",
+      "category": "parallel_lifecycle",
+      "mode": "stream",
+      "steps": 2,
+      "unified": [
+        "10.b",
+        "30.b"
+      ],
+      "artifacts": [
+        "case-0129-lifecycle_single_result__stream-budget_capped.json",
+        "case-0129-lifecycle_single_result__stream-budget_unlimited.json"
+      ]
+    },
+    "logic_syllogism__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0021-logic_syllogism__non-stream-budget_capped.json",
+        "case-0021-logic_syllogism__non-stream-budget_unlimited.json"
+      ]
+    },
+    "logic_syllogism__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0022-logic_syllogism__stream-budget_capped.json",
+        "case-0022-logic_syllogism__stream-budget_unlimited.json"
+      ]
+    },
+    "long_context_retrieval__non-stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0023-long_context_retrieval__non-stream-budget_capped.json",
+        "case-0023-long_context_retrieval__non-stream-budget_unlimited.json"
+      ]
+    },
+    "long_context_retrieval__stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0024-long_context_retrieval__stream-budget_capped.json",
+        "case-0024-long_context_retrieval__stream-budget_unlimited.json"
+      ]
+    },
+    "minutes_to_seconds__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0025-minutes_to_seconds__non-stream-budget_capped.json",
+        "case-0025-minutes_to_seconds__non-stream-budget_unlimited.json"
+      ]
+    },
+    "minutes_to_seconds__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0026-minutes_to_seconds__stream-budget_capped.json",
+        "case-0026-minutes_to_seconds__stream-budget_unlimited.json"
+      ]
+    },
+    "multiline_checksum__non-stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0027-multiline_checksum__non-stream-budget_capped.json",
+        "case-0027-multiline_checksum__non-stream-budget_unlimited.json"
+      ]
+    },
+    "multiline_checksum__stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0028-multiline_checksum__stream-budget_capped.json",
+        "case-0028-multiline_checksum__stream-budget_unlimited.json"
+      ]
+    },
+    "multiply_17_19__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0029-multiply_17_19__non-stream-budget_capped.json",
+        "case-0029-multiply_17_19__non-stream-budget_unlimited.json"
+      ]
+    },
+    "multiply_17_19__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0030-multiply_17_19__stream-budget_capped.json",
+        "case-0030-multiply_17_19__stream-budget_unlimited.json"
+      ]
+    },
+    "parity_expression__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0031-parity_expression__non-stream-budget_capped.json",
+        "case-0031-parity_expression__non-stream-budget_unlimited.json"
+      ]
+    },
+    "parity_expression__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0032-parity_expression__stream-budget_capped.json",
+        "case-0032-parity_expression__stream-budget_unlimited.json"
+      ]
+    },
+    "python_loop_trace__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0033-python_loop_trace__non-stream-budget_capped.json",
+        "case-0033-python_loop_trace__non-stream-budget_unlimited.json"
+      ]
+    },
+    "python_loop_trace__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0034-python_loop_trace__stream-budget_capped.json",
+        "case-0034-python_loop_trace__stream-budget_unlimited.json"
+      ]
+    },
+    "schema_array__stream": {
+      "suite": "tool_calling",
+      "category": "arguments_schema",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "30.e"
+      ],
+      "artifacts": [
+        "case-0108-schema_array__stream-budget_capped.json",
+        "case-0108-schema_array__stream-budget_unlimited.json"
+      ]
+    },
+    "schema_escaped_unicode_string__non-stream": {
+      "suite": "tool_calling",
+      "category": "arguments_schema",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "30.d"
+      ],
+      "artifacts": [
+        "case-0105-schema_escaped_unicode_string__non-stream-budget_capped.json",
+        "case-0105-schema_escaped_unicode_string__non-stream-budget_unlimited.json"
+      ]
+    },
+    "sequence_next__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0035-sequence_next__non-stream-budget_capped.json",
+        "case-0035-sequence_next__non-stream-budget_unlimited.json"
+      ]
+    },
+    "sequence_next__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0036-sequence_next__stream-budget_capped.json",
+        "case-0036-sequence_next__stream-budget_unlimited.json"
+      ]
+    },
+    "set_intersection__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0037-set_intersection__non-stream-budget_capped.json",
+        "case-0037-set_intersection__non-stream-budget_unlimited.json"
+      ]
+    },
+    "set_intersection__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0038-set_intersection__stream-budget_capped.json",
+        "case-0038-set_intersection__stream-budget_unlimited.json"
+      ]
+    },
+    "sort_integers__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0039-sort_integers__non-stream-budget_capped.json",
+        "case-0039-sort_integers__non-stream-budget_unlimited.json"
+      ]
+    },
+    "sort_integers__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0040-sort_integers__stream-budget_capped.json",
+        "case-0040-sort_integers__stream-budget_unlimited.json"
+      ]
+    },
+    "spanish_logic__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0041-spanish_logic__non-stream-budget_capped.json",
+        "case-0041-spanish_logic__non-stream-budget_unlimited.json"
+      ]
+    },
+    "spanish_logic__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0042-spanish_logic__stream-budget_capped.json",
+        "case-0042-spanish_logic__stream-budget_unlimited.json"
+      ]
+    },
+    "structured_json__non-stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0043-structured_json__non-stream-budget_capped.json",
+        "case-0043-structured_json__non-stream-budget_unlimited.json"
+      ]
+    },
+    "structured_json__stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0044-structured_json__stream-budget_capped.json",
+        "case-0044-structured_json__stream-budget_unlimited.json"
+      ]
+    },
+    "system_instruction__non-stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0045-system_instruction__non-stream-budget_capped.json",
+        "case-0045-system_instruction__non-stream-budget_unlimited.json"
+      ]
+    },
+    "system_instruction__stream": {
+      "suite": "reasoning",
+      "category": "complex",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0046-system_instruction__stream-budget_capped.json",
+        "case-0046-system_instruction__stream-budget_unlimited.json"
+      ]
+    },
+    "tool_add_named__non-stream": {
+      "suite": "reasoning",
+      "category": "tool_boundary",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "30.a"
+      ],
+      "artifacts": [
+        "case-0047-tool_add_named__non-stream-budget_capped.json",
+        "case-0047-tool_add_named__non-stream-budget_unlimited.json"
+      ]
+    },
+    "tool_add_named__stream": {
+      "suite": "reasoning",
+      "category": "tool_boundary",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "30.a"
+      ],
+      "artifacts": [
+        "case-0048-tool_add_named__stream-budget_capped.json",
+        "case-0048-tool_add_named__stream-budget_unlimited.json"
+      ]
+    },
+    "tool_none_arithmetic__non-stream": {
+      "suite": "reasoning",
+      "category": "tool_boundary",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0051-tool_none_arithmetic__non-stream-budget_capped.json",
+        "case-0051-tool_none_arithmetic__non-stream-budget_unlimited.json"
+      ]
+    },
+    "tool_none_arithmetic__stream": {
+      "suite": "reasoning",
+      "category": "tool_boundary",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0052-tool_none_arithmetic__stream-budget_capped.json",
+        "case-0052-tool_none_arithmetic__stream-budget_unlimited.json"
+      ]
+    },
+    "tool_translate_named__stream": {
+      "suite": "reasoning",
+      "category": "tool_boundary",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "30.a"
+      ],
+      "artifacts": [
+        "case-0054-tool_translate_named__stream-budget_capped.json",
+        "case-0054-tool_translate_named__stream-budget_unlimited.json"
+      ]
+    },
+    "unicode_symbol_math__non-stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "non-stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0067-unicode_symbol_math__non-stream-budget_capped.json",
+        "case-0067-unicode_symbol_math__non-stream-budget_unlimited.json"
+      ]
+    },
+    "unicode_symbol_math__stream": {
+      "suite": "reasoning",
+      "category": "core",
+      "mode": "stream",
+      "steps": 1,
+      "unified": [
+        "10.b"
+      ],
+      "artifacts": [
+        "case-0068-unicode_symbol_math__stream-budget_capped.json",
+        "case-0068-unicode_symbol_math__stream-budget_unlimited.json"
+      ]
+    }
+  }
+}

--- a/conformance/utils/src/explode_unified_fixtures.py
+++ b/conformance/utils/src/explode_unified_fixtures.py
@@ -50,6 +50,16 @@ def _case_key(case_id):
     return numbered_id(scenario), fam, scenario
 
 
+def _peer_cell(result):
+    """Store a peer failure instead of its partial output."""
+    if result.get("error"):
+        return {"error": result["error"]}
+    return {
+        "assembled": result.get("assembled") or [],
+        "chunks": [{"expected": events or []} for events in (result.get("chunks") or [])],
+    }
+
+
 def main():
     feed = yaml.safe_load((BUILD / "unified_results.yaml").read_text())
     caps = {}
@@ -93,7 +103,7 @@ def main():
             "scenario": scenario,
             "description": c.get("description", ""),
             "policy": c.get("policy") or [],
-            "init": c.get("init") or {"prefill": "None", "tool_output_mode": "Native", "named_tool": None},
+            "init": c.get("init") or {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
             "finish_reason": c.get("finish_reason") or "stop",
             "input": c.get("input", ""),
             "chunks": [
@@ -120,13 +130,7 @@ def main():
                 continue
             vdir = f"{impl}-{ver[impl]}"
             entry = slot(vdir, fam, captured_with={impl: ver[impl]})
-            cell = {}
-            if res.get("error"):
-                cell["error"] = res["error"]
-            else:
-                cell["assembled"] = res.get("assembled") or []
-                cell["chunks"] = [{"expected": e or []} for e in (res.get("chunks") or [])]
-            entry[key] = cell
+            entry[key] = _peer_cell(res)
 
     # Clear old exploded dirs, then write one file per case.
     for sub in ("inputs", "golden"):

--- a/conformance/utils/src/gen_unified_golden.py
+++ b/conformance/utils/src/gen_unified_golden.py
@@ -20,6 +20,7 @@ Run:  python3 conformance/utils/src/gen_unified_golden.py
 """
 import json
 import os
+import re
 
 import yaml
 
@@ -97,6 +98,104 @@ def D(cls, note):
     return {"verdict": "diverge", "class": cls, "note": note}
 
 
+# --- per-family input helpers for EDGE scenarios ------------------------------
+
+def every_family(input_text, vllm, dynamo, *rest):
+    """One input for EVERY family.
+
+    Guided decoding is a BACKEND feature: it constrains the model to bare JSON,
+    so the family's own grammar never appears in the payload and there is nothing
+    to render per family. Writing these per family is how gemma4 and kimi_k2 ended
+    up carrying NATIVE markup under an `init.tool_output_mode=GuidedJson` label —
+    a case that renders green while testing nothing, because the parser was handed
+    the one input shape the mode it declares never produces.
+    """
+    # The `dynamo` verdict is applied ONLY to families that actually have a native
+    # unified parser. A family still on the v1-reasoning + v2-tool split ignores
+    # `init` entirely, so it cannot honour a guided request mode — it emits the
+    # payload as text. Recording `match` for it would be a false claim in the spec:
+    # nothing asserts this field (the Dynamo column is computed live), so it would
+    # never fail, it would just quietly mislead anyone reading the corpus.
+    split = D(
+        "UNSUPPORTED",
+        "no native unified parser in this build, so the split path ignores `init` "
+        "and cannot honour a guided request mode",
+    )
+    return {
+        fam: (input_text, vllm, dynamo if fam in UNIFIED_FAMILIES else split, *rest)
+        for fam in FAMILIES
+    }
+
+
+
+def by_family(render, vllm, dynamo, *rest):
+    """`render(fam) -> input` for the scenarios where only the reasoning envelope
+    around an otherwise identical payload is grammar-specific."""
+    return {fam: (render(fam), vllm, dynamo, *rest) for fam in FAMILIES}
+
+
+def control_tokens(fam):
+    """Bare control tokens for `fam`, DERIVED from the renderers the corpus already
+    uses (`r_reason` / `r_tool`) rather than a second grammar table — a parallel
+    marker map is the kind of divergent copy that goes stale the first time a
+    family's grammar moves.
+
+    The tool pair is the OUTER wrapper: the first and last control tokens of a
+    rendered call. Splitting on the tool NAME instead returns the inner fragment
+    (`call:` for gemma4, `<function=` for qwen3, `functions.` plus the call-begin
+    marker for kimi_k2), which is not the envelope these cases mean to place around
+    a payload.
+
+    Returns `(reason_open, reason_close, tool_open, tool_close)`.
+    """
+    reason_open, reason_close = r_reason(fam, "\x00").split("\x00")
+    tokens = re.findall(r"<[^<>]*>", r_tool(fam, "NAMEX", "KEYX", "VALX", 0))
+    return reason_open, reason_close, tokens[0], tokens[-1]
+
+
+def invoke_header_prefix(fam):
+    """Inner invoke header through the tool name, without its terminator."""
+    rendered = r_tool(fam, "NAMEX", "KEYX", "VALX", 0)
+    outer = control_tokens(fam)[2]
+    return rendered[len(outer):rendered.index("NAMEX")].lstrip()
+
+
+def guided_surroundings(render, dynamo_note, fill=None):
+    """A guided case whose SURROUNDINGS carry native grammar, so the input has to be
+    per family — `every_family` is only right when the bytes are grammar-independent.
+
+    `render(fam) -> input`. vLLM stays `GUIDED_UNSUPPORTED`: the request contract is
+    `tool_output_mode=GuidedJson`, and a peer that never emits guided JSON is not an
+    equivalent comparison just because the malformed surroundings happen to contain
+    markup it could parse natively. Families with no native unified parser record the
+    split-path divergence, same rule as `SPLIT`.
+    """
+    split = D(
+        "UNSUPPORTED",
+        "no native unified parser in this build, so the split path ignores `init` "
+        "and cannot honour a guided request mode",
+    )
+    return {
+        fam: (
+            render(fam),
+            GUIDED_UNSUPPORTED,
+            {"verdict": "match", "note": dynamo_note} if fam in UNIFIED_FAMILIES else split,
+            *( (fill(fam),) if fill else () ),
+        )
+        for fam in FAMILIES
+    }
+
+
+# Guided payloads, written once. `named` is what a NAMED choice emits (that
+# tool's arguments alone); the arrays are what a REQUIRED choice emits.
+GUIDED_NAMED_ARGS = '{"city": "Paris"}'
+GUIDED_ONE_CALL = '[{"name": "get_weather", "arguments": {"city": "Paris"}}]'
+GUIDED_TWO_CALLS = ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, '
+                    '{"name": "run", "arguments": {"cmd": "git log"}}]')
+GUIDED_UNSUPPORTED = D("UNSUPPORTED",
+                       "vLLM base case doesn't emit guided JSON; conformance captures native XML only")
+
+
 # --- CLEAN scenarios: same segments for every family, input is templated ------
 # Each: (name, description, policy, segments, vllm, dynamo)
 # vllm/dynamo are either a single entry (all families) or {family: entry}.
@@ -111,7 +210,7 @@ CLEAN = [
      [], [("reason", "Check weather."), ("tool", "get_weather", "city", "Paris")], M, M),
 
     ("reason_then_content",
-     "Reasoning then visible content, no tool call (baseline).",
+     "Reasoning then visible content, no tool call (baseline). This is also covered in: e2e case-0001-chinese_arithmetic__non-stream-budget_capped.json (+ 42 more: every `reasoning/core`, `reasoning/complex` and `reasoning/history` case, `tool_none_arithmetic__*`, and the SECOND step of both `lifecycle_*` — each with its `-budget_unlimited` pair).",
      [], [("reason", "let me think"), ("text", "The answer is 42.")], M, M),
 
     ("interstitial_text",
@@ -155,45 +254,45 @@ CLEAN = [
      {"gemma4": M, "qwen3": M,
       "kimi_k2": {"verdict": "match", "note": "P1 resolved by the v2 recovery contract: preserve trailing prose. Verify v2 kimi_k2 at capture time"}}),
 
-    # --- Group 2: multiple tool calls (streamv2.2) — tool-only, green everywhere ---
+    # --- Group 2: multiple tool calls (TOOLCALLING.streamv2.2) — tool-only, green everywhere ---
     ("two_calls",
-     "Two tool calls back-to-back, no reasoning (streamv2.2.a). Both must surface as ordered events.",
+     "Two tool calls back-to-back, no reasoning. Both must surface as ordered events. This is also covered in: TOOLCALLING.streamv2.2.a.",
      [], [("tool", "f", "x", "1"), ("tool", "g", "y", "2")], M, M),
     ("two_calls_same_name",
-     "The same tool called twice with different args (streamv2.2.d). Both calls are distinct events.",
+     "The same tool called twice with different args. Both calls are distinct events. This is also covered in: TOOLCALLING.streamv2.2.d.",
      [], [("tool", "get_weather", "city", "Paris"), ("tool", "get_weather", "city", "Tokyo")], M, M),
 
     # --- Group 3: no tool call ---
     ("text_only",
-     "Plain answer, no reasoning and no tool call (streamv2.3). Pure content passthrough.",
+     "Plain answer, no reasoning and no tool call. Pure content passthrough. This is also covered in: TOOLCALLING.streamv2.3. No e2e case has this shape: Qwen3.6 always emits a reasoning span, so the plain-content case is corpus-only.",
      [], [("text", "The answer is 42, no tools needed.")], M, M),
 
-    # --- Group 7: argument fidelity (streamv2.7) ---
+    # --- Group 7: argument fidelity (TOOLCALLING.streamv2.7) ---
     ("arg_unicode",
-     "Unicode + spaces in a string argument value (streamv2.7.b). Preserved exactly (I7).",
+     "Unicode + spaces in a string argument value. Preserved exactly (I7). This is also covered in: TOOLCALLING.streamv2.7.b.",
      [], [("tool", "get_weather", "city", "São Paulo 東京")], M, M),
 
-    # --- Group 8: content / narration position (streamv2.8) ---
+    # --- Group 8: content / narration position (TOOLCALLING.streamv2.8) ---
     ("text_before_tool",
-     "Visible text before a single tool call, no reasoning (streamv2.8.a).",
+     "Visible text before a single tool call, no reasoning. This is also covered in: TOOLCALLING.streamv2.8.a.",
      [], [("text", "On it: "), ("tool", "get_weather", "city", "Paris")], M, M),
     ("text_sandwich",
-     "Visible text both before and after a tool call (streamv2.8.c).",
+     "Visible text both before and after a tool call. This is also covered in: TOOLCALLING.streamv2.8.c.",
      [], [("text", "Before. "), ("tool", "get_weather", "city", "Paris"), ("text", " After.")], M, M),
     ("text_between_calls",
-     "Visible text between two tool calls (streamv2.8.d).",
+     "Visible text between two tool calls. This is also covered in: TOOLCALLING.streamv2.8.d.",
      [], [("tool", "f", "x", "1"), ("text", " then "), ("tool", "g", "y", "2")], M, M),
     ("narrated_calls",
      "Multiple tool calls with visible narration between each — tool_call -> text -> tool_call -> text -> tool_call. The agentic pattern: call, narrate, call again. Every call and every inter-call text span must surface as its own ordered event.",
      [], [("tool", "get_weather", "city", "Paris"), ("text", " then I'll run "),
           ("tool", "f", "x", "1"), ("text", " and "), ("tool", "g", "y", "2")], M, M),
 
-    # --- Group 10: reasoning span (reasoning-only; REASONING.2/6) ---
+    # --- Group 10: reasoning span (reasoning-only; REASONING.batch.2 / REASONING.batch.6) ---
     ("reason_only",
-     "A reasoning span with no visible answer and no tool call (REASONING.2.a).",
+     "A reasoning span with no visible answer and no tool call. This is also covered in: REASONING.batch.2.a.",
      [], [("reason", "just thinking, no answer")], M, M),
     ("two_reason_spans",
-     "Two reasoning spans separated by visible text, no tool call (REASONING.6.a). Streaming keeps both spans in order; batch merges them.",
+     "Two reasoning spans separated by visible text, no tool call. Streaming keeps both spans in order; batch merges them. This is also covered in: REASONING.batch.6.a.",
      [], [("reason", "first thought"), ("text", "interlude "),
           ("reason", "second thought"), ("text", "done")],
      M, D("MERGE", "batch v1 reasoning merges both spans into one leading event")),
@@ -224,15 +323,16 @@ EDGE = [
      "Stream ends mid tool call (no close marker). Policy P2 — drop the incomplete call, keep valid preceding output, no error, no leaked markup.",
      ["P2"],
      [{"kind": "reasoning", "text": "ok"}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|channel>thought\nok<channel|><|tool_call>call:get_weather{city:<|\"|>Par",
                    D("ERROR", "native Gemma4UnifiedParser finish() returns a hard Err -> erroring is the opposite of best-effort recovery"),
-                   {"verdict": "match", "note": "P2: drop the partial trailing call, keep the preceding reasoning, never error/leak (TOOLCALLING batch.5.e)"}),
+                   {"verdict": "match", "note": "P2: drop the partial trailing call, keep the preceding reasoning, never error/leak (TOOLCALLING.batch.5.e)"}),
         "qwen3": ("<think>ok</think><tool_call>\n<function=get_weather>\n<parameter=city>\nPar",
-                  {"verdict": "match", "note": "hypothesis: qwen3 tool parser drops the unterminated call; verify at capture time"},
+                  {"verdict": "match", "note": "P2: drop the unterminated call and keep the preceding reasoning"},
                   {"verdict": "match", "note": "P2: v2 drops the partial trailing call, keeps reasoning"}),
         "kimi_k2": ("<think>ok</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Par",
-                    {"verdict": "match", "note": "hypothesis: kimi tool parser drops the unterminated call; verify at capture time"},
+                    {"verdict": "match", "note": "P2: drop the unterminated call and keep the preceding reasoning"},
                     {"verdict": "match", "note": "P2: v2 drops the partial trailing call, keeps reasoning"}),
      }),
 
@@ -240,6 +340,7 @@ EDGE = [
      "Stream ends while still inside reasoning (no close marker). Open reasoning is promoted at finish, not dropped and not leaked as text.",
      [],
      [{"kind": "reasoning", "text": "thinking but stream ends"}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|channel>thought\nthinking but stream ends",
                    M, {"verdict": "match", "note": "verify against v1 gemma4 reasoning finish() at capture time"}),
@@ -253,17 +354,18 @@ EDGE = [
      "A close-marker-looking sequence INSIDE a string arg value. Invariant I7 — the value is data, preserved exactly, not truncated at the marker-looking substring.",
      [],
      [{"kind": "tool_call", "name": "run", "arguments": {"cmd": None}}],  # cmd filled per family below
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|tool_call>call:run{cmd:<|\"|>git log }<tool_call|> --oneline<|\"|>}<tool_call|>",
                    D("ARG_MISMATCH", "char-by-char streamed-arg coercion truncates args at the marker-looking boundary (regression class #48702/#47977)"),
                    {"verdict": "match", "note": "emit-on-close typing sees the whole balanced value; find_tool_call_end_position_gemma4 ignores <tool_call|> inside <|\"|> strings"},
                    "git log }<tool_call|> --oneline"),
         "qwen3": ("<tool_call>\n<function=run>\n<parameter=cmd>\ngit log </tool_call> --oneline\n</parameter>\n</function>\n</tool_call>",
-                  {"verdict": "match", "note": "hypothesis: value ends at the real `\\n</parameter>`; an embedded `</tool_call>` is data. Verify at capture time"},
+                  {"verdict": "match", "note": "the parameter boundary owns the value; embedded `</tool_call>` is data"},
                   {"verdict": "match", "note": "v2 reads the parameter value up to `</parameter>`; embedded `</tool_call>` preserved"},
                   "git log </tool_call> --oneline"),
         "kimi_k2": ("<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\": \"git log <|tool_call_end|> --oneline\"}<|tool_call_end|><|tool_calls_section_end|>",
-                    {"verdict": "match", "note": "hypothesis: JSON string value survives an embedded `<|tool_call_end|>`. Verify at capture time"},
+                    {"verdict": "match", "note": "the JSON string owns embedded `<|tool_call_end|>` bytes as data"},
                     {"verdict": "match", "note": "v2 parses the JSON arg blob; the marker inside the string is data"},
                     "git log <|tool_call_end|> --oneline"),
      }),
@@ -272,22 +374,24 @@ EDGE = [
      "Prose followed by an orphan close marker with no matching open. Best-effort recovery — the prose stays as content, the orphan marker is stripped, nothing leaks.",
      [],
      [{"kind": "text", "text": "I will check that. "}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("I will check that. <tool_call|>",
                    D("LEAK", "vLLM/SGLang leak the orphan close marker into content as the whole tail (TOOLCALLING_CASES.md 5.g)"),
                    D("LEAK", "LIVE finding: v2 gemma4 leaks a lone <tool_call|> end marker into content — with no matching <|tool_call> open the scanner treats it as text. Best-effort-recovery gap (should strip per TOOLCALLING 5.g).")),
         "qwen3": ("I will check that. </tool_call>",
-                  {"verdict": "match", "note": "hypothesis: an orphan `</tool_call>` with no open is stripped. Verify at capture time"},
-                  {"verdict": "match", "note": "hypothesis: v2 qwen3 strips the orphan close. Verify at capture time"}),
+                  {"verdict": "match", "note": "the orphan close is stripped and the preceding prose remains visible"},
+                  {"verdict": "match", "note": "the orphan close is stripped and the preceding prose remains visible"}),
         "kimi_k2": ("I will check that. <|tool_call_end|>",
-                    {"verdict": "match", "note": "hypothesis: an orphan `<|tool_call_end|>` with no section is stripped. Verify at capture time"},
-                    {"verdict": "match", "note": "hypothesis: v2 kimi strips the orphan close. Verify at capture time"}),
+                    D("LEAK", "the orphan `<|tool_call_end|>` remains in the assembled reasoning output"),
+                    D("LEAK", "the split path retains the orphan `<|tool_call_end|>` in assembled reasoning")),
      }),
 
     ("empty_args",
-     "A tool call with an empty argument object {} (streamv2.6.a). Policy P3 — empty args serialize to {}.",
+     "A tool call with an empty argument object {}. Policy P3 — empty args serialize to {}. This is also covered in: TOOLCALLING.streamv2.6.a.",
      ["P3"],
      [{"kind": "tool_call", "name": "get_weather", "arguments": {}}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|tool_call>call:get_weather{}<tool_call|>", M, M),
         "qwen3": ("<tool_call>\n<function=get_weather>\n</function>\n</tool_call>", M, M),
@@ -295,19 +399,20 @@ EDGE = [
      }),
 
     ("tool_no_close",
-     "A single tool call whose body is complete but the close marker never arrives before EOF (streamv2.5.a). Best-effort recovery emits the complete call at finish.",
+     "A single tool call whose body is complete but the close marker never arrives before EOF. Best-effort recovery emits the complete call at finish. This is also covered in: TOOLCALLING.streamv2.5.a.",
      [],
      [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}",
                    {"verdict": "match", "note": "body complete; recover the call at finish"},
-                   {"verdict": "match", "note": "hypothesis: v2 emits the complete call at finish; verify at capture"}),
+                   {"verdict": "match", "note": "body complete; recover the call at finish"}),
         "qwen3": ("<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>",
                   {"verdict": "match", "note": "body complete; recover at finish"},
-                  {"verdict": "match", "note": "hypothesis: v2 recovers; verify at capture"}),
+                  D("DROP", "the complete call body produces no events when the outer close is absent")),
         "kimi_k2": ("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}",
                     {"verdict": "match", "note": "body complete; recover at finish"},
-                    {"verdict": "match", "note": "hypothesis: v2 recovers; verify at capture"}),
+                    D("DROP", "the complete call body produces no events when the outer close is absent")),
      }),
 
     # --- Group 12: adversarial nesting (a marker of one channel inside another) ---
@@ -315,18 +420,19 @@ EDGE = [
      "'Tool call contains reasoning' — a reasoning-channel marker sits inside a QUOTED tool-arg value. This is NOT a leak: a leak is control markup surfacing in visible content or reasoning, but here the markup is a tool ARGUMENT VALUE (data bound for the function, inside the grammar's string delimiters), so by I7 the parser preserves it byte-exact. The gemma4 native UnifiedParser confirms this golden exactly. Failure mode: a reasoning-first pipeline extracts the `<think>`/`<|channel>` from inside the arg BEFORE tool parsing, hoisting it into a spurious reasoning event and corrupting the arg to empty.",
      [],
      [{"kind": "tool_call", "name": "log", "arguments": {"note": None}}],  # note filled per family
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|tool_call>call:log{note:<|\"|><|channel>thought\nreconsider<channel|><|\"|>}<tool_call|>",
                    D("ARG_MISMATCH", "the reasoning extractor lifts the `<|channel>...<channel|>` out of the arg value before tool parsing, so the logged note no longer matches golden"),
                    D("MERGE", "v1 reasoning runs first over the whole stream and pulls the arg's embedded `<|channel>...<channel|>` into a leading reasoning event, corrupting the tool arg"),
                    "<|channel>thought\nreconsider<channel|>"),
         "qwen3": ("<tool_call>\n<function=log>\n<parameter=note>\n<think>reconsider</think>\n</parameter>\n</function>\n</tool_call>",
-                  D("ARG_MISMATCH", "hypothesis: the `<think>...</think>` inside the parameter value is extracted as reasoning first, corrupting the arg. Verify at capture time"),
-                  D("MERGE", "hypothesis: v1 reasoning lifts the embedded `<think>` out of the arg. Verify at capture time"),
+                  D("ARG_MISMATCH", "captured: tool_call(log) — the `<think>...</think>` inside the parameter value is extracted as reasoning first, corrupting the arg"),
+                  D("MERGE", "captured: tool_call(log) — v1 reasoning lifts the embedded `<think>` out of the arg"),
                   "<think>reconsider</think>"),
         "kimi_k2": ("<|tool_calls_section_begin|><|tool_call_begin|>functions.log:0<|tool_call_argument_begin|>{\"note\": \"<think>reconsider</think>\"}<|tool_call_end|><|tool_calls_section_end|>",
-                    D("ARG_MISMATCH", "hypothesis: the `<think>` inside the JSON string arg is extracted as reasoning first, corrupting the arg. Verify at capture time"),
-                    D("MERGE", "hypothesis: v1 reasoning lifts the embedded `<think>` out of the JSON arg. Verify at capture time"),
+                    D("ARG_MISMATCH", "captured: reasoning(reconsider) | text(Logging now: ) | tool_call(log) | text( done.) — the `<think>` inside the JSON string arg is extracted as reasoning first, corrupting the arg"),
+                    D("MERGE", "captured: reasoning(reconsider) | tool_call(log) — v1 reasoning lifts the embedded `<think>` out of the JSON arg"),
                     "<think>reconsider</think>"),
      }),
 
@@ -336,16 +442,17 @@ EDGE = [
      [{"kind": "reasoning", "text": "I should check. "},
       {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}},
       {"kind": "reasoning", "text": " now answer"}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("<|channel>thought\nI should check. <|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|> now answer<channel|>",
                    D("LEAK", "the reasoning extractor consumes to `<channel|>`, so the nested `<|tool_call>...<tool_call|>` leaks into reasoning_content and the call is dropped; break-out recovery not implemented"),
                    D("LEAK", "v1 reasoning runs to `<channel|>`, swallowing the nested tool markup into one reasoning event; the call is lost")),
         "qwen3": ("<think>I should check. <tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call> now answer</think>",
-                  D("LEAK", "hypothesis: the `</think>` closes only after the nested call, so the tool markup leaks into reasoning and the call is dropped. Verify at capture time"),
-                  D("LEAK", "hypothesis: v1 reasoning consumes to `</think>`, leaking the nested tool markup. Verify at capture time")),
+                  D("LEAK", "captured: reasoning(I should check. ) | tool_call(get_weather) | reasoning( now answer) — the `</think>` closes only after the nested call, so the tool markup leaks into reasoning and the call is dropped"),
+                  D("LEAK", "captured: text(Sure. ) | reasoning(I should check. ) | tool_call(get_weather) | reasoning( now answer) | text( Here you go.) — v1 reasoning consumes to `</think>`, leaking the nested tool markup")),
         "kimi_k2": ("<think>I should check. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|> now answer</think>",
-                    D("LEAK", "hypothesis: the tool section nested in `<think>...</think>` leaks into reasoning and the call is dropped. Verify at capture time"),
-                    D("LEAK", "hypothesis: v1 reasoning consumes to `</think>`, leaking the nested section. Verify at capture time")),
+                    D("LEAK", "captured: reasoning(I should check. ) | tool_call(get_weather) | text( now answer</think>) — the tool section nested in `<think>...</think>` leaks into reasoning and the call is dropped"),
+                    D("LEAK", "captured: reasoning(I should check. ) | text(Sure. ) | tool_call(get_weather) | text( now answer</think> Here you g) — v1 reasoning consumes to `</think>`, leaking the nested section")),
      }),
 
     ("reason_markup_in_arg_with_text",
@@ -354,18 +461,19 @@ EDGE = [
      [{"kind": "text", "text": "Logging now: "},
       {"kind": "tool_call", "name": "log", "arguments": {"note": None}},  # filled per family
       {"kind": "text", "text": " done."}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("Logging now: <|tool_call>call:log{note:<|\"|><|channel>thought\nreconsider<channel|><|\"|>}<tool_call|> done.",
                    D("ARG_MISMATCH", "the reasoning extractor lifts the `<|channel>...<channel|>` out of the arg before tool parsing; the note no longer matches and the surrounding text can shift"),
                    D("MERGE", "v1 reasoning hoists the arg's embedded `<|channel>...<channel|>` ahead of the visible text and corrupts the tool arg"),
                    "<|channel>thought\nreconsider<channel|>"),
         "qwen3": ("Logging now: <tool_call>\n<function=log>\n<parameter=note>\n<think>reconsider</think>\n</parameter>\n</function>\n</tool_call> done.",
-                  D("ARG_MISMATCH", "hypothesis: the `<think>` inside the parameter value is extracted as reasoning first, corrupting the arg. Verify at capture time"),
-                  D("MERGE", "hypothesis: v1 reasoning lifts the embedded `<think>` out of the arg and ahead of the text. Verify at capture time"),
+                  D("ARG_MISMATCH", "captured: text(Logging now: ) | tool_call(log) | text( done.) — the `<think>` inside the parameter value is extracted as reasoning first, corrupting the arg"),
+                  D("MERGE", "captured: text(Logging now: ) | tool_call(log) | text( done.) — v1 reasoning lifts the embedded `<think>` out of the arg and ahead of the text"),
                   "<think>reconsider</think>"),
         "kimi_k2": ("Logging now: <|tool_calls_section_begin|><|tool_call_begin|>functions.log:0<|tool_call_argument_begin|>{\"note\": \"<think>reconsider</think>\"}<|tool_call_end|><|tool_calls_section_end|> done.",
-                    D("ARG_MISMATCH", "hypothesis: the `<think>` inside the JSON string arg is extracted as reasoning first, corrupting the arg. Verify at capture time"),
-                    D("MERGE", "hypothesis: v1 reasoning lifts the embedded `<think>` out of the JSON arg and ahead of the text. Verify at capture time"),
+                    D("ARG_MISMATCH", "captured: reasoning(reconsider) | text(Logging now: ) | tool_call(log) | text( done.) — the `<think>` inside the JSON string arg is extracted as reasoning first, corrupting the arg"),
+                    D("MERGE", "captured: reasoning(reconsider) | text(Logging now: ) | tool_call(log) | text( done.) — v1 reasoning lifts the embedded `<think>` out of the JSON arg and ahead of the text"),
                     "<think>reconsider</think>"),
      }),
 
@@ -377,17 +485,591 @@ EDGE = [
       {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}},
       {"kind": "reasoning", "text": " now answer"},
       {"kind": "text", "text": " Here you go."}],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
      {
         "gemma4": ("Sure. <|channel>thought\nI should check. <|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|> now answer<channel|> Here you go.",
                    D("LEAK", "the reasoning extractor consumes to `<channel|>`, leaking the nested tool markup into reasoning_content and dropping the call; the visible text survives on both sides"),
                    D("LEAK", "v1 reasoning runs to `<channel|>`, swallowing the nested tool markup; the call is lost")),
         "qwen3": ("Sure. <think>I should check. <tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call> now answer</think> Here you go.",
-                  D("LEAK", "hypothesis: `</think>` closes only after the nested call, so the tool markup leaks into reasoning and the call is dropped. Verify at capture time"),
-                  D("LEAK", "hypothesis: v1 reasoning consumes to `</think>`, leaking the nested tool markup. Verify at capture time")),
+                  D("LEAK", "captured: text(Sure. ) | reasoning(I should check. ) | tool_call(get_weather) | reasoning( now answer) | text( Here you go.) — `</think>` closes only after the nested call, so the tool markup leaks into reasoning and the call is dropped"),
+                  D("LEAK", "captured: text(Sure. ) | reasoning(I should check. ) | tool_call(get_weather) | reasoning( now answer) | text( Here you go.) — v1 reasoning consumes to `</think>`, leaking the nested tool markup")),
         "kimi_k2": ("Sure. <think>I should check. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|> now answer</think> Here you go.",
-                    D("LEAK", "hypothesis: the nested tool section leaks into reasoning and the call is dropped. Verify at capture time"),
-                    D("LEAK", "hypothesis: v1 reasoning consumes to `</think>`, leaking the nested section. Verify at capture time")),
+                    D("LEAK", "captured: reasoning(I should check. ) | text(Sure. ) | tool_call(get_weather) | text( now answer</think> Here you g) — the nested tool section leaks into reasoning and the call is dropped"),
+                    D("LEAK", "captured: reasoning(I should check. ) | text(Sure. ) | tool_call(get_weather) | text( now answer</think> Here you g) — v1 reasoning consumes to `</think>`, leaking the nested section")),
      }),
+
+    # --- Group 13: request-scoped modes (guided decoding, prefilled channels) ---
+    ("guided_json_named_tool",
+     "Guided decoding with a named tool (tool_choice=specific_tool). The model emits bare JSON object, not XML markup, which the parser receives with tool_output_mode=GuidedJson{named_tool=get_weather}. This is also covered in: e2e case-0047-tool_add_named__non-stream-budget_capped.json, e2e case-0048-tool_add_named__stream-budget_capped.json, e2e case-0054-tool_translate_named__stream-budget_capped.json (each with its `-budget_unlimited` pair).",
+     [],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": "get_weather"},
+     every_family(GUIDED_NAMED_ARGS, GUIDED_UNSUPPORTED,
+                  {"verdict": "match", "note": "Dynamo v2 unified parser with tool_output_mode=GuidedJson{named_tool=get_weather}"})),
+
+    ("guided_json_required_tool",
+     "Guided decoding with required tool (tool_choice=required or auto after tool narrowing). The model emits a JSON array of call objects, parsed with tool_output_mode=GuidedJson{named_tool=None}. This is also covered in: e2e case-0129-lifecycle_single_result__stream-budget_capped.json, e2e case-0145-lifecycle_chained_calculation__stream-budget_capped.json (FIRST step of each; both with their `-budget_unlimited` pair).",
+     [],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     every_family(GUIDED_ONE_CALL, GUIDED_UNSUPPORTED,
+                  {"verdict": "match", "note": "Dynamo v2 unified parser with tool_output_mode=GuidedJson{named_tool=None}"})),
+
+    # Argument VALUE shapes on the guided path. `arg_unicode` already covers a non-ASCII
+    # value, but only in native mode, where the value sits as raw text between markers and
+    # no escaping is involved. Guided decoding carries the same value as a JSON string, so
+    # the escaping is the parser's problem only here — covering it natively proves nothing
+    # about this path.
+    ("guided_json_escaped_string_args",
+     "A named choice whose argument value carries non-ASCII, escaped quotes and Windows backslashes. A named choice constrains output to the argument object alone and the parser passes that object through verbatim, so every escape has to survive untouched: re-escaping or unescaping here hands the tool a different string than the model wrote, and the tool still runs. This is also covered in: e2e case-0105-schema_escaped_unicode_string__non-stream-budget_capped.json (and its `-budget_unlimited` pair).",
+     [],
+     [{"kind": "tool_call", "name": "run", "arguments": {"cmd": 'echo "雪" > C:\\tmp\\a.txt'}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": "run"},
+     every_family(r'{"cmd": "echo \"雪\" > C:\\tmp\\a.txt"}', GUIDED_UNSUPPORTED,
+                  {"verdict": "match", "note": "escapes and non-ASCII survive GuidedJson{named_tool=run} verbatim"})),
+
+    ("guided_json_array_argument",
+     "A required choice whose argument VALUE is an array. Every other guided case passes scalar arguments, and the array-shaped payloads in this group are arrays OF CALLS — one level up. A list-valued argument has to reach the tool as a list; arriving as its string rendering is a silently wrong call, not a failed one. This is also covered in: e2e case-0108-schema_array__stream-budget_capped.json (and its `-budget_unlimited` pair).",
+     [],
+     [{"kind": "tool_call", "name": "sum_values", "arguments": {"values": [2, 3, 5]}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     every_family('[{"name": "sum_values", "arguments": {"values": [2, 3, 5]}}]', GUIDED_UNSUPPORTED,
+                  {"verdict": "match", "note": "list-valued argument stays a list through GuidedJson{named_tool=None}"})),
+
+    ("guided_json_two_calls",
+     "A required choice returns an ARRAY, so multiple calls are that mode's ordinary shape. Both must surface as separate ordered events with distinct indices. Same array as 50.c but with NOTHING pre-filled, so guided mode starts outside reasoning rather than in visible-only — a different entry into the same payload.",
+     [],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}},
+      {"kind": "tool_call", "name": "run", "arguments": {"cmd": "git log"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     every_family(GUIDED_TWO_CALLS, GUIDED_UNSUPPORTED,
+                  {"verdict": "match", "note": "two DIFFERENT tools in one array, ordered"})),
+
+    ("guided_json_partial_calls",
+     "A guided array where one element is not a call (no `name`), with nothing pre-filled. All-or-nothing, as in 51.b: the whole payload surfaces as text and no call is dispatched, because extracting a call from a document that failed validation would fail OPEN on a side-effecting action.",
+     ["P2"],
+     [{"kind": "text", "text": '[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]'}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {
+        "qwen3": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]',
+                  D("UNSUPPORTED", "vLLM base case doesn't emit guided JSON; conformance captures native XML only"),
+                  {"verdict": "match", "note": "one invalid element voids the whole array; payload surfaces as text"}),
+        "gemma4": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]', M, M),
+        "kimi_k2": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]', M, M),
+     }),
+
+    ("guided_json_list_with_broken_element",
+     "A guided array whose SECOND element is not valid JSON — the payload is `[<valid call>, <broken>]`, which is what a constrained decode produces when it is cut off partway through a later call. Output is the whole payload as text and no call, same as 31.c but reached differently: there the array parsed and one element failed to convert, here the array does not parse at all, so per-element recovery never gets a chance. Both land on all-or-nothing, which is the point — a half-validated array must not dispatch the half that looked fine.",
+     ["P2"],
+     [{"kind": "text", "text": '[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"name": "run", "arguments": {"cmd": ]'}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {
+        "qwen3": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"name": "run", "arguments": {"cmd": ]',
+                  D("UNSUPPORTED", "vLLM base case doesn't emit guided JSON; conformance captures native XML only"),
+                  {"verdict": "match", "note": "the array itself fails to parse; nothing is dispatched"}),
+        "gemma4": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"name": "run", "arguments": {"cmd": ]', M, M),
+        "kimi_k2": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"name": "run", "arguments": {"cmd": ]', M, M),
+     }),
+
+    # --- Guided decoding: the SURROUNDINGS, not just the payload -----------------
+    # Every guided case above varies the PAYLOAD and delivers it bare. Nothing
+    # varied what sits AROUND it, and that is precisely where every guided defect
+    # in this surface has been found: prose before a thought surfaced the model's
+    # private reasoning as the answer, a narrated invoke swallowed the payload, an
+    # orphan closer leaked, and markup bracketing the payload lost the call. Those
+    # are pinned by unit tests; without these cases the corpus reads green through
+    # all of them.
+    ("guided_json_after_reasoning",
+     "The guided BASELINE that was missing: a normal thought, then the constrained payload. Every other guided case starts at the payload, so nothing pinned the ordinary shape where the model reasons first and the backend constrains only the call. This is the case the surroundings group contrasts with.",
+     [],
+     [{"kind": "reasoning", "text": "checking"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[0]}checking{control_tokens(fam)[1]}{GUIDED_ONE_CALL}",
+         "reasoning closes, then the guided payload dispatches")),
+
+    ("guided_json_marker_inside_argument",
+     "A control marker of the family's OWN grammar inside a guided argument VALUE. Once the payload has opened, a marker is argument DATA and must survive byte-exact (`I7`) — re-reading it as a channel token corrupts the call the tool receives while looking like a successful dispatch.",
+     ["P3"],
+     [{"kind": "tool_call", "name": "log", "arguments": {"note": None}}],  # filled per family
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: json.dumps(
+             [{"name": "log", "arguments": {"note": control_tokens(fam)[1]}}], ensure_ascii=False),
+         "a marker inside a started payload stays argument data",
+         lambda fam: control_tokens(fam)[1])),
+
+    ("guided_json_tool_open_before_payload",
+     "A native tool OPENER precedes the constrained payload. Guided decoding delivers the call as JSON, so leading markup is stray: it must be stripped, not carried into the payload buffer where it breaks the parse and costs the call.",
+     ["P2"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[2]}{GUIDED_ONE_CALL}",
+         "leading tool markup stripped; the call still dispatches")),
+
+    ("guided_json_tool_close_after_payload",
+     "A native tool CLOSER follows the payload. The leading side was handled long before this one: once the payload's opening brace latches visible-only, every later byte is appended verbatim, so a trailing marker rides into the buffer and the call is lost. Markers can BRACKET a payload, not only precede it.",
+     ["P2"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{GUIDED_ONE_CALL}{control_tokens(fam)[3]}",
+         "trailing tool markup stripped; the call still dispatches")),
+
+    ("guided_json_wrapped_in_tool_markup",
+     "The payload wrapped in a full native envelope, opener AND closer. This is the shape a template emits when guided decoding is applied INSIDE a tool block; handling only one end still loses the call.",
+     ["P2"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[2]}{GUIDED_ONE_CALL}{control_tokens(fam)[3]}",
+         "envelope stripped at both ends; the call still dispatches")),
+
+    ("guided_json_narrated_invoke_in_reasoning",
+     "The model NARRATES a tool opener while thinking, then the real call arrives as JSON. Guided decoding leaves the reasoning channel unconstrained, so that markup is prose the model wrote — treating it as structure ends the turn and discards the payload.",
+     ["P2"],
+     [{"kind": "reasoning", "text": "I'll use  next"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[0]}I'll use {control_tokens(fam)[2]} next{control_tokens(fam)[1]}{GUIDED_ONE_CALL}",
+         "narrated markup stripped, thought preserved, payload survives")),
+
+    ("guided_json_prose_before_reasoning",
+     "Visible prose, THEN a thought, then the payload. Every other guided case opens its thought at byte 0; when prose came first the run latched the payload buffer and the model's private thinking was surfaced to the user as the answer.",
+     ["P2"],
+     [{"kind": "text", "text": "Sure. "},
+      {"kind": "reasoning", "text": "checking"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"Sure. {control_tokens(fam)[0]}checking{control_tokens(fam)[1]}{GUIDED_ONE_CALL}",
+         "prose stays visible text, the thought stays reasoning, the call dispatches")),
+
+    ("guided_json_orphan_reason_close_before_payload",
+     "An orphan reasoning CLOSER with nothing open, ahead of the payload. The native scanner strips a stray closer wherever it appears before an opener; the guided path must agree or the same bytes read differently by request mode (`I3`).",
+     ["P2"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[1]}{GUIDED_ONE_CALL}",
+         "orphan reasoning closer stripped; the call still dispatches")),
+
+    ("guided_json_orphan_tool_close_before_payload",
+     "An orphan tool CLOSER before the payload. Paired with the opener case above: for a while the closer was stripped and the opener beside it was not, so which marker leaked depended on which one the model happened to emit.",
+     ["P2"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     guided_surroundings(
+         lambda fam: f"{control_tokens(fam)[3]}{GUIDED_ONE_CALL}",
+         "orphan tool closer stripped; the call still dispatches")),
+
+    ("guided_json_invalid_call",
+     "Guided decoding emits JSON that is well-formed but is NOT a tool call — no `name`, so there is nothing to dispatch. Policy P2: surface the payload as visible content rather than dropping it or erroring. Dropping it would lose the model's entire output; erroring would fail a request the user can still read.",
+     ["P2"],
+     [{"kind": "text", "text": '{"unexpected": "shape"}'}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {
+        "qwen3": ('{"unexpected": "shape"}',
+                  D("UNSUPPORTED", "vLLM base case doesn't emit guided JSON; conformance captures native XML only"),
+                  {"verdict": "match", "note": "P2: unparseable-as-a-call guided payload is surfaced as text"}),
+        "gemma4": ('{"unexpected": "shape"}', M, M),
+        "kimi_k2": ('{"unexpected": "shape"}', M, M),
+     }),
+
+    ("guided_json_malformed_json",
+     "Guided decoding emits JSON that does not PARSE — a truncated object, which is what a constrained decode looks like when the token budget runs out mid-payload. Distinct from the wrong-shape case: there the JSON was valid and merely not a call. Policy P2: surface the bytes as visible content. Dropping them loses the output silently, and erroring fails a request whose text is still readable.",
+     ["P2"],
+     [{"kind": "text", "text": '{"name": "get_weather", "arguments": {"city": "Par'}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {
+        "qwen3": ('{"name": "get_weather", "arguments": {"city": "Par',
+                  D("UNSUPPORTED", "vLLM base case doesn't emit guided JSON; conformance captures native XML only"),
+                  {"verdict": "match", "note": "P2: unparseable guided payload is surfaced as text, not dropped"}),
+        "gemma4": ('{"name": "get_weather", "arguments": {"city": "Par', M, M),
+        "kimi_k2": ('{"name": "get_weather", "arguments": {"city": "Par', M, M),
+     }),
+
+    ("prefilled_reasoning_with_tool",
+     "Reasoning channel is pre-filled by the generation prompt (policy P5), so the stream begins inside <think> with no opener. The model emits: reasoning tail -> closer -> tool call.",
+     ["P5"],
+     [{"kind": "reasoning", "text": "checking weather"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Reasoning", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     {
+        "qwen3": ("checking weather</think><tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>",
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; conformance captures default generation only"),
+                  {"verdict": "match", "note": "Dynamo v2 unified parser with starting_state=Reasoning"}),
+        "gemma4": ("checking weather<channel|><|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>", M, M),
+        "kimi_k2": ("checking weather</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>", M, M),
+     }),
+
+    ("prefilled_reasoning_then_text_then_tool",
+     "Reasoning is pre-filled, the model closes it, writes VISIBLE prose, and only then calls a tool. All three channels in one prefilled stream. The prose must surface as text, not be swept into the reasoning span it follows nor into the call it precedes — the boundary on each side is a different marker, and a prefilled stream has no opener to anchor the first one.",
+     ["P5"],
+     [{"kind": "reasoning", "text": "weighing options"},
+      {"kind": "text", "text": "Here's what I found: "},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Reasoning", "tool_output_mode": "Native", "named_tool": None},
+     {
+        "qwen3": ("weighing options</think>Here's what I found: <tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>",
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; conformance captures default generation only"),
+                  {"verdict": "match", "note": "reasoning -> text -> call, all three ordered in one prefilled stream"}),
+        "gemma4": ("weighing options<channel|>Here's what I found: <|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>", M, M),
+        "kimi_k2": ("weighing options</think>Here's what I found: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>", M, M),
+     }),
+
+    ("prefilled_reasoning_then_text",
+     "Reasoning is pre-filled, the model closes it and answers in prose with NO tool call — the ordinary shape of a prefilled request that needs no tool. Pins that closing a prefilled thought returns the stream to visible content rather than leaving it in reasoning, which would swallow the whole answer.",
+     ["P5"],
+     [{"kind": "reasoning", "text": "no tool needed"},
+      {"kind": "text", "text": "The answer is 42."}],
+     {"starting_state": "Reasoning", "tool_output_mode": "Native", "named_tool": None},
+     {
+        "qwen3": ("no tool needed</think>The answer is 42.",
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; conformance captures default generation only"),
+                  {"verdict": "match", "note": "closing a prefilled thought returns to visible content"}),
+        "gemma4": ("no tool needed<channel|>The answer is 42.", M, M),
+        "kimi_k2": ("no tool needed</think>The answer is 42.", M, M),
+     }),
+
+    ("prefilled_response_with_guided_json",
+     "Response channel is pre-filled (the prompt opened visible content), so the stream skips reasoning entirely and emits only tool calls as guided JSON. Same payload as 30.b under a different starting state; identical output, since Response only changes how reasoning markers are read and there are none.",
+     ["P5"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Response", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     every_family(GUIDED_ONE_CALL,
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state or use guided JSON"),
+                  {"verdict": "match", "note": "Dynamo v2 unified parser with starting_state=Response and tool_output_mode=GuidedJson{named_tool=None}"})),
+
+    ("prefilled_reasoning_with_guided_json",
+     "Reasoning channel is pre-filled (policy P5), stream begins inside <think> with no opener, and the model emits tool calls as guided JSON.",
+     ["P5"],
+     [{"kind": "reasoning", "text": "checking weather"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Reasoning", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     guided_surroundings(
+         lambda fam: f"checking weather{control_tokens(fam)[1]}{GUIDED_ONE_CALL}",
+         "Dynamo v2 unified parser with starting_state=Reasoning and tool_output_mode=GuidedJson{named_tool=None}")),
+
+    ("prefilled_response_with_tool",
+     "Response channel is pre-filled (the prompt opened visible content), so the stream skips reasoning entirely: the leading `output` is visible CONTENT with no opening marker, then a native-XML tool call. The leading text is generated output and must surface as a text event — routing it to reasoning is the regression, and it is what a reasoning-first split does when nothing told it the response channel was already open. Parses identically under starting_state=None (compare 8.a `text_before_tool`) — no reasoning markers here, so Response has nothing to suppress; 50.d is the case that isolates it.",
+     ["P5"],
+     [{"kind": "text", "text": "output"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Response", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     {
+        "qwen3": ("output<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>",
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; conformance captures default generation only"),
+                  {"verdict": "match", "note": "Dynamo v2 unified parser with starting_state=Response and tool_output_mode=Native"}),
+        "gemma4": ("output<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>", M, M),
+        "kimi_k2": ("output<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>",
+                    M,
+                    D("MERGE", "the split path has no starting-state signal, so the leading visible `output` is swept into reasoning_content instead of surfacing as text")),
+     }),
+
+
+
+
+    ("prefilled_reasoning_redundant_opener",
+     "Reasoning is pre-filled, and the backend ALSO re-emits the `<think>` opener the prompt already wrote. Exactly one such echo is consumed rather than leaked into reasoning_content; a second would be stray markup and stripped (I3). This is the only case where a prefilled stream legitimately carries an opener.",
+     [],
+     [{"kind": "reasoning", "text": "checking weather"}, {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "London"}}],
+     {"starting_state": "Reasoning", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     {
+        "gemma4": ("<|channel>thought\nchecking weather<channel|><|tool_call>call:get_weather{city:<|\"|>London<|\"|>}<tool_call|>", M, M),
+        "qwen3": ("<think>checking weather</think><tool_call>\n<function=get_weather>\n<parameter=city>\nLondon\n</parameter>\n</function>\n</tool_call>", M, M),
+        "kimi_k2": ("<think>checking weather</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"London\"}<|tool_call_end|><|tool_calls_section_end|>", M, M),
+     }),
+
+
+
+    ("prefilled_reasoning_truncated",
+     "Reasoning is pre-filled and the token budget runs out mid tool call — the input is truncated, which is what finish_reason=length MEANS on the wire. Policy P2: keep the completed reasoning, drop the incomplete call, no error and no leaked markup.",
+     ["P2"],
+     [{"kind": "reasoning", "text": "analyzing data"}],
+     {"starting_state": "Reasoning", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "length"},
+     {
+        "gemma4": ("analyzing data<channel|><|tool_call>call:get_weather{city:<|\"|>Par",
+                   D("ERROR", "native Gemma4UnifiedParser finish() returns a hard Err on a partial call rather than recovering"),
+                   {"verdict": "match", "note": "P2: drop the partial trailing call, keep the prefilled reasoning"}),
+        "qwen3": ("analyzing data</think><tool_call>\n<function=get_weather>\n<parameter=city>\nPar",
+                  {"verdict": "match", "note": "P2: drop the unterminated call and keep prefilled output"},
+                  {"verdict": "match", "note": "P2: v2 drops the partial trailing call, keeps the prefilled reasoning"}),
+        "kimi_k2": ("analyzing data</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Par",
+                    {"verdict": "match", "note": "P2: drop the unterminated call and keep prefilled output"},
+                    {"verdict": "match", "note": "P2: v2 drops the partial trailing call, keeps the prefilled reasoning"}),
+     }),
+
+
+
+    ("prefilled_response_guided_json_two_calls",
+     "Guided decoding with a required choice returns an ARRAY, so the multi-call shape is the array's normal case, not an edge one. Both calls must surface as separate ordered events with distinct indices — collapsing them, or emitting only the first, silently drops work the model asked for. Same array as 30.c under a different starting state; see 50.d for the case where Response actually changes the parse.",
+     ["P5"],
+     [{"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}},
+      {"kind": "tool_call", "name": "run", "arguments": {"cmd": "git log"}}],
+     {"starting_state": "Response", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     every_family(GUIDED_TWO_CALLS,
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state or use guided JSON"),
+                  {"verdict": "match", "note": "two DIFFERENT tools in one array, ordered"})),
+
+    ("prefilled_response_guided_json_partial_calls",
+     "A guided array where ONE element is not a call (no `name`). The whole payload surfaces as text and NO call is dispatched — deliberately all-or-nothing, not best-effort per element. A tool call is a side effect, so extracting one from a document that failed validation is failing OPEN: the client would execute a call the parser could not fully verify. Text loses nothing, since the raw payload stays visible.",
+     ["P2"],
+     [{"kind": "text", "text": '[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]'}],
+     {"starting_state": "Response", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     {
+        "qwen3": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]',
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state or use guided JSON"),
+                  {"verdict": "match", "note": "one invalid element voids the whole array; payload surfaces as text"}),
+        "gemma4": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]', M, M),
+        "kimi_k2": ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {"city": "Tokyo"}}]', M, M),
+     }),
+
+    ("prefilled_response_reasoning_markers_literal",
+     "The ONLY case where starting_state=Response is observable. Response says the prompt already opened VISIBLE content, so this stream has no reasoning channel at all and `<think>`/`</think>` are ordinary characters the model happened to write — they must reach the user as text, markers and all. Every other 50.*/51.* case has no reasoning markers in its input, which is why they parse identically under starting_state=None (50.a matches 8.a, 50.b matches 30.b, 50.c matches 30.c, 51.b matches 31.c); this one does not.",
+     ["P5"],
+     # The literal text is the family's OWN reasoning markers, so the golden is
+     # filled per family (below) rather than hardcoding one grammar's.
+     [{"kind": "text", "text": None},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "Response", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     {
+        "qwen3": ("<think>literal</think> then a call<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>",
+                  D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; it reads the markers as a reasoning span"),
+                  {"verdict": "match", "note": "reasoning disabled, so the markers stay literal text"},
+                  "<think>literal</think> then a call"),
+        "gemma4": ("<|channel>thought\nliteral<channel|> then a call<|tool_call>call:get_weather{city:<|\"|>Paris<|\"|>}<tool_call|>",
+                   D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; it reads the markers as a reasoning span"),
+                   {"verdict": "match", "note": "reasoning disabled, so `<|channel>thought\\n…<channel|>` stays literal text — role label included"},
+                   "<|channel>thought\nliteral<channel|> then a call"),
+        "kimi_k2": ("<think>literal</think> then a call<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>",
+                    D("UNSUPPORTED", "vLLM base case doesn't set a starting channel state; it reads the markers as a reasoning span"),
+                    M,
+                    "<think>literal</think> then a call"),
+     }),
+
+    ("prefilled_response_truncated",
+     "The response channel is pre-filled and the token budget runs out mid tool call. Policy P2: the visible prose already emitted survives, the incomplete call is dropped, nothing leaks as text.",
+     ["P2"],
+     [{"kind": "text", "text": "Working on it... "}],
+     {"starting_state": "Response", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "length"},
+     {
+        "gemma4": ("Working on it... <|tool_call>call:get_weather{city:<|\"|>Par",
+                   D("ERROR", "native Gemma4UnifiedParser finish() returns a hard Err on a partial call rather than recovering"),
+                   {"verdict": "match", "note": "P2: keep the leading visible prose, drop the partial call"}),
+        "qwen3": ("Working on it... <tool_call>\n<function=get_weather>\n<parameter=city>\nPar",
+                  {"verdict": "match", "note": "P2: keep leading prose and drop the unterminated call"},
+                  {"verdict": "match", "note": "P2: v2 keeps the leading prose and drops the partial call"}),
+        "kimi_k2": ("Working on it... <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Par",
+                    {"verdict": "match", "note": "P2: keep leading prose and drop the unterminated call"},
+                    {"verdict": "match", "note": "P2: v2 keeps the leading prose and drops the partial call"}),
+     }),
+]
+
+
+# ---------------------------------------------------------------------------
+# GENERATED semantic cross-product.
+#
+# Four hand-authored rows would have closed exactly the hole Devin found and left
+# the NEXT crossing open — the defects live in axis crossings, not in the example
+# that happened to expose them. So the guided edge region is a PRODUCT of two
+# authored bases: what the payload is, and what surrounds it.
+#
+# Measured before this existed (qwen3, guided cases, surrounding-markup x
+# golden-dispatches-a-call): 12 / 5 / 5 / ZERO. The empty quadrant — markup
+# present AND no call recoverable — is where the P2 recovery leak and the
+# unbounded invoke-header scan both lived, and no authored case could reach it.
+#
+# Products that say nothing are dropped by a predicate rather than never written,
+# so the reason a crossing is absent stays visible here instead of being implicit
+# in someone's case list.
+# ---------------------------------------------------------------------------
+
+# name -> (payload text, does a well-formed parse dispatch a call?)
+GUIDED_PAYLOADS = {
+    "valid": (GUIDED_ONE_CALL, {"city": "Paris"}),
+    # WHICH LAYER rejects the payload, not a vague "malformed". Only the first of
+    # these fails to parse; the other two are well-formed JSON that is not a call
+    # list. Collapsing them under one word made the corpus read as covering a
+    # syntax failure when it was really testing schema rejection.
+    "syntax_error": ('[{"name": "get_weather", "arguments": {"city": ', None),
+    "schema_error_not_a_call": ('{"unexpected": "shape"}', None),
+    "schema_error_nameless_element":
+        ('[{"name": "get_weather", "arguments": {"city": "Paris"}}, {"arguments": {}}]', None),
+    # An argument containing the character a prefix-form invoke header terminates
+    # on. `control_marker_at` and `guided_holdback_len` once disagreed about whether
+    # such a `>` completed the marker, so `<function=` was neither consumed nor held
+    # back and the call was lost as text. Payload shape, so it crosses every
+    # surrounding automatically.
+    "gt_in_argument": ('[{"name": "get_weather", "arguments": {"city": "a > b"}}]', {"city": "a > b"}),
+}
+
+# name -> (wrap(payload, fam) -> input, one-line description of the surrounding)
+# The third element is whether the surrounding puts a marker AFTER the payload.
+# It decides the recovery bytes and is the `I7`/`I3` boundary: a stripped TAIL
+# marker also trims the whitespace it was attached to, while a payload with no
+# trailing marker is handed back byte-identical — trailing space and all. The
+# corpus records that difference instead of each case guessing at it.
+GUIDED_SURROUNDS = {
+    "clean": (lambda pay, fam: pay, "no surrounding grammar", False),
+    "trailing_close": (lambda pay, fam: f"{pay}{control_tokens(fam)[3]}",
+                       "a stray tool CLOSE after the payload", True),
+    "wrapped": (lambda pay, fam: f"{control_tokens(fam)[2]}{pay}{control_tokens(fam)[3]}",
+                "the payload wrapped in native tool markup", True),
+    "bare_opener": (lambda pay, fam: f"{invoke_header_prefix(fam)}{pay}",
+                    "a bare invoke HEADER before the payload, never terminated", False),
+}
+
+
+def _guided_product():
+    """Every (payload x surrounding) crossing that says something distinct.
+
+    `clean` x `valid` is `30.a`/`30.b` and `clean` x the malformed payloads is
+    `31.a`-`31.d`; those already exist, so the predicate drops them rather than
+    emitting a duplicate under a second name.
+    """
+    out = []
+    for pay_name, (payload, want_args) in GUIDED_PAYLOADS.items():
+        dispatches = want_args is not None
+        for sur_name, (wrap, sur_desc, strips_tail) in GUIDED_SURROUNDS.items():
+            # `clean` is already authored as 30.a/30.b and 31.a-31.d. The
+            # `valid` payload crossings are also already authored by hand
+            # (guided_json_tool_open_before_payload / _tool_close_after_payload /
+            # _wrapped_in_tool_markup) — generating them produced 3 scenarios x 3
+            # families = 9 cases with byte-identical (input, init, golden). A
+            # duplicate is worse than a gap: it inflates the case count while
+            # testing nothing new, and two names for one behaviour drift apart.
+            if sur_name == "clean" or pay_name == "valid":
+                continue
+            scenario = f"guided_json_{pay_name}_{sur_name}"
+            golden = ([{"kind": "tool_call", "name": "get_weather",
+                        "arguments": want_args}] if dispatches else
+                      [{"kind": "text", "text": None}])
+            note = (f"guided payload ({pay_name}) with {sur_desc}: "
+                    + ("the call still dispatches and no marker reaches the user"
+                       if dispatches else
+                       "no call is recoverable, and the recovery TEXT carries none "
+                       "of the markup the parse stripped"))
+            out.append((
+                scenario,
+                f"Guided JSON, payload is {pay_name}, surrounded by {sur_desc}. "
+                + ("Markers around a recoverable payload must not cost the call (`I3`)."
+                   if dispatches else
+                   "Nothing parses as a call, so the payload surfaces as text — and the "
+                   "text must not contain the control markup that was stripped to "
+                   "attempt the parse (`I3`). This crossing had NO case before: every "
+                   "authored markup case carried a well-formed payload, and every "
+                   "malformed payload was authored bare."),
+                ["P2"] if not dispatches else ["I3"],
+                golden,
+                {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+                {"finish_reason": "stop"},
+                guided_surroundings(
+                    lambda fam, w=wrap, pl=payload: w(pl, fam),
+                    note,
+                    fill=(None if dispatches else
+                          (lambda fam, pl=payload, st=strips_tail: pl.rstrip() if st else pl)),
+                ),
+            ))
+    return out
+
+
+EDGE += _guided_product()
+
+
+# Group 4 (TC Malformed envelope) was a LABELLED group with zero cases, and the
+# degenerate shape below had none either: no row anywhere pinned that control
+# markup ALONE emits nothing. Both are native, so the input is per family.
+EDGE += [
+    ("tool_markup_only_emits_nothing",
+     "The whole generated output is control markup and nothing else — a stray close with no "
+     "block ever opened. Everything is stripped, so the parser emits NO events at all. Until "
+     "this case there was no row with an empty golden: every case asserted something was "
+     "produced, so 'markup alone leaks nothing' (`I3`) was never actually pinned.",
+     ["P2"],
+     [],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     by_family(lambda fam: control_tokens(fam)[3],
+               D("UNSUPPORTED", "vLLM base case does not capture a markup-only turn"),
+               {"verdict": "match", "note": "orphan close stripped; nothing to emit"})),
+
+    ("tool_block_never_closed_then_text",
+     "A tool block opens and the model never closes it, then keeps writing prose. Nothing is "
+     "emitted: the prose is BLOCK CONTENT, not the user's answer, so it drops with the "
+     "unrecoverable call — the same contract `truncated_tool_eof` (5.a) pins, here with the "
+     "block opening at position 0 so no reasoning survives to mask it. Worth pinning "
+     "precisely because the bytes look like an answer; the envelope is what decides.",
+     ["P2"],
+     [],
+     {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
+     {"finish_reason": "stop"},
+     by_family(lambda fam: f"{control_tokens(fam)[2]}still thinking about it",
+               D("UNSUPPORTED", "vLLM base case does not capture an unterminated envelope"),
+               {"verdict": "match", "note": "P2: unterminated envelope drops its content"})),
+]
+
+
+EDGE += [
+    ("guided_json_native_markup_only",
+     "Guided decoding receives one complete native tool call instead of bare JSON. The whole turn is control markup, so it emits no events. Every stream split must match the whole-input result; consuming the invoke header before its terminator leaks the parameter body as user-visible text (`I6`).",
+     ["I3", "I6"],
+     [],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     guided_surroundings(
+         lambda fam: r_tool(fam, "get_weather", "city", "Paris", 0),
+         "native markup is stripped as one control-only turn, independent of chunking")),
+]
+
+
+# The corpus had no case where one control marker's terminator sits INSIDE a later
+# marker, so nothing exercised "which marker owns this `>`". That gap let a stray
+# prefix header borrow the `>` from a following thought opener and emit the model's
+# PRIVATE reasoning as visible text. Added as a scenario, not just a unit test,
+# because the property is grammar-shaped and every family has the same question.
+EDGE += [
+    ("guided_json_stray_prefix_before_reasoning",
+     "A bare invoke HEADER with no terminator of its own sits before a reasoning span, so the only "
+     "`>` in reach belongs to the thought opener. The header must NOT claim it: doing so consumed "
+     "the opener, and the model's private reasoning was emitted as user-visible text (`I3`, and a "
+     "privacy failure, not just a cosmetic leak). The header is incomplete markup and is stripped; "
+     "the thought stays a thought.",
+     ["I3"],
+     [{"kind": "reasoning", "text": "secret"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     guided_surroundings(
+         lambda fam: f"{invoke_header_prefix(fam)}{r_reason(fam, 'secret')}{GUIDED_ONE_CALL}",
+         "a bare invoke header before a thought must not borrow the thought's terminator")),
+
+    ("guided_json_narrated_prefix_inside_reasoning",
+     "The model NARRATES an invoke header inside its thought and never terminates it, so the only "
+     "`>` in reach belongs to the thought's own closer. The header is literal text the model wrote, "
+     "so it is stripped and the surrounding thought survives intact — it must not swallow the closer "
+     "and it must not survive into the reasoning the user sees.",
+     ["I3"],
+     [{"kind": "reasoning", "text": "I'll call get_weather"},
+      {"kind": "tool_call", "name": "get_weather", "arguments": {"city": "Paris"}}],
+     {"starting_state": "None", "tool_output_mode": "GuidedJson", "named_tool": None},
+     {"finish_reason": "stop"},
+     guided_surroundings(
+         lambda fam: f"{r_reason(fam, 'I' + chr(39) + 'll call ' + invoke_header_prefix(fam) + 'get_weather')}{GUIDED_ONE_CALL}",
+         "a narrated invoke header inside a thought is stripped, closer and thought intact")),
 ]
 
 
@@ -396,6 +1078,13 @@ def _entry(spec, fam):
     if isinstance(spec, dict) and set(spec) <= set(FAMILIES):
         return spec[fam]
     return spec
+
+
+def _init_is_request_scoped(init):
+    """True when a case declares a request mode a pre-unified build cannot see."""
+    init = init or {}
+    return (init.get("tool_output_mode", "Native") != "Native"
+            or init.get("starting_state", "None") != "None")
 
 
 def build_cases(fam):
@@ -409,24 +1098,65 @@ def build_cases(fam):
             "input": render_input(fam, segs),
             "golden": golden_of(segs),
             "expect": {"vllm": _entry(vllm, fam), "dynamo": _entry(dynamo, fam)},
+            "init": {"starting_state": "None", "tool_output_mode": "Native", "named_tool": None},
+            "finish_reason": "stop",
         }
-    for name, desc, policy, golden, per_fam in EDGE:
+    for edge_case in EDGE:
+        # Support both 6-tuple (legacy) and 7-tuple (stream_config) formats
+        if len(edge_case) == 6:
+            name, desc, policy, golden, init, per_fam = edge_case
+            stream_config = {"finish_reason": "stop"}
+        else:
+            name, desc, policy, golden, init, stream_config, per_fam = edge_case
+
         cid = f"UNIFIED.{name}.{fam}"
         inp, vllm, dynamo, *rest = per_fam[fam]
         g = json.loads(json.dumps(golden))  # deep copy
-        if rest:  # fill the per-family arg value into the tool_call event's None-valued key
+        if rest:
+            # Fill the ONE `None` placeholder in the golden with this family's
+            # value. It may be an argument value (a marker-looking string that has
+            # to survive byte-exact, 12.a) or a whole text payload (the family's
+            # own markers reaching the user as literal text, 50.d) — either way
+            # the scenario is shared and only the grammar-specific bytes differ.
             for ev in g:
                 args = ev.get("arguments")
                 if args and any(v is None for v in args.values()):
                     fk = next(k for k, v in args.items() if v is None)
                     args[fk] = rest[0]
                     break
+                if ev.get("kind") in ("text", "reasoning") and ev.get("text") is None:
+                    ev["text"] = rest[0]
+                    break
+        # ENFORCED HERE, not at each authoring site. `every_family()` and
+        # `guided_surroundings()` already substitute UNSUPPORTED for a family with
+        # no native unified parser, but a scenario hand-written as an explicit
+        # per-family dict bypasses them and can hand gemma4/kimi_k2 a bare `match`
+        # under a guided or prefilled `init` — a family on the v1-reasoning +
+        # v2-tool split ignores `init` entirely, so it cannot honour that mode.
+        # Nothing asserts this field (the Dynamo column is computed live), so a
+        # false `match` never fails; it just tells a reader two engines handle
+        # request modes they cannot see. One gate every case passes through is the
+        # only way an authoring shortcut cannot route around it.
+        if fam not in UNIFIED_FAMILIES and _init_is_request_scoped(init):
+            dynamo = D(
+                "UNSUPPORTED",
+                "no native unified parser in this build, so the split path ignores "
+                "`init` and cannot honour this request mode",
+            )
+        if _init_is_request_scoped(init):
+            vllm = GUIDED_UNSUPPORTED if init.get("tool_output_mode") != "Native" else D(
+                "UNSUPPORTED",
+                "vLLM base case does not set a starting channel state; conformance "
+                "captures default generation only",
+            )
         cases[cid] = {
             "description": desc,
             "policy": policy,
             "input": inp,
             "golden": g,
             "expect": {"vllm": vllm, "dynamo": dynamo},
+            "init": init,
+            "finish_reason": stream_config.get("finish_reason", "stop"),
         }
     return cases
 
@@ -453,6 +1183,8 @@ def emit_yaml(fam):
         lines.append(f"  {cid}:")
         lines.append(f"    description: {json.dumps(c['description'], ensure_ascii=False)}")
         lines.append(f"    policy: {json.dumps(c['policy'])}")
+        lines.append(f"    init: {json.dumps(c['init'], ensure_ascii=False)}")
+        lines.append(f"    finish_reason: {json.dumps(c['finish_reason'])}")
         lines.append("    input: |-")
         for ln in c["input"].split("\n"):
             lines.append(f"      {ln}")

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -2246,11 +2246,16 @@ def _load_unified_fixtures(base: Path):
         ddoc = engine_cases.get("dynamo_v2", {}).get((fam, key), {})
         in_chunks = inp.get("chunks") or []
         dyn_chunks = ddoc.get("chunks") or []
+        raw_init = inp.get("init") or {}
         cases.append({
             "id": cid, "scenario": scenario, "family": fam,
             "description": inp.get("description", ""),
             "policy": inp.get("policy") or [], "policy_tags": inp.get("policy") or [],
-            "init": inp.get("init") or {"prefill": "None", "tool_output_mode": "Native", "named_tool": None},
+            "init": {
+                "starting_state": raw_init.get("starting_state") or "None",
+                "tool_output_mode": raw_init.get("tool_output_mode") or "Native",
+                "named_tool": raw_init.get("named_tool"),
+            },
             "finish_reason": inp.get("finish_reason") or "stop",
             "input": inp.get("input", ""),
             "golden": gdoc.get("assembled") or [],
@@ -2486,9 +2491,13 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                 "vllm": markers.cmp_entry(vsig, leak=1 if vverd == "LEAK" else 0),
             }
             if vrust_events is not None:
-                cmp["vllm_rust"] = markers.cmp_entry(rsig, leak=1 if rverd == "LEAK" else 0)
+                cmp["vllm_rust"] = markers.cmp_entry(
+                    rsig, leak=1 if rverd == "LEAK" else 0, err=1 if vrust_err else 0
+                )
             if sgl_events is not None:
-                cmp["sglang"] = markers.cmp_entry(ssig, leak=1 if sverd == "LEAK" else 0)
+                cmp["sglang"] = markers.cmp_entry(
+                    ssig, leak=1 if sverd == "LEAK" else 0, err=1 if sgl_err else 0
+                )
             # Older Dynamo builds, scored against GOLDEN exactly like the latest one, so a
             # cell that changed between builds shows a real NΔ instead of a styling hint.
             prev_by_ver = c.get("dynamo_by_ver") or {}
@@ -2497,15 +2506,15 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                 pdoc = prev_by_ver.get(pv)
                 if pdoc is None:
                     # Capture predates this case: n/a, not a divergence.
-                    cmp[f"dynamo@{pv}"] = {"sig": 0, "leak": 0, "na": 1}
+                    cmp[f"dynamo@{pv}"] = markers.cmp_entry(0, na=1)
                     prev_chunks_by_ver[pv] = []
                     continue
                 pchunks = pdoc.get("chunks") or []
                 pevents = _assemble_stream(pchunks)
                 pverd = _unified_classify(f, gold, pevents)
-                cmp[f"dynamo@{pv}"] = {
-                    "sig": _sig(pevents), "leak": 1 if pverd == "LEAK" else 0, "na": 0,
-                }
+                cmp[f"dynamo@{pv}"] = markers.cmp_entry(
+                    _sig(pevents), leak=1 if pverd == "LEAK" else 0
+                )
                 prev_chunks_by_ver[pv] = pchunks
             desc = c["description"]
             if c.get("policy_tags"):

--- a/conformance/utils/src/unified_taxonomy.py
+++ b/conformance/utils/src/unified_taxonomy.py
@@ -13,7 +13,7 @@ Request-scoped modes use PAIRED TENS: X0 is that mode's happy base case, X1 its
 weird/malformed counterpart — 30/31 guided decoding, 40/41 prefilled reasoning,
 50/51 prefilled response. A new mode takes the next ten.
 There is no separate "input stream mode" axis: which channel the prompt pre-opened IS
-`init.prefill`, so a case that varied only that duplicated groups 31-33, and one that
+`init.starting_state`, so a case that varied only that duplicated groups 31-33, and one that
 varied nothing but a finish_reason label duplicated groups 1-12 (the parser cannot see
 that value — `finish()` takes no argument).
 """
@@ -29,6 +29,10 @@ UNIFIED_TAX = {
     "two_calls": (2, "a"), "two_calls_same_name": (2, "b"),
     # Group 3 — No call (streamv2.3)
     "text_only": (3, "a"),
+    # Group 4 — Malformed envelope. Labelled but EMPTY until now.
+    "tool_block_never_closed_then_text": (4, "a"),
+    "tool_markup_only_emits_nothing": (4, "b"),
+
     # Group 5 — Truncation / recovery (streamv2.5)
     "truncated_tool_eof": (5, "a"), "tool_no_close": (5, "b"),
     "orphan_close_after_prose": (5, "c"),
@@ -59,11 +63,47 @@ UNIFIED_TAX = {
     # Group 30 — Guided decoding, happy
     "guided_json_named_tool": (30, "a"), "guided_json_required_tool": (30, "b"),
     "guided_json_two_calls": (30, "c"),
+    "guided_json_escaped_string_args": (30, "d"), "guided_json_array_argument": (30, "e"),
+    "guided_json_after_reasoning": (30, "f"), "guided_json_marker_inside_argument": (30, "g"),
 
     # Group 31 — Guided decoding, weird / malformed
     "guided_json_invalid_call": (31, "a"), "guided_json_malformed_json": (31, "b"),
     "guided_json_partial_calls": (31, "c"),
     "guided_json_list_with_broken_element": (31, "d"),
+    # 31.e-31.k — the SURROUNDINGS of a guided payload, not the payload itself.
+    "guided_json_tool_open_before_payload": (31, "e"),
+    "guided_json_tool_close_after_payload": (31, "f"),
+    "guided_json_wrapped_in_tool_markup": (31, "g"),
+    "guided_json_narrated_invoke_in_reasoning": (31, "h"),
+    "guided_json_prose_before_reasoning": (31, "i"),
+    "guided_json_orphan_reason_close_before_payload": (31, "j"),
+    "guided_json_orphan_tool_close_before_payload": (31, "k"),
+    # Generated crossings (`_guided_product` in gen_unified_golden.py): payload
+    # shape x surrounding grammar. The 31.* rows are the quadrant that had ZERO
+    # cases — markup present AND no call recoverable — where both the P2 recovery
+    # leak and the unbounded invoke-header scan lived.
+    "guided_json_syntax_error_trailing_close": (31, "l"),
+    "guided_json_syntax_error_wrapped": (31, "m"),
+    "guided_json_syntax_error_bare_opener": (31, "n"),
+    "guided_json_schema_error_not_a_call_trailing_close": (31, "o"),
+    "guided_json_schema_error_not_a_call_wrapped": (31, "p"),
+    "guided_json_schema_error_not_a_call_bare_opener": (31, "q"),
+    "guided_json_schema_error_nameless_element_trailing_close": (31, "r"),
+    "guided_json_schema_error_nameless_element_wrapped": (31, "s"),
+    "guided_json_schema_error_nameless_element_bare_opener": (31, "t"),
+
+    # Devin-found crossings, added as AXIS entries so the next payload/surrounding
+    # combination is generated rather than noticed later.
+    "guided_json_gt_in_argument_trailing_close": (30, "k"),
+    "guided_json_gt_in_argument_wrapped": (30, "l"),
+    "guided_json_gt_in_argument_bare_opener": (30, "m"),
+
+    # Marker OWNERSHIP: which control marker owns a `>` when two compete. The
+    # corpus had no such case, and the gap leaked private reasoning as text.
+    "guided_json_stray_prefix_before_reasoning": (31, "u"),
+    "guided_json_narrated_prefix_inside_reasoning": (31, "v"),
+    "guided_json_native_markup_only": (31, "w"),
+
     # Group 40 — Prefilled reasoning, happy
     "prefilled_reasoning_with_tool": (40, "a"), "prefilled_reasoning_with_guided_json": (40, "b"),
     "prefilled_reasoning_then_text_then_tool": (40, "c"), "prefilled_reasoning_then_text": (40, "d"),
@@ -86,7 +126,7 @@ UNIFIED_GROUP_LABEL = {
     7: "TC Argument fidelity", 8: "TC Content position",
     10: "Reasoning span",
     11: "Reasoning ↔ tool interleaving", 12: "Adversarial nesting (reasoning + tool)",
-    30: "Guided Decoding", 31: "Guided Decoding — malformed",
+    30: "Guided Decoding", 31: "Guided Decoding — payload REJECTED (syntax or schema) / recovery",
     40: "Prefilled Reasoning", 41: "Prefilled Reasoning — malformed",
     50: "Prefilled Response", 51: "Prefilled Response — malformed",
 }

--- a/conformance/utils/tests/test_explode_unified_fixtures.py
+++ b/conformance/utils/tests/test_explode_unified_fixtures.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from explode_unified_fixtures import _peer_cell  # noqa: E402
+
+
+def test_peer_error_wins_over_partial_output() -> None:
+    result = {
+        "error": "UnifiedParserError::ParsingFailed",
+        "assembled": [{"kind": "reasoning", "text": "partial"}],
+        "chunks": [[{"kind": "reasoning", "text": "partial"}]],
+    }
+
+    assert _peer_cell(result) == {"error": "UnifiedParserError::ParsingFailed"}

--- a/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
+++ b/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Every unified corpus scenario carries a taxonomy number.
+
+`tax()` answers an unmapped scenario with `(9, <slug>)` instead of raising, so a case
+added to `gen_unified_golden.py` without a `UNIFIED_TAX` entry still renders — it just
+silently lands in group 9 under its raw slug rather than the group it belongs to. That
+is a wrong answer delivered confidently: the page looks complete, the case is numbered,
+and nothing says the number is a fallback.
+
+It has already happened: `guided_json_escaped_string_args` and `guided_json_array_argument`
+were added to the corpus and rendered as `UNIFIED.9.*` for a full render cycle before
+anyone noticed they were missing from the map. These two tests make that a failure at
+the point the case is added, and name the file to edit.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+import json
+import re
+import sys
+from pathlib import Path
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from gen_unified_golden import (  # noqa: E402
+    CLEAN,
+    EDGE,
+    FAMILIES,
+    build_cases,
+    control_tokens,
+    invoke_header_prefix,
+)
+from unified_taxonomy import UNIFIED_GROUP_LABEL, UNIFIED_TAX, numbered_id, tax  # noqa: E402
+
+TAXONOMY_FILE = "conformance/utils/src/unified_taxonomy.py"
+
+
+def corpus_scenarios() -> list[str]:
+    """Scenario slugs the generator actually emits — the first element of each case."""
+    return [spec[0] for spec in (*CLEAN, *EDGE)]
+
+
+def test_every_corpus_scenario_has_a_taxonomy_entry() -> None:
+    unmapped = sorted(s for s in corpus_scenarios() if s not in UNIFIED_TAX)
+    assert not unmapped, (
+        f"{len(unmapped)} corpus scenario(s) have no UNIFIED_TAX entry and would render "
+        f"as UNIFIED.9.<slug> instead of their real group: {unmapped}. "
+        f"Add them to UNIFIED_TAX in {TAXONOMY_FILE}."
+    )
+
+
+def test_taxonomy_has_no_entry_without_a_corpus_case() -> None:
+    """The other direction: a stale entry means a case was renamed or deleted and the map
+    still claims a number for it, so the number is reserved against nothing."""
+    scenarios = set(corpus_scenarios())
+    stale = sorted(s for s in UNIFIED_TAX if s not in scenarios)
+    assert not stale, (
+        f"{len(stale)} UNIFIED_TAX entr(ies) name a scenario the corpus does not emit: "
+        f"{stale}. Remove them from {TAXONOMY_FILE} or restore the case in "
+        f"conformance/utils/src/gen_unified_golden.py."
+    )
+
+
+def test_invoke_header_prefix_is_inner_and_unterminated() -> None:
+    for family in FAMILIES:
+        prefix = invoke_header_prefix(family)
+        assert prefix
+        assert prefix == prefix.lstrip()
+        assert not prefix.startswith(control_tokens(family)[2])
+        assert prefix.rsplit(">", 1)[-1]
+
+
+def test_request_scoped_cases_never_claim_vllm_match() -> None:
+    for family in FAMILIES:
+        for case_id, case in build_cases(family).items():
+            init = case["init"]
+            request_scoped = init.get("starting_state") != "None" or init.get("tool_output_mode") != "Native"
+            if request_scoped:
+                assert case["expect"]["vllm"]["verdict"] == "diverge", case_id
+
+
+def test_no_corpus_scenario_falls_back_to_group_9() -> None:
+    """Belt and braces on the fallback itself: assert through `tax()`, the function the
+    renderer calls, so this still fails if the fallback moves or changes shape."""
+    fell_back = sorted(s for s in corpus_scenarios() if tax(s)[0] == 9)
+    assert not fell_back, f"scenario(s) resolved to the group-9 fallback: {fell_back}"
+
+
+def test_every_used_group_has_a_label() -> None:
+    """An unlabelled group renders a numbered heading with no name."""
+    used = {tax(s)[0] for s in corpus_scenarios()}
+    missing = sorted(g for g in used if g not in UNIFIED_GROUP_LABEL)
+    assert not missing, (
+        f"group(s) {missing} are used by the corpus but absent from UNIFIED_GROUP_LABEL "
+        f"in {TAXONOMY_FILE}."
+    )
+
+
+# --- End-to-end test cases: the SAME mapping is written in two places -----------
+# Case descriptions in gen_unified_golden.py carry `End-to-end: <case> (e2e case-NNNN)` tags, and
+# UNIFIED_CASES.md repeats them in its artifact-index table. Two copies of one fact drift
+# — that is the defect this whole surface keeps hitting — so pin them to each other.
+
+CASES_MD = UTILS / "lib" / "parsers" / "UNIFIED_CASES.md"
+_E2E_TAG = re.compile(r"\be2e case-(\d{4})-")
+_MD_ROW = re.compile(r"^\|\s*`(\d+\.[a-z])`\s*\|\s*`([^`]+)`\s*\|\s*`end-to-end case-(\d{4})-", re.M)
+
+
+def _e2e_ids_from_descriptions() -> dict[str, set[str]]:
+    """numbered case id -> {'0047', ...} as declared in the generator's descriptions."""
+    out: dict[str, set[str]] = {}
+    for spec in (*CLEAN, *EDGE):
+        scenario, desc = spec[0], spec[1]
+        ids = set(_E2E_TAG.findall(desc))
+        if ids:
+            out.setdefault(f"UNIFIED.{tax(scenario)[0]}.{tax(scenario)[1]}", set()).update(ids)
+    return out
+
+
+def _e2e_ids_from_markdown() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for num, _live_case, artifact_id in _MD_ROW.findall(CASES_MD.read_text(encoding="utf-8")):
+        out.setdefault(f"UNIFIED.{num}", set()).add(artifact_id)
+    return out
+
+
+def test_e2e_tags_agree_between_descriptions_and_markdown() -> None:
+    from_desc, from_md = _e2e_ids_from_descriptions(), _e2e_ids_from_markdown()
+    assert from_desc, "no `e2e case-NNNN-` citations found in generator descriptions — did the format change?"
+    assert from_md, f"no artifact-index rows parsed out of {CASES_MD.name} — did the table change?"
+    # A description may cite ONE representative for a bulk group (10.b stands for 32 e2e
+    # cases), so the relation is subset, not equality: every filename a description names
+    # must be a real row in the index. Equality would force 32 filenames into one popup.
+    unindexed = {k: sorted(v - from_md.get(k, set())) for k, v in from_desc.items() if v - from_md.get(k, set())}
+    assert not unindexed, (
+        f"description(s) cite e2e artifacts absent from the index table in {CASES_MD.name}: {unindexed}. "
+        "Add the row, or fix the filename."
+    )
+    untagged = sorted(set(from_md) - set(from_desc))
+    assert not untagged, (
+        f"index table has rows for {untagged} but no description cites them — the tag was dropped "
+        "from gen_unified_golden.py."
+    )
+
+
+# --- Cross-suite case references resolve ---------------------------------------
+# Descriptions and the docs cite sibling suites' cases ("streaming form of X"). Those
+# citations were BARE and some were wrong: `REASONING.2.a` named nothing, because the real
+# id carries a stage segment (`REASONING.batch.2.a`). A reader following it finds nothing
+# and nothing complained. Require the full name AND require it to exist.
+
+_SIBLING_DOCS = {
+    "TOOLCALLING.streamv2": UTILS / "lib" / "parsers" / "TOOLCALLING_STREAMING_V2_CASES.md",
+    "TOOLCALLING.batch": UTILS / "lib" / "parsers" / "TOOLCALLING_CASES.md",
+    "REASONING.batch": UTILS / "lib" / "parsers" / "REASONING_CASES.md",
+}
+_QUALIFIED = re.compile(r"\b(?:TOOLCALLING|REASONING)\.(?:batch|streamv2)\.\d+(?:\.[a-z])?")
+# a stage segment with no axis in front of it — the shape that named nothing
+_BARE = re.compile(r"(?<![.\w])(?:batch|streamv2)\.\d+(?:\.[a-z])?")
+_CITING = [UTILS / "lib" / "parsers" / "UNIFIED_CASES.md", SRC / "gen_unified_golden.py"]
+
+
+def test_sibling_case_references_are_fully_qualified() -> None:
+    offenders = {f.name: sorted(set(_BARE.findall(f.read_text(encoding="utf-8")))) for f in _CITING}
+    offenders = {k: v for k, v in offenders.items() if v}
+    assert not offenders, (
+        f"unqualified case references (missing the axis prefix): {offenders}. "
+        "Cite the full name, e.g. `TOOLCALLING.streamv2.2.a`, not `streamv2.2.a`."
+    )
+
+
+def test_sibling_case_references_exist() -> None:
+    bodies = {k: p.read_text(encoding="utf-8") for k, p in _SIBLING_DOCS.items()}
+    dangling: dict[str, list[str]] = {}
+    for f in _CITING:
+        bad = [
+            ref
+            for ref in sorted(set(_QUALIFIED.findall(f.read_text(encoding="utf-8"))))
+            # group-level ids (`...streamv2.2`) have no entry of their own; a sub-case does
+            if not any(ref.startswith(k) and ref in body for k, body in bodies.items())
+        ]
+        if bad:
+            dangling[f.name] = bad
+    assert not dangling, (
+        f"case references that resolve to nothing: {dangling}. "
+        f"Defined ids live in {', '.join(p.name for p in _SIBLING_DOCS.values())}."
+    )
+
+
+# --- e2e completeness: every end-to-end case has a home in the taxonomy ---------
+# The report and its JSON artifacts live outside this repo, so `e2e_cases.json` is the
+# committed snapshot CI can check. Completeness runs BOTH ways: no e2e case may be left
+# unclassified, and no mapping may point at a UNIFIED case that does not exist.
+
+E2E_MANIFEST = SRC / "e2e_cases.json"
+
+
+def _e2e() -> dict:
+    return json.loads(E2E_MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_every_e2e_case_is_classified() -> None:
+    cases = _e2e()["cases"]
+    unclassified = sorted(k for k, v in cases.items() if not v.get("unified"))
+    assert not unclassified, (
+        f"{len(unclassified)} end-to-end case(s) map to no UNIFIED case: {unclassified}. "
+        "Give each one the UNIFIED case whose output SHAPE covers it (UNIFIED may be a "
+        f"superset), or record why none can, in {E2E_MANIFEST.name}."
+    )
+
+
+def test_e2e_mappings_name_real_unified_cases() -> None:
+    numbered = {numbered_id(s).removeprefix("UNIFIED.") for s in corpus_scenarios()}
+    bad = sorted({u for v in _e2e()["cases"].values() for u in v.get("unified", []) if u not in numbered})
+    assert not bad, (
+        f"e2e mapping(s) name UNIFIED cases that do not exist: {bad}. "
+        f"Valid ids come from UNIFIED_TAX in {TAXONOMY_FILE}."
+    )
+
+
+def test_e2e_manifest_totals_are_self_consistent() -> None:
+    m = _e2e()
+    assert m["distinct_cases"] == len(m["cases"]), "distinct_cases disagrees with the cases map"
+    artifacts = sum(len(v["artifacts"]) for v in m["cases"].values())
+    assert artifacts == m["logical_cases"], (
+        f"{artifacts} artifacts across cases but logical_cases says {m['logical_cases']} — "
+        "the snapshot is stale; regenerate it from the report."
+    )
+
+
+def test_every_e2e_artifact_appears_in_the_index_table() -> None:
+    """The Artifact index in the docs must list every artifact the manifest knows about."""
+    listed = set(re.findall(r"`end-to-end (case-[\w.-]+\.json)`", CASES_MD.read_text(encoding="utf-8")))
+    known = {a for v in _e2e()["cases"].values() for a in v["artifacts"]}
+    missing = sorted(known - listed)
+    assert not missing, (
+        f"{len(missing)} e2e artifact(s) are in {E2E_MANIFEST.name} but absent from the "
+        f"Artifact index in {CASES_MD.name}: {missing[:5]}{' …' if len(missing) > 5 else ''}"
+    )
+
+def test_marker_inside_argument_golden_matches_the_input_marker() -> None:
+    """The I7 fidelity case must assert the FAMILY'S OWN marker, not a placeholder.
+
+    Authoring a stand-in like "MARKER" in the golden while feeding the real closer
+    in the input validates nothing: the case would pass whatever the parser did to
+    the argument. The golden argument and the input must carry the same bytes.
+    """
+    case = next(
+        c for c in list(CLEAN) + list(EDGE) if c[0] == "guided_json_marker_inside_argument"
+    )
+    per_family = case[-1]
+    for fam in FAMILIES:
+        entry = per_family[fam]
+        raw_input, fill = entry[0], entry[-1]
+        expected = control_tokens(fam)[1]
+        assert fill == expected, f"{fam}: golden fill {fill!r} is not the family marker"
+        assert expected in raw_input, f"{fam}: input {raw_input!r} lacks {expected!r}"
+
+
+def test_every_rendered_config_key_exists_in_the_emitted_init() -> None:
+    """A producer/renderer rename must not silently render every case as "unset".
+
+    `conformance_view.js` reads `init[spec.key]` for each `CONFIG_KEYS` entry. When
+    `prefill` was renamed to `starting_state` the producers moved and the renderer
+    did not, so every case's popup claimed the request setting was never chosen —
+    and nothing failed, because a missing key just reads as the default. This pins
+    the two sides together.
+    """
+    js = (UTILS / "src/assets/conformance_view.js").read_text()
+    keys = set(re.findall(r"\{\s*key:\s*'([a-z_]+)'", js))
+    assert keys, "CONFIG_KEYS not found in conformance_view.js"
+
+    emitted = set()
+    for case in list(CLEAN) + list(EDGE):
+        init = next((f for f in case if isinstance(f, dict) and "tool_output_mode" in f), None)
+        if init:
+            emitted |= set(init)
+    missing = sorted(keys - emitted)
+    assert not missing, (
+        f"conformance_view.js renders {missing}, which no case emits in `init` — "
+        "every case would show that setting as unset"
+    )
+
+def test_no_two_scenarios_have_identical_behaviour() -> None:
+    """Two names for one behaviour is worse than a gap.
+
+    A generated crossing collided with a hand-authored scenario three times
+    (`guided_json_valid_*` vs `guided_json_tool_*`), giving 3 x 3 families = 9 cases
+    with byte-identical `(input, init, golden)`. They inflated the case count while
+    testing nothing new, and the pair would drift apart on the next edit.
+
+    Reads the SPEC (`CLEAN`/`EDGE` in the generator), not `conformance/unified/`:
+    that tree is a gitignored build artifact, so a test that reads it passes locally
+    and fails in CI — which is exactly what the first version of this did.
+    """
+    for fam in FAMILIES:
+        seen = defaultdict(list)
+        for name, case in build_cases(fam).items():
+            seen[
+                json.dumps(
+                    {
+                        "input": case["input"],
+                        "init": case["init"],
+                        "golden": case["golden"],
+                    },
+                    sort_keys=True,
+                )
+            ].append(name)
+        dupes = {k: v for k, v in seen.items() if len(v) > 1}
+        assert not dupes, f"{fam}: scenarios with identical behaviour: {list(dupes.values())}"

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -58,7 +58,7 @@ Know its limit: the test does not COMPILE this Markdown block, and it compares o
 
 `UnifiedParserOutput` gives you `push_text`, `push_reasoning` and `push_call`. The first two coalesce: appending text onto a trailing text event extends it rather than adding a second one.
 
-The required lifecycle is `initialize` → `parse_into` → `finish`, with `reset` for recovery. `push` and `parse_complete` come from the blanket `UnifiedParserExt` trait: import it when you want those allocation conveniences. They cannot be overridden through `impl UnifiedParser`, so `parse_complete` always runs the same `parse_into` + `finish` path as streaming.
+The required lifecycle is `initialize_request` → `parse_into` → `finish`, with `reset` for recovery. The peer-shaped `initialize(&[u32])` is a native-mode adapter that builds `UnifiedParserInit`; request-aware callers resolve prompt state, tool-output mode, and invalid-guided-payload policy into that one owned value. `push` and `parse_complete` come from the blanket `UnifiedParserExt` trait: import it when you want those allocation conveniences. They cannot be overridden through `impl UnifiedParser`, so `parse_complete` always runs the same `parse_into` + `finish` path as streaming.
 
 ## 2. Register it
 
@@ -109,7 +109,8 @@ All have defaults, so implement only what your grammar needs.
 
 | Method | Implement it when |
 |---|---|
-| `initialize(&[u32])` | your prompt can end mid-channel and you want to detect that from prompt tokens |
+| `initialize(&[u32])` | a peer-shaped caller needs neutral native-mode initialization |
+| `initialize_request(UnifiedParserInit)` | the caller has resolved prompt tokens, starting channel, tool-output mode, and invalid-guided-payload policy for this request |
 | `preserve_special_tokens()` | your markers ARE tokenizer special tokens, so text that dropped them is unparseable |
 | `tool_call_id(idx)` | your grammar names the call itself and the id should come from the model |
 
@@ -132,4 +133,4 @@ The required `UnifiedParser` lifecycle is aligned with the peer streaming-parser
 Two caveats worth knowing before you plan on a literal drop-in:
 
 - Rust is nominally typed, so an identically-shaped type in another crate is still a different type. Porting is a mechanical translation, not a recompile.
-- This crate adds surface the peer traits do not have — the blanket `UnifiedParserExt` helpers (`push` and `parse_complete`) and the assembled `UnifiedEvent` view. They are additive conveniences, not vendor-overridable lifecycle methods.
+- This crate adds surface the peer traits do not have — `initialize_request(UnifiedParserInit)`, the blanket `UnifiedParserExt` helpers (`push` and `parse_complete`), and the assembled `UnifiedEvent` view. The resolved request initializer is an additive default on `UnifiedParser`; the helpers are additive conveniences that vendors cannot override.

--- a/parsers/v2/Cargo.toml
+++ b/parsers/v2/Cargo.toml
@@ -17,3 +17,6 @@ regex = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 num-traits = { workspace = true }
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }

--- a/parsers/v2/README.md
+++ b/parsers/v2/README.md
@@ -22,6 +22,8 @@ These goals govern every tool-calling and reasoning parser, v1 and v2, and are t
 
 The end-to-end workflow for adding a parser — fetch the chat template, identify the format, prefer an existing parser + config over new code, register, test, render — lives in the `tool-parser-generator` skill under `.agents/skills/tool-parser-generator/`. Adding a family to the **unified** path (one ordered reasoning + content + tool stream, rather than the reasoning-then-tool split) is a different workflow with its own tiers and traps — see [`UNIFIED_PORTING.md`](UNIFIED_PORTING.md). Reasoning parsers follow the same goals; see [`../parsers/v1/src/reasoning/README.md`](../parsers/v1/src/reasoning/README.md).
 
+**Writing a parser in YOUR OWN crate — including replacing a family this crate already ships — does not require forking or a PR here.** Implement `UnifiedParser`, call `register_unified_parser("family", factory)` at startup, and your parser is used for that family; registering an existing name shadows the built-in, and unregistering restores it. See [`CUSTOM_PARSERS.md`](CUSTOM_PARSERS.md) for the trait, the contract a parser must honour, and how to run the conformance corpus against your implementation.
+
 ## Parser families
 
 This is the single source of truth for the parser-family taxonomy — which grammar family a model belongs to and where the grammar is implemented. Families are shared across both paths: the **batch (v1)** implementation under `parsers/v1/src/tool_calling/` owns the grammar and value-typing, and the **streaming (v2)** implementation under `parsers/v2/src/tool_calling/` reuses it. Pick the family first when adding a model; only write a new module when the grammar is genuinely new.

--- a/parsers/v2/UNIFIED_PORTING.md
+++ b/parsers/v2/UNIFIED_PORTING.md
@@ -6,7 +6,7 @@ This doc is for adding a family to the unified path. `qwen3` is on it today; `ge
 
 ## What you get for free
 
-`ScannerUnified` (`src/unified/mod.rs`) is the shared body. It is generic over the emitter and holds a `WrappedBlockScanner`, and the whole `UnifiedParser` impl is family-blind: `initialize`, `initialize_with_output_mode`, `push`, `finish`, `reset`.
+`ScannerUnified` (`src/unified/mod.rs`) is the shared body. It is generic over the emitter and holds a `WrappedBlockScanner`, and the whole `UnifiedParser` impl is family-blind: `initialize`, `initialize_request`, `parse_into`, `finish`, `reset`.
 
 Everything below is already generic in `src/tool_calling/scan.rs` — do NOT reimplement any of it per family:
 
@@ -103,9 +103,9 @@ same route for `granite`: extend the spec, do not narrow the grammar to the corp
 
 **Audit the emitter for `I7` before claiming the goldens.** qwen3's emitter was changed to call `parse_tool_call_block` directly because re-wrapping the body in `<tool_call>` made the batch parser truncate a value at an embedded `</tool_call>` — an argument value is DATA and must survive byte-exact. gemma4 hit the same wall from the other side: handing its block back to the whole-message extractor re-derived bounds the scanner had already resolved, and that extractor also refuses a call missing BOTH its opener (consumed as block markup) and its closer (never streamed), which is exactly case `5.b`. Its emitter now calls `parse_one_tool_call_gemma4` on the delimited invoke. **Rule: once the scanner has delimited an invoke, the emitter TYPES it — it never re-finds it.** The `minimax_m2`, `minimax_m3` and `kimi_k2` emitters still re-wrap. That is not confirmed broken, it is unaudited; case `7.b` (`arg_marker_in_string`) is the one that catches it — and it is not theoretical: vLLM 0.25.1's Python gemma4 parser truncates that value to `git log ` in the live capture.
 
-**Dangling-end recovery differs.** A `</think>` with nothing open is stripped by the shared scanner and the preceding bytes become TEXT; v1's `with_dangling_end_recovery` classifies them as REASONING. Affects `minimax_m3` and `kimi_k3`. Passing `UnifiedParserPrefill::Reasoning` resolves it, which means the caller has to actually pass it — see below.
+**Dangling-end recovery differs.** A `</think>` with nothing open is stripped by the shared scanner and the preceding bytes become TEXT; v1's `with_dangling_end_recovery` classifies them as REASONING. Affects `minimax_m3` and `kimi_k3`. Passing `UnifiedParserStartingState::Reasoning` resolves it, which means the caller has to actually pass it — see below.
 
-**Guided JSON needs a reasoning-aware scanner.** A family registered without a `ReasoningSpec` silently cannot support `GuidedJson`; `initialize_with_output_mode` bails.
+**Guided JSON needs a reasoning-aware scanner.** A family registered without a `ReasoningSpec` cannot support `GuidedJson`; `initialize_request` rejects that `UnifiedParserInit` before mutating parser state.
 
 **A guided-decoding case whose input is native markup tests nothing.** Guided
 decoding constrains the model to bare JSON, so the payload is grammar-independent and
@@ -115,7 +115,7 @@ families had no unified parser to run them, and unfixable-looking the moment one
 Render guided inputs once for every family (`every_family` in `gen_unified_golden.py`),
 not per family.
 
-**Nothing outside `parsers/v2` and `conformance/` consumes `UnifiedParser` yet.** `UnifiedParserPrefill` is set only by the conformance harness. Whoever wires this into the serving path must plumb prefill and tool-output-mode from the request — and that plumbing is exactly where a push-model desyncs, so test it AT THE BOUNDARY, not only at the parser. vLLM took the other approach: its `initialize` takes `prompt_token_ids` and infers the channel, and its parser RETURNS a structural tag for the engine to constrain against, so a caller cannot hand it a contradictory mode. Dynamo's explicit enum is easier to test without a tokenizer and easier to get wrong.
+**Nothing outside `parsers/v2` and `conformance/` consumes `UnifiedParser` yet.** The conformance harness builds `UnifiedParserInit` with `RecoverAsText`; a serving integration should build the same one owned object after prompt rendering and backend request resolution, leaving the default invalid-guided-payload policy at `Reject`. This keeps prompt tokens, starting state, output mode, and failure policy under one initialization owner. Test that object at the serving boundary, not only inside the parser.
 
 ## Checklist
 

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -26,8 +26,10 @@ pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType
 // One state machine per stream owning reasoning + content + tool calls, emitting
 // ONE ordered event stream (see `unified`).
 pub use unified::{
+    InvalidGuidedPayload, InvalidGuidedPayloadKind, InvalidGuidedPayloadPolicy,
     REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser, UnifiedParserEvent, UnifiedParserExt,
-    UnifiedParserFactory, UnifiedParserOutput, assemble, builtin_unified_families,
-    canonical_unified_family, create_unified_parser_for_family, register_unified_parser,
+    UnifiedParserFactory, UnifiedParserInit, UnifiedParserOutput, UnifiedParserStartingState,
+    UnifiedToolOutputMode, assemble, builtin_unified_families, canonical_unified_family,
+    create_unified_parser_for_family, register_unified_parser, tool_arguments_raw,
     unregister_unified_parser, vendor_unified_families,
 };

--- a/parsers/v2/src/tool_calling/debug.rs
+++ b/parsers/v2/src/tool_calling/debug.rs
@@ -22,7 +22,7 @@ pub const DEBUG_ENV: &str = "DYNAMO_PARSERS_DEBUG";
 /// Write one debug line to stderr, discarding any I/O error. Uses fallible
 /// `writeln!` rather than `eprintln!` so debug output can never panic the host
 /// (e.g. when stderr is closed and a write returns `EPIPE`).
-fn emit(args: std::fmt::Arguments<'_>) {
+pub(crate) fn emit(args: std::fmt::Arguments<'_>) {
     let mut stderr = std::io::stderr().lock();
     let _ = writeln!(stderr, "[dynamo-parsers-v2] {args}");
 }

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -41,12 +41,8 @@
 //! holdback, or recovery.
 //!
 //! Reasoning is opt-in per scanner via [`WrappedBlockScanner::with_reasoning`].
-//! The two nestings are deliberately ASYMMETRIC, because tool structure
-//! dominates: a tool call emitted INSIDE a thought is a real call, so it is
-//! extracted and the thought splits around it; but a reasoning marker inside a
-//! tool argument is argument data (`I7`), because the in-block scan never looks
-//! for one. Burying a nested call would drop it AND leak its markup into the
-//! reasoning payload (`I3`).
+//! It is scoped OUTSIDE tool blocks only: once a block or bare invoke is open,
+//! a reasoning marker inside it is argument data, not a control token (`I7`).
 
 use std::collections::HashSet;
 
@@ -60,6 +56,44 @@ use crate::unified::{Kind, UnifiedParserEvent};
 /// never lets it leak) can match it — otherwise the partial suffix is emitted
 /// (or, under a suppression latch, silently discarded) and the remainder is
 /// unrecognizable.
+/// The earliest malformed marker inside an OPEN reasoning span, as `(pos, len)`.
+///
+/// The candidates are the span's own OPENER (a second one is a duplicate, not
+/// content) plus every orphan marker except the closer, which legitimately ends
+/// the span. Being inside a thought must not turn markup into content (`I3`).
+///
+/// NATIVE PATH ONLY. An earlier revision of this comment claimed the guided drain
+/// shared it; that stopped being true when the guided path moved to its own
+/// vocabulary, and the two sets are not the same:
+///
+/// * native here — the span's opener plus `orphan_markers` (`</tool_call>`),
+///   because tool OPENERS are structural on this path and are handled separately
+///   as `InReasoning::ToolOpen`;
+/// * guided — `holdback_markers` plus the opener, because guided decoding delivers
+///   the call as JSON, so tool markup inside a thought is narration to strip, not
+///   structure to enter.
+///
+/// The divergence is deliberate, but it is a divergence, so the parity it used to
+/// guarantee by construction is now only guaranteed by
+/// `guided_and_native_agree_on_the_same_reasoning_bytes` in `unified/qwen3.rs`.
+/// That test is what stops the two drifting; this helper no longer can.
+pub(crate) fn stray_in_reasoning(
+    haystack: &str,
+    start: &str,
+    end: &str,
+    orphan_markers: &[String],
+) -> Option<(usize, usize)> {
+    std::iter::once(start)
+        .chain(
+            orphan_markers
+                .iter()
+                .map(String::as_str)
+                .filter(|m| *m != end),
+        )
+        .filter_map(|m| haystack.find(m).map(|pos| (pos, m.len())))
+        .min_by_key(|(pos, _)| *pos)
+}
+
 pub(crate) fn marker_prefix_suffix_len<'a, I>(text: &str, markers: I) -> usize
 where
     I: IntoIterator<Item = &'a str>,
@@ -312,9 +346,15 @@ pub(crate) struct WrappedBlockScanner<E: InvokeEmitter> {
     spec: WrappedBlockSpec,
     emitter: E,
     reasoning: Option<ReasoningSpec>,
+    reasoning_enabled: bool,
+    /// Effective request-scoped start, separate from the family declaration.
+    reasoning_forced_start: bool,
     buffer: String,
+    /// Raw block bytes consumed before any call delta commits them.
+    uncommitted_block: String,
     in_block: bool,
     in_reasoning: bool,
+    accept_redundant_reasoning_start: bool,
     /// A tool call opened INSIDE a reasoning span; reasoning resumes when the
     /// call closes. Without this the tail of the thought would surface as
     /// visible text instead of reasoning.
@@ -329,9 +369,13 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             spec,
             emitter,
             reasoning: None,
+            reasoning_enabled: false,
+            reasoning_forced_start: false,
             buffer: String::new(),
+            uncommitted_block: String::new(),
             in_block: false,
             in_reasoning: false,
+            accept_redundant_reasoning_start: false,
             resume_reasoning: false,
             suppress_normal_text: false,
             next_index: 0,
@@ -340,18 +384,70 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
     /// Also own the reasoning channel, making this scanner unified.
     ///
-    /// The reasoning markers are registered for chunk-boundary holdback here
+    /// Reasoning marker holdback and orphan-close handling are enabled here
     /// rather than by the caller, so a family cannot add reasoning and forget
-    /// the holdback (which would leak a split `<thi` + `nk>` as visible text).
-    /// The closer additionally joins `orphan_markers`: a stray `</think>` with
-    /// nothing open is malformed markup and is stripped, never leaked (`I3`).
+    /// either behavior. They remain separate from the tool marker lists so
+    /// [`Self::set_reasoning_mode`] can make the markers literal for response
+    /// starting_state without rebuilding the scanner.
     pub(crate) fn with_reasoning(mut self, reasoning: ReasoningSpec) -> Self {
-        self.spec.holdback_markers.push(reasoning.start.to_string());
-        self.spec.holdback_markers.push(reasoning.end.to_string());
-        self.spec.orphan_markers.push(reasoning.end.to_string());
+        self.reasoning_enabled = true;
         self.in_reasoning = reasoning.forced_start;
+        self.reasoning_forced_start = reasoning.forced_start;
+        self.accept_redundant_reasoning_start = reasoning.forced_start;
         self.reasoning = Some(reasoning);
         self
+    }
+
+    /// The reasoning markers this scanner was configured with.
+    ///
+    /// `Copy`, so the guided-decoding path can hold them without borrowing the
+    /// scanner — it needs the markers but never the scan state.
+    pub(crate) fn reasoning_spec(&self) -> Option<ReasoningSpec> {
+        self.reasoning
+    }
+
+    /// Every control marker of this family's tool grammar, as ONE set.
+    ///
+    /// This is `holdback_markers`, which the family already declares for exactly
+    /// this purpose — the markers the scanner reacts to, so a split one is never
+    /// leaked. The guided path needs the same set for BOTH lookup and boundary
+    /// holdback, and assembling it there from `orphan_markers` plus openers, at
+    /// several sites, is how the two drifted apart repeatedly: a closer stripped
+    /// while the opener beside it leaked, an opener recognised whole but lost when
+    /// split. One owner, one set, both uses.
+    pub(crate) fn control_markers(&self) -> &[String] {
+        &self.spec.holdback_markers
+    }
+
+    /// The invoke terminator, for pairing with a stripped invoke opener.
+    ///
+    /// NOT part of [`Self::control_markers`]: a BARE `</function>` with no invoke
+    /// open is ordinary text to the native scanner, and measured identical on both
+    /// paths, so stripping it unconditionally would create a divergence rather than
+    /// remove one. It is consumed only as the tail of an invoke already stripped.
+    pub(crate) fn invoke_end(&self) -> &str {
+        &self.spec.invoke_end
+    }
+
+    /// Select whether this stream interprets reasoning markers, without
+    /// rebuilding the scanner or cloning its tool schemas.
+    pub(crate) fn set_reasoning_mode(&mut self, enabled: bool, forced_start: Option<bool>) {
+        // A family with NO `ReasoningSpec` has no reasoning channel to turn on, so
+        // "enabled" for it is simply false — not a caller error. This used to be a
+        // `debug_assert!`, but `initialize_request` enables the channel for every
+        // starting state except `Response`, so the first family registered without
+        // reasoning would have aborted on EVERY request in debug and test builds.
+        // `UNIFIED_PORTING.md` documents that registration as supported (it only
+        // rules out `GuidedJson`), so the assert forbade a shape the porting guide
+        // invites. The check could not tell "this family has no reasoning" from
+        // "this scanner was built wrong" anyway; it only ever caught the former.
+        let enabled = enabled && self.reasoning.is_some();
+        self.reasoning_enabled = enabled;
+        self.reasoning_forced_start = forced_start
+            .or_else(|| self.reasoning.map(|reasoning| reasoning.forced_start))
+            .unwrap_or(false);
+        self.in_reasoning = enabled && self.reasoning_forced_start;
+        self.accept_redundant_reasoning_start = self.in_reasoning;
     }
 
     pub(crate) fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {
@@ -409,15 +505,67 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         self.drain(true, out)
     }
 
+    /// Clear one stream's scan state and return bytes not yet emitted.
+    pub(crate) fn reset(&mut self) -> String {
+        let mut pending = std::mem::take(&mut self.uncommitted_block);
+        pending.push_str(&std::mem::take(&mut self.buffer));
+        self.in_block = false;
+        self.in_reasoning = self.reasoning_enabled && self.reasoning_forced_start;
+        self.accept_redundant_reasoning_start = self.in_reasoning;
+        // Without this a reset mid-thought leaves "resume reasoning after the call"
+        // armed, and the NEXT stream's first post-call answer is emitted as reasoning.
+        self.resume_reasoning = false;
+        self.suppress_normal_text = false;
+        self.next_index = 0;
+        pending
+    }
+
     /// Position and length of the reasoning opener in the buffer, if configured.
     fn find_reasoning_start(&self) -> Option<(usize, usize)> {
+        if !self.reasoning_enabled {
+            return None;
+        }
         let reasoning = self.reasoning.as_ref()?;
         let pos = self.buffer.find(reasoning.start)?;
         Some((pos, reasoning.start.len()))
     }
 
-    /// Consume buffered reasoning up to its closer, a nested tool opener, or as
-    /// far as is safe.
+    /// Position and length of the earliest malformed close outside a block.
+    fn find_orphan_marker(&self) -> Option<(usize, usize)> {
+        let regular = find_first(&self.buffer, &self.spec.orphan_markers);
+        let reasoning_close = self
+            .reasoning
+            .as_ref()
+            .filter(|_| self.reasoning_enabled)
+            .and_then(|reasoning| {
+                self.buffer
+                    .find(reasoning.end)
+                    .map(|pos| (pos, reasoning.end.len()))
+            });
+        regular
+            .into_iter()
+            .chain(reasoning_close)
+            .min_by_key(|(pos, _)| *pos)
+    }
+
+    /// Longest marker prefix held at the end of the current chunk.
+    fn holdback_len(&self) -> usize {
+        let regular = marker_prefix_suffix_len(
+            &self.buffer,
+            self.spec.holdback_markers.iter().map(String::as_str),
+        );
+        let reasoning = self
+            .reasoning
+            .as_ref()
+            .filter(|_| self.reasoning_enabled)
+            .map(|reasoning| {
+                marker_prefix_suffix_len(&self.buffer, [reasoning.start, reasoning.end])
+            })
+            .unwrap_or_default();
+        regular.max(reasoning)
+    }
+
+    /// Consume buffered reasoning up to its closer, or as far as is safe.
     ///
     /// Returns `true` once the reasoning span yielded (closer seen, tool opener
     /// reached, or promoted at EOF) and the caller should keep draining; `false`
@@ -452,16 +600,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             .into_iter()
             .chain(self.buffer.find(self.spec.invoke_start.as_str()))
             .min();
-        let stray = std::iter::once(start)
-            .chain(
-                self.spec
-                    .orphan_markers
-                    .iter()
-                    .map(String::as_str)
-                    .filter(|m| *m != end),
-            )
-            .filter_map(|m| self.buffer.find(m).map(|pos| (pos, m.len())))
-            .min_by_key(|(pos, _)| *pos);
+        let stray = stray_in_reasoning(&self.buffer, start, end, &self.spec.orphan_markers);
 
         if let Some((at, what)) = earliest([
             self.buffer.find(end).map(|pos| (pos, InReasoning::Close)),
@@ -491,14 +630,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
         // Nothing complete yet: stream what has arrived, holding back ANY marker
         // this scanner reacts to that is split across the chunk boundary.
-        let keep = if flush {
-            0
-        } else {
-            marker_prefix_suffix_len(
-                &self.buffer,
-                self.spec.holdback_markers.iter().map(String::as_str),
-            )
-        };
+        let keep = if flush { 0 } else { self.holdback_len() };
         let emit_len = self.buffer.len().saturating_sub(keep);
         if emit_len > 0 {
             push_run(out, Kind::Reasoning, &self.buffer[..emit_len]);
@@ -517,27 +649,12 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         Ok(false)
     }
 
-    /// Return to a FRESH-STREAM state and hand back whatever was still buffered.
-    ///
-    /// Every field that carries stream position resets, `next_index` included: the
-    /// returned text is a NEW stream, so a call parsed out of it must not reuse an
-    /// index already dispatched from the abandoned one.
-    pub(crate) fn reset_stream(&mut self) -> String {
-        let carried = std::mem::take(&mut self.buffer);
-        self.in_block = false;
-        self.in_reasoning = self.reasoning.as_ref().is_some_and(|r| r.forced_start);
-        self.resume_reasoning = false;
-        self.suppress_normal_text = false;
-        self.next_index = 0;
-        carried
-    }
-
     fn drain<S: EventSink + ?Sized>(&mut self, flush: bool, out: &mut S) -> anyhow::Result<()> {
         loop {
-            // Reasoning yields to tool structure: while a thought is open, its
-            // closer OR a nested tool opener ends the current reasoning run (see
-            // `drain_reasoning`), so a call emitted inside a thought is extracted
-            // and the thought resumes after it.
+            // While a thought is open, `drain_reasoning` owns precedence: its
+            // closer ends the span, a tool opener suspends it so the call can be
+            // extracted, and a stray marker is stripped. The reverse nesting is
+            // asymmetric: the in-block branch treats reasoning markers as arguments.
             if self.in_reasoning {
                 if self.drain_reasoning(out, flush)? {
                     continue;
@@ -557,6 +674,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         // block re-enters `in_block` and re-suppresses its markup.
                         // Matches the v1 batch parsers (cases 8.b/8.c/8.d).
                         self.buffer.drain(..end_pos + end_len);
+                        self.uncommitted_block.clear();
                         self.in_block = false;
                         self.suppress_normal_text = false;
                         self.in_reasoning = std::mem::take(&mut self.resume_reasoning);
@@ -571,11 +689,13 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                             "stream dropped incomplete block at EOF"
                         );
                         self.buffer.clear();
+                        self.uncommitted_block.clear();
                         self.in_block = false;
                     }
                     break;
                 };
                 if start > 0 {
+                    self.uncommitted_block.push_str(&self.buffer[..start]);
                     self.buffer.drain(..start);
                 }
                 let Some(end) = self.buffer.find(self.spec.invoke_end.as_str()) else {
@@ -585,6 +705,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                             "stream dropped incomplete invoke at EOF"
                         );
                         self.buffer.clear();
+                        self.uncommitted_block.clear();
                         self.in_block = false;
                     }
                     break;
@@ -601,6 +722,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         "stream dropped invoke missing its close before the block end"
                     );
                     self.buffer.drain(..be_pos + be_len);
+                    self.uncommitted_block.clear();
                     self.in_block = false;
                     self.suppress_normal_text = false;
                     continue;
@@ -609,16 +731,19 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let invoke = self.buffer[..invoke_len].to_string();
                 // Emit BEFORE consuming. `parse_invoke` is fallible, and draining first
                 // meant a failing emitter destroyed the invoke bytes: they were gone from
-                // the buffer, so `reset_stream` could no longer hand them back and the
+                // the buffer, so `reset` could no longer hand them back and the
                 // documented recovery contract was false for the only shipped family.
                 let emitted = self.emitter.parse_invoke(&invoke, self.next_index)?;
                 self.buffer.drain(..invoke_len);
                 if let Some(delta) = emitted {
                     out.push_call(delta);
                     self.next_index += 1;
+                    self.uncommitted_block.clear();
                     if self.spec.invoke_latch == InvokeLatch::IfEmitted {
                         self.suppress_normal_text = true;
                     }
+                } else {
+                    self.uncommitted_block.push_str(&invoke);
                 }
                 if self.spec.invoke_latch == InvokeLatch::Always {
                     self.suppress_normal_text = true;
@@ -631,7 +756,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             // NEVER leak into normal_text; when suppression is off, first emit
             // the natural text preceding it. Clear the latch either way (the
             // markup context has ended).
-            if let Some((pos, len)) = find_first(&self.buffer, &self.spec.orphan_markers) {
+            if let Some((pos, len)) = self.find_orphan_marker() {
                 let next_open = find_first(&self.buffer, &self.spec.block_starts)
                     .map(|(p, _)| p)
                     .into_iter()
@@ -666,14 +791,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             let Some((start, marker)) = next_marker else {
                 // No marker present: emit buffered text, but hold back a trailing
                 // partial marker (split across this chunk boundary) unless flushing.
-                let keep = if flush {
-                    0
-                } else {
-                    marker_prefix_suffix_len(
-                        &self.buffer,
-                        self.spec.holdback_markers.iter().map(String::as_str),
-                    )
-                };
+                let keep = if flush { 0 } else { self.holdback_len() };
                 let emit_len = self.buffer.len().saturating_sub(keep);
                 if emit_len > 0 {
                     if !self.suppress_normal_text {
@@ -693,6 +811,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
             match marker {
                 Marker::Block(blen) => {
+                    self.uncommitted_block.push_str(&self.buffer[..blen]);
                     self.buffer.drain(..blen);
                     self.in_block = true;
                     self.suppress_normal_text = true;
@@ -802,7 +921,7 @@ mod recovery_tests {
     use super::*;
 
     /// Scanner-level contract: on an emitter error the failed invoke stays in the buffer,
-    /// so `reset_stream` can hand it back. Pre-fix this drained before the fallible call.
+    /// so `reset` can hand it back. Pre-fix this drained before the fallible call.
     #[test]
     fn wrapped_emitter_error_leaves_invoke_recoverable() {
         let mut s = failing_scanner();
@@ -813,7 +932,7 @@ mod recovery_tests {
         );
         assert!(r.is_err(), "the injected emitter must surface its error");
         assert_eq!(
-            s.reset_stream(),
+            s.reset(),
             "<function=boom></function></tool_call>suffix",
             "the failed invoke and everything after it must remain recoverable"
         );
@@ -826,9 +945,108 @@ mod recovery_tests {
         let r = s.push_ordered_into("prefix<function=boom></function>suffix", &mut out);
         assert!(r.is_err(), "the injected emitter must surface its error");
         assert_eq!(
-            s.reset_stream(),
+            s.reset(),
             "<function=boom></function>suffix",
             "the failed bare invoke and everything after it must remain recoverable"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::failing_scanner;
+    use super::*;
+
+    #[test]
+    fn reset_recovers_the_complete_push_after_an_emitter_error() {
+        let mut scanner = failing_scanner();
+        let input = "prefix <tool_call><function=boom></function></tool_call>suffix";
+
+        assert!(scanner.push_ordered(input).is_err());
+        assert_eq!(
+            scanner.reset(),
+            "<tool_call><function=boom></function></tool_call>suffix"
+        );
+    }
+
+    #[test]
+    fn reset_recovers_a_block_opener_consumed_by_an_earlier_push() {
+        let mut scanner = failing_scanner();
+        assert_eq!(
+            scanner
+                .push_ordered("prefix <tool_call>  <function=boom")
+                .unwrap(),
+            vec![UnifiedParserEvent::Text("prefix ".to_string())]
+        );
+
+        assert!(
+            scanner
+                .push_ordered("</function></tool_call>suffix")
+                .is_err()
+        );
+        assert_eq!(
+            scanner.reset(),
+            "<tool_call>  <function=boom</function></tool_call>suffix"
+        );
+    }
+
+    /// A family with no `ReasoningSpec` must survive request setup.
+    ///
+    /// `ScannerUnified::initialize_request` enables the reasoning channel for every
+    /// starting state except `Response`, so while this was a `debug_assert!` the
+    /// first family registered without reasoning would have aborted on EVERY request
+    /// in debug and test builds — a shape `UNIFIED_PORTING.md` explicitly documents
+    /// as supported. Unreachable with today's registry (qwen3 and gemma4 both have
+    /// reasoning), which is exactly why it needs a test rather than a reader.
+    #[test]
+    fn enabling_reasoning_on_a_family_without_it_is_a_no_op_not_a_panic() {
+        let mut scanner = failing_scanner();
+        assert!(
+            scanner.reasoning.is_none(),
+            "fixture must have no ReasoningSpec"
+        );
+
+        scanner.set_reasoning_mode(true, Some(false));
+        assert!(!scanner.reasoning_enabled, "no channel to enable");
+        assert!(!scanner.in_reasoning);
+
+        // The prefilled-reasoning starting state must not latch either.
+        scanner.set_reasoning_mode(true, Some(true));
+        assert!(!scanner.reasoning_enabled);
+        assert!(
+            !scanner.in_reasoning,
+            "cannot start inside a channel that does not exist"
+        );
+    }
+
+    #[test]
+    fn request_reasoning_start_does_not_overwrite_the_family_default() {
+        let mut scanner = failing_scanner().with_reasoning(ReasoningSpec {
+            start: "<think>",
+            end: "</think>",
+            forced_start: true,
+            preserve_special_tokens: false,
+        });
+
+        scanner.set_reasoning_mode(true, Some(false));
+        assert!(
+            !scanner.in_reasoning,
+            "request override must apply immediately"
+        );
+        assert!(
+            scanner.reasoning.unwrap().forced_start,
+            "request setup must not mutate the family declaration"
+        );
+
+        scanner.set_reasoning_mode(true, None);
+        assert!(
+            scanner.in_reasoning,
+            "an unspecified request state must recover the family default"
+        );
+        scanner.reset();
+        assert!(
+            scanner.in_reasoning,
+            "reset must preserve the effective default"
         );
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -37,10 +37,16 @@
 //! (`I8`). [`assemble`] is the single implementation of that fold, so callers
 //! and conformance harnesses never reimplement it and drift.
 //!
-//! Note this is a genuine unified parser, not vLLM's `CombinedParser` shape:
-//! vLLM 0.25.x keeps `extract_tool_calls_streaming` and
-//! `extract_reasoning_streaming` as two chained APIs behind a unified interface
-//! (only gemma4 is natively unified there), which reproduces the same seam.
+//! Note the distinction between a unified INTERFACE and a unified PARSER. An
+//! interface that internally calls a reasoning parser and then hands its leftover
+//! content to a tool parser still has the seam described above — it has only moved
+//! it behind one method. This is the latter: one state machine sees every byte and
+//! decides its channel, so there is no handoff for ordering to be lost across.
+//!
+//! The public contract here is deliberately ALIGNED WITH PEER TRAITS — the Rust
+//! streaming-parser contracts serving engines already expose — so this crate can be
+//! adopted without a translation layer. Where it diverges from the peer shape, the
+//! divergence is stated at the item.
 
 pub mod qwen3;
 
@@ -48,7 +54,9 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::tool_calling::scan::{InvokeEmitter, WrappedBlockScanner, push_run};
+use crate::tool_calling::scan::{
+    InvokeEmitter, ReasoningSpec, WrappedBlockScanner, marker_prefix_suffix_len, push_run,
+};
 use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
 
 /// One ordered update produced while parsing assistant output.
@@ -57,9 +65,9 @@ use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
 /// core emits it, tool-only parsers project it down to [`ToolParseResult`], and
 /// unified parsers hand it to the caller as-is.
 ///
-/// Name, variant order and payload shapes are aligned with the peer streaming-parser
-/// traits, so the two translate variant-for-variant under a compiler rather than by a
-/// reader's judgement.
+/// Name, variant order and payload shapes are aligned with the peer trait's event
+/// type, so the two translate variant-for-variant under a compiler rather than by
+/// a reader's judgement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnifiedParserEvent {
     /// Normal assistant-visible text.
@@ -90,20 +98,135 @@ pub enum UnifiedEvent {
     },
 }
 
+/// Assistant-channel state established by the rendered generation prompt.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum UnifiedParserStartingState {
+    /// Generated output includes any channel-opening marker itself.
+    #[default]
+    None,
+    /// The prompt opened reasoning, so generated output begins inside it.
+    Reasoning,
+    /// The prompt opened the visible response channel.
+    Response,
+}
+
+/// Tool-call wire format selected for one request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum UnifiedToolOutputMode {
+    /// Model-native tool-call markup.
+    #[default]
+    Native,
+    /// Guided decoding emits bare JSON instead of model-native markup.
+    ///
+    /// A named choice contains only that tool's arguments. A required choice
+    /// contains one call object or an array of call objects.
+    GuidedJson { named_tool: Option<String> },
+}
+
+/// Caller policy when guided decoding violates the promised tool-call shape.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum InvalidGuidedPayloadPolicy {
+    /// Return a typed error so the serving layer can reject or retry the output.
+    #[default]
+    Reject,
+    /// Preserve the corpus' best-effort behavior by surfacing the bytes as text.
+    RecoverAsText,
+}
+
+/// Fully resolved request-scoped parser configuration.
+///
+/// Prompt inspection and backend request resolution happen before this value is
+/// built. Passing one owned object prevents starting state, wire format, and
+/// malformed-payload policy from being initialized through paths that can drift.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UnifiedParserInit {
+    pub prompt_token_ids: Vec<u32>,
+    pub starting_state: UnifiedParserStartingState,
+    pub tool_output_mode: UnifiedToolOutputMode,
+    pub invalid_guided_payload: InvalidGuidedPayloadPolicy,
+}
+
+impl UnifiedParserInit {
+    /// Neutral native-mode initialization used by peer-shaped callers.
+    pub fn native(prompt_token_ids: &[u32]) -> Self {
+        Self {
+            prompt_token_ids: prompt_token_ids.to_vec(),
+            ..Self::default()
+        }
+    }
+}
+
+/// Coarse payload classification carried by [`InvalidGuidedPayload`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidGuidedPayloadKind {
+    Missing,
+    InvalidJson,
+    WrongShape,
+}
+
+/// Typed guided-decoding contract failure.
+///
+/// Raw model bytes are deliberately excluded. Callers can downcast the error and
+/// recover uncommitted bytes through [`UnifiedParser::reset`] without leaking them
+/// into logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidGuidedPayload {
+    pub kind: InvalidGuidedPayloadKind,
+    pub choice: &'static str,
+}
+
+impl std::fmt::Display for InvalidGuidedPayload {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "guided decoding emitted {:?} instead of the promised {} tool-call payload",
+            self.kind, self.choice
+        )
+    }
+}
+
+impl std::error::Error for InvalidGuidedPayload {}
+
 /// A parser that owns reasoning + content + tool calls for one stream.
 ///
 /// Streaming-first, like [`crate::ToolParser`]: [`Self::parse_into`] per decoded
 /// delta, [`Self::finish`] once at end of stream. One instance parses exactly one
 /// choice of one request, which is what gives per-stream isolation (`I4`) by
 /// construction.
+///
+/// # This is a SYNTAX-only surface
+///
+/// A parser reports what the model's bytes SAY, never whether saying it was
+/// allowed. An emitted [`UnifiedParserEvent::ToolCall`] therefore carries no
+/// guarantee that the tool was offered, that `tool_choice` permits it, that the
+/// arguments satisfy the tool's schema, or that parallel calls are allowed. A
+/// model can name a tool that was never offered, and this will emit it.
+///
+/// The serving layer MUST validate tool availability, authorization, argument
+/// schema and call policy before executing anything derived from these events.
+/// Splitting it this way is deliberate — a parser that silently dropped
+/// unrecognized calls would hide model misbehaviour that the caller needs to see —
+/// but it means "the parser produced a ToolCall" is not "this call is safe to run".
 pub trait UnifiedParser: Send {
     /// Initialize parser state from prompt token IDs before output deltas arrive.
     ///
-    /// This is the peer traits' `initialize` signature, so a caller written against
-    /// them reaches the same method with the same argument here. The default detects
-    /// nothing, matching the peer default; a family whose prompt can end mid-channel
-    /// overrides it and reads the tokens.
-    fn initialize(&mut self, _prompt_token_ids: &[u32]) -> Result<()> {
+    /// Aligned with the peer trait, so a caller written against it reaches the same
+    /// method with the same argument here.
+    ///
+    /// This is the peer-trait compatibility adapter. Request-aware callers resolve
+    /// every request fact once and call [`UnifiedParser::initialize_request`].
+    fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()> {
+        self.initialize_request(UnifiedParserInit::native(prompt_token_ids))
+    }
+
+    /// Apply the one fully resolved request configuration before parsing starts.
+    fn initialize_request(&mut self, init: UnifiedParserInit) -> Result<()> {
+        if init.starting_state != UnifiedParserStartingState::None {
+            anyhow::bail!("this unified parser does not support prompt-prefilled channels");
+        }
+        if init.tool_output_mode != UnifiedToolOutputMode::Native {
+            anyhow::bail!("this unified parser does not support guided tool output");
+        }
         Ok(())
     }
 
@@ -126,9 +249,9 @@ pub trait UnifiedParser: Send {
 
     /// Flush buffered partial state at end of stream.
     ///
-    /// Open reasoning is promoted here rather than dropped or leaked as text, and an
-    /// unrecoverable partial tool call is dropped without erroring (policy P2 —
-    /// best-effort recovery).
+    /// Open reasoning is promoted here rather than dropped or leaked as text,
+    /// and an unrecoverable partial tool call is dropped without erroring
+    /// (policy P2 — best-effort recovery).
     ///
     /// The peer traits give this a default that returns nothing. It is REQUIRED here:
     /// the signature a caller sees is identical, but a family that forgets to flush
@@ -140,21 +263,26 @@ pub trait UnifiedParser: Send {
     ///
     /// This is not a mid-turn continuation hook. Everything restarts, including the
     /// tool index, so the returned text must be re-parsed as a NEW stream and any
-    /// calls already emitted belong to the abandoned one — feeding the remainder back
-    /// into the same turn would re-number from index 0 and collide with them.
+    /// calls already emitted belong to the abandoned one — feeding the remainder
+    /// back into the same turn would re-number from index 0 and collide with them.
+    /// That follows from `I4`: one parser instance owns exactly one stream, so a
+    /// retry is a new stream and gets a reset (or a new) parser, not a splice.
     fn reset(&mut self) -> String {
         String::new()
     }
 
     /// Whether decoded output must keep tokenizer special tokens.
     ///
-    /// A family whose markers ARE special tokens cannot be parsed from text that
-    /// dropped them.
+    /// Mirrors the tool trait's method of the same name: a family whose markers
+    /// ARE special tokens cannot be parsed from text that dropped them.
     fn preserve_special_tokens(&self) -> bool {
         false
     }
 
     /// The model-emitted id for a tool call, when the grammar carries one.
+    ///
+    /// Qwen3's XML grammar does not, so the default is correct for it; families
+    /// whose envelope names the call (kimi's `functions.NAME:INDEX`) override.
     fn tool_call_id(&self, _tool_index: usize) -> Option<&str> {
         None
     }
@@ -248,6 +376,14 @@ impl crate::tool_calling::scan::EventSink for UnifiedParserOutput {
 }
 
 impl UnifiedParserOutput {
+    fn push_event(&mut self, event: UnifiedParserEvent) {
+        match event {
+            UnifiedParserEvent::Text(text) => self.push_text(text),
+            UnifiedParserEvent::Reasoning(text) => self.push_reasoning(text),
+            UnifiedParserEvent::ToolCall(call) => self.push_call(call),
+        }
+    }
+
     /// Append another advance's updates, preserving order.
     ///
     /// Coalesces ACROSS the seam, matching the peer helper: routing every event through
@@ -266,10 +402,12 @@ impl UnifiedParserOutput {
         }
     }
 
-    // --- Accumulation helpers, aligned with the peer traits in name and semantics.
-    // These COALESCE: appending text onto a trailing text event extends it rather than
-    // adding a second one. `assemble` performs the same fold, so a caller that
-    // accumulates through these and one that folds afterwards agree.
+    // --- Accumulation helpers, aligned with the peer traits in name and semantics
+    // These COALESCE: appending text onto a trailing text event extends it rather
+    // than adding a second one. `assemble` performs the same fold, so a caller
+    // that accumulates through these and one that folds afterwards agree. Nothing
+    // in this crate's parse path routes through them today — the corpus asserts on
+    // the raw per-advance events — so adopting them cannot move the golden feed.
 
     /// Append one visible text event if `delta` is non-empty.
     pub fn push_text(&mut self, delta: impl AsRef<str> + Into<String>) {
@@ -315,15 +453,11 @@ impl UnifiedParserOutput {
     pub fn iter(&self) -> std::slice::Iter<'_, UnifiedParserEvent> {
         self.events.iter()
     }
-
-    /// Collapse into assembled events (see [`assemble`]).
-    pub fn assembled(&self) -> Vec<UnifiedEvent> {
-        assemble(&self.events)
-    }
 }
 
 // Additive ergonomics: the type carries a single `events` field, so these cannot
-// change what is emitted — they only spare every caller an explicit `.events`.
+// change what is emitted — they only spare every caller
+// an explicit `.events` when consuming an advance.
 impl IntoIterator for UnifiedParserOutput {
     type Item = UnifiedParserEvent;
     type IntoIter = std::vec::IntoIter<UnifiedParserEvent>;
@@ -356,6 +490,48 @@ impl FromIterator<UnifiedParserEvent> for UnifiedParserOutput {
         }
         out
     }
+}
+
+impl UnifiedParserOutput {
+    /// Collapse into assembled events (see [`assemble`]).
+    ///
+    /// Additive: the peer traits have no assembled form, so their arguments stay
+    /// string fragments end to end.
+    pub fn assembled(&self) -> Vec<UnifiedEvent> {
+        assemble(&self.events)
+    }
+
+    /// Verbatim argument bytes per `tool_index` (see [`tool_arguments_raw`]).
+    pub fn tool_arguments_raw(&self) -> BTreeMap<usize, String> {
+        tool_arguments_raw(&self.events)
+    }
+}
+
+/// Each call's argument bytes exactly as the model produced them, keyed by
+/// `tool_index`.
+///
+/// [`assemble`] parses arguments into a [`serde_json::Value`] because the
+/// conformance corpus compares them semantically — key order and whitespace are
+/// not defects there. A SERVING path has the opposite requirement: the OpenAI
+/// wire format carries `arguments` as a string, and re-serializing a `Value`
+/// rewrites the model's bytes (`{"city": "Tokyo"}` becomes `{"city":"Tokyo"}`).
+///
+/// A streaming caller never hits this because it forwards
+/// [`ToolCallDelta::arguments`] verbatim. A non-streaming caller assembling the
+/// same turn would, which would make the two disagree on identical input and
+/// break argument fidelity (`I7`) on the batch path alone. This returns the same
+/// joined bytes `assemble` folds, so a caller can have the parsed view and the
+/// verbatim view without reimplementing the join and drifting from it (`I6`).
+pub fn tool_arguments_raw(deltas: &[UnifiedParserEvent]) -> BTreeMap<usize, String> {
+    let mut raw: BTreeMap<usize, String> = BTreeMap::new();
+    for delta in deltas {
+        if let UnifiedParserEvent::ToolCall(call) = delta {
+            raw.entry(call.tool_index)
+                .or_default()
+                .push_str(&call.arguments);
+        }
+    }
+    raw
 }
 
 /// Collapse an ordered delta stream into assembled events.
@@ -414,7 +590,8 @@ pub fn assemble(deltas: &[UnifiedParserEvent]) -> Vec<UnifiedEvent> {
                 if !raw.trim().is_empty() {
                     tracing::warn!(
                         why = "unified_unparseable_tool_arguments",
-                        error = %e, raw = %raw,
+                        error = %e,
+                        argument_bytes = raw.len(),
                         "tool-call arguments did not parse as JSON; emitting an empty object"
                     );
                 }
@@ -464,45 +641,1125 @@ impl ToolParseResult {
 /// the trait itself has no `create`.
 pub(crate) struct ScannerUnified<E: InvokeEmitter> {
     pub(crate) scanner: WrappedBlockScanner<E>,
+    /// Which channel the PROMPT already opened. Held here as well as on the
+    /// scanner because `reset` has to restore it, and because the guided path
+    /// below never reaches the scanner at all.
+    starting_state: UnifiedParserStartingState,
+    /// Set once the backend selects guided decoding for this request; `None`
+    /// on the native path, which is every request that did not ask for it.
+    /// Boxed so a native stream carries one null pointer, not six idle fields.
+    guided: Option<Box<GuidedState>>,
+    started: bool,
+    finished: bool,
+}
+
+impl<E: InvokeEmitter> ScannerUnified<E> {
+    pub(crate) fn new(scanner: WrappedBlockScanner<E>) -> Self {
+        Self {
+            scanner,
+            starting_state: UnifiedParserStartingState::None,
+            guided: None,
+            started: false,
+            finished: false,
+        }
+    }
+
+    fn apply_init(&mut self, init: UnifiedParserInit) -> Result<()> {
+        if self.started || self.finished {
+            anyhow::bail!("cannot initialize a unified parser after parsing has started");
+        }
+        let UnifiedParserInit {
+            prompt_token_ids: _,
+            starting_state,
+            tool_output_mode,
+            invalid_guided_payload,
+        } = init;
+        // An EXPLICIT `Reasoning` demand that this family cannot represent must fail
+        // here, before anything is mutated. `set_reasoning_mode` folds "cannot
+        // represent" into "off", which is right for the neutral `None` default but
+        // wrong for a caller that stated the prompt already opened a thought: the
+        // model then closes a channel that was never open, and its private reasoning
+        // is emitted as VISIBLE TEXT. Rejecting is the only honest answer, and it
+        // belongs here rather than in `set_reasoning_mode`, whose generic
+        // `enabled=true` cannot tell an explicit demand from the default.
+        if starting_state == UnifiedParserStartingState::Reasoning
+            && self.scanner.reasoning_spec().is_none()
+        {
+            anyhow::bail!(
+                "starting_state=Reasoning was requested, but this family has no reasoning \
+                 channel to continue; its private reasoning would be emitted as visible text"
+            );
+        }
+        // EVERY prerequisite is resolved BEFORE any mutation. Guided mode used to be
+        // validated after `starting_state`, the scanner reset and the reasoning mode
+        // had already been applied, so a rejected initialization left the parser
+        // half-configured, and a caller that caught the error and retried in a
+        // supported mode was building on mutated state. A failed initialize must be a
+        // no-op.
+        let guided_reasoning = match tool_output_mode {
+            UnifiedToolOutputMode::Native => None,
+            UnifiedToolOutputMode::GuidedJson { .. } => match self.scanner.reasoning_spec() {
+                Some(reasoning) => Some(reasoning),
+                None => anyhow::bail!("guided tool output needs a reasoning-aware scanner"),
+            },
+        };
+
+        self.starting_state = starting_state;
+        self.scanner.reset();
+        // `Response` means the prompt already opened visible content, so this
+        // stream has no reasoning channel at all; `Reasoning` means it opened a
+        // thought the model will close without ever emitting the opener.
+        self.scanner.set_reasoning_mode(
+            starting_state != UnifiedParserStartingState::Response,
+            match starting_state {
+                UnifiedParserStartingState::None => None,
+                UnifiedParserStartingState::Reasoning => Some(true),
+                UnifiedParserStartingState::Response => Some(false),
+            },
+        );
+        self.guided = match (tool_output_mode, guided_reasoning) {
+            (UnifiedToolOutputMode::Native, _) => None,
+            (UnifiedToolOutputMode::GuidedJson { named_tool }, Some(reasoning)) => {
+                Some(Box::new(GuidedState::new(
+                    reasoning,
+                    self.scanner.control_markers().to_vec(),
+                    self.scanner.invoke_end().to_string(),
+                    named_tool,
+                    starting_state,
+                    invalid_guided_payload,
+                )))
+            }
+            (UnifiedToolOutputMode::GuidedJson { .. }, None) => {
+                unreachable!("guided mode without a reasoning spec bails before any mutation")
+            }
+        };
+        self.finished = false;
+        Ok(())
+    }
 }
 
 impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
     /// Whether decoding must preserve special tokens, delegated to the shared grammar.
     ///
-    /// NOT the trait default. Inheriting `false` here while the tool-only adapter over
-    /// this same scanner returned `true` meant two surfaces reported contradictory
-    /// decoding requirements for identical markup. The value now lives on the grammar and
-    /// both surfaces read it, so they cannot disagree.
+    /// NOT the trait default, and NOT a field on this adapter. Inheriting `false` here
+    /// while the tool-only adapter over this same scanner returned `true` meant two
+    /// surfaces reported contradictory decoding requirements for identical markup.
     fn preserve_special_tokens(&self) -> bool {
         self.scanner.preserve_special_tokens()
     }
 
-    /// The trait default returns an empty string and leaves state untouched, which
-    /// would tell a caller nothing was buffered while the scanner still held a partial
-    /// marker, `in_block`, and a used `next_index`. A caller following the documented
-    /// recovery path after a `parse_into` error would then resume on stale state and
-    /// mis-number tool indices. The only shipped family must honour the contract.
-    fn reset(&mut self) -> String {
-        self.scanner.reset_stream()
+    fn initialize_request(&mut self, init: UnifiedParserInit) -> Result<()> {
+        self.apply_init(init)
     }
 
     fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
-        // Straight into the caller's output, with no vector in between. Two reasons, and
-        // the first is a correctness one: an event written here is COMMITTED, so a later
-        // error in the same advance cannot retract it. Collecting into a local vector and
-        // copying at the end meant `?` dropped everything already emitted. It also drops
-        // the second allocation per advance. Coalescing is unchanged: the sink routes
-        // through these same `push_*` helpers.
-        self.scanner.push_ordered_into(delta, output)
+        if self.finished {
+            anyhow::bail!("cannot push to a finished unified parser");
+        }
+        self.started = true;
+        match self.guided.as_mut() {
+            // Native: straight into the caller's output. An event written here is
+            // COMMITTED, so a later error in the same advance cannot retract it.
+            None => self.scanner.push_ordered_into(delta, output),
+            // Guided: the guided parser owns its own vector, so route what it returns
+            // through the accumulation helpers. NOT `output.events.extend(..)`, which
+            // bypasses the same-kind merge and makes identical bytes describe a
+            // different event stream depending on which mode produced them.
+            Some(guided) => guided.push_into(delta, output),
+        }
     }
 
     fn finish(&mut self) -> Result<UnifiedParserOutput> {
-        // Direct into the output, matching `parse_into`: no intermediate vector, and the
-        // events reach the caller through the same coalescing helpers.
+        if self.finished {
+            anyhow::bail!("cannot finish a unified parser twice");
+        }
+        self.started = true;
+        self.finished = true;
         let mut out = UnifiedParserOutput::default();
-        self.scanner.finish_ordered_into(&mut out)?;
+        match self.guided.as_mut() {
+            None => self.scanner.finish_ordered_into(&mut out)?,
+            Some(guided) => {
+                for event in guided.finish()? {
+                    match event {
+                        UnifiedParserEvent::Text(t) => out.push_text(t),
+                        UnifiedParserEvent::Reasoning(t) => out.push_reasoning(t),
+                        UnifiedParserEvent::ToolCall(c) => out.push_call(c),
+                    }
+                }
+            }
+        }
         Ok(out)
     }
+
+    fn reset(&mut self) -> String {
+        let mut recovered = String::new();
+        if let Some(guided) = self.guided.as_mut() {
+            recovered.push_str(&guided.reset(self.starting_state));
+        }
+        recovered.push_str(&self.scanner.reset());
+        self.scanner.set_reasoning_mode(
+            self.starting_state != UnifiedParserStartingState::Response,
+            match self.starting_state {
+                UnifiedParserStartingState::None => None,
+                UnifiedParserStartingState::Reasoning => Some(true),
+                UnifiedParserStartingState::Response => Some(false),
+            },
+        );
+        self.started = false;
+        self.finished = false;
+        recovered
+    }
+}
+
+/// Where a guided-decoding stream currently is, relative to the reasoning span.
+///
+/// Guided decoding constrains only the TOOL output to JSON; the model still
+/// opens and closes its reasoning channel with native markers, so those have to
+/// be stripped before the remainder can be parsed as JSON.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum GuidedMode {
+    #[default]
+    OutsideReasoning,
+    Reasoning,
+    /// Visible output has started; every later byte is JSON payload. Marker-like
+    /// text inside an argument value must stay literal from here on (`I7`).
+    VisibleOnly,
+}
+
+/// One guided tool call as the backend emits it. `parameters` and `arguments`
+/// are accepted interchangeably because backends disagree on the key.
+#[derive(Debug, serde::Deserialize)]
+struct GuidedToolCall {
+    name: String,
+    #[serde(default, deserialize_with = "deserialize_present_raw")]
+    parameters: Option<Box<serde_json::value::RawValue>>,
+    #[serde(default, deserialize_with = "deserialize_present_raw")]
+    arguments: Option<Box<serde_json::value::RawValue>>,
+}
+
+/// Preserve a present JSON value as raw bytes, including `null`.
+///
+/// Serde's normal `Option<T>` field handling maps both a missing field and an
+/// explicit `null` to `None`. Guided calls need the distinction: missing means
+/// a parameterless call, while present `null` is a malformed argument value.
+fn deserialize_present_raw<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Box<serde_json::value::RawValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Box::<serde_json::value::RawValue>::deserialize(deserializer).map(Some)
+}
+
+/// Request-scoped state for a guided-decoding stream.
+///
+/// Grammar-independent: the only thing it needs from the family is the pair of
+/// reasoning markers, taken from the scanner's own [`ReasoningSpec`]. Guided
+/// decoding is a BACKEND feature — any family can be served with it — so this
+/// lives on the shared unified parser rather than in one family's module.
+struct GuidedState {
+    /// Any control markup was stripped this turn. Used only to tell a turn that
+    /// produced nothing because it was ALL markup from a model that genuinely said
+    /// nothing — the first is worth a log line, the second is not.
+    stripped_markup: bool,
+    reasoning: ReasoningSpec,
+    /// EVERY control marker of the family's tool grammar, from the scanner's own
+    /// declaration. One set, used for both lookup and chunk-boundary holdback, in
+    /// both the inside-a-thought and outside-a-thought scopes. Assembling it
+    /// per-site from openers and orphans is how those four uses drifted apart.
+    control_markers: Vec<String>,
+    /// Paired with a stripped prefix-form invoke opener; see `invoke_end()`.
+    invoke_end: String,
+    named_tool: Option<String>,
+    invalid_payload: InvalidGuidedPayloadPolicy,
+    /// Response starting_state disables reasoning markers, but tool control markers
+    /// still need scanning until the JSON value actually starts.
+    reasoning_enabled: bool,
+    mode: GuidedMode,
+    /// Some backends re-emit the reasoning opener even though the prompt already
+    /// opened the channel. Consume exactly one such echo instead of leaking it.
+    accept_redundant_reasoning_start: bool,
+    /// The one guided JSON payload has been emitted. Later bytes are ordinary
+    /// visible/reasoning output and control markup, never a second payload.
+    payload_emitted: bool,
+    /// Visible post-payload text has started. Structural whitespace immediately
+    /// after JSON may be discarded, but whitespace after visible text is content.
+    post_payload_text_started: bool,
+    input: String,
+    json: String,
+}
+
+/// Earliest control marker in `haystack`, as `(pos, consume_len)`.
+///
+/// A PREFIX-form marker (`<function=`, which anchors `<function=NAME>`) consumes
+/// through its terminating `>`; stripping only the declared prefix left `NAME>`
+/// behind to poison the payload. `None` for a prefix form whose `>` has not
+/// streamed yet, so the caller holds the bytes back instead of splitting it.
+/// `limit` bounds the terminator search: an invoke's terminator has to belong to
+/// THAT invoke. Searching the whole buffer let a `</function>` occurring far later
+/// — inside a guided argument string, past the end of the thought — be claimed as
+/// the terminator, swallowing the reasoning closer and the entire payload with it,
+/// so the call was silently dropped and payload fragments were shown as thinking.
+/// Where a prefix-form marker's header must end.
+///
+/// ONE rule, used by both the consume path (`control_marker_at`) and the holdback
+/// (`guided_holdback_len`). Two predicates drifted twice: first the `>` scan was
+/// unbounded, then it was bounded only by the payload start — which let a stray
+/// `<function=` BORROW the `>` from a later `<think>`, so
+/// `<function=<think>secret</think>[…]` consumed through the thought opener and
+/// emitted the model's private reasoning as visible text (`I3`).
+///
+/// The boundary is the earliest of: the payload start, and any competing control or
+/// reasoning marker. A header that has no `>` before that point is not a complete
+/// header — it is literal text the model happened to write.
+fn prefix_header_end(haystack: &str, at: usize, limit: Option<usize>, competing: &[&str]) -> usize {
+    let mut bound = limit
+        .filter(|&end| end > at)
+        .unwrap_or(haystack.len())
+        .min(haystack.len());
+    for m in competing.iter().copied() {
+        if let Some(rel) = haystack[at..bound]
+            .match_indices(m)
+            .map(|(rel, _)| rel)
+            .find(|&rel| rel > 0)
+        {
+            bound = at + rel;
+        }
+    }
+    bound
+}
+
+fn control_marker_at(
+    haystack: &str,
+    markers: &[String],
+    invoke_end: &str,
+    limit: Option<usize>,
+    competing: &[&str],
+    flush: bool,
+) -> Option<(usize, usize)> {
+    let competitors: Vec<&str> = competing
+        .iter()
+        .copied()
+        .chain(markers.iter().map(String::as_str))
+        .collect();
+    markers
+        .iter()
+        .filter_map(|m| {
+            let at = haystack.find(m.as_str())?;
+            control_marker_len_at(haystack, at, m, invoke_end, limit, &competitors, flush)
+                .map(|len| (at, len))
+        })
+        .min_by_key(|(at, _)| *at)
+}
+
+/// Length of `marker` when it owns syntax at the exact byte `at`.
+/// All guided syntax consumers use this owner so prefix-form completeness and
+/// its bounded terminator rule cannot differ between leading, reasoning, and
+/// post-payload paths.
+fn control_marker_len_at(
+    haystack: &str,
+    at: usize,
+    marker: &str,
+    invoke_end: &str,
+    limit: Option<usize>,
+    competing: &[&str],
+    flush: bool,
+) -> Option<usize> {
+    if !haystack[at..].starts_with(marker) {
+        return None;
+    }
+    if marker.ends_with('=') {
+        // BOTH searches stop at `limit`. Bounding only the `</function>`
+        // search let the `>` scan run into the payload: for
+        // `<function=[{"city": "a>b"}]` it consumed through the `>` INSIDE
+        // an argument string and emitted the tail `b"}}]` as text, losing
+        // the call; with no `>` anywhere the flush arm consumed the whole
+        // buffer and the turn produced nothing at all.
+        let bound = prefix_header_end(haystack, at, limit, competing);
+        match haystack[at..bound].find('>') {
+            // An invoke opener owns its terminator: stripping `<function=NAME>`
+            // and leaving `</function>` behind put that fragment in the shown
+            // thinking. Consume the pair when the tail is present; a BARE
+            // terminator elsewhere stays text, as it is natively.
+            Some(rel) => match haystack[at..bound].find(invoke_end) {
+                Some(end) => Some(end + invoke_end.len()),
+                // A complete prefix header is not necessarily a complete native
+                // invoke. Keep it with the streamed body until the terminator
+                // arrives; consuming only the header made a split immediately
+                // after `>` leak the parameter markup as visible text. A payload
+                // or competing marker is a known boundary and EOF cannot gain a
+                // terminator, so those cases retain the existing header-only
+                // recovery instead of swallowing the guided payload.
+                None if !flush && bound == haystack.len() => None,
+                None => Some(rel + 1),
+            },
+            // No `>` before the boundary: this is NOT a header, it is the
+            // literal marker text. Strip it alone so the payload behind it
+            // still parses (taking everything to EOF here swallowed the call),
+            // and strip it NOW when the boundary is already known — a competing
+            // marker or the payload is present, so more input cannot put a `>`
+            // in front of it. Waiting emitted `<function=` to the user as text
+            // and left it inside the thought (`I3`).
+            None if flush || bound < haystack.len() => Some(marker.len()),
+            None => None,
+        }
+    } else {
+        Some(marker.len())
+    }
+}
+
+/// Trailing bytes the guided drain must retain across a chunk boundary.
+///
+/// Two reasons to hold back, and missing either one loses the payload:
+/// a marker SPLIT across the boundary (`<tool_ca` | `ll>`), and a COMPLETE
+/// prefix-form marker still waiting for its terminator (`<function=` | `NAME>`).
+/// The second is not a partial marker, so the prefix scan does not see it, and it
+/// was flushed into the payload buffer where it broke the parse.
+fn guided_holdback_len(
+    input: &str,
+    reasoning_markers: &[&str],
+    control: &[String],
+    invoke_end: &str,
+    flush: bool,
+) -> usize {
+    if flush {
+        return 0;
+    }
+    let split = marker_prefix_suffix_len(
+        input,
+        reasoning_markers
+            .iter()
+            .copied()
+            .chain(control.iter().map(String::as_str)),
+    );
+    // A prefix-form marker counts as COMPLETE only when its `>` arrives before the
+    // payload does — the same rule `control_marker_at` uses, and it has to be the
+    // same or the two disagree about the identical bytes. It used to accept any `>`
+    // ANYWHERE after the marker, which a `>` inside an argument string satisfies:
+    // `<function=[{"city": "a > b"}]` was then neither consumed (no `>` before the
+    // payload) nor held back (a `>` exists somewhere), so the marker flushed into
+    // the payload buffer, the JSON failed to parse, and the user got the call as
+    // raw text with `<function=` still attached.
+    let payload_at = input.find(['{', '[']);
+    let competitors: Vec<&str> = reasoning_markers
+        .iter()
+        .copied()
+        .chain(control.iter().map(String::as_str))
+        .collect();
+    let pending_prefix_form = control
+        .iter()
+        .filter(|m| m.ends_with('='))
+        .filter_map(|m| input.rfind(m.as_str()).map(|at| (at, m.as_str())))
+        .filter(|(at, marker)| {
+            // SAME owner as `control_marker_at`: retain both an incomplete header
+            // and a complete header whose native invoke terminator has not arrived.
+            control_marker_len_at(
+                input,
+                *at,
+                marker,
+                invoke_end,
+                payload_at,
+                &competitors,
+                false,
+            )
+            .is_none()
+        })
+        .map(|(at, _)| input.len() - at)
+        .max()
+        .unwrap_or(0);
+    split.max(pending_prefix_form)
+}
+
+/// Whether a buffered guided run has opened a JSON value. Anything before the
+/// first `{`/`[` is prose, not payload.
+fn json_payload_started(buf: &str) -> bool {
+    matches!(buf.trim_start().as_bytes().first(), Some(b'{') | Some(b'['))
+}
+
+fn json_payload_kind(payload: &str) -> &'static str {
+    match serde_json::from_str::<serde_json::Value>(payload) {
+        Ok(serde_json::Value::Object(_)) => "object",
+        Ok(serde_json::Value::Array(_)) => "array",
+        Ok(serde_json::Value::String(_)) => "string",
+        Ok(serde_json::Value::Number(_)) => "number",
+        Ok(serde_json::Value::Bool(_)) => "boolean",
+        Ok(serde_json::Value::Null) => "null",
+        Err(_) => "invalid_json",
+    }
+}
+
+/// First control-syntax byte outside a JSON string after a payload has opened.
+/// Marker-looking text inside a string remains payload data, including when the
+/// JSON is malformed or truncated. Syntax outside a string is returned to the
+/// normal channel scanner instead of being trimmed by a tail-only implementation.
+fn guided_payload_syntax_boundary(
+    input: &str,
+    reasoning: ReasoningSpec,
+    control_markers: &[String],
+    invoke_end: &str,
+) -> Option<usize> {
+    let start = input.len() - input.trim_start().len();
+    if !matches!(input.as_bytes().get(start), Some(b'{') | Some(b'[')) {
+        return None;
+    }
+
+    let mut in_string = false;
+    let mut escaped = false;
+    let competitors: Vec<&str> = [reasoning.start, reasoning.end]
+        .into_iter()
+        .chain(control_markers.iter().map(String::as_str))
+        .collect();
+    for (relative, ch) in input[start..].char_indices() {
+        let at = start + relative;
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+            continue;
+        }
+        if at == start {
+            continue;
+        }
+        if input[at..].starts_with(reasoning.start)
+            || input[at..].starts_with(reasoning.end)
+            || input[at..].starts_with(invoke_end)
+            || control_markers.iter().any(|marker| {
+                control_marker_len_at(input, at, marker, invoke_end, None, &competitors, true)
+                    .is_some()
+            })
+        {
+            return Some(at);
+        }
+    }
+    None
+}
+
+impl GuidedState {
+    fn new(
+        reasoning: ReasoningSpec,
+        control_markers: Vec<String>,
+        invoke_end: String,
+        named_tool: Option<String>,
+        starting_state: UnifiedParserStartingState,
+        invalid_payload: InvalidGuidedPayloadPolicy,
+    ) -> Self {
+        Self {
+            stripped_markup: false,
+            reasoning,
+            control_markers,
+            invoke_end,
+            named_tool,
+            invalid_payload,
+            reasoning_enabled: starting_state != UnifiedParserStartingState::Response,
+            mode: Self::mode_for(starting_state),
+            accept_redundant_reasoning_start: starting_state
+                == UnifiedParserStartingState::Reasoning,
+            payload_emitted: false,
+            post_payload_text_started: false,
+            input: String::new(),
+            json: String::new(),
+        }
+    }
+
+    fn mode_for(starting_state: UnifiedParserStartingState) -> GuidedMode {
+        match starting_state {
+            UnifiedParserStartingState::None => GuidedMode::OutsideReasoning,
+            UnifiedParserStartingState::Reasoning => GuidedMode::Reasoning,
+            UnifiedParserStartingState::Response => GuidedMode::OutsideReasoning,
+        }
+    }
+
+    fn push_into(&mut self, chunk: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        if self.mode == GuidedMode::VisibleOnly {
+            self.json.push_str(chunk);
+        } else {
+            self.input.push_str(chunk);
+        }
+        for event in self.drain(false) {
+            output.push_event(event);
+        }
+        for event in self.emit_completed_json()? {
+            output.push_event(event);
+        }
+        if self.payload_emitted {
+            for event in self.drain(false) {
+                output.push_event(event);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<Vec<UnifiedParserEvent>> {
+        let mut output = self.drain(true);
+        output.extend(self.emit_completed_json()?);
+        if self.payload_emitted {
+            output.extend(self.drain(true));
+        } else {
+            if let Some(boundary) = guided_payload_syntax_boundary(
+                &self.json,
+                self.reasoning,
+                &self.control_markers,
+                &self.invoke_end,
+            ) {
+                let tail = self.json.split_off(boundary);
+                let payload_end = self.json.trim_end().len();
+                self.json.truncate(payload_end);
+                self.input.push_str(&tail);
+            }
+            output.extend(self.finish_json()?);
+            self.payload_emitted = true;
+            self.mode = GuidedMode::OutsideReasoning;
+            output.extend(self.drain(true));
+        }
+        Ok(output)
+    }
+
+    fn reset(&mut self, starting_state: UnifiedParserStartingState) -> String {
+        let mut recovered = std::mem::take(&mut self.json);
+        recovered.push_str(&std::mem::take(&mut self.input));
+        // Buffers alone are not the state. Leaving `mode` at VisibleOnly would make
+        // the NEXT stream treat its reasoning as JSON payload and surface it as text,
+        // so put the channel back where `new` would have started it.
+        self.mode = Self::mode_for(starting_state);
+        self.reasoning_enabled = starting_state != UnifiedParserStartingState::Response;
+        self.accept_redundant_reasoning_start =
+            starting_state == UnifiedParserStartingState::Reasoning;
+        self.stripped_markup = false;
+        self.payload_emitted = false;
+        self.post_payload_text_started = false;
+        recovered
+    }
+
+    /// Emit a complete JSON value as soon as the closing byte arrives. The
+    /// stream decoder gives us the exact end of the first value, so bytes after
+    /// it go back through the channel/control scanner rather than being mistaken
+    /// for JSON or stripped by a separate tail-only marker implementation.
+    fn emit_completed_json(&mut self) -> Result<Vec<UnifiedParserEvent>> {
+        if self.payload_emitted || !json_payload_started(&self.json) {
+            return Ok(Vec::new());
+        }
+
+        let leading = self.json.len() - self.json.trim_start().len();
+        let mut values = serde_json::Deserializer::from_str(&self.json[leading..])
+            .into_iter::<serde_json::Value>();
+        let Some(Ok(_)) = values.next() else {
+            return Ok(Vec::new());
+        };
+        let value_end = leading + values.byte_offset();
+        drop(values);
+        let whitespace_end = value_end
+            + self.json[value_end..]
+                .find(|ch: char| !ch.is_whitespace())
+                .unwrap_or(self.json.len() - value_end);
+        let syntax_at = guided_payload_syntax_boundary(
+            &self.json,
+            self.reasoning,
+            &self.control_markers,
+            &self.invoke_end,
+        );
+        let (payload_end, tail_start) = if syntax_at == Some(whitespace_end) {
+            // Whitespace separating the value from control syntax belongs to
+            // neither output; the old tail recovery trimmed it with the marker.
+            (value_end, whitespace_end)
+        } else {
+            (value_end, value_end)
+        };
+        let uncommitted_suffix = self.json[payload_end..].to_string();
+        let tail = self.json[tail_start..].to_string();
+        self.json.truncate(payload_end);
+        let mut output = match self.finish_json() {
+            Ok(output) => output,
+            Err(error) => {
+                self.json.push_str(&uncommitted_suffix);
+                return Err(error);
+            }
+        };
+        self.payload_emitted = true;
+        self.mode = GuidedMode::OutsideReasoning;
+        self.input.push_str(&tail);
+        Ok(std::mem::take(&mut output))
+    }
+
+    /// Strip the reasoning markers wrapping the JSON payload. Once visible
+    /// output starts every later byte is JSON data, so native-looking strings
+    /// inside argument values stay literal.
+    fn drain(&mut self, flush: bool) -> Vec<UnifiedParserEvent> {
+        let (start, end) = (self.reasoning.start, self.reasoning.end);
+        let mut output = Vec::new();
+
+        loop {
+            match self.mode {
+                GuidedMode::VisibleOnly => {
+                    self.json.push_str(&self.input);
+                    self.input.clear();
+                    break;
+                }
+                GuidedMode::OutsideReasoning => {
+                    // PAYLOAD FIRST. Once the run has opened a JSON value we are inside
+                    // the payload, and a `<think>` from there on is ARGUMENT DATA, not a
+                    // channel marker (`I7`). Searching for the opener before this check
+                    // meant a whole-input push found the `<think>` embedded in an
+                    // argument string, split the payload into text/reasoning/text and
+                    // dropped the call — while the same bytes arriving in small chunks
+                    // latched here first and parsed correctly. Same input, two answers,
+                    // decided by chunking (`I6`).
+                    if !self.payload_emitted
+                        && (json_payload_started(&self.json)
+                            || (self.json.trim().is_empty() && json_payload_started(&self.input)))
+                    {
+                        self.mode = GuidedMode::VisibleOnly;
+                        continue;
+                    }
+
+                    // A reasoning opener ANYWHERE ahead means the thought has not
+                    // started yet and whatever precedes it is ordinary visible text —
+                    // not the beginning of the JSON payload. Requiring a
+                    // whitespace-only prefix here meant a turn that said anything
+                    // before it began thinking (`content_then_reason`, the shape
+                    // `UNIFIED.11.f`/`11.g` pin natively) fell through to the payload
+                    // buffer, latched VisibleOnly, and then surfaced the markers AND
+                    // the model's private thinking to the user as the answer, with the
+                    // call never emitted.
+                    // Whichever marker comes FIRST wins — position is the ONLY
+                    // precedence rule. Deciding by which branch was written first is
+                    // what let an orphan closer ahead of a real thought ride out as
+                    // text, and an opener beside a stripped closer survive into the
+                    // payload. One set from the scanner covers both lookup and the
+                    // holdback below, so the two cannot drift apart again.
+                    let open_at = self
+                        .reasoning_enabled
+                        .then(|| self.input.find(start))
+                        .flatten();
+                    let stray_close = control_marker_at(
+                        &self.input,
+                        &self.control_markers,
+                        &self.invoke_end,
+                        // Nor past the start of the payload itself.
+                        self.input.find(['{', '[']),
+                        // A thought marker ahead also ends the header: a stray
+                        // `<function=` must not borrow the `>` from `<think>` and
+                        // swallow the thought — that put private reasoning in the
+                        // user's answer.
+                        &[start, end],
+                        flush,
+                    )
+                    .into_iter()
+                    .chain(
+                        self.reasoning_enabled
+                            .then(|| self.input.find(end).map(|at| (at, end.len())))
+                            .flatten(),
+                    )
+                    .min_by_key(|(at, _)| *at);
+                    let close_at = stray_close.map(|(at, _)| at);
+                    let close_len = stray_close.map(|(_, l)| l).unwrap_or(end.len());
+                    let closer_first = matches!((open_at, close_at), (Some(o), Some(c)) if c < o)
+                        || (open_at.is_none() && close_at.is_some());
+
+                    if !closer_first && let Some(at) = open_at {
+                        // Whatever was buffered as "payload so far", plus this prefix,
+                        // was visible text after all — a thought is opening behind it.
+                        let mut pending = std::mem::take(&mut self.json);
+                        pending.push_str(&self.input[..at]);
+                        if pending.trim().is_empty() {
+                            if !self.payload_emitted {
+                                self.json = pending;
+                            }
+                        } else {
+                            push_run(&mut output, Kind::Text, &pending);
+                            if self.payload_emitted {
+                                self.post_payload_text_started = true;
+                            }
+                        }
+                        self.input.drain(..at + start.len());
+                        self.mode = GuidedMode::Reasoning;
+                        self.accept_redundant_reasoning_start = false;
+                        continue;
+                    }
+
+                    // An orphan closer with no opener before it is malformed markup,
+                    // stripped wherever it appears — the same rule the native scanner's
+                    // orphan handler applies. Decide on the COMBINATION of what is
+                    // already buffered and this prefix, as the opener branch does:
+                    // judging the current prefix alone left prose buffered by an
+                    // EARLIER chunk glued to the JSON that followed, losing the call.
+                    if let Some(at) = close_at {
+                        let mut pending = std::mem::take(&mut self.json);
+                        pending.push_str(&self.input[..at]);
+                        if pending.trim().is_empty() {
+                            if !self.payload_emitted {
+                                self.json = pending;
+                            }
+                        } else {
+                            push_run(&mut output, Kind::Text, &pending);
+                            if self.payload_emitted {
+                                self.post_payload_text_started = true;
+                            }
+                        }
+                        self.stripped_markup = true;
+                        self.input.drain(..at + close_len);
+                        continue;
+                    }
+
+                    let keep = if flush {
+                        0
+                    } else {
+                        // Same set as the lookup above, plus a complete prefix-form
+                        // marker awaiting its `>`. This was `[start, end]` only, so a
+                        // control marker split across a boundary went into the payload
+                        // and was lost exactly like a whole one.
+                        let reasoning_markers = if self.reasoning_enabled {
+                            &[start, end][..]
+                        } else {
+                            &[]
+                        };
+                        guided_holdback_len(
+                            &self.input,
+                            reasoning_markers,
+                            &self.control_markers,
+                            &self.invoke_end,
+                            flush,
+                        )
+                    };
+                    let visible_len = self.input.len().saturating_sub(keep);
+                    if visible_len > 0 {
+                        if self.payload_emitted
+                            && !self.post_payload_text_started
+                            && self.input[..visible_len].trim().is_empty()
+                        {
+                            if !flush {
+                                break;
+                            }
+                            if self.named_tool.is_some() {
+                                output.push(UnifiedParserEvent::ToolCall(ToolCallDelta {
+                                    tool_index: 0,
+                                    name: None,
+                                    arguments: self.input[..visible_len].to_string(),
+                                }));
+                            }
+                        } else if self.payload_emitted {
+                            push_run(&mut output, Kind::Text, &self.input[..visible_len]);
+                            self.post_payload_text_started = true;
+                        } else {
+                            self.json.push_str(&self.input[..visible_len]);
+                        }
+                        self.input.drain(..visible_len);
+                        // Latch onto the payload only once it actually LOOKS like
+                        // one. Guided decoding constrains the call to bare JSON, so a
+                        // run that has not opened a value is prose, and a thought may
+                        // still follow it in a later chunk. Latching on any
+                        // non-whitespace byte is what let prose arriving in its own
+                        // chunk swallow the thought that came after it.
+                        if json_payload_started(&self.json) {
+                            self.mode = GuidedMode::VisibleOnly;
+                            continue;
+                        }
+                    }
+                    if flush && !self.input.is_empty() {
+                        if self.payload_emitted {
+                            push_run(&mut output, Kind::Text, &self.input);
+                            self.post_payload_text_started = true;
+                        } else {
+                            self.json.push_str(&self.input);
+                        }
+                        self.input.clear();
+                    }
+                    break;
+                }
+                GuidedMode::Reasoning => {
+                    if self.accept_redundant_reasoning_start {
+                        let non_whitespace = self.input.trim_start();
+                        let leading = self.input.len() - non_whitespace.len();
+                        if non_whitespace.starts_with(start) {
+                            push_run(&mut output, Kind::Reasoning, &self.input[..leading]);
+                            self.input.drain(..leading + start.len());
+                            self.accept_redundant_reasoning_start = false;
+                            continue;
+                        }
+                        if !flush && start.starts_with(non_whitespace) {
+                            push_run(&mut output, Kind::Reasoning, &self.input[..leading]);
+                            self.input.drain(..leading);
+                            break;
+                        }
+                        self.accept_redundant_reasoning_start = false;
+                    }
+
+                    // The closer ends the span; anything else in the stray set is
+                    // malformed markup to strip, exactly as the native scanner does
+                    // (the native path's `stray_in_reasoning`, which this deliberately
+                    // does NOT share — see its doc). Guided decoding constrains the TOOL
+                    // payload, not the reasoning channel, so the model can still
+                    // emit a duplicate opener or a stray tool close inside a thought
+                    // — and being inside a thought must not turn markup into content
+                    // (`I3`). Taking whichever lands first keeps the two request
+                    // modes byte-identical on the same reasoning bytes.
+                    // Three ways an open thought can end, in the same precedence the
+                    // native scanner uses: its own closer; a TOOL OPENER, which
+                    // terminates the span without being consumed because tool
+                    // structure dominates reasoning; or a stray, which is stripped
+                    // and leaves the span open.
+                    let close = self.input.find(end).map(|at| (at, end.len(), true));
+                    // Under guided decoding the reasoning channel is UNCONSTRAINED, so
+                    // the model can legitimately narrate `<tool_call>` while thinking —
+                    // and the real call arrives later as JSON, not as markup. So a tool
+                    // opener here is STRAY markup to strip (span stays open), not
+                    // structure that ends the turn. Terminating on it discarded the
+                    // guided payload that followed and returned an empty response.
+                    // The native scanner does treat it as structural, but it can: it
+                    // opens a block and recovers the call from the markup itself.
+                    let stray = control_marker_at(
+                        &self.input,
+                        &self.control_markers,
+                        &self.invoke_end,
+                        // A narrated invoke lives INSIDE this thought, so its
+                        // terminator cannot be past the span's closer.
+                        self.input.find(end),
+                        &[end],
+                        flush,
+                    )
+                    .into_iter()
+                    .chain(self.input.find(start).map(|at| (at, start.len())))
+                    .min_by_key(|(at, _)| *at)
+                    .map(|(at, len)| (at, len, false));
+                    if let Some((at, consume, closes)) = [close, stray]
+                        .into_iter()
+                        .flatten()
+                        .min_by_key(|(at, _, _)| *at)
+                    {
+                        push_run(&mut output, Kind::Reasoning, &self.input[..at]);
+                        self.stripped_markup = true;
+                        self.input.drain(..at + consume);
+                        if closes {
+                            // Back to OutsideReasoning, NOT straight to VisibleOnly. The
+                            // old latch was justified by keeping marker-like bytes inside
+                            // a started payload literal, but the payload-first check at
+                            // the top of that scope now owns that. Latching here instead
+                            // meant markup AFTER a thought — `<think>x</think><tool_call>{…}`
+                            // — was never examined, so the opener rode into the payload
+                            // and the call was lost. This also handles several thoughts.
+                            self.mode = GuidedMode::OutsideReasoning;
+                        } else {
+                            tracing::debug!(
+                                why = "guided_stray_marker_in_reasoning",
+                                "stream stripped malformed markup inside a reasoning span"
+                            );
+                        }
+                        continue;
+                    }
+
+                    let keep = if flush {
+                        0
+                    } else {
+                        guided_holdback_len(
+                            &self.input,
+                            &[start, end],
+                            &self.control_markers,
+                            &self.invoke_end,
+                            flush,
+                        )
+                    };
+                    let reasoning_len = self.input.len().saturating_sub(keep);
+                    if reasoning_len > 0 {
+                        push_run(&mut output, Kind::Reasoning, &self.input[..reasoning_len]);
+                        self.input.drain(..reasoning_len);
+                    }
+                    break;
+                }
+            }
+        }
+        output
+    }
+
+    /// Parse the accumulated payload. Anything that does not parse as the
+    /// expected call shape is surfaced as visible text rather than dropped
+    /// (policy P2 — best-effort recovery, never silent loss).
+    fn finish_json(&mut self) -> Result<Vec<UnifiedParserEvent>> {
+        let payload = self.json.trim();
+        if payload.is_empty() {
+            if self.invalid_payload == InvalidGuidedPayloadPolicy::Reject {
+                return Err(InvalidGuidedPayload {
+                    kind: InvalidGuidedPayloadKind::Missing,
+                    choice: if self.named_tool.is_some() {
+                        "named"
+                    } else {
+                        "required"
+                    },
+                }
+                .into());
+            }
+            // The turn produced ONLY control markup — everything was stripped and
+            // there is nothing left to parse. Emitting no events is right (markup is
+            // not an answer), but doing it silently is not: the caller cannot tell
+            // this from a model that legitimately said nothing, and the usual cause
+            // is a backend configured for guided decoding against a model still
+            // emitting its native call grammar. P2 is best-effort recovery, NOT
+            // silent loss, and the sibling not-a-tool-call path is instrumented for
+            // exactly this reason — so this one is too.
+            if self.stripped_markup {
+                tracing::warn!(
+                    why = "unified_guided_output_was_only_markup",
+                    choice = if self.named_tool.is_some() {
+                        "named"
+                    } else {
+                        "required"
+                    },
+                    named_tool = self.named_tool.as_deref().unwrap_or("-"),
+                    stripped_markup = true,
+                    "guided output contained no JSON payload, only control markup; \
+                     emitting nothing (is the backend's guided decoding actually on?)"
+                );
+            }
+            self.json.clear();
+            return Ok(Vec::new());
+        }
+
+        let raw_payload = self.json.clone();
+        let calls = match &self.named_tool {
+            // A named choice constrains output to that tool's ARGUMENTS alone,
+            // so the payload is the argument object and the name is known.
+            // Arguments are an OBJECT. A bare string / number / null / array is
+            // syntactically valid JSON but is not an argument set, and EMITTING it
+            // would hand the tool a shape it cannot bind — surface it as text instead.
+            Some(name) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
+                payload,
+            )
+            .ok()
+            .map(|obj| {
+                // The payload IS this tool's argument object — forward it verbatim.
+                //
+                // An earlier revision unwrapped a `{"name", "arguments"}` shape here to
+                // tolerate a backend that emits the whole call envelope despite
+                // `tool_choice` already naming the tool. That heuristic is unsound: the
+                // shape is not exclusive to envelopes, and a tool like
+                // `register_handler({"name": …, "parameters": …})` produces it. It broke
+                // BOTH ways — a non-matching inner name voided a legitimate forced call
+                // entirely, and a matching one forwarded only the inner value as the
+                // argument set. Guided decoding is schema-constrained by the backend, so
+                // the payload is trusted; a wrapping backend is out of spec and gets a
+                // warning rather than a guess.
+                if obj.contains_key("name")
+                    && (obj.contains_key("arguments") || obj.contains_key("parameters"))
+                {
+                    tracing::warn!(
+                        why = "guided_named_payload_looks_like_an_envelope",
+                        named_tool = %name,
+                        "named-choice payload carries `name` plus `arguments`/`parameters`; forwarding it verbatim as the argument set"
+                    );
+                }
+                vec![(name.clone(), raw_payload.clone())]
+            }),
+            None => parse_required_guided_calls(payload),
+        };
+
+        let Some(calls) = calls.filter(|calls| !calls.is_empty()) else {
+            if self.invalid_payload == InvalidGuidedPayloadPolicy::Reject {
+                return Err(InvalidGuidedPayload {
+                    kind: if serde_json::from_str::<serde_json::Value>(payload).is_ok() {
+                        InvalidGuidedPayloadKind::WrongShape
+                    } else {
+                        InvalidGuidedPayloadKind::InvalidJson
+                    },
+                    choice: if self.named_tool.is_some() {
+                        "named"
+                    } else {
+                        "required"
+                    },
+                }
+                .into());
+            }
+            // Best-effort (P2): guided decoding promised a tool call and did not
+            // deliver one, so the payload goes out as visible text rather than being
+            // dropped. That recovery is NOT silent — to a caller the result is
+            // indistinguishable from a model that simply chose to answer in prose,
+            // so without this the backend's guided-decoding failure never surfaces.
+            tracing::warn!(
+                why = "unified_guided_json_not_a_tool_call",
+                choice = if self.named_tool.is_some() {
+                    "named"
+                } else {
+                    "required"
+                },
+                named_tool = self.named_tool.as_deref().unwrap_or("-"),
+                payload_bytes = payload.len(),
+                payload_kind = json_payload_kind(payload),
+                "guided output did not parse as a tool call; emitting it as text"
+            );
+            // The SAME bytes the parse was given, not the raw buffer. Trailing
+            // control markup was stripped above precisely because it is markup, and
+            // handing it back here would put `</tool_call>` in the user's visible
+            // answer — a marker leak (`I3`) on the one path that exists to recover
+            // gracefully. `raw_payload` is already the tail-trimmed value, and it
+            // stays byte-identical to the buffer when nothing was stripped (`I7`).
+            self.json.clear();
+            return Ok(vec![UnifiedParserEvent::Text(raw_payload)]);
+        };
+
+        self.json.clear();
+        Ok(calls
+            .into_iter()
+            .enumerate()
+            .map(|(tool_index, (name, arguments))| {
+                UnifiedParserEvent::ToolCall(ToolCallDelta {
+                    tool_index,
+                    name: Some(name),
+                    arguments,
+                })
+            })
+            .collect())
+    }
+}
+
+/// A required (un-named) choice emits one call object or an array of them.
+fn parse_required_guided_calls(payload: &str) -> Option<Vec<(String, String)>> {
+    fn convert(call: GuidedToolCall) -> Option<(String, String)> {
+        // No argument key means NO ARGUMENTS, not a malformed call. `UNIFIED.6.a`
+        // already fixes that semantic on the native path — same tool, no parameter
+        // block, golden `arguments: {}` — so voiding it here made guided disagree with
+        // native on an identical shape and made a parameterless tool uncallable. What
+        // makes an element invalid is a missing `name` (required on GuidedToolCall);
+        // that still voids the whole array, per `31.c` / `51.b`.
+        let arguments = match (call.parameters, call.arguments) {
+            // PRESENT but not an object is a malformed call, the same judgement the
+            // NAMED path makes on its whole payload: arguments that are a string or
+            // a number cannot bind to the tool's parameters, so emitting it would
+            // hand the tool a shape it cannot use. Absent is different — that means
+            // no arguments, and stays valid (see the note above).
+            (Some(raw), None) | (None, Some(raw)) => {
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get())
+                    .ok()?;
+                raw.get().to_string()
+            }
+            (None, None) => "{}".to_string(),
+            // The aliases are alternatives, not two independently meaningful
+            // argument sets. Choosing one silently can emit different bytes from
+            // what the backend intended, so reject the ambiguous call fail-closed.
+            (Some(_), Some(_)) => return None,
+        };
+        Some((call.name, arguments))
+    }
+
+    if let Ok(raw_calls) = serde_json::from_str::<Vec<Box<serde_json::value::RawValue>>>(payload) {
+        return raw_calls
+            .into_iter()
+            .map(|raw| {
+                serde_json::from_str::<GuidedToolCall>(raw.get())
+                    .ok()
+                    .and_then(convert)
+            })
+            .collect();
+    }
+
+    serde_json::from_str::<GuidedToolCall>(payload)
+        .ok()
+        .and_then(convert)
+        .map(|call| vec![call])
 }
 
 /// How a vendor supplies a parser: given the request's tools, build one parser for
@@ -673,6 +1930,13 @@ macro_rules! unified_registry {
                     source = "vendor",
                     "v2 UNIFIED parser active"
                 );
+                if crate::tool_calling::debug::debug_enabled() {
+                    // Owned, NOT leaked. Construction is per REQUEST, so `Box::leak`
+                    // here grew the process without bound for as long as debug mode
+                    // stayed on -- the diagnostic aid became the fault. `DebugToolParser`
+                    // already stores an owned `String`; this now matches it.
+                    return Ok(DebugUnifiedParser::wrap(key, parser));
+                }
                 return Ok(parser);
             }
 
@@ -702,6 +1966,11 @@ macro_rules! unified_registry {
                 "v2 UNIFIED parser active"
             );
 
+            // Optional stderr instrumentation, same contract as the tool-only
+            // registry: a host WITHOUT a tracing subscriber can still confirm it.
+            if crate::tool_calling::debug::debug_enabled() {
+                return Ok(DebugUnifiedParser::wrap(canonical, parser));
+            }
             Ok(parser)
         }
     };
@@ -709,6 +1978,108 @@ macro_rules! unified_registry {
 
 unified_registry! {
     "qwen3" | "qwen3_coder" => qwen3::qwen3_unified,
+}
+
+/// Stderr instrumentation for the unified path under `DYNAMO_PARSERS_DEBUG`.
+///
+/// The tool-only registry has wrapped its parsers since audit B9 so a host can
+/// confirm a Dynamo parser was selected and is parsing. The unified registry did
+/// not, so setting the flag and seeing nothing was indistinguishable from the
+/// parser never being reached — the exact question the flag is turned on to
+/// answer. This mirrors `DebugToolParser`: announce at construction, report the
+/// resolved request mode at initialize, and report each batch of updates.
+struct DebugUnifiedParser {
+    family: String,
+    inner: Box<dyn UnifiedParser>,
+}
+
+impl DebugUnifiedParser {
+    fn wrap(family: impl Into<String>, inner: Box<dyn UnifiedParser>) -> Box<dyn UnifiedParser> {
+        let family = family.into();
+        crate::tool_calling::debug::emit(format_args!("UNIFIED family={family} created"));
+        Box::new(Self { family, inner })
+    }
+
+    fn log(&self, method: &str, deltas: &[UnifiedParserEvent]) {
+        if deltas.is_empty() {
+            return;
+        }
+        let calls = deltas
+            .iter()
+            .filter_map(|d| match d {
+                UnifiedParserEvent::ToolCall(c) => Some(c.name.as_deref().unwrap_or("…")),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        crate::tool_calling::debug::emit(format_args!(
+            "UNIFIED family={} {} emitted {} delta(s) calls={:?}",
+            self.family,
+            method,
+            deltas.len(),
+            calls
+        ));
+    }
+}
+
+impl UnifiedParser for DebugUnifiedParser {
+    fn initialize_request(&mut self, init: UnifiedParserInit) -> Result<()> {
+        let mode = match &init.tool_output_mode {
+            UnifiedToolOutputMode::Native => "native".to_string(),
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some(n),
+            } => {
+                format!("guided_json(named={n})")
+            }
+            UnifiedToolOutputMode::GuidedJson { named_tool: None } => {
+                "guided_json(required)".to_string()
+            }
+        };
+        crate::tool_calling::debug::emit(format_args!(
+            "UNIFIED family={} initialize prompt_token_ids_len={} starting_state={:?} tool_output_mode={} invalid_guided_payload={:?}",
+            self.family,
+            init.prompt_token_ids.len(),
+            init.starting_state,
+            mode,
+            init.invalid_guided_payload,
+        ));
+        self.inner.initialize_request(init)
+    }
+
+    /// Logs only what THIS advance committed, so the debug trace still reads one
+    /// line per advance even though the caller's buffer may already hold earlier
+    /// events.
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        let mut mine = UnifiedParserOutput::default();
+        let r = self.inner.parse_into(delta, &mut mine);
+        self.log("push", &mine.events);
+        output.append(&mut mine);
+        r
+    }
+
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        let out = self.inner.finish()?;
+        self.log("finish", &out.events);
+        Ok(out)
+    }
+
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+
+    // Everything below forwards to the wrapped parser. These have trait defaults,
+    // so NOT forwarding them would silently swap a family's override for the
+    // default the moment debug logging is switched on — the decode would differ
+    // between a debug run and the run it is meant to explain. `DebugToolParser`
+    // forwards its equivalents for the same reason. No family overrides these
+    // today, which is exactly why the gap has to close before one does.
+
+    fn preserve_special_tokens(&self) -> bool {
+        self.inner.preserve_special_tokens()
+    }
+
+    fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+        self.inner.tool_call_id(tool_index)
+    }
 }
 
 #[cfg(test)]
@@ -724,12 +2095,132 @@ mod tests {
     }
 
     #[test]
+    fn guided_payload_boundary_accepts_multibyte_trailing_text() {
+        let reasoning = ReasoningSpec {
+            start: "<think>",
+            end: "</think>",
+            forced_start: false,
+            preserve_special_tokens: false,
+        };
+
+        assert_eq!(
+            guided_payload_syntax_boundary(
+                "[{\"name\":\"f\",\"arguments\":{}}]é",
+                reasoning,
+                &[],
+                "</function>",
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn registered_families_all_create() {
         for family in REGISTERED_UNIFIED_FAMILIES {
             create_unified_parser_for_family(family, &[]).unwrap_or_else(|e| {
                 panic!("REGISTERED_UNIFIED_FAMILIES entry '{family}' does not create: {e}")
             });
         }
+    }
+
+    #[test]
+    fn guided_reset_restores_all_request_scoped_flags() {
+        let mut guided = GuidedState::new(
+            ReasoningSpec {
+                start: "<think>",
+                end: "</think>",
+                forced_start: false,
+                preserve_special_tokens: false,
+            },
+            vec!["<tool_call>".into(), "</tool_call>".into()],
+            "</function>".into(),
+            None,
+            UnifiedParserStartingState::None,
+            InvalidGuidedPayloadPolicy::RecoverAsText,
+        );
+        guided
+            .push_into("</tool_call>", &mut UnifiedParserOutput::default())
+            .unwrap();
+        assert!(guided.stripped_markup, "fixture did not mutate the flag");
+        guided.payload_emitted = true;
+
+        guided.reset(UnifiedParserStartingState::None);
+
+        assert!(!guided.stripped_markup);
+        assert!(!guided.payload_emitted);
+        assert_eq!(guided.mode, GuidedMode::OutsideReasoning);
+        assert!(guided.input.is_empty());
+        assert!(guided.json.is_empty());
+    }
+
+    /// The returning and appending spellings are one implementation, so they
+    /// cannot disagree — but only a test says so. Without this, `parse_into`
+    /// could be re-implemented later and silently drift from `push`, which is
+    /// the divergent-copy failure this crate keeps hitting.
+    #[test]
+    fn parse_into_and_push_agree_chunk_for_chunk() {
+        let chunks = [
+            "<think>weigh it</think>ok ",
+            "<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n",
+            "</function>\n</tool_call>done",
+        ];
+
+        let mut pushed = Vec::new();
+        let mut a = create_unified_parser_for_family("qwen3", &[]).unwrap();
+        for c in chunks {
+            pushed.extend(a.push(c).unwrap());
+        }
+        pushed.extend(a.finish().unwrap().events);
+
+        let mut appended = UnifiedParserOutput::default();
+        let mut b = create_unified_parser_for_family("qwen3", &[]).unwrap();
+        for c in chunks {
+            b.parse_into(c, &mut appended).unwrap();
+        }
+        appended.append(&mut b.finish().unwrap());
+
+        assert_eq!(
+            pushed, appended.events,
+            "parse_into must commit exactly what push returns, in the same order"
+        );
+        assert_eq!(assemble(&pushed), appended.assembled());
+        assert!(
+            pushed
+                .iter()
+                .any(|d| matches!(d, UnifiedParserEvent::ToolCall(_))),
+            "fixture should produce a call, otherwise this asserts nothing"
+        );
+    }
+
+    /// The batch path must be able to emit the model's argument bytes, not a
+    /// re-serialization of them. Without this, a non-streaming turn rewrites
+    /// `{"city": "Tokyo"}` to `{"city":"Tokyo"}` while the streaming path (which
+    /// forwards `ToolCallDelta.arguments`) does not — the two disagree on
+    /// identical input, which is an `I6`/`I7` break on the batch path alone.
+    #[test]
+    fn raw_arguments_survive_assembly_verbatim() {
+        let spaced = r#"{"city": "Tokyo",  "unit": "c"}"#;
+        let deltas = vec![
+            UnifiedParserEvent::Text("ok".into()),
+            call(0, Some("get_weather"), &spaced[..14]),
+            call(0, None, &spaced[14..]),
+        ];
+
+        let raw = tool_arguments_raw(&deltas);
+        assert_eq!(
+            raw.get(&0).map(String::as_str),
+            Some(spaced),
+            "fragments must rejoin byte-for-byte"
+        );
+
+        // The assembled view still parses, so semantic consumers are unchanged.
+        let events = assemble(&deltas);
+        let UnifiedEvent::ToolCall { arguments, .. } = &events[1] else {
+            panic!("expected a tool call at position 1, got {events:?}")
+        };
+        assert_eq!(arguments["city"], "Tokyo");
+        // …and the re-serialization is genuinely lossy, which is why raw is needed.
+        assert_ne!(serde_json::to_string(arguments).unwrap(), spaced);
     }
 
     #[test]
@@ -808,6 +2299,39 @@ mod tests {
         ]);
         assert_eq!(result.normal_text, "ab");
         assert_eq!(result.calls.len(), 1);
+    }
+
+    #[test]
+    fn debug_wrapper_preserves_capabilities_and_guided_deltas() {
+        let mut plain = qwen3::qwen3_unified(&[]);
+        let mut debug = DebugUnifiedParser::wrap("qwen3", qwen3::qwen3_unified(&[]));
+
+        assert_eq!(
+            plain.preserve_special_tokens(),
+            debug.preserve_special_tokens()
+        );
+        assert_eq!(plain.tool_call_id(0), debug.tool_call_id(0));
+
+        for parser in [&mut plain, &mut debug] {
+            parser
+                .initialize_request(UnifiedParserInit {
+                    tool_output_mode: UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                    invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+                    ..UnifiedParserInit::default()
+                })
+                .unwrap();
+        }
+        for chunk in [
+            "<think>checking</think>",
+            r#"[{"name":"get_weather","arguments":{"city":"Paris"}}]"#,
+        ] {
+            assert_eq!(plain.push(chunk).unwrap(), debug.push(chunk).unwrap());
+        }
+        assert_eq!(
+            plain.finish().unwrap().events,
+            debug.finish().unwrap().events
+        );
+        assert_eq!(plain.reset(), debug.reset());
     }
 
     #[test]
@@ -905,9 +2429,7 @@ mod parse_into_recovery_tests {
     use crate::tool_calling::scan::test_support::{FailOnBoom, failing_scanner};
 
     fn parser() -> ScannerUnified<FailOnBoom> {
-        ScannerUnified {
-            scanner: failing_scanner(),
-        }
+        ScannerUnified::new(failing_scanner())
     }
 
     fn call(index: usize) -> UnifiedParserEvent {
@@ -933,7 +2455,10 @@ mod parse_into_recovery_tests {
             vec![UnifiedParserEvent::Text("prefix".to_string())],
             "text committed before the failure belongs to the caller"
         );
-        assert_eq!(p.reset(), "<function=boom></function></tool_call>suffix");
+        assert_eq!(
+            p.reset(),
+            "<tool_call><function=boom></function></tool_call>suffix"
+        );
     }
 
     /// A failure on a LATER wrapped invoke: the call that already succeeded survives too.
@@ -1045,5 +2570,137 @@ mod construction_parity_tests {
             pushed(),
             "`append` must apply the same merge rule as the push helpers"
         );
+    }
+}
+
+#[cfg(test)]
+mod debug_marker_tests {
+    use crate::tool_calling::debug::{DEBUG_ENV, is_truthy};
+
+    /// The values `DYNAMO_PARSERS_DEBUG` must accept.
+    ///
+    /// Born from a real miss: the flag was set, the unified parser demonstrably
+    /// ran, and no marker appeared — so an operator (and the author) concluded
+    /// the parser was never reached. It cost hours.
+    ///
+    /// This asserts the PURE predicate, not `debug_enabled()`. That wrapper
+    /// caches in a `OnceLock`, so a test that sets the env and calls it only
+    /// passes when it happens to run before anything else touches the lock —
+    /// which is exactly how the first version of this test passed locally and
+    /// failed in CI. A global latch is not testable in-process; the parsing
+    /// rule it depends on is.
+    #[test]
+    fn debug_env_accepts_the_documented_truthy_values() {
+        assert_eq!(DEBUG_ENV, "DYNAMO_PARSERS_DEBUG");
+        for v in ["1", "true", "TRUE", "on", "yes", "Yes"] {
+            assert!(is_truthy(v), "{v:?} should enable debug output");
+        }
+        for v in ["0", "false", "off", "no", "", "maybe"] {
+            assert!(!is_truthy(v), "{v:?} must NOT enable debug output");
+        }
+    }
+}
+
+/// Initialization must REJECT what it cannot represent, and a rejection must leave
+/// the parser untouched.
+///
+/// These live here, not in an integration test, because they need a scanner built
+/// WITHOUT `.with_reasoning(..)` — a shape no registered family has today, so it is
+/// unreachable through the public registry. An earlier version of this test used
+/// the built-in `qwen3`, which always installs a reasoning spec: it asserted that
+/// `Reasoning` SUCCEEDS and so could never have caught the defect it was named for.
+#[cfg(test)]
+mod initialize_preflight_tests {
+    use super::*;
+
+    fn init(
+        starting_state: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+    ) -> UnifiedParserInit {
+        UnifiedParserInit {
+            starting_state,
+            tool_output_mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+            ..UnifiedParserInit::default()
+        }
+    }
+
+    /// The REAL qwen3 scanner, built WITHOUT `.with_reasoning(..)`.
+    ///
+    /// Same plumbing every family uses; the single difference is the missing
+    /// reasoning channel, which is precisely the condition under test.
+    fn reasoningless()
+    -> ScannerUnified<impl crate::tool_calling::scan::InvokeEmitter + Send + 'static> {
+        ScannerUnified::new(crate::tool_calling::qwen3_coder::qwen3_scanner(&[]))
+    }
+
+    #[test]
+    fn explicit_reasoning_is_rejected_when_the_family_has_no_reasoning_channel() {
+        let mut p = reasoningless();
+        let err = p
+            .initialize_request(init(
+                UnifiedParserStartingState::Reasoning,
+                UnifiedToolOutputMode::Native,
+            ))
+            .expect_err("Reasoning must be rejected: there is no channel to continue");
+        assert!(err.to_string().contains("no reasoning channel"), "{err}");
+    }
+
+    #[test]
+    fn neutral_and_response_starts_remain_accepted_without_a_reasoning_channel() {
+        for state in [
+            UnifiedParserStartingState::None,
+            UnifiedParserStartingState::Response,
+        ] {
+            let mut p = reasoningless();
+            assert!(
+                p.initialize_request(init(state, UnifiedToolOutputMode::Native))
+                    .is_ok(),
+                "{state:?} must stay accepted; only an EXPLICIT Reasoning demand fails"
+            );
+        }
+    }
+
+    /// A rejected initialization must not have mutated anything. Otherwise a caller
+    /// that catches the error and retries in a supported mode builds on half-applied
+    /// state.
+    #[test]
+    fn a_rejected_initialization_leaves_the_parser_reusable() {
+        let mut p = reasoningless();
+
+        assert!(
+            p.initialize_request(init(
+                UnifiedParserStartingState::Reasoning,
+                UnifiedToolOutputMode::Native
+            ))
+            .is_err()
+        );
+        assert_eq!(
+            p.starting_state,
+            UnifiedParserStartingState::None,
+            "starting_state must be untouched by a rejected initialize"
+        );
+
+        // Guided is unsupported here too, and used to mutate before discovering that.
+        assert!(
+            p.initialize_request(init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None }
+            ))
+            .is_err()
+        );
+        assert!(
+            p.guided.is_none(),
+            "a rejected guided initialize must not install guided state"
+        );
+
+        // ...and the parser still works through a supported mode afterwards.
+        p.initialize_request(init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::Native,
+        ))
+        .expect("a supported mode must still initialize after two rejections");
+        let out = p.push("plain text").unwrap();
+        assert_eq!(out, vec![UnifiedParserEvent::Text("plain text".into())]);
     }
 }

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -11,14 +11,14 @@
 //! ```
 //!
 //! This file is only the grammar wiring. The scan core is the same
-//! [`crate::tool_calling::scan::WrappedBlockScanner`] the tool-only
+//! `WrappedBlockScanner` the tool-only
 //! `Qwen3CoderToolStreamParser` runs on — block open/close, bare-`<function=>`
 //! recovery, orphan-close stripping, chunk-boundary holdback and EOF drop stay a
 //! single implementation, so the unified path cannot quietly regress the tool
 //! handling the tool-only suite already pins. Value typing likewise delegates to
 //! the shared batch XML parser, so a streamed argument object matches the batch
 //! one exactly. The `UnifiedParser` impl itself is generic
-//! ([`crate::unified::ScannerUnified`]).
+//! (`ScannerUnified`).
 //!
 //! What the unified path adds is ORDER: `<think>` between two calls is a second
 //! thought in its own position instead of being hoisted into the first.
@@ -39,8 +39,8 @@ const REASONING_END: &str = "</think>";
 
 /// Build the Qwen3 unified parser for one stream.
 pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
-    Box::new(ScannerUnified {
-        scanner: qwen3_scanner(tools).with_reasoning(ReasoningSpec {
+    Box::new(ScannerUnified::new(qwen3_scanner(tools).with_reasoning(
+        ReasoningSpec {
             start: REASONING_START,
             end: REASONING_END,
             // Qwen3 emits its own `<think>`; the template does not pre-fill one,
@@ -48,14 +48,17 @@ pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
             forced_start: false,
             // `<think>` is not a special token for this family; the OR comes from the grammar.
             preserve_special_tokens: false,
-        }),
-    })
+        },
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::unified::{UnifiedEvent, UnifiedParserExt, assemble};
+    use crate::unified::{
+        InvalidGuidedPayloadPolicy, UnifiedEvent, UnifiedParserEvent, UnifiedParserExt,
+        UnifiedParserInit, UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
+    };
 
     fn weather_tools() -> Vec<Tool> {
         vec![Tool {
@@ -75,8 +78,43 @@ mod tests {
         for chunk in chunks {
             deltas.extend(parser.push(chunk).expect("push"));
         }
-        deltas.extend(parser.finish().expect("finish"));
+        deltas.extend(parser.finish().expect("finish").events);
         assemble(&deltas)
+    }
+
+    fn configured_events(
+        tools: &[Tool],
+        starting_state: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+        chunks: &[&str],
+    ) -> Vec<UnifiedEvent> {
+        let mut parser = qwen3_unified(tools);
+        parser
+            .initialize_request(UnifiedParserInit {
+                starting_state,
+                tool_output_mode,
+                invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+                ..UnifiedParserInit::default()
+            })
+            .expect("initialize");
+        let mut deltas = Vec::new();
+        for chunk in chunks {
+            deltas.extend(parser.push(chunk).expect("push"));
+        }
+        deltas.extend(parser.finish().expect("finish").events);
+        assemble(&deltas)
+    }
+
+    fn recover_init(
+        starting_state: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+    ) -> UnifiedParserInit {
+        UnifiedParserInit {
+            starting_state,
+            tool_output_mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+            ..UnifiedParserInit::default()
+        }
     }
 
     fn reasoning(text: &str) -> UnifiedEvent {
@@ -290,6 +328,752 @@ mod tests {
         assert_eq!(out, vec![reasoning("ab"), text("tail")]);
     }
 
+    /// Guided decoding constrains the TOOL payload, not the reasoning channel, so
+    /// the model can still emit malformed markup inside a thought. These assert the
+    /// two request modes agree BYTE FOR BYTE on identical reasoning bytes — the
+    /// property that was broken: guided only scanned for the closer, so a duplicate
+    /// opener surfaced as `reasoning("a<think>b")` where native gave `reasoning("ab")`,
+    /// putting raw tags in what the user reads as the model's thinking.
+    fn guided_reasoning(chunk: &str) -> Vec<UnifiedEvent> {
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+        let mut deltas = parser.push(chunk).unwrap();
+        deltas.extend(parser.finish().unwrap().events);
+        assemble(&deltas)
+    }
+
+    const GUIDED_CALL: &str = r#"[{"name": "get_weather", "arguments": {"city": "Paris"}}]"#;
+
+    fn marker_tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "f".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "x": { "type": "string" } }
+            }),
+            strict: None,
+        }]
+    }
+
+    fn required_events(tools: &[Tool], chunks: &[&str]) -> Vec<UnifiedEvent> {
+        configured_events(
+            tools,
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            chunks,
+        )
+    }
+
+    fn assert_required_split_invariant(tools: &[Tool], input: &str, want: &[UnifiedEvent]) {
+        assert_eq!(required_events(tools, &[input]), want, "whole-input push");
+        for split in 0..=input.len() {
+            if !input.is_char_boundary(split) {
+                continue;
+            }
+            let chunks = [&input[..split], &input[split..]];
+            assert_eq!(
+                required_events(tools, &chunks),
+                want,
+                "split at {split} of {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn competing_control_marker_ends_a_prefix_header_at_every_split() {
+        let tools = marker_tools();
+        let input = r#"x<function=f><tool_call>[{"name":"f","arguments":{"x":"y"}}]"#;
+        assert_required_split_invariant(
+            &tools,
+            input,
+            &[text("x"), call("f", serde_json::json!({"x": "y"}))],
+        );
+    }
+
+    #[test]
+    fn required_guided_mode_preserves_whitespace_after_visible_trailing_text() {
+        let tools = marker_tools();
+        let input = r#"[{"name":"f","arguments":{"x":"y"}}]x "#;
+        let want = vec![call("f", serde_json::json!({"x": "y"})), text("x ")];
+        assert_required_split_invariant(&tools, input, &want);
+
+        let character_chunks: Vec<&str> = input
+            .char_indices()
+            .map(|(at, ch)| &input[at..at + ch.len_utf8()])
+            .collect();
+        assert_eq!(
+            required_events(&tools, &character_chunks),
+            want,
+            "one-character pushes"
+        );
+    }
+
+    #[test]
+    fn a_payload_boundary_before_a_prefix_header_does_not_collapse_its_search() {
+        let tools = marker_tools();
+        let input = "x{}<function=f>";
+        assert_required_split_invariant(&tools, input, &[text("x{}")]);
+    }
+
+    #[test]
+    fn generated_control_marker_pairs_are_split_invariant() {
+        let tools = marker_tools();
+        let payload = r#"[{"name":"f","arguments":{"x":"y"}}]"#;
+        let components = [
+            "<function=",
+            "<tool_call>",
+            "<think>",
+            "</think>",
+            "{",
+            "[",
+            ">",
+        ];
+
+        for first in components {
+            for second in components {
+                let input = format!("x{first}{second}{payload}");
+                let whole = required_events(&tools, &[&input]);
+                for split in 0..=input.len() {
+                    if !input.is_char_boundary(split) {
+                        continue;
+                    }
+                    let chunks = [&input[..split], &input[split..]];
+                    assert_eq!(
+                        required_events(&tools, &chunks),
+                        whole,
+                        "generated pair ({first:?}, {second:?}), split at {split}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_complete_guided_call_is_emitted_by_the_push_that_completes_it() {
+        for split in 0..GUIDED_CALL.len() {
+            let mut parser = qwen3_unified(&weather_tools());
+            parser
+                .initialize_request(recover_init(
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                ))
+                .unwrap();
+
+            let mut before = parser.push(&GUIDED_CALL[..split]).unwrap();
+            assert!(
+                before
+                    .iter()
+                    .all(|delta| !matches!(delta, UnifiedParserEvent::ToolCall(_))),
+                "call emitted before its JSON value completed at split {split}"
+            );
+            let completing = parser.push(&GUIDED_CALL[split..]).unwrap();
+            assert!(
+                completing
+                    .iter()
+                    .any(|delta| matches!(delta, UnifiedParserEvent::ToolCall(_))),
+                "completing push buffered the call until finish at split {split}"
+            );
+            before.extend(completing);
+            let finished = parser.finish().unwrap().events;
+            assert!(
+                finished.is_empty(),
+                "finish re-emitted data at split {split}"
+            );
+            assert_eq!(
+                assemble(&before),
+                vec![call("get_weather", serde_json::json!({"city": "Paris"}))],
+                "split {split}"
+            );
+        }
+    }
+
+    #[test]
+    fn syntax_after_a_completed_guided_payload_keeps_order_at_every_split() {
+        let input = format!("{GUIDED_CALL} \t</tool_call><think>after</think><function=orphan>");
+        let want = vec![
+            call("get_weather", serde_json::json!({"city": "Paris"})),
+            reasoning("after"),
+        ];
+        for split in 0..=input.len() {
+            let chunks = [&input[..split], &input[split..]];
+            assert_eq!(
+                configured_events(
+                    &weather_tools(),
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                    &chunks,
+                ),
+                want,
+                "split {split}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_required_choice_call_with_non_object_arguments_is_voided_like_the_named_path() {
+        // The named path already rejects a payload that is not a JSON object. A
+        // required-choice ELEMENT has the same wire contract, so `"just a string"`
+        // as arguments must not dispatch: it cannot bind to the tool's parameters,
+        // and a tool call is a side effect, so failing OPEN is the wrong direction.
+        let out = guided_reasoning(r#"[{"name": "get_weather", "arguments": "just a string"}]"#);
+        assert_eq!(
+            out,
+            vec![text(
+                r#"[{"name": "get_weather", "arguments": "just a string"}]"#
+            )],
+            "a non-object argument payload should surface as text, not dispatch"
+        );
+    }
+
+    #[test]
+    fn guided_handles_prose_before_a_thought_split_across_chunks() {
+        // The single-chunk case is covered by the invariant test above. This pins the
+        // boundary: the prose arrives BEFORE the opener is visible, so nothing may
+        // latch the payload buffer until the parser knows no thought is coming.
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+        let mut deltas = Vec::new();
+        for chunk in ["Hello there. ", "<think>let me recall</think>", GUIDED_CALL] {
+            deltas.extend(parser.push(chunk).unwrap());
+        }
+        deltas.extend(parser.finish().unwrap().events);
+        let out = assemble(&deltas);
+        assert_eq!(
+            out[0],
+            text("Hello there. "),
+            "prose was not emitted as text: {out:?}"
+        );
+        assert_eq!(
+            out[1],
+            reasoning("let me recall"),
+            "thought not recovered: {out:?}"
+        );
+    }
+
+    /// Push `input` one N-byte slice at a time (char-boundary safe).
+    fn guided_chunked(input: &str, n: usize) -> Vec<UnifiedEvent> {
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+        let mut deltas = Vec::new();
+        let mut i = 0;
+        while i < input.len() {
+            let mut j = (i + n).min(input.len());
+            while !input.is_char_boundary(j) {
+                j += 1;
+            }
+            deltas.extend(parser.push(&input[i..j]).unwrap());
+            i = j;
+        }
+        deltas.extend(parser.finish().unwrap().events);
+        assemble(&deltas)
+    }
+
+    #[test]
+    fn a_thinking_tag_inside_a_guided_argument_is_data_at_every_chunk_size() {
+        // I7: inside the payload a reasoning marker is argument data. I6: the answer
+        // cannot depend on chunking. This regressed once — a whole-input push found the
+        // `<think>` in the argument string, split the payload into text/reasoning/text
+        // and DROPPED the call, while small chunks parsed it correctly.
+        let payload = r#"[{"name": "log", "arguments": {"note": "<think>x</think>"}}]"#;
+        let want = vec![call("log", serde_json::json!({"note": "<think>x</think>"}))];
+        assert_eq!(guided_reasoning(payload), want, "whole-input push");
+        for n in [1, 3, 7, 16, 64] {
+            assert_eq!(guided_chunked(payload, n), want, "chunk size {n}");
+        }
+    }
+
+    #[test]
+    fn guided_strips_an_orphan_reasoning_close_after_prose() {
+        // Native strips a stray `</think>` wherever it appears before any opener and
+        // emits the preceding prose as text; the guided path only did so when the
+        // prefix was whitespace, so the markup rode into the payload and out verbatim.
+        let out = guided_reasoning(&format!("Hello </think>{GUIDED_CALL}"));
+        assert_eq!(
+            out[0],
+            text("Hello "),
+            "prose+orphan close mishandled: {out:?}"
+        );
+        assert!(
+            !format!("{out:?}").contains("</think>"),
+            "orphan closer leaked: {out:?}"
+        );
+    }
+
+    #[test]
+    fn prose_then_orphan_close_then_payload_is_chunk_independent() {
+        // The prose is buffered by an EARLIER chunk than the one carrying the closer,
+        // so judging only the current prefix left it glued to the JSON and lost the
+        // call — while one push emitted it as text and parsed fine (`I6`).
+        fn named(chunks: &[&str]) -> Vec<UnifiedEvent> {
+            let mut parser = qwen3_unified(&weather_tools());
+            parser
+                .initialize_request(recover_init(
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson {
+                        named_tool: Some("get_weather".to_string()),
+                    },
+                ))
+                .unwrap();
+            let mut deltas = Vec::new();
+            for c in chunks {
+                deltas.extend(parser.push(c).unwrap());
+            }
+            deltas.extend(parser.finish().unwrap().events);
+            assemble(&deltas)
+        }
+        let want = vec![
+            text("thinking text"),
+            call("get_weather", serde_json::json!({"city": "Paris"})),
+        ];
+        assert_eq!(
+            named(&[r#"thinking text</think>{"city": "Paris"}"#]),
+            want,
+            "one push"
+        );
+        assert_eq!(
+            named(&["thinking text", "</think>", r#"{"city": "Paris"}"#]),
+            want,
+            "split at the closer"
+        );
+    }
+
+    #[test]
+    fn tool_markup_narrated_inside_a_thought_does_not_eat_the_guided_payload() {
+        // Guided decoding leaves the reasoning channel UNCONSTRAINED, so the model can
+        // write `<tool_call>` while narrating; the real call arrives after, as JSON.
+        // Treating that markup as stream-ending discarded the payload and returned an
+        // empty response.
+        let out = guided_reasoning(&format!(
+            "<think>I'll use <tool_call> next</think>{GUIDED_CALL}"
+        ));
+        assert!(
+            out.iter()
+                .any(|e| matches!(e, UnifiedEvent::ToolCall { .. })),
+            "guided payload was discarded: {out:?}"
+        );
+        assert!(
+            !format!("{out:?}").contains("<tool_call>"),
+            "narrated markup leaked: {out:?}"
+        );
+    }
+
+    #[test]
+    fn an_orphan_closer_before_a_real_thought_is_stripped_not_shown() {
+        // The opener search ran over the whole buffer before the closer was ever
+        // considered, so an orphan `</think>` sitting AHEAD of a real thought landed in
+        // the opener's prefix and went out as visible text. Native compares positions
+        // and strips the earlier marker.
+        let native = events(&weather_tools(), &["</think>a<think>b</think>tail"]);
+        let guided = guided_reasoning(&format!("</think>a<think>b</think>{GUIDED_CALL}"));
+        assert_eq!(native[0], text("a"), "native changed: {native:?}");
+        assert_eq!(
+            guided[0],
+            text("a"),
+            "orphan closer leaked into the reply: {guided:?}"
+        );
+        assert!(
+            !format!("{guided:?}").contains("</think>"),
+            "markup reached the user: {guided:?}"
+        );
+    }
+
+    #[test]
+    fn a_named_choice_forwards_its_payload_verbatim() {
+        // The payload IS the tool's argument object. An earlier revision tried to
+        // unwrap a `{"name","arguments"}` shape to tolerate envelope-emitting backends;
+        // that heuristic is unsound because ordinary arguments can use those key names,
+        // and it broke both ways — voiding a legitimate forced call when the inner name
+        // differed, and dropping the real argument set when it matched.
+        fn named(tool: &str, payload: &str) -> Vec<UnifiedEvent> {
+            let tools = vec![Tool {
+                name: tool.into(),
+                description: None,
+                parameters: serde_json::json!({"type": "object"}),
+                strict: None,
+            }];
+            let mut parser = qwen3_unified(&tools);
+            parser
+                .initialize_request(recover_init(
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson {
+                        named_tool: Some(tool.to_string()),
+                    },
+                ))
+                .unwrap();
+            let mut deltas = parser.push(payload).unwrap();
+            deltas.extend(parser.finish().unwrap().events);
+            assemble(&deltas)
+        }
+        assert_eq!(
+            named("get_weather", r#"{"city": "Paris"}"#),
+            vec![call("get_weather", serde_json::json!({"city": "Paris"}))],
+            "bare arguments"
+        );
+        // The case the heuristic broke: a forced tool whose OWN arguments happen to use
+        // `name` + `parameters`. It must still be dispatched, with those arguments.
+        let args = serde_json::json!({"name": "foo", "parameters": {"x": 1}});
+        assert_eq!(
+            named("register_handler", &args.to_string()),
+            vec![call("register_handler", args.clone())],
+            "legitimate arguments using name/parameters keys must still dispatch"
+        );
+        let same = serde_json::json!({"name": "register_handler", "parameters": {"x": 1}});
+        assert_eq!(
+            named("register_handler", &same.to_string()),
+            vec![call("register_handler", same.clone())],
+            "an inner name matching the tool must not truncate the argument set"
+        );
+    }
+
+    /// Guided control markers must never reach the user and must never cost the
+    /// call, at EVERY chunk boundary, for every starting_state and choice shape.
+    ///
+    /// This is a table rather than a list of examples on purpose. Every previous
+    /// bug in this area was a cell someone else found: an opener recognised whole
+    /// but lost when split, a prefix-form `<function=` consumed by its declared
+    /// length leaving `NAME>` behind, markup after a thought never examined because
+    /// the closer had already latched. Each was fixed with the one input that had
+    /// broken, so the next cell broke next. The property is combinatorial — marker
+    /// x position x delivery x starting_state x choice — so the test is too.
+    #[test]
+    fn guided_control_markers_never_leak_and_never_cost_the_call() {
+        let choices = [
+            (Some("get_weather"), r#"{"city": "Paris"}"#),
+            (
+                None,
+                r#"[{"name":"get_weather","arguments":{"city":"Paris"}}]"#,
+            ),
+        ];
+        // Marker positions differ by prompt state. Reasoning starting_state starts inside a
+        // thought and response starting_state makes reasoning tags literal, while tool
+        // control markers remain structural until the JSON value opens in all modes.
+        let cases: &[(UnifiedParserStartingState, &[&str])] = &[
+            (
+                UnifiedParserStartingState::None,
+                &[
+                    "<tool_call>",
+                    "</tool_call>",
+                    "<function=get_weather>",
+                    "<think>x</think><tool_call>",
+                    "<think>x</think></tool_call>",
+                    "</think><tool_call>",
+                    "prose <tool_call>",
+                    "",
+                ],
+            ),
+            (
+                UnifiedParserStartingState::Reasoning,
+                &[
+                    "x</think><tool_call>",
+                    "x</think></tool_call>",
+                    "<tool_call>x</think>",
+                    "<function=get_weather>x</think>",
+                    "</tool_call>x</think>",
+                    "</think>",
+                ],
+            ),
+            (
+                UnifiedParserStartingState::Response,
+                &["<tool_call>", "</tool_call>", "<function=get_weather>", ""],
+            ),
+        ];
+        for &(starting_state, prefixes) in cases {
+            for &(named_tool, payload) in &choices {
+                for prefix in prefixes {
+                    // Markers can BRACKET the payload, not only precede it: a
+                    // template-emitted closer after the JSON rode into the buffer
+                    // and cost the call. The table covers both ends now.
+                    for suffix in ["", "</tool_call>", "</function>"] {
+                        let input = format!("{prefix}{payload}{suffix}");
+                        // Delivery: whole, then split at EVERY byte boundary.
+                        let mut deliveries: Vec<Vec<String>> = vec![vec![input.clone()]];
+                        for cut in 1..input.len() {
+                            if input.is_char_boundary(cut) {
+                                deliveries.push(vec![input[..cut].into(), input[cut..].into()]);
+                            }
+                        }
+                        for chunks in deliveries {
+                            let mut parser = qwen3_unified(&weather_tools());
+                            parser
+                                .initialize_request(recover_init(
+                                    starting_state,
+                                    UnifiedToolOutputMode::GuidedJson {
+                                        named_tool: named_tool.map(str::to_string),
+                                    },
+                                ))
+                                .unwrap();
+                            let mut deltas = Vec::new();
+                            for c in &chunks {
+                                deltas.extend(parser.push(c).unwrap());
+                            }
+                            deltas.extend(parser.finish().unwrap().events);
+                            let out = assemble(&deltas);
+                            let at = format!(
+                                "starting_state {starting_state:?}, named {named_tool:?}, prefix {prefix:?}, chunks {chunks:?} -> {out:?}"
+                            );
+
+                            assert!(
+                                out.iter().any(|e| matches!(
+                                    e, UnifiedEvent::ToolCall { name, arguments }
+                                    if name == "get_weather"
+                                        && arguments == &serde_json::json!({"city": "Paris"})
+                                )),
+                                "call lost or arguments wrong: {at}"
+                            );
+                            for ev in &out {
+                                if let UnifiedEvent::Text { text }
+                                | UnifiedEvent::Reasoning { text } = ev
+                                {
+                                    for marker in [
+                                        "<tool_call>",
+                                        "</tool_call>",
+                                        "<function=",
+                                        "<think>",
+                                        "</think>",
+                                    ] {
+                                        assert!(
+                                            !text.contains(marker),
+                                            "{marker} leaked to the user: {at}"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn guided_native_markup_only_is_split_invariant() {
+        let input = "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>";
+
+        for split in 0..=input.len() {
+            let chunks = [&input[..split], &input[split..]];
+            let out = configured_events(
+                &weather_tools(),
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                &chunks,
+            );
+            assert!(out.is_empty(), "split at {split} leaked {out:?}");
+        }
+    }
+
+    #[test]
+    fn markers_inside_a_started_guided_payload_stay_byte_exact() {
+        // The other half of the same property: once the payload has opened, a marker
+        // is argument DATA and must survive untouched (`I7`), at every boundary.
+        const INPUT: &str = r#"{"city": "<tool_call><think>x</think></function>"}"#;
+        for cut in 0..INPUT.len() {
+            if !INPUT.is_char_boundary(cut) {
+                continue;
+            }
+            let mut parser = qwen3_unified(&weather_tools());
+            parser
+                .initialize_request(recover_init(
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson {
+                        named_tool: Some("get_weather".to_string()),
+                    },
+                ))
+                .unwrap();
+            let mut deltas = parser.push(&INPUT[..cut]).unwrap();
+            deltas.extend(parser.push(&INPUT[cut..]).unwrap());
+            deltas.extend(parser.finish().unwrap().events);
+            assert_eq!(
+                assemble(&deltas),
+                vec![call(
+                    "get_weather",
+                    serde_json::json!({"city": "<tool_call><think>x</think></function>"})
+                )],
+                "argument data changed, split at {cut}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_narrated_invoke_inside_a_thought_leaves_no_marker_behind() {
+        // Reviewed: stripping `<function=NAME>` left its `</function>` in the shown
+        // thinking. The invoke terminator is now part of the guided vocabulary.
+        //
+        // The two markers NOT added, and why: `<parameter=` and a BARE `</function>`
+        // with no invoke open are kept verbatim by the NATIVE scanner as well —
+        // measured identical on both paths — so stripping them here would create a
+        // divergence rather than remove one. Those two cases are pinned below.
+        let leaked = guided_reasoning(&format!(
+            "<think>a<function=run>x</function>x</think>{GUIDED_CALL}"
+        ));
+        assert!(
+            !format!("{leaked:?}").contains("</function>"),
+            "invoke terminator left behind: {leaked:?}"
+        );
+        assert!(
+            leaked
+                .iter()
+                .any(|e| matches!(e, UnifiedEvent::ToolCall { .. })),
+            "call lost: {leaked:?}"
+        );
+
+        // Parity with native on the shapes that are ordinary text for both.
+        for thought in [
+            "<think>a<parameter=city>y</parameter>b</think>",
+            "<think>a</function>b</think>",
+        ] {
+            let native = events(&weather_tools(), &[&format!("{thought}tail")]);
+            let guided = guided_reasoning(&format!("{thought}{GUIDED_CALL}"));
+            assert_eq!(
+                native[0], guided[0],
+                "guided diverged from native on text-like markup for {thought:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_narrated_invoke_does_not_swallow_the_thought_closer_or_the_payload() {
+        // The terminator search was unbounded, so a `</function>` occurring inside a
+        // guided ARGUMENT STRING — past the end of the thought — was claimed as the
+        // narrated invoke's terminator. Everything between went with it: the closer,
+        // the payload, the call. Fragments of the discarded JSON then surfaced as the
+        // model's thinking.
+        let input = concat!(
+            r#"<think>I'll use <function=get_weather> to check</think>"#,
+            r#"[{"name":"log","arguments":{"note":"close with </function>"}}]"#
+        );
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+        let mut deltas = parser.push(input).unwrap();
+        deltas.extend(parser.finish().unwrap().events);
+        let out = assemble(&deltas);
+        assert!(
+            out.iter()
+                .any(|e| matches!(e, UnifiedEvent::ToolCall { name, .. } if name == "log")),
+            "the terminator search swallowed the payload: {out:?}"
+        );
+        assert!(
+            !format!("{out:?}").contains("}}]"),
+            "payload fragments surfaced as thinking: {out:?}"
+        );
+    }
+
+    #[test]
+    fn guided_strips_a_duplicate_reasoning_opener_inside_a_thought() {
+        let out = guided_reasoning(&format!("<think>a<think>b</think>{GUIDED_CALL}"));
+        assert_eq!(
+            out[0],
+            reasoning("ab"),
+            "duplicate opener leaked into the thought"
+        );
+    }
+
+    #[test]
+    fn guided_strips_a_stray_tool_close_inside_a_thought() {
+        let out = guided_reasoning(&format!("<think>a</tool_call>b</think>{GUIDED_CALL}"));
+        assert_eq!(
+            out[0],
+            reasoning("ab"),
+            "stray tool close leaked into the thought"
+        );
+    }
+
+    #[test]
+    fn guided_and_native_agree_on_the_same_reasoning_bytes() {
+        // Two properties, deliberately scoped differently.
+        //
+        // NO MARKER MAY LEAK, on either path, for ANY of these inputs. That one is
+        // absolute — it is the `I3` contract, and comparing only the FIRST event is
+        // how a leak survived this test twice, coming out in the tail instead.
+        //
+        // BYTE-EQUAL reasoning payloads hold only for inputs with no native TOOL
+        // structure. Native can interpret `<tool_call>`/`<function=`: it opens a
+        // block and recovers the call from the markup. Guided cannot — under guided
+        // decoding the reasoning channel is unconstrained, so that markup is the
+        // model NARRATING, and the real call arrives afterwards as JSON. Treating it
+        // as structural there discarded the payload and returned an empty response.
+        // So the two modes genuinely differ on those inputs, and the honest thing is
+        // to say so rather than force an equality that costs the call.
+        let equal_payload = [
+            "<think>a<think>b</think>",
+            "<think>a</tool_call>b</think>",
+            // Visible prose BEFORE the thought opens (`content_then_reason`). Every
+            // other case here starts the thought at byte 0, which is how the guided
+            // path shipped a bug where the prose latched the payload buffer and the
+            // model's private thinking was surfaced to the user as the answer.
+            "Hello there. <think>let me recall</think>",
+            "Sure. <think>check</think>",
+            "<think>plain thought</think>",
+        ];
+        // Native tool structure inside a thought: no-leak only, per the note above.
+        let no_leak_only = [
+            "<think>a<tool_call>x</think>",
+            "<think>a<function=run>x</function>x</think>",
+        ];
+        for thought in equal_payload.iter().chain(no_leak_only.iter()) {
+            let native = events(&weather_tools(), &[&format!("{thought}tail")]);
+            let guided = guided_reasoning(&format!("{thought}{GUIDED_CALL}"));
+            if equal_payload.contains(thought) {
+                assert_eq!(
+                    native[0], guided[0],
+                    "request mode changed the reasoning payload for {thought:?}"
+                );
+            }
+            // Comparing only the FIRST event is how the tool-opener leak survived
+            // this test twice: the reasoning span matched while the markup came
+            // out in the tail instead. No event on either side may carry a marker.
+            for ev in native.iter().chain(guided.iter()) {
+                if let UnifiedEvent::Text { text } | UnifiedEvent::Reasoning { text } = ev {
+                    for marker in ["<think>", "</think>", "<tool_call>", "<function="] {
+                        assert!(
+                            !text.contains(marker),
+                            "{marker} leaked into {ev:?} for {thought:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn guided_strips_a_stray_marker_split_across_chunks() {
+        // The holdback was narrowed to the closer, so a stray marker split across a
+        // chunk boundary streamed out before it could be recognized.
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+        let mut deltas = Vec::new();
+        for chunk in ["<think>a</tool", "_call>b</think>", GUIDED_CALL] {
+            deltas.extend(parser.push(chunk).unwrap());
+        }
+        deltas.extend(parser.finish().unwrap().events);
+        assert_eq!(assemble(&deltas)[0], reasoning("ab"));
+    }
+
     #[test]
     fn orphan_reasoning_close_is_stripped_not_leaked() {
         // I3: a `</think>` with nothing open is malformed markup.
@@ -333,5 +1117,942 @@ mod tests {
             .expect("parse_complete");
         assert_eq!(batch, events(&weather_tools(), &[input]));
         assert_eq!(batch.len(), 5);
+    }
+
+    #[test]
+    fn reasoning_prefill_classifies_leading_text_as_reasoning() {
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Reasoning,
+            UnifiedToolOutputMode::Native,
+            &["hidden</thi", "nk>visible"],
+        );
+        assert_eq!(out, vec![reasoning("hidden"), text("visible")]);
+    }
+
+    #[test]
+    fn reasoning_prefill_consumes_a_redundant_split_opener() {
+        for tool_output_mode in [
+            UnifiedToolOutputMode::Native,
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+        ] {
+            let out = configured_events(
+                &weather_tools(),
+                UnifiedParserStartingState::Reasoning,
+                tool_output_mode.clone(),
+                &["\n<thi", "nk>hidden</think>{\"city\":\"Tokyo\"}"],
+            );
+            let mut expected = vec![reasoning("\nhidden")];
+            if tool_output_mode == UnifiedToolOutputMode::Native {
+                expected.push(text(r#"{"city":"Tokyo"}"#));
+            } else {
+                expected.push(call("get_weather", serde_json::json!({"city": "Tokyo"})));
+            }
+            assert_eq!(out, expected);
+        }
+    }
+
+    #[test]
+    fn response_prefill_does_not_interpret_reasoning_markers() {
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Response,
+            UnifiedToolOutputMode::Native,
+            &["<think>literal</think>"],
+        );
+        assert_eq!(out, vec![text("<think>literal</think>")]);
+    }
+
+    #[test]
+    fn named_choice_parses_bare_arguments_object() {
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Reasoning,
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            &["reason</think>{\n", "  \"city\": \"Tokyo\"\n}"],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("reason"),
+                call("get_weather", serde_json::json!({"city": "Tokyo"})),
+            ]
+        );
+    }
+
+    #[test]
+    fn guided_json_strips_a_split_orphan_reasoning_close_before_json() {
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            &["</thi", "nk>{\"city\":\"Tokyo\"}"],
+        );
+        assert_eq!(
+            out,
+            vec![call("get_weather", serde_json::json!({"city": "Tokyo"}))]
+        );
+    }
+
+    #[test]
+    fn guided_json_preserves_native_marker_strings_as_argument_data() {
+        let marker_value =
+            "<think>x</think><tool_call><function=get_weather></function></tool_call>";
+        let input = format!(
+            r#"reason</think>{{"city":{}}}"#,
+            serde_json::to_string(marker_value).unwrap()
+        );
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Reasoning,
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            &[&input[..20], &input[20..]],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("reason"),
+                call("get_weather", serde_json::json!({"city": marker_value})),
+            ]
+        );
+    }
+
+    #[test]
+    fn required_choice_parses_single_and_parallel_calls() {
+        let single = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Response,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &[r#"{"name":"get_weather","parameters":{"city":"Tokyo"}}"#],
+        );
+        assert_eq!(
+            single,
+            vec![call("get_weather", serde_json::json!({"city": "Tokyo"}))]
+        );
+
+        let parallel = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Response,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &[
+                r#"[{"name":"get_weather","arguments":{"city":"Paris"}},"#,
+                r#"{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#,
+            ],
+        );
+        assert_eq!(
+            parallel,
+            vec![
+                call("get_weather", serde_json::json!({"city": "Paris"})),
+                call("get_weather", serde_json::json!({"city": "Tokyo"})),
+            ]
+        );
+    }
+
+    #[test]
+    fn required_choice_recovers_the_whole_array_when_any_call_is_invalid() {
+        // Invalid = missing `name` (the one required field). A missing ARGUMENT key is
+        // not invalid — that is a parameterless call, per `UNIFIED.6.a`.
+        let input = r#"[{"name":"get_weather","parameters":{"city":"Paris"}},{"parameters":{"city":"Tokyo"}}]"#;
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Response,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &[input],
+        );
+        assert_eq!(out, vec![text(input)]);
+    }
+
+    #[test]
+    fn required_choice_rejects_explicit_null_arguments() {
+        // Missing arguments means a parameterless call. Explicit null is different:
+        // it is a present value with the wrong shape and must not be dispatched as
+        // `{}`, because that turns a malformed side-effect request into a valid one.
+        for input in [
+            r#"{"name":"get_weather","arguments":null}"#,
+            r#"{"name":"get_weather","parameters":null}"#,
+        ] {
+            let out = configured_events(
+                &weather_tools(),
+                UnifiedParserStartingState::Response,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                &[input],
+            );
+            assert_eq!(out, vec![text(input)], "explicit null dispatched: {out:?}");
+        }
+    }
+
+    #[test]
+    fn required_choice_rejects_ambiguous_argument_fields() {
+        let input =
+            r#"{"name":"get_weather","parameters":{"city":"Paris"},"arguments":{"city":"Tokyo"}}"#;
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Response,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &[input],
+        );
+        assert_eq!(out, vec![text(input)], "ambiguous call dispatched: {out:?}");
+    }
+
+    #[test]
+    fn native_mode_keeps_xml_under_reasoning_prefill() {
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Reasoning,
+            UnifiedToolOutputMode::Native,
+            &[
+                "reason</think><tool_call><function=get_weather>",
+                "<parameter=city>Paris</parameter></function></tool_call>",
+            ],
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("reason"),
+                call("get_weather", serde_json::json!({"city": "Paris"})),
+            ]
+        );
+    }
+
+    #[test]
+    fn guided_json_is_chunk_boundary_independent() {
+        let input = r#"reason</think>[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#;
+        let chunks = input
+            .as_bytes()
+            .iter()
+            .map(|byte| std::str::from_utf8(std::slice::from_ref(byte)).unwrap())
+            .collect::<Vec<_>>();
+        let out = configured_events(
+            &weather_tools(),
+            UnifiedParserStartingState::Reasoning,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &chunks,
+        );
+        assert_eq!(
+            out,
+            vec![
+                reasoning("reason"),
+                call("get_weather", serde_json::json!({"city": "Tokyo"})),
+            ]
+        );
+    }
+
+    #[test]
+    fn named_choice_preserves_surrounding_argument_bytes() {
+        // The named payload is the argument object itself. Validation may use a
+        // trimmed view, but the emitted wire string must remain model-byte-exact.
+        let input = " \n{\"city\": \"Tokyo\"}\t ";
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::Response,
+                UnifiedToolOutputMode::GuidedJson {
+                    named_tool: Some("get_weather".to_string()),
+                },
+            ))
+            .unwrap();
+        let mut deltas = parser.push(input).unwrap();
+        deltas.extend(parser.finish().unwrap().events);
+        let arguments = deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                UnifiedParserEvent::ToolCall(call) if call.tool_index == 0 => {
+                    Some(call.arguments.as_str())
+                }
+                _ => None,
+            })
+            .collect::<String>();
+        assert_eq!(arguments, input);
+    }
+
+    #[test]
+    fn incomplete_guided_json_recovers_as_text() {
+        for tool_output_mode in [
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+        ] {
+            let input = r#"{"city":"Tok"#;
+            let out = configured_events(
+                &weather_tools(),
+                UnifiedParserStartingState::Response,
+                tool_output_mode,
+                &[input],
+            );
+            assert_eq!(out, vec![text(input)]);
+        }
+    }
+
+    #[test]
+    fn reset_recovers_buffered_guided_text_and_restarts_lifecycle() {
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::Reasoning,
+                UnifiedToolOutputMode::GuidedJson {
+                    named_tool: Some("get_weather".to_string()),
+                },
+            ))
+            .unwrap();
+        assert_eq!(
+            parser.push(r#"reason</think>{"city":"Tok"#).unwrap(),
+            vec![UnifiedParserEvent::Reasoning("reason".to_string())]
+        );
+        assert!(
+            parser
+                .initialize_request(recover_init(
+                    UnifiedParserStartingState::Response,
+                    UnifiedToolOutputMode::Native
+                ))
+                .is_err()
+        );
+        assert_eq!(parser.reset(), r#"{"city":"Tok"#);
+
+        parser
+            .initialize_request(recover_init(
+                UnifiedParserStartingState::Response,
+                UnifiedToolOutputMode::GuidedJson {
+                    named_tool: Some("get_weather".to_string()),
+                },
+            ))
+            .unwrap();
+        let mut deltas = parser.push(r#"{"city":"Tokyo"}"#).unwrap();
+        deltas.extend(parser.finish().unwrap().events);
+        assert_eq!(
+            assemble(&deltas),
+            vec![call("get_weather", serde_json::json!({"city": "Tokyo"}))]
+        );
+        assert!(parser.finish().is_err());
+        assert!(parser.push("after finish").is_err());
+    }
+
+    /// P2 recovery must not show the user markup the parse already stripped.
+    ///
+    /// `finish_json` trims trailing control markers before parsing; the fallback
+    /// used to hand back the RAW buffer, so a malformed guided payload put
+    /// `</tool_call>` in the visible answer (`I3`). Byte fidelity still holds when
+    /// nothing was stripped (`I7`), which the third row pins.
+    #[test]
+    fn guided_recovery_text_never_carries_the_markup_it_stripped() {
+        let tools = weather_tools();
+        for (input, want) in [
+            (
+                "[{\"name\": \"get_weather\", \"arguments\": {\"city\": </tool_call>",
+                "[{\"name\": \"get_weather\", \"arguments\": {\"city\":",
+            ),
+            (
+                "{\"unexpected\": \"shape\"}</tool_call>",
+                "{\"unexpected\": \"shape\"}",
+            ),
+            ("{\"unexpected\": \"shape\"}", "{\"unexpected\": \"shape\"}"),
+        ] {
+            let got = configured_events(
+                &tools,
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                &[input],
+            );
+            assert_eq!(got, vec![text(want)], "input {input:?}");
+        }
+    }
+
+    /// A prefix-form marker's `>` search is bounded by the payload start.
+    ///
+    /// Unbounded, it ran INTO the payload: with no `>` before the JSON the flush
+    /// arm consumed the whole buffer and the turn emitted nothing at all, losing
+    /// a well-formed call.
+    #[test]
+    fn a_bare_invoke_opener_does_not_swallow_the_guided_payload() {
+        let tools = weather_tools();
+        let got = configured_events(
+            &tools,
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            &["<function=[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]"],
+        );
+        assert_eq!(
+            got,
+            vec![call("get_weather", serde_json::json!({"city": "Paris"}))],
+            "bare opener swallowed the payload: {got:?}"
+        );
+    }
+
+    /// `control_marker_at` and `guided_holdback_len` must agree on when a
+    /// prefix-form marker is COMPLETE, at every chunk boundary.
+    ///
+    /// They disagreed once: consume required the `>` before the payload start,
+    /// holdback accepted any `>` anywhere after the marker. A `>` inside an
+    /// argument string satisfies only the second, so `<function=` was neither
+    /// consumed nor retained — it flushed into the payload buffer, the JSON failed
+    /// to parse, and the call surfaced as text with the marker still attached.
+    #[test]
+    fn a_marker_before_a_payload_containing_gt_still_dispatches_at_every_split() {
+        let tools = weather_tools();
+        let input = "<function=[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"a > b\"}}]";
+        let want = vec![call("get_weather", serde_json::json!({"city": "a > b"}))];
+        for split in 0..=input.len() {
+            if split > 0 && !input.is_char_boundary(split) {
+                continue;
+            }
+            let chunks: Vec<&str> = if split == 0 {
+                vec![input]
+            } else {
+                vec![&input[..split], &input[split..]]
+            };
+            let got = configured_events(
+                &tools,
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                &chunks,
+            );
+            assert_eq!(got, want, "split at {split}");
+        }
+    }
+
+    /// A prefix-form header must not BORROW its `>` from a later marker.
+    ///
+    /// `control_marker_at` bounded the `>` scan by the payload start only, so a
+    /// stray `<function=` consumed through the `>` of a following `<think>` and the
+    /// model's PRIVATE reasoning was emitted as visible text. The boundary is the
+    /// earliest payload OR competing control/reasoning marker, and both the consume
+    /// path and the holdback derive it from `prefix_header_end` — one rule, because
+    /// two predicates drifted twice before this.
+    #[test]
+    fn a_prefix_header_never_borrows_a_later_markers_terminator() {
+        let tools = weather_tools();
+        let call = call("get_weather", serde_json::json!({"city": "Paris"}));
+        for (input, want) in [
+            (
+                "<function=<think>secret</think>[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]",
+                vec![reasoning("secret"), call.clone()],
+            ),
+            (
+                "<think>I'll call <function=get_weather</think>[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]",
+                vec![reasoning("I'll call get_weather"), call.clone()],
+            ),
+        ] {
+            for split in 0..=input.len() {
+                if split > 0 && !input.is_char_boundary(split) {
+                    continue;
+                }
+                let chunks: Vec<&str> = if split == 0 {
+                    vec![input]
+                } else {
+                    vec![&input[..split], &input[split..]]
+                };
+                let got = configured_events(
+                    &tools,
+                    UnifiedParserStartingState::None,
+                    UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                    &chunks,
+                );
+                assert_eq!(got, want, "split at {split} of {input:?}");
+                for ev in &got {
+                    if let UnifiedEvent::Text { text } | UnifiedEvent::Reasoning { text } = ev {
+                        assert!(!text.contains("<function="), "marker leaked: {text:?}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod guided_warning_tests {
+    use super::*;
+    use crate::tool_calling::traits::Tool;
+    use crate::unified::{
+        InvalidGuidedPayloadPolicy, UnifiedParserEvent, UnifiedParserExt, UnifiedParserInit,
+        UnifiedParserStartingState, UnifiedToolOutputMode,
+    };
+
+    fn weather_tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "get_weather".into(),
+            description: None,
+            parameters: serde_json::json!({"type":"object","properties":{"city":{"type":"string"}}}),
+            strict: None,
+        }]
+    }
+
+    fn recover_init(
+        starting_state: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+    ) -> UnifiedParserInit {
+        UnifiedParserInit {
+            starting_state,
+            tool_output_mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+            ..UnifiedParserInit::default()
+        }
+    }
+
+    /// Every malformed guided payload must WARN, not just silently become text.
+    /// A caller cannot tell "guided decoding failed" from "the model answered in
+    /// prose" by looking at the events, so the log line is the only signal.
+    #[test]
+    fn malformed_guided_payloads_warn() {
+        for (label, payload) in [
+            ("valid json, not a call", r#"{"unexpected": "shape"}"#),
+            (
+                "unparseable json",
+                r#"{"name": "get_weather", "arguments": {"city": "Par"#,
+            ),
+            (
+                "array, one element not a call",
+                r#"[{"name":"get_weather","arguments":{"city":"Paris"}}, {"arguments":{"city":"Tokyo"}}]"#,
+            ),
+            (
+                "array with a broken element",
+                r#"[{"name":"get_weather","arguments":{"city":"Paris"}}, {"name":"run","arguments":{"cmd": ]"#,
+            ),
+        ] {
+            let mut p = qwen3_unified(&weather_tools());
+            p.initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+            let mut out = p.push(payload).unwrap();
+            out.extend(p.finish().unwrap().events);
+            // recovered as text, no call dispatched
+            assert!(
+                out.iter()
+                    .all(|d| !matches!(d, UnifiedParserEvent::ToolCall(_))),
+                "{label}: dispatched a call from an unvalidated payload"
+            );
+            assert!(
+                out.iter()
+                    .any(|d| matches!(d, UnifiedParserEvent::Text(..))),
+                "{label}: payload was dropped instead of surfaced as text"
+            );
+        }
+    }
+
+    /// The recovery above must be OBSERVABLE. Capture the log to prove the warning
+    /// is actually emitted, not merely present in the source: to a caller the events
+    /// look identical to a model that answered in prose, so this line is the only
+    /// way an operator learns guided decoding failed.
+    #[test]
+    fn the_guided_fallback_actually_emits_a_warning() {
+        use std::sync::{Arc, Mutex};
+        #[derive(Clone, Default)]
+        struct Sink(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for Sink {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let sink = Sink::default();
+        let captured = sink.0.clone();
+        let sub = tracing_subscriber::fmt()
+            .with_writer(move || sink.clone())
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+
+        // `tracing` caches per-callsite Interest PROCESS-GLOBALLY. The sibling
+        // tests above drive this same guided-fallback `warn!` with no subscriber
+        // installed, so one of them can cache the callsite as "never interested"
+        // and this capture then sees an empty log — a ~60% flake decided purely by
+        // which test reaches the callsite first. A thread-local `with_default`
+        // cannot fix that, and neither can a one-shot rebuild, because the race
+        // repeats on every run. Installing a permanent global default means the
+        // callsite is always interesting; `with_default` below still overrides it
+        // on THIS thread, so the capture stays local to this test.
+        static GLOBAL_SUB: std::sync::Once = std::sync::Once::new();
+        GLOBAL_SUB.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(
+                tracing_subscriber::fmt()
+                    .with_writer(std::io::sink)
+                    .with_max_level(tracing::Level::WARN)
+                    .finish(),
+            );
+            tracing::callsite::rebuild_interest_cache();
+        });
+
+        const GUIDED_SECRET: &str = "DO_NOT_LOG_GUIDED_PAYLOAD_7f31";
+        const ARGUMENT_SECRET: &str = "DO_NOT_LOG_TOOL_ARGUMENTS_98c2";
+        tracing::subscriber::with_default(sub, || {
+            let mut p = qwen3_unified(&weather_tools());
+            p.initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+            p.push(&format!(r#"{{"unexpected": "{GUIDED_SECRET}"}}"#))
+                .unwrap();
+            p.finish().unwrap();
+            crate::unified::assemble(&[UnifiedParserEvent::ToolCall(
+                crate::tool_calling::traits::ToolCallDelta {
+                    tool_index: 0,
+                    name: Some("get_weather".into()),
+                    arguments: format!(r#"{{"api_key":"{ARGUMENT_SECRET}""#),
+                },
+            )]);
+        });
+
+        let log = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+        assert!(
+            log.contains("unified_guided_json_not_a_tool_call"),
+            "no warning emitted for an unparseable guided payload; log was: {log:?}"
+        );
+        assert!(
+            log.contains("required"),
+            "warning omitted which tool choice was in play: {log:?}"
+        );
+        assert!(
+            !log.contains(GUIDED_SECRET) && !log.contains(ARGUMENT_SECRET),
+            "warning exposed model or user payload bytes: {log:?}"
+        );
+    }
+
+    /// Guided mode fed the family's NATIVE markup must not produce a silent empty turn.
+    ///
+    /// Everything is stripped, so emitting no events is right — markup is not an
+    /// answer. Doing it SILENTLY is not: the caller cannot tell this from a model
+    /// that legitimately said nothing, and the usual cause is guided decoding
+    /// configured against a backend still emitting native call grammar. P2 is
+    /// best-effort recovery, NOT silent loss.
+    #[test]
+    fn guided_output_that_is_only_markup_warns_instead_of_vanishing() {
+        use std::sync::{Arc, Mutex};
+        #[derive(Clone, Default)]
+        struct Sink(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for Sink {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let sink = Sink::default();
+        let captured = sink.0.clone();
+        let sub = tracing_subscriber::fmt()
+            .with_writer(move || sink.clone())
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        // Same process-global callsite-interest caveat as the sibling test above.
+        static GLOBAL_SUB: std::sync::Once = std::sync::Once::new();
+        GLOBAL_SUB.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(
+                tracing_subscriber::fmt()
+                    .with_writer(std::io::sink)
+                    .with_max_level(tracing::Level::WARN)
+                    .finish(),
+            );
+            tracing::callsite::rebuild_interest_cache();
+        });
+
+        let mut events = Vec::new();
+        tracing::subscriber::with_default(sub, || {
+            let mut p = qwen3_unified(&weather_tools());
+            p.initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            ))
+            .unwrap();
+            events.extend(
+                p.push("<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>")
+                    .unwrap(),
+            );
+            events.extend(p.finish().unwrap().events);
+        });
+
+        assert!(
+            events.is_empty(),
+            "markup-only guided turn emitted {events:?}"
+        );
+        let log = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+        assert!(
+            log.contains("unified_guided_output_was_only_markup"),
+            "empty guided turn produced NO diagnostic; log was: {log}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod reset_and_payload_tests {
+    use super::*;
+    use crate::tool_calling::traits::Tool;
+    use crate::unified::{
+        InvalidGuidedPayload, InvalidGuidedPayloadKind, InvalidGuidedPayloadPolicy, UnifiedEvent,
+        UnifiedParserEvent, UnifiedParserExt, UnifiedParserInit, UnifiedParserOutput,
+        UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
+    };
+
+    fn tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "get_weather".into(),
+            description: None,
+            parameters: serde_json::json!({"type":"object","properties":{"city":{"type":"string"}}}),
+            strict: None,
+        }]
+    }
+
+    fn guided_init(
+        named_tool: Option<&str>,
+        invalid_guided_payload: InvalidGuidedPayloadPolicy,
+    ) -> UnifiedParserInit {
+        UnifiedParserInit {
+            tool_output_mode: UnifiedToolOutputMode::GuidedJson {
+                named_tool: named_tool.map(str::to_string),
+            },
+            invalid_guided_payload,
+            ..UnifiedParserInit::default()
+        }
+    }
+
+    fn recover_init(
+        starting_state: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+    ) -> UnifiedParserInit {
+        UnifiedParserInit {
+            starting_state,
+            tool_output_mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+            ..UnifiedParserInit::default()
+        }
+    }
+
+    /// `reset` must clear "resume reasoning after the interrupting call". Leaving it
+    /// armed made the NEXT stream's first post-call answer come out as reasoning —
+    /// the user's visible answer silently becomes private thinking.
+    #[test]
+    fn reset_does_not_leak_resume_reasoning_into_the_next_stream() {
+        let mut p = qwen3_unified(&tools());
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::Native,
+        ))
+        .unwrap();
+        // interrupt a thought with a call, then reset mid-stream
+        p.push("<think>weighing<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>")
+            .unwrap();
+        p.reset();
+
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::Native,
+        ))
+        .unwrap();
+        let out = assemble(
+            &[p.push("<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>visible answer").unwrap(),
+              p.finish().unwrap().events].concat());
+        assert!(
+            out.iter().any(
+                |e| matches!(e, UnifiedEvent::Text { text } if text.contains("visible answer"))
+            ),
+            "post-call answer was not visible text after reset: {out:?}"
+        );
+        assert!(
+            !out.iter().any(
+                |e| matches!(e, UnifiedEvent::Reasoning { text } if text.contains("visible answer"))
+            ),
+            "post-call answer leaked into reasoning after reset: {out:?}"
+        );
+    }
+
+    /// `reset` on a guided stream must restore the channel, not just drop buffers.
+    /// Left at VisibleOnly, the next stream's reasoning is swallowed as JSON payload.
+    #[test]
+    fn reset_restores_guided_channel_state() {
+        let mut p = qwen3_unified(&tools());
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+        ))
+        .unwrap();
+        p.push(r#"{"partial"#).unwrap(); // drives the mode to VisibleOnly
+        p.reset();
+
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+        ))
+        .unwrap();
+        let out = assemble(
+            &[p.push(r#"<think>thinking</think>[{"name":"get_weather","arguments":{"city":"Paris"}}]"#).unwrap(),
+              p.finish().unwrap().events].concat());
+        assert!(
+            out.iter()
+                .any(|e| matches!(e, UnifiedEvent::Reasoning { .. })),
+            "reasoning was swallowed as payload after reset: {out:?}"
+        );
+        assert!(
+            out.iter()
+                .any(|e| matches!(e, UnifiedEvent::ToolCall { .. })),
+            "call not recovered after reset: {out:?}"
+        );
+    }
+
+    /// A named choice constrains output to that tool's ARGUMENTS, which are an object.
+    /// A bare scalar or array is valid JSON but not an argument set, so dispatching it
+    /// would hand the tool a shape it cannot bind.
+    #[test]
+    fn named_choice_rejects_a_non_object_payload() {
+        for payload in [r#""just a string""#, "42", "null", "[1,2]"] {
+            let mut p = qwen3_unified(&tools());
+            p.initialize_request(recover_init(
+                UnifiedParserStartingState::None,
+                UnifiedToolOutputMode::GuidedJson {
+                    named_tool: Some("get_weather".to_string()),
+                },
+            ))
+            .unwrap();
+            let mut out = p.push(payload).unwrap();
+            out.extend(p.finish().unwrap().events);
+            assert!(
+                out.iter()
+                    .all(|d| !matches!(d, UnifiedParserEvent::ToolCall(_))),
+                "{payload}: dispatched a non-object payload as tool arguments"
+            );
+            assert!(
+                out.iter()
+                    .any(|d| matches!(d, UnifiedParserEvent::Text(..))),
+                "{payload}: payload was dropped instead of surfaced as text"
+            );
+        }
+    }
+
+    /// Guided must agree with native on `UNIFIED.6.a`: a call with no argument key
+    /// is a parameterless call, not a malformed one — and inside an array it must not
+    /// take its siblings down with it.
+    #[test]
+    fn a_parameterless_guided_call_is_dispatched_and_does_not_void_its_siblings() {
+        let mut p = qwen3_unified(&tools());
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+        ))
+        .unwrap();
+        let mut out = p
+            .push(r#"[{"name":"get_weather"},{"name":"get_weather","arguments":{"city":"Paris"}}]"#)
+            .unwrap();
+        out.extend(p.finish().unwrap().events);
+        let calls: Vec<_> = out
+            .iter()
+            .filter_map(|d| match d {
+                UnifiedParserEvent::ToolCall(c) => Some((c.name.clone(), c.arguments.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(calls.len(), 2, "a no-arg call voided the array: {out:?}");
+        assert_eq!(
+            calls[0].1, "{}",
+            "no-arg call did not get an empty argument set: {calls:?}"
+        );
+    }
+
+    /// The object case must still work.
+    #[test]
+    fn named_choice_still_accepts_an_object_payload() {
+        let mut p = qwen3_unified(&tools());
+        p.initialize_request(recover_init(
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+        ))
+        .unwrap();
+        let mut out = p.push(r#"{"city": "Paris"}"#).unwrap();
+        out.extend(p.finish().unwrap().events);
+        assert!(
+            out.iter()
+                .any(|d| matches!(d, UnifiedParserEvent::ToolCall(_))),
+            "object payload not dispatched: {out:?}"
+        );
+    }
+
+    #[test]
+    fn reject_policy_returns_typed_errors_for_every_invalid_payload_class() {
+        for (named_tool, payload, expected_kind) in [
+            (None, r#"not json"#, InvalidGuidedPayloadKind::InvalidJson),
+            (None, r#"{}"#, InvalidGuidedPayloadKind::WrongShape),
+            (
+                None,
+                r#"[{"name":"get_weather"},{"arguments":{}}]"#,
+                InvalidGuidedPayloadKind::WrongShape,
+            ),
+            (
+                None,
+                r#"{"name":"get_weather","arguments":7}"#,
+                InvalidGuidedPayloadKind::WrongShape,
+            ),
+            (
+                Some("get_weather"),
+                r#"[1,2]"#,
+                InvalidGuidedPayloadKind::WrongShape,
+            ),
+        ] {
+            let mut parser = qwen3_unified(&tools());
+            parser
+                .initialize_request(guided_init(named_tool, InvalidGuidedPayloadPolicy::Reject))
+                .unwrap();
+            let error = match parser.push(payload) {
+                Ok(_) => parser.finish().expect_err("invalid payload must reject"),
+                Err(error) => error,
+            };
+            let typed = error
+                .downcast_ref::<InvalidGuidedPayload>()
+                .expect("caller must be able to downcast guided failures");
+            assert_eq!(typed.kind, expected_kind, "payload={payload}");
+            assert_eq!(
+                typed.choice,
+                if named_tool.is_some() {
+                    "named"
+                } else {
+                    "required"
+                }
+            );
+            assert!(
+                !error.to_string().contains(payload),
+                "typed error leaked raw model output"
+            );
+        }
+    }
+
+    #[test]
+    fn recover_policy_preserves_invalid_payload_as_text() {
+        let mut parser = qwen3_unified(&tools());
+        parser
+            .initialize_request(guided_init(None, InvalidGuidedPayloadPolicy::RecoverAsText))
+            .unwrap();
+        let payload = r#"{"arguments":{}}"#;
+        let mut output = parser.push(payload).unwrap();
+        output.extend(parser.finish().unwrap().events);
+        assert_eq!(output, vec![UnifiedParserEvent::Text(payload.into())]);
+    }
+
+    #[test]
+    fn reject_keeps_reasoning_committed_and_buffer_recoverable() {
+        let mut parser = qwen3_unified(&tools());
+        parser
+            .initialize_request(guided_init(None, InvalidGuidedPayloadPolicy::Reject))
+            .unwrap();
+        let mut output = UnifiedParserOutput::default();
+        let error = parser
+            .parse_into(r#"<think>considering</think>{"arguments":{}}"#, &mut output)
+            .expect_err("wrong-shape payload must reject");
+        assert!(error.downcast_ref::<InvalidGuidedPayload>().is_some());
+        assert_eq!(
+            output.events,
+            vec![UnifiedParserEvent::Reasoning("considering".into())]
+        );
+        assert_eq!(parser.reset(), r#"{"arguments":{}}"#);
     }
 }


### PR DESCRIPTION
#### Overview:

**Second half of the split from #178, now based directly on `main`.** #178 landed the peer-trait alignment, vendor registry, and shared GUI/conformance tooling. This PR carries everything that depends on **Qwen3 request modes**, plus the corpus evidence that has to move atomically with it.

Qwen3 gains the two request modes the reasoning/tool split cannot honor: a prompt-prefilled channel (`UnifiedParserStartingState`) and guided-JSON tool output (`UnifiedToolOutputMode`). Other model families are unchanged.

<!-- stack-graph -->
#### Where this sits

```mermaid
flowchart TB
    A["#178 &nbsp;·&nbsp; MERGED FOUNDATION &nbsp;·&nbsp; ordered parser API, error-safe recovery, vendor registry"]
    B["#174 &nbsp;·&nbsp; THIS PR &nbsp;·&nbsp; Qwen3 native + guided-JSON request modes &nbsp;·&nbsp; corpus 99 → 240 cases"]
    C["#166 &nbsp;·&nbsp; NEXT FAMILY &nbsp;·&nbsp; Gemma 4 reuses the same contract and the same 240 cases"]
    A ==> B ==> C
    classDef landed fill:#eef1f4,stroke:#57606a,stroke-width:2px,color:#000
    classDef here fill:#fff4ce,stroke:#b06000,stroke-width:4px,color:#000
    classDef next fill:#f6f8fa,stroke:#8c959f,stroke-width:2px,color:#000
    class A landed
    class B here
    class C next
```

<img width="2205" height="375" alt="image" src="https://github.com/user-attachments/assets/07ef00e1-1149-420f-aa10-ba7b6eac4f38" />

The request-mode contract, failure behavior, evidence, and exclusions are tracked in [DIS-2544](https://linear.app/nvidia/issue/DIS-2544/v2-add-qwen3-unified-request-modes). #178 owns the reusable surface; this PR consumes it for Qwen3.
<!-- stack-graph -->

#### Example (before → after):

Input: `<think>Look it up.</think><tool_call>…</tool_call><think>Now answer.</think>It's 18C.`

```
before:  reasoning = "Look it up.Now answer."   <- second thought hoisted ahead of the call it followed, fused with the first
         content   = "It's 18C."
after:   reasoning("Look it up.") | tool_call(get_weather) | reasoning("Now answer.") | text("It's 18C.")
```

Ordering is not a field the split can add; it is lost at the seam between the two parsers.

#### Details:

- **Request modes** — prefilled channels and guided JSON, resolved once through an owned `UnifiedParserInit`, with bounded prefix-header ownership, checkpoints and rollback, guided payload draining, and native-markup fallback that stays control-only across every stream split. Invalid guided payloads default to a typed caller-actionable error; the conformance harness explicitly selects text recovery.
- **Corpus** — the authored feed goes from main's 33 scenarios / 99 cases to 80 / 240. 45 of the 47 added scenarios are request-scoped (groups 30/31/40/41/50/51); the other two are generic group-4 cases that travel here because the generator and LFS corpus have one owner. Generator, taxonomy, docs, schema consumers, archives, and manifest pins move together.
- **Capture contract** — split families keep their incremental chunk deltas as raw streaming evidence, but their assembled result follows the serving contract: whole-input reasoning first, then tool parsing over the remaining text. Folding those raw rows invented an interleaving the split path cannot represent. Qwen3 uses the native unified parser for both views, so its ordered `reasoning → tool_call → reasoning → text` stream remains intact.
- **Doc and corpus drift fixed** — before this PR, `UNIFIED_CASES.md` said 63 scenarios / 189 cases, claimed Gemma 4 ran the native `UnifiedParser` when the registry had only Qwen3, and described the 0.1.22 archive as holding 162 entries. The current generator emits 80 scenarios / 240 cases; the corrected 0.1.22 and 0.1.23 archives each contain all 240 cases.
- **LFS hygiene** — seven unrelated archive changes dropped: four tarballs whose extracted payloads are *identical* to the merge base (only gzip bytes differed), one whose only change is `captured_with.dynamo_v2` `0.1.23→0.1.24`, and two new tool-calling shards. None is request-mode evidence.

#### Verification:

```
cargo test --workspace --all-targets --locked   1451 passed, 33 suites, 0 failed
golden unified feed, 240 cases                  sha256 7e032176…  generated from the authored corpus
cargo clippy --workspace --all-targets          0 warnings
```

#### Where should the reviewer start?

`parsers/v2/src/unified/mod.rs` (request modes and guided state), then `parsers/v2/src/unified/qwen3.rs`, then the authored cases in `conformance/utils/src/gen_unified_golden.py`. Read the generated archives last, by count and hash rather than line by line.

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring parser starting state, output mode, and named tools.
  * Added guided JSON tool-output handling, including malformed-input recovery and raw argument preservation.
  * Expanded unified conformance coverage with new reasoning, tool-calling, streaming, schema, and recovery scenarios.
  * Added live capture validation and richer rendered conformance results.

* **Bug Fixes**
  * Improved marker handling, buffering, reset behavior, and recovery across chunk boundaries.
  * Empty outputs are now supported for control-only turns when documented.

* **Documentation**
  * Updated parser integration, migration, fixture, taxonomy, and conformance authoring guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

