### PR TITLE
refactor(parsers): align the unified parser surface with peer traits, and let vendors supply their own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.27"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dev-dependencies]
 anyhow = { workspace = true }
 dynamo-parsers = { workspace = true }
-dynamo-parsers-v2 = { path = "../parsers/v2", version = "0.1.27" }
+dynamo-parsers-v2 = { path = "../parsers/v2", version = "0.2.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.9"

--- a/conformance/tests/capture_cross_version.rs
+++ b/conformance/tests/capture_cross_version.rs
@@ -243,15 +243,15 @@ fn fold_chunks(rows: &[Vec<Value>]) -> Vec<serde_yaml::Value> {
 /// Per-chunk rows record RAW deltas, not assembled events — `arguments` stays the
 /// literal fragment the parser emitted. Mirrors `unified_render::unified_delta_json`.
 /// (Assembling per chunk instead produces a mapping and makes every case look changed.)
-fn delta_to_yaml(d: &dynamo_parsers_v2::UnifiedDelta) -> serde_yaml::Value {
+fn delta_to_yaml(d: &dynamo_parsers_v2::UnifiedParserEvent) -> serde_yaml::Value {
     let v = match d {
-        dynamo_parsers_v2::UnifiedDelta::Reasoning { text } => {
+        dynamo_parsers_v2::UnifiedParserEvent::Reasoning(text) => {
             serde_json::json!({"kind": "reasoning", "text": text})
         }
-        dynamo_parsers_v2::UnifiedDelta::Text { text } => {
+        dynamo_parsers_v2::UnifiedParserEvent::Text(text) => {
             serde_json::json!({"kind": "text", "text": text})
         }
-        dynamo_parsers_v2::UnifiedDelta::ToolCall(c) => {
+        dynamo_parsers_v2::UnifiedParserEvent::ToolCall(c) => {
             serde_json::json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
         }
     };

--- a/conformance/tests/capture_cross_version.rs
+++ b/conformance/tests/capture_cross_version.rs
@@ -37,7 +37,8 @@ use std::path::{Path, PathBuf};
 
 use dynamo_parsers::{ReasoningParser, ReasoningParserType};
 use dynamo_parsers_v2::{
-    Tool, UnifiedEvent, assemble, create_tool_parser_for_family, create_unified_parser_for_family,
+    Tool, UnifiedEvent, UnifiedParserExt, assemble, create_tool_parser_for_family,
+    create_unified_parser_for_family,
 };
 use serde_json::{Value, json};
 

--- a/conformance/tests/unified_parity.rs
+++ b/conformance/tests/unified_parity.rs
@@ -20,7 +20,8 @@ mod common;
 use std::collections::BTreeMap;
 
 use dynamo_parsers_v2::{
-    REGISTERED_UNIFIED_FAMILIES, Tool, UnifiedEvent, assemble, create_unified_parser_for_family,
+    REGISTERED_UNIFIED_FAMILIES, Tool, UnifiedEvent, UnifiedParserExt, assemble,
+    create_unified_parser_for_family,
 };
 use serde::Deserialize;
 use serde_json::json;

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -23,7 +23,8 @@ use std::path::PathBuf;
 
 use dynamo_parsers::{ReasoningParser, ReasoningParserType};
 use dynamo_parsers_v2::{
-    Tool, assemble, create_tool_parser_for_family, create_unified_parser_for_family,
+    Tool, UnifiedParserExt, assemble, create_tool_parser_for_family,
+    create_unified_parser_for_family,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -155,13 +155,13 @@ impl From<dynamo_parsers_v2::UnifiedEvent> for Ev {
     }
 }
 
-fn unified_delta_json(d: &dynamo_parsers_v2::UnifiedDelta) -> Value {
+fn unified_delta_json(d: &dynamo_parsers_v2::UnifiedParserEvent) -> Value {
     match d {
-        dynamo_parsers_v2::UnifiedDelta::Reasoning { text } => {
+        dynamo_parsers_v2::UnifiedParserEvent::Reasoning(text) => {
             json!({"kind": "reasoning", "text": text})
         }
-        dynamo_parsers_v2::UnifiedDelta::Text { text } => json!({"kind": "text", "text": text}),
-        dynamo_parsers_v2::UnifiedDelta::ToolCall(c) => {
+        dynamo_parsers_v2::UnifiedParserEvent::Text(text) => json!({"kind": "text", "text": text}),
+        dynamo_parsers_v2::UnifiedParserEvent::ToolCall(c) => {
             json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
         }
     }

--- a/conformance/utils/piece1_coupling_gate.sh
+++ b/conformance/utils/piece1_coupling_gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Falsifiable gate: prove a candidate PIECE-1 tree carries NO request-mode coupling.
+#
+# Piece 1 (peer-trait alignment + vendor registry + GUI + conformance tooling) must be
+# correct ON ITS OWN, because it sits on main while piece 2 is still in review and is
+# what an external implementor sees during that window. "I read the diff and it looked
+# clean" is not evidence -- every defect this session survived exactly that check.
+#
+# Usage:  piece1_coupling_gate.sh [BASE]      (BASE defaults to origin/main)
+# Exit 0 only if every check passes. Any failure prints what and why.
+
+set -uo pipefail
+BASE="${1:-origin/main}"
+fail=0
+note() { printf "  %-52s %s\n" "$1" "$2"; }
+bad()  { fail=1; printf "  FAIL %-47s %s\n" "$1" "$2"; }
+
+# 1. Request-mode symbols must not appear ANYWHERE in the base..HEAD diff.
+#    Searching the diff, not the repo, is deliberate: the repo may legitimately
+#    contain these names on main one day; what must stay clean is what THIS piece adds.
+SYMS=(UnifiedParserStartingState UnifiedToolOutputMode UnifiedParserInit UnifiedPrompt
+      UnifiedStartingStateInput initialize_request initialize_with_state
+      initialize_with_output_mode initialize_from_prompt GuidedState GuidedJson)
+# Exclude THIS script: it necessarily contains every forbidden symbol name, so
+# scanning a diff that adds it makes the gate fail on itself.
+diff_text="$(git diff "$BASE"...HEAD -- . ':(exclude)conformance/utils/piece1_coupling_gate.sh')"
+for s in "${SYMS[@]}"; do
+  n=$(printf '%s' "$diff_text" | grep -cE "^[+-].*\b${s}\b" || true)
+  if [ "$n" -gt 0 ]; then bad "symbol '$s'" "appears $n time(s) in the diff"; fi
+done
+[ "$fail" -eq 0 ] && note "request-mode symbols in diff" "none (${#SYMS[@]} checked)"
+
+# 2. Fixtures and the manifest must be untouched. Piece 1 owns no corpus data.
+if git diff --exit-code --quiet "$BASE" -- conformance/fixtures conformance/fixtures-manifest.json; then
+  note "conformance/fixtures + manifest" "byte-identical to $BASE"
+else
+  bad "conformance/fixtures + manifest" "MODIFIED — piece 1 must not touch corpus data"
+fi
+
+# 3. The two LFS pointers that pin the corpus must still be main's.
+#    A pointer change is how a corpus transition leaks in without touching many files.
+for f in conformance/fixtures/unified/golden.tar.gz conformance/fixtures/unified/inputs.tar.gz; do
+  b=$(git show "$BASE:$f" 2>/dev/null | grep -oE 'oid sha256:[0-9a-f]+' | cut -d: -f2)
+  h=$(git show "HEAD:$f"  2>/dev/null | grep -oE 'oid sha256:[0-9a-f]+' | cut -d: -f2)
+  if [ -n "$b" ] && [ "$b" = "$h" ]; then note "$(basename "$f") pointer" "${b:0:16} (unchanged)"
+  else bad "$(basename "$f") pointer" "${b:0:16} -> ${h:0:16}"; fi
+done
+
+# 4. The emitted corpus must still be main's 33 scenarios x 3 = 99 cases.
+#    Counted from the GENERATOR, not the taxonomy map: the map reserves names the
+#    generator does not emit, which is how a false 156-case denominator arose before.
+if [ -f conformance/utils/src/gen_unified_golden.py ]; then
+  # Written to a temp file rather than an inline heredoc: `$( <<EOF ... EOF || echo X )`
+  # is a bash syntax error, and the check silently produced nothing until it was run
+  # with output visible. A check that cannot fail loudly is not a check.
+  _cnt_py=$(mktemp /tmp/piece1_count_XXXX.py)
+  cat > "$_cnt_py" <<'PYEOF'
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location("g", pathlib.Path("src/gen_unified_golden.py"))
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+print(len(getattr(m, "CLEAN", [])) + len(getattr(m, "EDGE", [])))
+PYEOF
+  cnt=$( (cd conformance/utils && PYTHONPATH=src python3 "$_cnt_py") 2>/dev/null )
+  rm -f "$_cnt_py"
+  if [ "$cnt" = "33" ]; then note "generator scenarios" "33 (99 cases) — main's shape"
+  elif [ -z "$cnt" ]; then bad "generator scenarios" "count FAILED to run — check manually"
+  else bad "generator scenarios" "$cnt, expected 33 — corpus expansion belongs to piece 2"; fi
+fi
+
+# 5. The peer surface must be present and complete, with peer-shaped defaults.
+M=parsers/v2/src/unified/mod.rs
+if [ -f "$M" ]; then
+  grep -q 'fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()>;' "$M" \
+    && note "parse_into" "required (no default)" || bad "parse_into" "not the required method"
+  grep -q 'fn finish(&mut self) -> Result<UnifiedParserOutput>' "$M" \
+    && note "finish" "returns UnifiedParserOutput" || bad "finish" "wrong return type"
+  grep -qE 'fn initialize\(&mut self, _?prompt_token_ids: &\[u32\]\)' "$M" \
+    && note "initialize(&[u32])" "peer signature present" || bad "initialize(&[u32])" "missing"
+  grep -q 'Text(String)' "$M" && grep -q 'Reasoning(String)' "$M" \
+    && note "UnifiedParserEvent" "peer tuple variants" || bad "UnifiedParserEvent" "not peer shape"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "  PIECE-1 COUPLING GATE: PASS"; else echo "  PIECE-1 COUPLING GATE: FAIL"; fi
+exit "$fail"

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -5,6 +5,8 @@
 body { font-family: -apple-system, system-ui, sans-serif; margin: 1.5em; }
 table { border-collapse: collapse; font-family: ui-monospace, monospace; font-size: 13px; }
 th, td { border: 1px solid #ccc; padding: 3px 4px; }
+/* Case columns carry no text of their own — trim their padding too. */
+th.case-sub, td.cell { padding-left: 1px; padding-right: 1px; }
 th { background: #f5f5f5; }
 th.case-group { font-family: -apple-system, system-ui, sans-serif; font-size: 12px; }
 th.case-group.case-band-0 { background: #f1f3f5; }
@@ -34,7 +36,12 @@ td.parser a:hover { background: #ffd; }
 .arch-combined { background: #fef3e0; color: #9a5b00; border-color: #f0c98a; }
 [data-theme="dark"] .arch-unified { background: #14361f; color: #7fe0a0; border-color: #2f6b45; }
 [data-theme="dark"] .arch-combined { background: #3a2a12; color: #f0be7c; border-color: #6b4e24; }
-td.cell { position: relative; text-align: center; width: 44px; min-width: 44px; max-width: 44px; font-weight: 400; }
+/* Cell content is a 1-3 char marker and is absolutely positioned, so the column
+   width is pure padding — and across the widest tabs 44px each made the table
+   thousands of pixels wide for markers that need a fraction of it.
+   26px still clears the widest marker; the header labels are short ids (`31.n`),
+   not scenario names, so they fit too. */
+td.cell { position: relative; text-align: center; width: 26px; min-width: 26px; max-width: 26px; font-weight: 400; }
 /* One color = one meaning, whether or not the cell has compare data. A cell without
    `data-cmp` (an n/a stub or a missing fixture) must read exactly like a compare cell
    of the same meaning: gray = n/a, light-gray = Base-only, near-white = missing. The
@@ -636,9 +643,20 @@ body.transpose-mode .tab-panel.active .transpose-table { display: table; }
    shrink-wrap to its content (make the marker in-flow, click-anchor out of flow). */
 body.view-overview .transpose-table td.cell,
 body.view-overview .transpose-table th.tcol-model { width: 30px; min-width: 30px; max-width: 30px; }
+/* Transposed DETAILS keeps the marker in normal flow (`position: static` below),
+   so unlike the upright table the marker text really does drive column width.
+   `max-width: none` then let one long marker (e.g. `VPB?SRB?`) stretch its whole
+   column and, with a column per engine, the table far past the viewport. Cap it:
+   `width: auto` still shrink-wraps short columns, the cap just stops the long
+   ones, and the marker ellipsizes rather than forcing the table wider. */
 body.view-details .transpose-table td.cell,
-body.view-details .transpose-table th.tcol-model { width: auto; min-width: 22px; max-width: none; }
-body.view-details .transpose-table td.cell { padding: 3px 2px; }
+body.view-details .transpose-table th.tcol-model { width: auto; min-width: 22px; max-width: 40px; }
+/* NO `overflow: hidden` on the cell: `.ttip` is a CHILD of td.cell, so clipping
+   the cell clips the hover popup itself — the width cap below belongs on the
+   marker span, which is the only thing that needs truncating. */
+body.view-details .transpose-table td.cell { padding: 3px 1px; }
+body.view-details .transpose-table td.cell .marker-text {
+  display: inline-block; max-width: 38px; overflow: hidden; text-overflow: ellipsis; vertical-align: bottom; }
 body.view-details .transpose-table td.cell .cell-marker,
 body.view-details .transpose-table td.cell .cmp-marker { position: static; }
 body.view-details .transpose-table td.cell > a { position: absolute; inset: 0; }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -697,22 +697,36 @@
   // still read `touch`, call `preventDefault()` and pin — suppressing the link the
   // keyboard user asked for. `pointercancel` clears it too, so an aborted gesture
   // cannot arm a later click.
+  // Both the KIND of pointer and WHERE it went down. The kind alone is a document-wide
+  // global: a tap that lands anywhere else — a header, a scroll, any element that is not a
+  // tooltip host — leaves `touch` armed, because only a tooltip host's click consumes it.
+  // The next MOUSE click on a host would then read that stale `touch`, pin, and
+  // `preventDefault()` the parser-source link the mouse user actually asked for. Requiring
+  // the pointerdown to have landed inside the same host makes the provenance belong to
+  // this interaction rather than to whatever touched the page last.
   let pendingPointerType = '';
+  let pendingPointerTarget = null;
   document.addEventListener('pointerdown', function (e) {
     pendingPointerType = e.pointerType || '';
+    pendingPointerTarget = e.target;
   }, true);
   document.addEventListener('pointercancel', function () {
     pendingPointerType = '';
+    pendingPointerTarget = null;
   }, true);
   // A click that came from a finger or stylus has no hover behind it, so it must open the
   // popup and pin it. A mouse click must not: hover already showed the popup, and pinning
   // is modal (see `hoverAllowed`), so a mouse pin would switch hover off page-wide.
   // Unknown/empty pointerType (synthetic `.click()`, keyboard activation) is treated as
   // NOT touch, matching the mouse/keyboard contract.
-  const consumeClickShouldPin = function () {
+  const consumeClickShouldPin = function (cell) {
     const t = pendingPointerType;
+    const target = pendingPointerTarget;
     pendingPointerType = '';
-    return t === 'touch' || t === 'pen';
+    pendingPointerTarget = null;
+    if (t !== 'touch' && t !== 'pen') { return false; }
+    // The gesture must have STARTED in this host, or it belongs to something else.
+    return !!(cell && target && cell.contains(target));
   };
   let pinnedCell = null;
   function unpinCell(c) { if (c && c._ttipUnpin) { c._ttipUnpin(); } }
@@ -839,7 +853,7 @@
       // so leaving the provenance unconsumed on any of them hands a stale `touch` to the
       // NEXT click — the defect consume-on-use exists to prevent, one branch over. A tap
       // on the popup's own links or its ✕ takes this return, and used to leave it armed.
-      const shouldPin = consumeClickShouldPin();
+      const shouldPin = consumeClickShouldPin(cell);
       if (e.target.closest('.ttip')) { return; }
       // Decided per-interaction, not per-page: only a finger or stylus pins. A mouse click
       // falls through to the cell's own parser-source link, and never enters modal pin mode.

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -674,10 +674,46 @@
   }
 
   // Touch devices have no hover, so the tooltip is opened by TAP and pinned open
-  // (with an ✕ to close) rather than shown on pointerenter. Desktop keeps hover;
-  // a click there also pins (handy for reading a big tooltip without holding the
-  // mouse still). Only one tooltip is pinned at a time.
-  const hoverCapable = window.matchMedia('(hover: hover)').matches;
+  // (with an ✕ to close) rather than shown on pointerenter. Where hover EXISTS, hover is
+  // the only affordance — clicking never pins, because pinning is modal and one stray
+  // click otherwise disabled hover page-wide. So pinning is a touch-only mechanism now.
+  // Only one tooltip is pinned at a time.
+  // NEVER gate event REGISTRATION on a media query. `(hover: hover)` and
+  // `(any-hover: hover)` are advisory descriptions of a device; they are not a statement
+  // about which events the browser will deliver. Chrome on Keiven's desktop reports BOTH
+  // false while delivering real hover — the cell matched CSS `:hover` and the lazy content
+  // builder ran on `pointerover`, but no `pointerenter` listener existed to open the popup,
+  // so hovering did nothing at all. The same gate silently removed keyboard access, because
+  // `focusin`/`focusout` sat behind it too.
+  //
+  // So: listeners are always attached (below), and the ONE thing that genuinely needs to
+  // know the input device — whether a tap should pin — is decided from the actual
+  // `PointerEvent.pointerType` of the interaction in hand, which is a fact rather than a
+  // guess. `pendingPointerType` is written on `pointerdown`, which always precedes the click
+  // it belongs to.
+  // CONSUMED by the click it belongs to, then cleared. Holding it until the next
+  // `pointerdown` made it stale rather than click-scoped: a keyboard activation issues
+  // no `pointerdown` at all, so after any touch the next Enter on a focused link would
+  // still read `touch`, call `preventDefault()` and pin — suppressing the link the
+  // keyboard user asked for. `pointercancel` clears it too, so an aborted gesture
+  // cannot arm a later click.
+  let pendingPointerType = '';
+  document.addEventListener('pointerdown', function (e) {
+    pendingPointerType = e.pointerType || '';
+  }, true);
+  document.addEventListener('pointercancel', function () {
+    pendingPointerType = '';
+  }, true);
+  // A click that came from a finger or stylus has no hover behind it, so it must open the
+  // popup and pin it. A mouse click must not: hover already showed the popup, and pinning
+  // is modal (see `hoverAllowed`), so a mouse pin would switch hover off page-wide.
+  // Unknown/empty pointerType (synthetic `.click()`, keyboard activation) is treated as
+  // NOT touch, matching the mouse/keyboard contract.
+  const consumeClickShouldPin = function () {
+    const t = pendingPointerType;
+    pendingPointerType = '';
+    return t === 'touch' || t === 'pen';
+  };
   let pinnedCell = null;
   function unpinCell(c) { if (c && c._ttipUnpin) { c._ttipUnpin(); } }
   // "Inside a pinnable element" must mean EXACTLY the set `attachTooltip` wired, so ask
@@ -786,18 +822,29 @@
       }, hideDelayMs);
     }
 
-    // Tap (or click) toggles a pinned tooltip. Taps INSIDE the tooltip (its links,
-    // the ✕) behave normally. On touch there's no hover, so a tap on the cell must
-    // open the tooltip instead of following the cell's own parser-source link —
-    // preventDefault blocks that navigation. On desktop, a click on the cell link
-    // still navigates; a click on the cell body pins.
+    // TOUCH ONLY. Tap toggles a pinned tooltip; taps INSIDE the tooltip (its links, the ✕)
+    // behave normally. Touch has no hover, so a tap on the cell must open the tooltip
+    // instead of following the cell's own parser-source link — preventDefault blocks that
+    // navigation. Without this, a touch user could not read a popup at all.
+    //
+    // There is deliberately NO click-to-pin where hover exists. Pinning is MODAL
+    // (`hoverAllowed()` below): while one cell is pinned, hover opens nothing anywhere
+    // else. That made a single stray click kill hover for the whole page until the pin
+    // was released, and in details view "click somewhere else to dismiss" almost always
+    // lands on another wired cell, which just moves the pin — so hover never came back.
+    // On a hover-capable device hover is the only affordance, and a click on a cell now
+    // does what the cell says it does: follow its parser-source link.
     cell.addEventListener('click', function (e) {
+      // Consume FIRST, unconditionally. Every early return below still ends this click,
+      // so leaving the provenance unconsumed on any of them hands a stale `touch` to the
+      // NEXT click — the defect consume-on-use exists to prevent, one branch over. A tap
+      // on the popup's own links or its ✕ takes this return, and used to leave it armed.
+      const shouldPin = consumeClickShouldPin();
       if (e.target.closest('.ttip')) { return; }
-      if (!hoverCapable) {
-        e.preventDefault();
-      } else if (e.target.closest('a, button, input, label')) {
-        return;
-      }
+      // Decided per-interaction, not per-page: only a finger or stylus pins. A mouse click
+      // falls through to the cell's own parser-source link, and never enters modal pin mode.
+      if (!shouldPin) { return; }
+      e.preventDefault();
       if (ttip.classList.contains('ttip-pinned')) { unpin(); } else { pin(); }
     });
     // Hover show/hide only where hover exists; on touch it just flickers. A pinned
@@ -810,20 +857,32 @@
     // their own. Hover resumes when the pin is released (✕, clicking the pinned cell
     // again, or clicking outside).
     const hoverAllowed = function () { return pinnedCell === null || pinnedCell === cell; };
-    if (hoverCapable) {
-      cell.addEventListener('pointerenter', function () {
-        if (hoverAllowed() && !ttip.classList.contains('ttip-pinned')) { scheduleShow(); }
-      });
-      cell.addEventListener('pointerleave', function () {
-        if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
-      });
-      cell.addEventListener('focusin', function () {
-        if (hoverAllowed()) { scheduleShow(); }
-      });
-      cell.addEventListener('focusout', function () {
-        if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
-      });
-    }
+    // Registered UNCONDITIONALLY — see the `pendingPointerType` note above. If a device has no
+    // hover these simply never fire; if it does, they work regardless of what the media
+    // queries claim. `focusin`/`focusout` additionally give keyboard users the popup.
+    const onEnter = function () {
+      if (hoverAllowed() && !ttip.classList.contains('ttip-pinned')) { scheduleShow(); }
+    };
+    const onLeave = function () {
+      if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
+    };
+    cell.addEventListener('pointerenter', onEnter);
+    cell.addEventListener('pointerleave', onLeave);
+    // ALSO the classic mouse events, deliberately not instead. `pointerenter` is the
+    // modern spelling, but it does not fire on movement when the browser classifies the
+    // input as a touch pointer — and a device can report no hover capability, deliver a
+    // real mouse, and still surprise us about which family of events it sends. These two
+    // are what every browser has emitted for a moving mouse for twenty years. Both paths
+    // funnel into the same scheduleShow/scheduleHide, which are idempotent (they clear
+    // their own timers), so a browser sending BOTH opens exactly one popup.
+    cell.addEventListener('mouseenter', onEnter);
+    cell.addEventListener('mouseleave', onLeave);
+    cell.addEventListener('focusin', function () {
+      if (hoverAllowed()) { scheduleShow(); }
+    });
+    cell.addEventListener('focusout', function () {
+      if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
+    });
   }
   // The elements present at load. `th.case-sub` carries the per-column grammar popup (the
   // same case in every family's grammar); it uses the identical hover/pin machinery as a

--- a/conformance/utils/src/assets/conformance_view.js
+++ b/conformance/utils/src/assets/conformance_view.js
@@ -62,6 +62,16 @@
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
   }
+  // Monospace the things that ARE literals: backtick spans the corpus already
+  // writes (`reasoning/core`), and e2e artifact filenames like
+  // `case-0105-schema_escaped_unicode_string__non-stream-budget_capped.json`,
+  // which otherwise wrap mid-token in prose and read as a sentence.
+  // Runs AFTER escapeHtml, so the input is already inert and this only adds tags.
+  function codeSpans(escaped) {
+    return String(escaped)
+      .replace(/`([^`]+)`/g, '<tt>$1</tt>')
+      .replace(/(^|[\s(])(case-\d{3,}-[A-Za-z0-9_.-]+\.json)/g, '$1<tt>$2</tt>');
+  }
   function escapeAttr(s) { return escapeHtml(s); }
   function num(x) { return String(x == null ? 0 : x); }
 
@@ -218,7 +228,7 @@
   }
 
   // --- Output block rendering (mirrors _format_output_block_html) ------------
-  function outputBlock(b, family, ctx) {
+  function outputBlock(b, family, ctx, goldenKinds) {
     if (!b) { return '—'; }
     if (b.unavailable != null) {
       // Prose, not payload: these carry n/a rationale and TODO notes.
@@ -254,7 +264,18 @@
       // A blank line separates the monospaced event stream from the explanation
       // lines (verdict / TODO / note) so they don't read as another event.
       var expl = [];
-      if (b.verdict && b.verdict !== 'MATCH') { expl.push('diverges: ' + escapeHtml(b.verdict)); }
+      if (b.verdict && b.verdict !== 'MATCH') {
+        expl.push('diverges: ' + escapeHtml(b.verdict));
+        // ORDER/MERGE mean every BYTE survived and only the SEQUENCE is wrong.
+        // Naming the class without showing the sequence makes the reader diff
+        // two event lists by eye — so print both orders explicitly.
+        if ((b.verdict === 'ORDER' || b.verdict === 'MERGE') && goldenKinds) {
+          var arrow = ' \u2192 ';
+          var gotKinds = (b.events || []).map(function (ev) { return ev.kind; });
+          expl.push('want: ' + escapeHtml(goldenKinds.join(arrow)));
+          expl.push('got:  ' + escapeHtml(gotKinds.join(arrow)));
+        }
+      }
       if (b.todo) { expl.push(escapeHtml(String(b.todo))); }
       if (b.note) { expl.push(escapeHtml(String(b.note))); }
       if (expl.length) {
@@ -387,6 +408,9 @@
       if (c.key === 'golden') { golden = c; return false; }
       return true;
     });
+    var goldenKinds = golden && golden.block && golden.block.events
+      ? golden.block.events.map(function (ev) { return ev.kind; })
+      : null;
     var header = '';
     cands.forEach(function (c, ci) {
       header += '<th data-cand="' + escapeAttr(c.key) + '" data-cand-order="' + ci + '">'
@@ -425,7 +449,7 @@
       var diverges = c.block && c.block.verdict && c.block.verdict !== 'MATCH';
       fin += '<td data-cand="' + escapeAttr(c.key) + '" data-cand-order="' + ci + '"'
         + (diverges ? ' class="cand-diverge"' : '') + '>'
-        + outputBlock(c.block, family, ctx).replace(/\n/g, '<br>') + '</td>';
+        + outputBlock(c.block, family, ctx, goldenKinds).replace(/\n/g, '<br>') + '</td>';
     });
     fin += '</tr>';
     var inputHdr = golden ? 'input / golden output' : 'input';
@@ -517,10 +541,10 @@
     // the loud section blue). Falls back to its own line only when there is no id/head.
     if (m.head) {
       h += '<div class="ttip-head">' + escapeHtml(m.head)
-        + (m.description ? ' <span class="ttip-head-desc">' + escapeHtml(m.description) + '</span>' : '')
+        + (m.description ? ' <span class="ttip-head-desc">' + codeSpans(escapeHtml(m.description)) + '</span>' : '')
         + '</div>';
     } else if (m.description) {
-      h += '<div class="ttip-casedesc"><span class="ttip-head-desc">' + escapeHtml(m.description) + '</span></div>';
+      h += '<div class="ttip-casedesc"><span class="ttip-head-desc">' + codeSpans(escapeHtml(m.description)) + '</span></div>';
     }
     // Parser configuration for THIS case, one knob per line, directly under the
     // description it qualifies.
@@ -755,7 +779,7 @@
     // Id + description on ONE line: the id keeps its accent color, the description follows
     // inline in the normal tooltip text color (not the loud section blue).
     var h = '<div class="ttip-head">' + escapeHtml(m.head || '')
-      + (m.desc ? ' <span class="ttip-head-desc">' + escapeHtml(m.desc) + '</span>' : '')
+      + (m.desc ? ' <span class="ttip-head-desc">' + codeSpans(escapeHtml(m.desc)) + '</span>' : '')
       + '</div>';
     // Same builder as the cell popup: a column header and the cells under it describe
     // one configuration, so they cannot drift into showing different knobs.
@@ -798,9 +822,13 @@
       // One OUTPUT column per candidate (golden pinned first, then Reference, then the
       // rest). data-cand/-order/-pin let applyCtl show only golden + the active columns
       // and order them REF-first, exactly like the cell popup's candidate columns.
+      var goldenBlock = r.blocks && r.blocks.golden;
+      var goldenKinds = goldenBlock && goldenBlock.events
+        ? goldenBlock.events.map(function (ev) { return ev.kind; })
+        : null;
       outCell = cands.map(function (c, ci) {
         var blk = r.blocks && r.blocks[c.key];
-        var inner = blk ? outputBlock(blk, r.family || null, ctx).replace(/\n/g, '<br>')
+        var inner = blk ? outputBlock(blk, r.family || null, ctx, goldenKinds).replace(/\n/g, '<br>')
                         : '<span class="parser-base">—</span>';
         return '<td class="gro" data-cand="' + escapeAttr(c.key) + '" data-cand-order="' + ci + '"'
           + (c.pin ? ' data-cand-pin="1"' : '') + '>' + inner + '</td>';
@@ -918,6 +946,13 @@
       td.appendChild(a);
     }
     if (cell.tooltip) {
+      var hasSequenceDivergence = (cell.tooltip.candidates || []).some(function (candidate) {
+        var verdict = candidate.block && candidate.block.verdict;
+        return verdict === 'ORDER' || verdict === 'MERGE';
+      });
+      if (hasSequenceDivergence) {
+        td.setAttribute('data-sequence-divergence', '1');
+      }
       var ttip = document.createElement('div');
       ttip.className = 'ttip';
       td.appendChild(ttip);

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -765,3 +765,48 @@ def test_touch_then_keyboard_does_not_pin(driver):
             "a touch tap inside a tooltip left pointer provenance armed, so the next "
             "keyboard activation inherited it"
         )
+
+
+def test_touch_outside_a_host_does_not_arm_the_next_mouse_click(driver):
+    """A tap that lands anywhere else must not make the NEXT mouse click pin.
+
+    Pointer provenance recorded only the KIND of pointer, in one document-wide
+    variable. Only a tooltip host's own click consumed it, so a tap on a header —
+    or any element that is not a host — left `touch` armed indefinitely. The next
+    genuine MOUSE click on a host then read that stale `touch`, pinned, and
+    `preventDefault()`ed the parser-source link the mouse user actually asked for.
+    Provenance now also records WHERE the pointer went down and is only honoured
+    when the gesture started inside the same host.
+    """
+    drv = driver
+    drv.execute_script(
+        "const v=document.querySelector('[data-view-detailed]'); if(v && !v.checked){v.checked=true; v.dispatchEvent(new Event('change'));}"
+    )
+    time.sleep(0.4)
+
+    pinned = drv.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active') || document;
+        const cell = p.querySelector('[data-ttip-wired]');
+        if (!cell) { return 'no-cell'; }
+
+        // A touch that goes down on something that is NOT a tooltip host, and whose
+        // click therefore never reaches a host's handler to consume the provenance.
+        const outside = document.querySelector('h1, h2, header, .legend') || document.body;
+        outside.dispatchEvent(new PointerEvent('pointerdown',
+            {bubbles: true, cancelable: true, pointerType: 'touch', isPrimary: true}));
+        outside.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+
+        // Now an activation on a host that carries NO pointerdown of its own — a keyboard
+        // Enter or a synthetic click. It cannot overwrite the stale provenance, so this is
+        // the interaction that actually reads it.
+        cell.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+
+        return !!document.querySelector('.ttip.ttip-pinned');
+        """
+    )
+    assert pinned != 'no-cell', "no wired tooltip host found to exercise"
+    assert pinned is False, (
+        "a pointerdown-less activation pinned because an unrelated touch elsewhere left "
+        "the provenance armed — pinning must require the gesture to start in this host"
+    )

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -773,10 +773,12 @@ def test_touch_outside_a_host_does_not_arm_a_pointerdownless_activation(driver):
     Pointer provenance recorded only the KIND of pointer, in one document-wide
     variable. Only a tooltip host's own click consumed it, so a tap on a header —
     or any element that is not a host — left `touch` armed indefinitely. The next
-    genuine MOUSE click on a host then read that stale `touch`, pinned, and
-    `preventDefault()`ed the parser-source link the mouse user actually asked for.
-    Provenance now also records WHERE the pointer went down and is only honoured
-    when the gesture started inside the same host.
+    activation on a host that carries NO pointerdown of its own — keyboard Enter, a
+    synthetic click — then read that stale `touch`, pinned, and `preventDefault()`ed
+    the parser-source link the user actually asked for. A genuine mouse click is NOT
+    the vulnerable case: it brings its own mouse `pointerdown`, which overwrites the
+    stale value before the click arrives. Provenance now also records WHERE the
+    pointer went down and is only honoured when the gesture started in the same host.
     """
     drv = driver
     drv.execute_script(

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -767,8 +767,8 @@ def test_touch_then_keyboard_does_not_pin(driver):
         )
 
 
-def test_touch_outside_a_host_does_not_arm_the_next_mouse_click(driver):
-    """A tap that lands anywhere else must not make the NEXT mouse click pin.
+def test_touch_outside_a_host_does_not_arm_a_pointerdownless_activation(driver):
+    """A tap that lands anywhere else must not arm the next pointerdown-less activation.
 
     Pointer provenance recorded only the KIND of pointer, in one document-wide
     variable. Only a tooltip host's own click consumed it, so a tap on a header —

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -44,8 +44,7 @@ window.matchMedia = function (q) {
 """
 
 
-@pytest.fixture(scope="module")
-def driver(rendered_page):
+def _chrome(rendered_page, force_hover):
     opts = Options()
     for a in ("--headless=new", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--window-size=1600,1200"):
         opts.add_argument(a)
@@ -53,11 +52,165 @@ def driver(rendered_page):
         d = webdriver.Chrome(options=opts)
     except Exception as exc:  # noqa: BLE001 — environment without a usable driver
         pytest.skip(f"could not start Chrome webdriver: {exc}")
-    d.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {"source": _FORCE_HOVER_JS})
+    if force_hover:
+        d.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {"source": _FORCE_HOVER_JS})
     d.get(f"file://{rendered_page}")
     d.implicitly_wait(2)
+    return d
+
+
+@pytest.fixture(scope="module")
+def driver(rendered_page):
+    d = _chrome(rendered_page, force_hover=True)
     yield d
     d.quit()
+
+
+@pytest.fixture(scope="module")
+def unforced_driver(rendered_page):
+    """Chrome with its REAL media-query values — no matchMedia patch.
+
+    Headless Chrome reports `(hover: hover)` and `(any-hover: hover)` false, which is
+    precisely what Chrome reported on the desktop where hovering opened nothing. Every
+    other lane forces those true and therefore cannot observe that failure. This is the
+    negative control: it must pass while the browser claims no hover capability.
+    """
+    d = _chrome(rendered_page, force_hover=False)
+    yield d
+    d.quit()
+
+
+@pytest.fixture(scope="module")
+def touch_driver(rendered_page):
+    """A driver on the TOUCH branch — no matchMedia patch, so `(hover: hover)` is false.
+
+    Tap-to-pin only exists here: pinning is modal, so a mouse click must never pin or it
+    would disable hover page-wide. The page decides from `PointerEvent.pointerType`, and
+    the tap is delivered by `_tap`, which fires a genuine `pointerdown` carrying
+    `pointerType: 'touch'` before the click. A bare `.click()` carries no pointerdown and
+    would be classified (correctly) as not-touch, testing nothing; CDP mouse-to-touch
+    emulation was tried first and deadlocks ActionChains. This fixture is what keeps the
+    pin machinery under test.
+    """
+    d = _chrome(rendered_page, force_hover=False)
+    yield d
+    d.quit()
+
+
+def _tap(drv, el):
+    """Tap `el` as a finger would: pointerdown(pointerType=touch), then the click."""
+    drv.execute_script(
+        """
+        const el = arguments[0];
+        el.dispatchEvent(new PointerEvent('pointerdown',
+            {bubbles: true, cancelable: true, pointerType: 'touch', isPrimary: true}));
+        el.dispatchEvent(new PointerEvent('pointerup',
+            {bubbles: true, cancelable: true, pointerType: 'touch', isPrimary: true}));
+        el.click();
+        """,
+        el,
+    )
+
+
+def _assert_tooltip_actually_visible(drv, where):
+    """A human must SEE text — not merely a `.ttip-visible` class somewhere in the DOM.
+
+    The class-only assertion is what let this suite stay green through a page on which
+    hovering did nothing: the popup can carry the class and still be zero-size, fully
+    transparent, off-viewport, or underneath another element.
+    """
+    r = drv.execute_script(
+        """
+        const t = document.querySelector('.tab-panel.active .ttip.ttip-visible')
+              || document.querySelector('.ttip.ttip-visible');
+        if (!t) return {found: false};
+        const b = t.getBoundingClientRect(), cs = getComputedStyle(t);
+        const cx = b.x + b.width / 2, cy = b.y + b.height / 2;
+        const top = document.elementFromPoint(cx, cy);
+        return {found: true, w: b.width, h: b.height,
+                text: (t.innerText || '').trim().length,
+                display: cs.display, visibility: cs.visibility, opacity: parseFloat(cs.opacity),
+                onScreen: b.right > 0 && b.bottom > 0 && b.x < innerWidth && b.y < innerHeight,
+                topmostInside: !!(top && t.contains(top))};
+        """
+    )
+    assert r["found"], f"{where}: no visible tooltip at all"
+    assert r["text"] > 0, f"{where}: tooltip is visible but has no text: {r}"
+    assert r["w"] > 0 and r["h"] > 0, f"{where}: tooltip has zero size: {r}"
+    assert r["display"] != "none" and r["visibility"] == "visible", f"{where}: {r}"
+    assert r["opacity"] > 0.5, f"{where}: tooltip is transparent: {r}"
+    assert r["onScreen"], f"{where}: tooltip is off-viewport: {r}"
+    assert r["topmostInside"], f"{where}: something is covering the tooltip: {r}"
+
+
+def test_real_mouse_hover_opens_a_visible_tooltip(unforced_driver):
+    """THE production contract: a real mouse move over a cell shows readable text.
+
+    Runs on `unforced_driver`, which does NOT patch matchMedia — headless Chrome reports
+    `(hover: hover)` and `(any-hover: hover)` false there, exactly as Chrome did on the
+    desktop where hovering was dead. The page must not consult those queries to decide
+    whether to listen for hover, so this lane fails if that gate ever comes back.
+    """
+    drv = unforced_driver
+    assert drv.execute_script(
+        "return !window.matchMedia('(hover: hover)').matches"
+        " && !window.matchMedia('(any-hover: hover)').matches;"
+    ), "this lane is only meaningful while the browser reports NO hover capability"
+    drv.execute_script(
+        "const v=document.querySelector('[data-view-detailed]'); if(v && !v.checked){v.checked=true; v.dispatchEvent(new Event('change'));}"
+    )
+    time.sleep(0.5)
+    el = drv.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active') || document;
+        const c = [...p.querySelectorAll('td.cell')].filter(e => e.offsetParent !== null
+                                                             && e.querySelector('.ttip'))[20];
+        if (!c) return null;
+        c.scrollIntoView({block: 'center'});
+        return c;
+        """
+    )
+    if el is None:
+        pytest.skip("no visible cell with a tooltip on the active tab")
+    # A REAL pointer move, not a synthetic dispatch — a synthetic event would fire the
+    # listener even if the browser would never deliver one to a human.
+    webdriver.ActionChains(drv).move_to_element(el).perform()
+    deadline = time.time() + 4
+    while time.time() < deadline:
+        if drv.execute_script("return !!document.querySelector('.ttip.ttip-visible');"):
+            break
+        time.sleep(0.1)
+    assert drv.execute_script(
+        "return arguments[0].matches(':hover');", el
+    ), "the browser did not deliver a real hover to the cell; test setup is wrong"
+    _assert_tooltip_actually_visible(drv, "real mouse hover, no forced media queries")
+
+
+def test_keyboard_focus_opens_a_visible_tooltip(unforced_driver):
+    """Focus must open the popup too — `focusin` sat behind the same gate as hover."""
+    drv = unforced_driver
+    opened = drv.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active') || document;
+        for (const el of p.querySelectorAll('[data-ttip-wired]')) {
+          if (!el.querySelector('.ttip') || el.offsetParent === null) continue;
+          const f = el.querySelector('a, button, [tabindex]');
+          if (!f) continue;
+          el.scrollIntoView({block: 'center'});
+          f.focus();
+          return true;
+        }
+        return false;
+        """
+    )
+    if not opened:
+        pytest.skip("no focusable element inside a wired tooltip host on this tab")
+    deadline = time.time() + 4
+    while time.time() < deadline:
+        if drv.execute_script("return !!document.querySelector('.ttip.ttip-visible');"):
+            break
+        time.sleep(0.1)
+    _assert_tooltip_actually_visible(drv, "keyboard focus")
 
 
 def test_hover_shows_tooltip(driver):
@@ -89,6 +242,24 @@ def test_hover_shows_tooltip(driver):
             break
         time.sleep(0.1)
     assert visible, "tooltip did not become visible on hover"
+
+
+def test_order_divergence_shows_golden_and_candidate_sequences(driver):
+    """ORDER/MERGE explanations come from the golden candidate in the model."""
+    text = driver.execute_script(
+        """
+        const el = document.querySelector('[data-sequence-divergence]');
+        if (!el) return null;
+        window.__buildTooltip(el);
+        const tip = el.querySelector('.ttip');
+        return tip ? tip.textContent : null;
+        """
+    )
+    assert text, "rendered producer data had no ORDER/MERGE divergence"
+    assert "want:" in text and "got:" in text, text
+    want = text.split("want:", 1)[1].split("got:", 1)[0].strip()
+    got = text.split("got:", 1)[1].splitlines()[0].strip()
+    assert want and got and want != got, text
 
 
 def test_compare_candidates_are_per_tab(driver):
@@ -323,9 +494,68 @@ def test_transpose_honors_collapsed_case_group(driver):
     assert hidden is True, f"transposed rows for collapsed group {key} should be hidden"
 
 
+def test_click_never_pins_where_hover_exists(driver):
+    """Where hover exists, a click must NOT pin — hover stays live afterwards.
+
+    Pinning is modal: `hoverAllowed()` returns false for every other cell while one is
+    pinned. When a desktop click also pinned, a single stray click disabled hover for the
+    whole page until the pin was released, and in details view "click elsewhere to
+    dismiss" almost always lands on another wired cell, which only moves the pin. This
+    pins the fix: on a hover-capable device no click pins anything, so hover cannot be
+    switched off by clicking.
+    """
+    driver.execute_script(
+        "const v=document.querySelector('[data-view-detailed]'); if(v && !v.checked){v.checked=true; v.dispatchEvent(new Event('change'));}"
+    )
+    clicked = driver.execute_script(
+        """
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const el of tab.querySelectorAll('[data-ttip-wired]')) {
+          if (!el.querySelector('.ttip')) continue;
+          if (el.offsetParent === null) continue;
+          el.click();
+          window.__clicked = el;
+          return true;
+        }
+        return false;
+        """
+    )
+    if not clicked:
+        pytest.skip("no wired elements with a tooltip on the active tab")
+    time.sleep(0.6)
+    assert not driver.execute_script(
+        "return !!document.querySelector('.ttip.ttip-pinned');"
+    ), "a click pinned a popup on a hover-capable device"
+    assert not driver.execute_script(
+        "return document.body.classList.contains('ttip-pin-mode');"
+    ), "a click put the page into modal pin mode on a hover-capable device"
+
+    # And hover still opens a popup on a DIFFERENT cell afterwards — the actual symptom.
+    driver.execute_script(
+        """
+        const tab = document.querySelector('.tab-panel.active') || document;
+        for (const el of tab.querySelectorAll('[data-ttip-wired]')) {
+          if (!el.querySelector('.ttip')) continue;
+          if (el.offsetParent === null || el === window.__clicked) continue;
+          el.dispatchEvent(new PointerEvent('pointerenter', {bubbles: false}));
+          return;
+        }
+        """
+    )
+    deadline = time.time() + 3
+    shown = False
+    while time.time() < deadline and not shown:
+        shown = driver.execute_script("return !!document.querySelector('.ttip.ttip-visible');")
+        time.sleep(0.1)
+    assert shown, "hover stopped opening popups after a click"
+
+
 @pytest.mark.parametrize("transposed", [False, True], ids=["normal", "transposed"])
-def test_every_wired_element_stays_pinned(driver, transposed):
-    """Clicking anything with a popup PINS it, and the same click must not close it.
+def test_every_wired_element_stays_pinned(touch_driver, transposed):
+    """TOUCH: tapping anything with a popup PINS it, and the same tap must not close it.
+
+    Runs on `touch_driver` because tap-to-pin is now touch-only; where hover exists there
+    is no click-to-pin at all (see test_click_never_pins_where_hover_exists).
 
     The document-level outside-click handler decides what counts as "inside". While it
     enumerated classes, it kept drifting from the set `attachTooltip` actually wires: first
@@ -338,10 +568,10 @@ def test_every_wired_element_stays_pinned(driver, transposed):
     element it wires. This test walks that same set, one element per distinct tag+class, so
     a newly wired kind of element is covered without anyone remembering to add it here.
     """
-    driver.execute_script(
+    touch_driver.execute_script(
         "const v=document.querySelector('[data-view-detailed]'); if(v && !v.checked){v.checked=true; v.dispatchEvent(new Event('change'));}"
     )
-    toggled = driver.execute_script(
+    toggled = touch_driver.execute_script(
         """
         const t = document.querySelector('[data-transpose-toggle]');
         if (!t) return false;
@@ -355,12 +585,18 @@ def test_every_wired_element_stays_pinned(driver, transposed):
 
     # One representative per tag+class, so the test scales with the wired set instead of a
     # hand-kept list, but does not click hundreds of identical data cells.
-    kinds = driver.execute_script(
+    kinds = touch_driver.execute_script(
         """
         const tab = document.querySelector('.tab-panel.active') || document;
         const seen = new Set();
         for (const el of tab.querySelectorAll('[data-ttip-wired]')) {
           if (!el.querySelector('.ttip')) continue;
+            // Skip anything not actually RENDERED. A collapsed column is
+            // `display: none` (`.col-hidden`), so its cells cannot be clicked and
+            // have no popup to pin. This remains a product-facing assertion even
+            // though the module-scoped driver is reloaded around every test: hidden
+            // elements are not user-interactable and cannot own a visible popup.
+          if (el.offsetParent === null) continue;
           const key = el.tagName.toLowerCase() + '.' + (el.className || '');
           if (!seen.has(key)) seen.add(key);
         }
@@ -373,22 +609,31 @@ def test_every_wired_element_stays_pinned(driver, transposed):
     for key in kinds:
         # A real .click() so the event bubbles to the document handler, which is the whole
         # point — a synthetic dispatch on the element alone would never reproduce the bug.
-        driver.execute_script(
+        # A REAL tap through the input pipeline. Under the fixture's CDP touch emulation
+        # this produces `pointerdown` with `pointerType == 'touch'`, which is what the page
+        # keys tap-to-pin off. A JS `.click()` carries no pointerdown at all, so it would be
+        # classified as not-touch and would silently test nothing.
+        el = touch_driver.execute_script(
             """
             const tab = document.querySelector('.tab-panel.active') || document;
             for (const el of tab.querySelectorAll('[data-ttip-wired]')) {
               if (!el.querySelector('.ttip')) continue;
+              if (el.offsetParent === null) continue;
               if (el.tagName.toLowerCase() + '.' + (el.className || '') !== arguments[0]) continue;
-              el.click();
-              return;
+              el.scrollIntoView({block: 'center'});
+              return el;
             }
+            return null;
             """,
             key,
         )
+        if el is None:
+            continue
+        _tap(touch_driver, el)
         deadline = time.time() + 3
         pinned = False
         while time.time() < deadline:
-            pinned = driver.execute_script(
+            pinned = touch_driver.execute_script(
                 "return !!document.querySelector('[data-ttip-wired] .ttip.ttip-pinned');"
             )
             if pinned:
@@ -396,7 +641,7 @@ def test_every_wired_element_stays_pinned(driver, transposed):
             time.sleep(0.1)
         assert pinned, f"popup on {key} did not stay pinned after its own click"
         # Unpin before the next kind, so a stale pin can't make the next assertion pass.
-        driver.execute_script(
+        touch_driver.execute_script(
             "document.querySelectorAll('.ttip.ttip-pinned').forEach(t => { const c = t.querySelector('.ttip-close'); if (c) c.click(); });"
         )
 
@@ -432,3 +677,91 @@ def test_legend_is_detailed_only(driver):
     detailed = legend_shown()
     assert not overview, "legend visible in Overview; it should be Detailed-only"
     assert detailed, "legend hidden in Detailed; it should be visible there"
+
+
+def test_touch_then_keyboard_does_not_pin(driver):
+    """A keyboard activation after a touch must NOT inherit the touch's pinning.
+
+    Pointer provenance used to persist until the next `pointerdown`. A keyboard
+    activation issues none, so after any touch the next Enter on a focused link
+    still read `touch`, called `preventDefault()` and pinned — suppressing the
+    navigation the keyboard user asked for. Provenance is now consumed by the click
+    it belongs to and cleared.
+    """
+    drv = driver
+    drv.execute_script(
+        "const v=document.querySelector('[data-view-detailed]'); if(v && !v.checked){v.checked=true; v.dispatchEvent(new Event('change'));}"
+    )
+    time.sleep(0.4)
+
+    # 1. A touch tap: pointerdown(touch) then click. This one MAY pin.
+    ok = drv.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active') || document;
+        const els = [...p.querySelectorAll('[data-ttip-wired]')]
+            .filter(e => e.offsetParent !== null && e.querySelector('.ttip'));
+        if (els.length < 2) return false;
+        window.__a = els[0]; window.__b = els[1];
+        window.__a.dispatchEvent(new PointerEvent('pointerdown',
+            {bubbles: true, cancelable: true, pointerType: 'touch', isPrimary: true}));
+        window.__a.click();
+        return true;
+        """
+    )
+    if not ok:
+        pytest.skip("need two wired elements on the active tab")
+    time.sleep(0.4)
+
+    # 2. A KEYBOARD activation on a different cell: a click with NO pointerdown.
+    #    It must not pin, and must not have been preventDefault()-ed.
+    prevented = drv.execute_script(
+        """
+        const ev = new MouseEvent('click', {bubbles: true, cancelable: true});
+        window.__b.dispatchEvent(ev);
+        return ev.defaultPrevented;
+        """
+    )
+    time.sleep(0.4)
+    assert not prevented, (
+        "a keyboard activation was preventDefault()-ed, so it inherited the earlier "
+        "touch's pointer provenance instead of being treated as keyboard"
+    )
+    pinned_on_b = drv.execute_script(
+        "return !!(window.__b && window.__b.querySelector('.ttip.ttip-pinned'));"
+    )
+    assert not pinned_on_b, "keyboard activation must not pin"
+
+    drv.execute_script(
+        "document.querySelectorAll('.ttip.ttip-pinned').forEach(t => { const c = t.querySelector('.ttip-close'); if (c) c.click(); });"
+    )
+
+    # 3. A touch tap INSIDE a tooltip takes the `.ttip` early return. That path must also
+    #    consume the provenance, or it stays armed for the next keyboard activation —
+    #    the same defect one branch over.
+    tapped_inside = drv.execute_script(
+        """
+        const p = document.querySelector('.tab-panel.active') || document;
+        for (const el of p.querySelectorAll('[data-ttip-wired]')) {
+          const tip = el.querySelector('.ttip');
+          if (!tip || el.offsetParent === null) continue;
+          tip.dispatchEvent(new PointerEvent('pointerdown',
+              {bubbles: true, cancelable: true, pointerType: 'touch', isPrimary: true}));
+          tip.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+          return true;
+        }
+        return false;
+        """
+    )
+    if tapped_inside:
+        time.sleep(0.3)
+        prevented2 = drv.execute_script(
+            """
+            const ev = new MouseEvent('click', {bubbles: true, cancelable: true});
+            window.__b.dispatchEvent(ev);
+            return ev.defaultPrevented;
+            """
+        )
+        assert not prevented2, (
+            "a touch tap inside a tooltip left pointer provenance armed, so the next "
+            "keyboard activation inherited it"
+        )

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -702,7 +702,9 @@ def test_template_has_compare_picker_and_reasoning_candidates() -> None:
 def test_template_overview_cells_do_not_expand_from_hidden_marker_text() -> None:
     # Static styles now live in the CSS asset, inlined at render (audit B7).
     css = (SRC / "assets" / "conformance.css").read_text()
-    assert "td.cell { position: relative; text-align: center; width: 44px; min-width: 44px; max-width: 44px;" in css
+    # 26px, not 44px: cell content is a 1-3 char marker that is absolutely positioned,
+    # so the column width is pure padding. 44px made the table needlessly wide.
+    assert "td.cell { position: relative; text-align: center; width: 26px; min-width: 26px; max-width: 26px;" in css
     assert ".view-overview td.cell { font-size: 0; line-height: 0; }" in css
     assert ".view-overview td.cell .cell-marker { display: none; }" in css
     assert ".view-overview td.cell .ttip { font-size: 12px; line-height: 1.4; }" in css
@@ -759,11 +761,16 @@ def test_template_cells_do_not_clip_hover_tooltips() -> None:
     assert cell_rule is not None
     assert "overflow: hidden" not in cell_rule.group(1)
     assert ".ttip-visible" in css
-    # Hover-show is now gated on hover-capable devices (touch uses tap-to-pin), so
-    # the listener is wired inside a `matchMedia('(hover: hover)')` branch rather
-    # than as a bare top-level call. Assert both the gate and the pointerenter wiring.
-    assert "matchMedia('(hover: hover)')" in js
+    # Hover listeners are registered UNCONDITIONALLY. They used to sit behind a
+    # `matchMedia('(hover: hover)')` gate, and this assertion pinned that gate in place as
+    # if it were the contract — while Chrome on a normal desktop reported the query false
+    # and delivered real hover anyway, so the popup never opened and this test stayed green.
+    # A media query describes a device; it does not decide which events arrive. Assert the
+    # gate is GONE and the listeners are top-level.
     assert "cell.addEventListener('pointerenter'" in js
+    assert "matchMedia" not in js, (
+        "hover/pointer listener registration must not depend on a media query"
+    )
 
 
 def test_toolcalling_parser_options_are_mode_specific() -> None:

--- a/parsers/v2-py/Cargo.toml
+++ b/parsers/v2-py/Cargo.toml
@@ -22,5 +22,5 @@ name = "dynamo_parsers_v2"
 crate-type = ["cdylib"]
 
 [dependencies]
-dynamo-parsers-v2 = { path = "../v2", version = "0.1.27" }
+dynamo-parsers-v2 = { path = "../v2", version = "0.2.0" }
 pyo3 = { workspace = true }

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -52,7 +52,9 @@ impl UnifiedParser for AcmeParser {
 
 This example is compiled and run as an integration test — [`tests/vendor_parser_example.rs`](tests/vendor_parser_example.rs). It uses only this crate's public API, exactly as your crate would.
 
-The block above and that file are compared **by a test**, not by hand: `doc_example_matches_compiled_example` parses the first Rust block out of this file and asserts its `parse_into` and `finish` bodies equal the compiled ones. That check exists because the claim it replaces was false — the two drifted, the documented example double-emitted its buffer, and nothing caught it.
+The block above and that file are compared **by a test**, not by hand: `doc_trait_method_bodies_match_compiled_example` parses the first Rust block out of this file and asserts that the two implement the same trait METHODS with the same bodies. That check exists because the claim it replaces was false — the two drifted, the documented example double-emitted its buffer, and nothing caught it.
+
+Know its limit: the test does not COMPILE this Markdown block, and it compares only the `impl UnifiedParser` methods. Renaming a struct field or changing an import here alone would break the documented example while the test stays green. The compiled file is the authority; treat this block as a copy that is guarded at the method level.
 
 `UnifiedParserOutput` gives you `push_text`, `push_reasoning` and `push_call`. The first two coalesce: appending text onto a trailing text event extends it rather than adding a second one.
 

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -43,6 +43,10 @@ impl UnifiedParser for AcmeParser {
         out.push_text(std::mem::take(&mut self.buffered));
         Ok(out)
     }
+
+    fn reset(&mut self) -> String {
+        std::mem::take(&mut self.buffered)
+    }
 }
 ```
 

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -10,7 +10,7 @@ One method is required. `finish` is required too, because a parser that forgets 
 
 ```rust
 use dynamo_parsers_v2::{
-    Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput,
+    Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserExt, UnifiedParserOutput,
 };
 use anyhow::Result;
 
@@ -58,6 +58,8 @@ Know its limit: the test does not COMPILE this Markdown block, and it compares o
 
 `UnifiedParserOutput` gives you `push_text`, `push_reasoning` and `push_call`. The first two coalesce: appending text onto a trailing text event extends it rather than adding a second one.
 
+The required lifecycle is `initialize` → `parse_into` → `finish`, with `reset` for recovery. `push` and `parse_complete` come from the blanket `UnifiedParserExt` trait: import it when you want those allocation conveniences. They cannot be overridden through `impl UnifiedParser`, so `parse_complete` always runs the same `parse_into` + `finish` path as streaming.
+
 ## 2. Register it
 
 ```rust
@@ -97,7 +99,7 @@ These are the responsibilities a unified parser carries, and the reasons they ex
 | **Split-invariance** | The same bytes must produce the same ASSEMBLED output regardless of where the transport split them. Test every split point around your markers, not just a few. Raw event boundaries may legitimately differ between splits — one chunking can commit `Text("alpha ")` + `Text("rest")` where another commits `Text("alpha rest")` — which is why the check is `assembled()`, not the event vector. |
 | **Never leak your own markup** | Bytes you consumed as structure must not reappear in visible text. |
 | **Arguments keep their meaning and order** | Do not drop, duplicate, or corrupt argument values, and preserve the model's key order where the family contract depends on it. If you emit incremental fragments, the fragments you chose must concatenate into the intended arguments JSON. Verbatim BYTES are only required where the model already emits API-shaped JSON — the shipped XML families deliberately schema-type and re-serialize, then restore source key order. |
-| **Recover, do not panic** | Malformed or truncated output is normal. Emit what you can and drop what you cannot; returning an error should be reserved for genuinely unusable input. When driven through `parse_into`, whatever you already appended to the caller's output stays committed on `Err`; `push` owns its buffer and returns `Result<Vec<_>>`, which has nowhere to carry partial output, so it cannot honour that guarantee. |
+| **Recover, do not panic** | Malformed or truncated output is normal. Emit what you can and drop what you cannot; returning an error should be reserved for genuinely unusable input. When driven through `parse_into`, whatever you already appended to the caller's output stays committed on `Err`; the `UnifiedParserExt::push` helper owns its buffer and returns `Result<Vec<_>>`, which has nowhere to carry partial output, so it cannot honour that guarantee. |
 | **Flush on `finish`** | Do not silently drop the tail of a stream. What to DO with an unterminated channel is your family's policy — the shipped Qwen parser promotes open reasoning rather than leaking it as text, but a grammar with no reasoning channel, or one that treats an unterminated opener as visible recovery text, is making a different and equally valid call. State yours. |
 | **Override `reset` if you buffer** | The default returns an empty string and clears nothing. A parser that holds bytes back MUST override it, or a caller following the documented recovery path after a `parse_into` error resumes on your stale buffer and mis-numbers tool indices. Reset every field that carries stream position, tool index included — the text you hand back is a NEW stream. |
 
@@ -125,9 +127,9 @@ A family with no cases would otherwise report as covered while nothing measured 
 
 ## 7. Alignment with peer traits
 
-This trait is aligned with the peer streaming-parser traits other serving engines expose: `parse_into` is the required method, `finish` returns an output buffer, the event type carries the same variants in the same order, and `initialize` takes prompt token IDs. A parser written against a peer trait ports here mostly by renaming.
+The required `UnifiedParser` lifecycle is aligned with the peer streaming-parser traits other serving engines expose: `parse_into` is the required advance method, `finish` returns an output buffer, the event type carries the same variants in the same order, and `initialize` takes prompt token IDs. A parser written against a peer trait ports here mostly by renaming.
 
 Two caveats worth knowing before you plan on a literal drop-in:
 
 - Rust is nominally typed, so an identically-shaped type in another crate is still a different type. Porting is a mechanical translation, not a recompile.
-- This crate adds surface the peer traits do not have — `parse_complete` and the assembled `UnifiedEvent` view. Both are additive, so a peer-shaped caller never sees them, and a peer-shaped parser that does not provide them falls back to their defaults.
+- This crate adds surface the peer traits do not have — the blanket `UnifiedParserExt` helpers (`push` and `parse_complete`) and the assembled `UnifiedEvent` view. They are additive conveniences, not vendor-overridable lifecycle methods.

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -86,17 +86,17 @@ This is deliberately supported. Disagreeing with one of our families should cost
 
 ## 4. What the contract requires
 
-These are the properties the conformance corpus checks, and the reasons it checks them. A parser that violates one will look correct in a demo and fail in production.
+These are the responsibilities a unified parser carries, and the reasons they exist. A parser that violates one will look correct in a demo and fail in production. The built-in conformance corpus exercises several of them for the families it ships; it cannot check factory/global-state isolation or your parser's own `reset` and error behaviour, and it does not run your parser at all until you enrol it (see below).
 
 | | Requirement |
 |---|---|
 | **One parser per stream** | A factory builds one parser for one choice of one request. Keep per-stream state in the parser, never in the factory or a global. |
 | **Order is the output** | Emit events in the order the model produced them. Do not hoist all reasoning to the front; that is precisely the defect the ordered event stream exists to remove. |
-| **Split-invariance** | The same bytes must produce the same events regardless of where the transport split them. Test every split point around your markers, not just a few. |
+| **Split-invariance** | The same bytes must produce the same ASSEMBLED output regardless of where the transport split them. Test every split point around your markers, not just a few. Raw event boundaries may legitimately differ between splits — one chunking can commit `Text("alpha ")` + `Text("rest")` where another commits `Text("alpha rest")` — which is why the check is `assembled()`, not the event vector. |
 | **Never leak your own markup** | Bytes you consumed as structure must not reappear in visible text. |
-| **Argument bytes are verbatim** | Forward argument fragments exactly as the model emitted them. Do not reformat, reorder keys, or re-serialize. |
-| **Recover, do not panic** | Malformed or truncated output is normal. Emit what you can and drop what you cannot; returning an error should be reserved for genuinely unusable input. On `Err`, whatever you already appended stays committed. |
-| **Flush on `finish`** | Open reasoning is promoted, not dropped and not leaked as text. |
+| **Arguments keep their meaning and order** | Do not drop, duplicate, or corrupt argument values, and preserve the model's key order where the family contract depends on it. If you emit incremental fragments, the fragments you chose must concatenate into the intended arguments JSON. Verbatim BYTES are only required where the model already emits API-shaped JSON — the shipped XML families deliberately schema-type and re-serialize, then restore source key order. |
+| **Recover, do not panic** | Malformed or truncated output is normal. Emit what you can and drop what you cannot; returning an error should be reserved for genuinely unusable input. When driven through `parse_into`, whatever you already appended to the caller's output stays committed on `Err`; `push` owns its buffer and returns `Result<Vec<_>>`, which has nowhere to carry partial output, so it cannot honour that guarantee. |
+| **Flush on `finish`** | Do not silently drop the tail of a stream. What to DO with an unterminated channel is your family's policy — the shipped Qwen parser promotes open reasoning rather than leaking it as text, but a grammar with no reasoning channel, or one that treats an unterminated opener as visible recovery text, is making a different and equally valid call. State yours. |
 | **Override `reset` if you buffer** | The default returns an empty string and clears nothing. A parser that holds bytes back MUST override it, or a caller following the documented recovery path after a `parse_into` error resumes on your stale buffer and mis-numbers tool indices. Reset every field that carries stream position, tool index included — the text you hand back is a NEW stream. |
 
 ## 5. Optional capabilities
@@ -111,13 +111,15 @@ All have defaults, so implement only what your grammar needs.
 
 ## 6. Check it against the corpus
 
-The conformance corpus is the useful part of this repo. Point it at your parser to find the cases you have not thought of: malformed envelopes, markers split mid-token, marker-looking text inside a JSON string, reasoning interleaved with calls, guided payloads that fail schema rather than syntax.
+The conformance corpus is the useful part of this repo — the cases you have not thought of: malformed envelopes, markers split mid-token, marker-looking text inside a JSON string, reasoning interleaved with calls.
+
+Running the workspace command below does NOT exercise a vendor parser. There is no flag that points the suite at a registered family: the suite iterates `builtin_unified_families()`, and a vendor registration deliberately does not enrol itself there. Adding your family means adding cases to the corpus and wiring it into the harness. Until you do, a green run says nothing about your parser.
 
 ```bash
 cargo test --workspace --all-targets --locked
 ```
 
-`builtin_unified_families()` is what the suite iterates, and a vendor registration deliberately does NOT enrol itself there — a family with no cases would otherwise report as covered while nothing measured it. Add cases for your family before trusting a green run.
+A family with no cases would otherwise report as covered while nothing measured it, which is why enrolment is deliberate rather than automatic.
 
 ## 7. Alignment with peer traits
 

--- a/parsers/v2/CUSTOM_PARSERS.md
+++ b/parsers/v2/CUSTOM_PARSERS.md
@@ -1,0 +1,125 @@
+# Writing your own unified parser
+
+You do not need to fork this crate to change how a model's output is parsed. You can implement the `UnifiedParser` trait in your own crate, register it by family name, and it will be used for every request routed to that name — including for a family this crate already ships, which your registration shadows.
+
+Everything below uses only the public API. There is nothing private you need.
+
+## 1. Implement the trait
+
+One method is required. `finish` is required too, because a parser that forgets to flush would silently drop the tail of every stream.
+
+```rust
+use dynamo_parsers_v2::{
+    Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput,
+};
+use anyhow::Result;
+
+#[derive(Default)]
+struct AcmeParser {
+    buffered: String,
+}
+
+impl UnifiedParser for AcmeParser {
+    /// Called once per decoded delta. Emit only what is now COMMITTED, and keep
+    /// back only what is still ambiguous — here, a trailing `<` that might be the
+    /// start of a marker. Emitting `delta` AND retaining it would emit it twice.
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        self.buffered.push_str(delta);
+        if let Some(cut) = self.buffered.rfind('<') {
+            let emit: String = self.buffered[..cut].to_string();
+            self.buffered = self.buffered[cut..].to_string();
+            output.push_text(emit);
+        } else {
+            let all = std::mem::take(&mut self.buffered);
+            output.push_text(all);
+        }
+        Ok(())
+    }
+
+    /// Called once at end of stream. Whatever is still held back is ordinary text
+    /// once the stream has ended.
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        let mut out = UnifiedParserOutput::default();
+        out.push_text(std::mem::take(&mut self.buffered));
+        Ok(out)
+    }
+}
+```
+
+This example is compiled and run as an integration test — [`tests/vendor_parser_example.rs`](tests/vendor_parser_example.rs). It uses only this crate's public API, exactly as your crate would.
+
+The block above and that file are compared **by a test**, not by hand: `doc_example_matches_compiled_example` parses the first Rust block out of this file and asserts its `parse_into` and `finish` bodies equal the compiled ones. That check exists because the claim it replaces was false — the two drifted, the documented example double-emitted its buffer, and nothing caught it.
+
+`UnifiedParserOutput` gives you `push_text`, `push_reasoning` and `push_call`. The first two coalesce: appending text onto a trailing text event extends it rather than adding a second one.
+
+## 2. Register it
+
+```rust
+fn acme_factory(_tools: &[Tool]) -> Result<Box<dyn UnifiedParser>> {
+    Ok(Box::new(AcmeParser::default()))
+}
+
+fn main() {
+    dynamo_parsers_v2::register_unified_parser("acme_v1", acme_factory);
+    // ... start serving. Requests for family "acme_v1" now use your parser.
+}
+```
+
+Register during startup, before serving. Registration is process-wide and takes effect for parsers created after it returns; a parser already mid-stream keeps the implementation it was built with, so a request cannot straddle the change.
+
+## 3. Replacing a family this crate already ships
+
+Register under the existing name. Your factory is consulted first, so it wins:
+
+```rust
+// You disagree with how this crate parses qwen3. Use yours instead.
+dynamo_parsers_v2::register_unified_parser("qwen3", my_qwen3_factory);
+```
+
+`unregister_unified_parser("qwen3")` removes yours and the built-in becomes reachable again — the built-in is shadowed, never replaced. `builtin_unified_families()` tells you what ships here; `vendor_unified_families()` tells you what has been registered on top.
+
+This is deliberately supported. Disagreeing with one of our families should cost you a registration call, not a fork.
+
+## 4. What the contract requires
+
+These are the properties the conformance corpus checks, and the reasons it checks them. A parser that violates one will look correct in a demo and fail in production.
+
+| | Requirement |
+|---|---|
+| **One parser per stream** | A factory builds one parser for one choice of one request. Keep per-stream state in the parser, never in the factory or a global. |
+| **Order is the output** | Emit events in the order the model produced them. Do not hoist all reasoning to the front; that is precisely the defect the ordered event stream exists to remove. |
+| **Split-invariance** | The same bytes must produce the same events regardless of where the transport split them. Test every split point around your markers, not just a few. |
+| **Never leak your own markup** | Bytes you consumed as structure must not reappear in visible text. |
+| **Argument bytes are verbatim** | Forward argument fragments exactly as the model emitted them. Do not reformat, reorder keys, or re-serialize. |
+| **Recover, do not panic** | Malformed or truncated output is normal. Emit what you can and drop what you cannot; returning an error should be reserved for genuinely unusable input. On `Err`, whatever you already appended stays committed. |
+| **Flush on `finish`** | Open reasoning is promoted, not dropped and not leaked as text. |
+| **Override `reset` if you buffer** | The default returns an empty string and clears nothing. A parser that holds bytes back MUST override it, or a caller following the documented recovery path after a `parse_into` error resumes on your stale buffer and mis-numbers tool indices. Reset every field that carries stream position, tool index included — the text you hand back is a NEW stream. |
+
+## 5. Optional capabilities
+
+All have defaults, so implement only what your grammar needs.
+
+| Method | Implement it when |
+|---|---|
+| `initialize(&[u32])` | your prompt can end mid-channel and you want to detect that from prompt tokens |
+| `preserve_special_tokens()` | your markers ARE tokenizer special tokens, so text that dropped them is unparseable |
+| `tool_call_id(idx)` | your grammar names the call itself and the id should come from the model |
+
+## 6. Check it against the corpus
+
+The conformance corpus is the useful part of this repo. Point it at your parser to find the cases you have not thought of: malformed envelopes, markers split mid-token, marker-looking text inside a JSON string, reasoning interleaved with calls, guided payloads that fail schema rather than syntax.
+
+```bash
+cargo test --workspace --all-targets --locked
+```
+
+`builtin_unified_families()` is what the suite iterates, and a vendor registration deliberately does NOT enrol itself there — a family with no cases would otherwise report as covered while nothing measured it. Add cases for your family before trusting a green run.
+
+## 7. Alignment with peer traits
+
+This trait is aligned with the peer streaming-parser traits other serving engines expose: `parse_into` is the required method, `finish` returns an output buffer, the event type carries the same variants in the same order, and `initialize` takes prompt token IDs. A parser written against a peer trait ports here mostly by renaming.
+
+Two caveats worth knowing before you plan on a literal drop-in:
+
+- Rust is nominally typed, so an identically-shaped type in another crate is still a different type. Porting is a mechanical translation, not a recompile.
+- This crate adds surface the peer traits do not have — `parse_complete` and the assembled `UnifiedEvent` view. Both are additive, so a peer-shaped caller never sees them, and a peer-shaped parser that does not provide them falls back to their defaults.

--- a/parsers/v2/Cargo.toml
+++ b/parsers/v2/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name = "dynamo-parsers-v2"
-version = "0.1.27"
+version = "0.2.0"
 edition.workspace = true
 license = "Apache-2.0"
 description = "Token-incremental tool-call streaming parsers for Dynamo"

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -26,7 +26,7 @@ pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType
 // One state machine per stream owning reasoning + content + tool calls, emitting
 // ONE ordered event stream (see `unified`).
 pub use unified::{
-    REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser, UnifiedParserEvent,
+    REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser, UnifiedParserEvent, UnifiedParserExt,
     UnifiedParserFactory, UnifiedParserOutput, assemble, builtin_unified_families,
     canonical_unified_family, create_unified_parser_for_family, register_unified_parser,
     unregister_unified_parser, vendor_unified_families,

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -26,6 +26,8 @@ pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType
 // One state machine per stream owning reasoning + content + tool calls, emitting
 // ONE ordered event stream (see `unified`).
 pub use unified::{
-    REGISTERED_UNIFIED_FAMILIES, UnifiedDelta, UnifiedEvent, UnifiedParser, assemble,
-    create_unified_parser_for_family,
+    REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser, UnifiedParserEvent,
+    UnifiedParserFactory, UnifiedParserOutput, assemble, builtin_unified_families,
+    canonical_unified_family, create_unified_parser_for_family, register_unified_parser,
+    unregister_unified_parser, vendor_unified_families,
 };

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -136,7 +136,7 @@ impl ToolParser for KimiK2ToolStreamParser {
     }
 
     fn preserve_special_tokens(&self) -> bool {
-        true
+        self.scanner.preserve_special_tokens()
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -70,6 +70,8 @@ fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
         bare_recovery_latch: BareRecoveryLatch::Set,
         invoke_latch: InvokeLatch::Always,
         drop_invoke_crossing_block_end: true,
+        // Every wrapped family's markers are special tokens today.
+        preserve_special_tokens: true,
     }
 }
 

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -74,6 +74,8 @@ fn spec() -> WrappedBlockSpec {
         bare_recovery_latch: BareRecoveryLatch::Clear,
         invoke_latch: InvokeLatch::IfEmitted,
         drop_invoke_crossing_block_end: false,
+        // Every wrapped family's markers are special tokens today.
+        preserve_special_tokens: true,
     }
 }
 

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -136,7 +136,7 @@ impl ToolParser for MiniMaxM2ToolStreamParser {
     }
 
     fn preserve_special_tokens(&self) -> bool {
-        true
+        self.scanner.preserve_special_tokens()
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -126,7 +126,7 @@ impl ToolParser for MiniMaxM3ToolStreamParser {
     }
 
     fn preserve_special_tokens(&self) -> bool {
-        true
+        self.scanner.preserve_special_tokens()
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -61,6 +61,8 @@ fn spec() -> WrappedBlockSpec {
         bare_recovery_latch: BareRecoveryLatch::Set,
         invoke_latch: InvokeLatch::IfEmitted,
         drop_invoke_crossing_block_end: false,
+        // Every wrapped family's markers are special tokens today.
+        preserve_special_tokens: true,
     }
 }
 

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -51,6 +51,8 @@ fn spec() -> WrappedBlockSpec {
         bare_recovery_latch: BareRecoveryLatch::Set,
         invoke_latch: InvokeLatch::IfEmitted,
         drop_invoke_crossing_block_end: false,
+        // Every wrapped family's markers are special tokens today.
+        preserve_special_tokens: true,
     }
 }
 
@@ -126,7 +128,9 @@ impl ToolParser for Qwen3CoderToolStreamParser {
     }
 
     fn preserve_special_tokens(&self) -> bool {
-        true
+        // Delegated, not restated: the unified adapter over this same scanner must not
+        // be able to answer differently for identical markup.
+        self.scanner.preserve_special_tokens()
     }
 
     fn push(&mut self, chunk: &str) -> anyhow::Result<ToolParseResult> {

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -31,7 +31,7 @@
 //!
 //! # Ordered output
 //!
-//! The drain loop emits [`UnifiedDelta`]s — text, reasoning and calls in the
+//! The drain loop emits [`UnifiedParserEvent`]s — text, reasoning and calls in the
 //! order the model produced them. Tool-only parsers project that down to
 //! [`ToolParseResult`] via `push`/`finish` and see no behavior change (that
 //! projection is lossy about order, which is all the tool-only contract ever
@@ -51,7 +51,7 @@
 use std::collections::HashSet;
 
 use crate::tool_calling::traits::{ToolCallDelta, ToolParseResult};
-use crate::unified::{Kind, UnifiedDelta};
+use crate::unified::{Kind, UnifiedParserEvent};
 
 /// Longest non-empty proper prefix of any `marker` that `text` ends with, so a
 /// marker split across chunk boundaries is held back instead of leaked as
@@ -234,20 +234,16 @@ enum InReasoning {
 /// never emits a string of adjacent same-kind fragments (`I8`). The or-pattern is
 /// the whole point: text and reasoning coalesce by identical rules, so there is
 /// one implementation to get right instead of two that can drift.
-pub(crate) fn push_run(out: &mut Vec<UnifiedDelta>, kind: Kind, text: &str) {
+pub(crate) fn push_run(out: &mut Vec<UnifiedParserEvent>, kind: Kind, text: &str) {
     if text.is_empty() {
         return;
     }
     match (out.last_mut(), kind) {
-        (Some(UnifiedDelta::Text { text: prev }), Kind::Text)
-        | (Some(UnifiedDelta::Reasoning { text: prev }), Kind::Reasoning) => prev.push_str(text),
+        (Some(UnifiedParserEvent::Text(prev)), Kind::Text)
+        | (Some(UnifiedParserEvent::Reasoning(prev)), Kind::Reasoning) => prev.push_str(text),
         _ => out.push(match kind {
-            Kind::Text => UnifiedDelta::Text {
-                text: text.to_string(),
-            },
-            Kind::Reasoning => UnifiedDelta::Reasoning {
-                text: text.to_string(),
-            },
+            Kind::Text => UnifiedParserEvent::Text(text.to_string()),
+            Kind::Reasoning => UnifiedParserEvent::Reasoning(text.to_string()),
         }),
     }
 }
@@ -315,12 +311,12 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         Ok(ToolParseResult::from_deltas(self.finish_ordered()?))
     }
 
-    pub(crate) fn push_ordered(&mut self, chunk: &str) -> anyhow::Result<Vec<UnifiedDelta>> {
+    pub(crate) fn push_ordered(&mut self, chunk: &str) -> anyhow::Result<Vec<UnifiedParserEvent>> {
         self.buffer.push_str(chunk);
         self.drain(false)
     }
 
-    pub(crate) fn finish_ordered(&mut self) -> anyhow::Result<Vec<UnifiedDelta>> {
+    pub(crate) fn finish_ordered(&mut self) -> anyhow::Result<Vec<UnifiedParserEvent>> {
         self.drain(true)
     }
 
@@ -339,7 +335,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// means more input is needed.
     fn drain_reasoning(
         &mut self,
-        out: &mut Vec<UnifiedDelta>,
+        out: &mut Vec<UnifiedParserEvent>,
         flush: bool,
     ) -> anyhow::Result<bool> {
         let Some(reasoning) = self.reasoning else {
@@ -432,8 +428,23 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         Ok(false)
     }
 
-    fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedDelta>> {
-        let mut out: Vec<UnifiedDelta> = Vec::new();
+    /// Return to a FRESH-STREAM state and hand back whatever was still buffered.
+    ///
+    /// Every field that carries stream position resets, `next_index` included: the
+    /// returned text is a NEW stream, so a call parsed out of it must not reuse an
+    /// index already dispatched from the abandoned one.
+    pub(crate) fn reset_stream(&mut self) -> String {
+        let carried = std::mem::take(&mut self.buffer);
+        self.in_block = false;
+        self.in_reasoning = self.reasoning.as_ref().is_some_and(|r| r.forced_start);
+        self.resume_reasoning = false;
+        self.suppress_normal_text = false;
+        self.next_index = 0;
+        carried
+    }
+
+    fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedParserEvent>> {
+        let mut out: Vec<UnifiedParserEvent> = Vec::new();
 
         loop {
             // Reasoning yields to tool structure: while a thought is open, its
@@ -510,7 +521,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
                 self.buffer.drain(..end + self.spec.invoke_end.len());
                 if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
-                    out.push(UnifiedDelta::ToolCall(delta));
+                    out.push(UnifiedParserEvent::ToolCall(delta));
                     self.next_index += 1;
                     if self.spec.invoke_latch == InvokeLatch::IfEmitted {
                         self.suppress_normal_text = true;
@@ -623,7 +634,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                             tool_index = delta.tool_index,
                             "stream recovered a complete bare invoke"
                         );
-                        out.push(UnifiedDelta::ToolCall(delta));
+                        out.push(UnifiedParserEvent::ToolCall(delta));
                         self.next_index += 1;
                         self.suppress_normal_text =
                             self.spec.bare_recovery_latch == BareRecoveryLatch::Set;

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -161,6 +161,14 @@ pub(crate) struct WrappedBlockSpec {
     /// the `invoke_end` means the call is malformed — drop it and close the
     /// block (Kimi K2's mismatched-fences rule).
     pub drop_invoke_crossing_block_end: bool,
+    /// Whether a decoder must keep tokenizer special tokens so this grammar's
+    /// markers survive to the parser.
+    ///
+    /// Lives on the GRAMMAR, not on an adapter, because it is a property of the
+    /// markers being scanned. Two adapters over one scanner previously answered
+    /// differently for identical markup — the tool-only parser said `true` while the
+    /// unified one inherited the trait default `false`.
+    pub preserve_special_tokens: bool,
 }
 
 /// The reasoning channel a unified scanner also owns.
@@ -179,6 +187,8 @@ pub(crate) struct ReasoningSpec {
     /// pre-filled it (policy P5). Qwen3 is not one of these; DeepSeek-R1-style
     /// forced-reasoning templates are.
     pub forced_start: bool,
+    /// Whether the reasoning markers require special-token preservation.
+    pub preserve_special_tokens: bool,
 }
 
 /// Per-family hook: parse one complete invoke (opener..closer inclusive) into
@@ -234,17 +244,58 @@ enum InReasoning {
 /// never emits a string of adjacent same-kind fragments (`I8`). The or-pattern is
 /// the whole point: text and reasoning coalesce by identical rules, so there is
 /// one implementation to get right instead of two that can drift.
-pub(crate) fn push_run(out: &mut Vec<UnifiedParserEvent>, kind: Kind, text: &str) {
-    if text.is_empty() {
-        return;
+/// Where the drain loop puts events as it commits them.
+///
+/// The loop writes through this rather than into a local `Vec` it returns at the end.
+/// That is what makes the error contract honest: an event handed to the sink belongs to
+/// the CALLER, so a later `Err` in the same advance cannot take it back. A local vector
+/// is dropped by `?` on the way out, which silently un-commits everything already
+/// emitted in that advance.
+///
+/// Method names match the peer accumulation helpers, so an implementation reads the
+/// same on both sides.
+pub(crate) trait EventSink {
+    /// Append visible text, merging into a trailing text event.
+    fn push_text(&mut self, text: &str);
+    /// Append reasoning text, merging into a trailing reasoning event.
+    fn push_reasoning(&mut self, text: &str);
+    /// Append one tool call. Calls never merge.
+    fn push_call(&mut self, call: ToolCallDelta);
+}
+
+/// The batch/tool-only path still collects into a vector.
+impl EventSink for Vec<UnifiedParserEvent> {
+    fn push_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(UnifiedParserEvent::Text(prev)) = self.last_mut() {
+            prev.push_str(text);
+            return;
+        }
+        self.push(UnifiedParserEvent::Text(text.to_string()));
     }
-    match (out.last_mut(), kind) {
-        (Some(UnifiedParserEvent::Text(prev)), Kind::Text)
-        | (Some(UnifiedParserEvent::Reasoning(prev)), Kind::Reasoning) => prev.push_str(text),
-        _ => out.push(match kind {
-            Kind::Text => UnifiedParserEvent::Text(text.to_string()),
-            Kind::Reasoning => UnifiedParserEvent::Reasoning(text.to_string()),
-        }),
+
+    fn push_reasoning(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(UnifiedParserEvent::Reasoning(prev)) = self.last_mut() {
+            prev.push_str(text);
+            return;
+        }
+        self.push(UnifiedParserEvent::Reasoning(text.to_string()));
+    }
+
+    fn push_call(&mut self, call: ToolCallDelta) {
+        self.push(UnifiedParserEvent::ToolCall(call));
+    }
+}
+
+pub(crate) fn push_run<S: EventSink + ?Sized>(out: &mut S, kind: Kind, text: &str) {
+    match kind {
+        Kind::Text => out.push_text(text),
+        Kind::Reasoning => out.push_reasoning(text),
     }
 }
 
@@ -311,13 +362,51 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         Ok(ToolParseResult::from_deltas(self.finish_ordered()?))
     }
 
+    /// Whether decoding must preserve special tokens for THIS scanner's grammar.
+    ///
+    /// The OR over every component whose markers the scan consumes — the peer's
+    /// `CombinedParser` rule, expressed over one scanner rather than two wrapped
+    /// parser objects. A component that needs preservation cannot have its
+    /// requirement dropped by the composition.
+    pub(crate) fn preserve_special_tokens(&self) -> bool {
+        self.spec.preserve_special_tokens
+            || self
+                .reasoning
+                .as_ref()
+                .is_some_and(|r| r.preserve_special_tokens)
+    }
+
     pub(crate) fn push_ordered(&mut self, chunk: &str) -> anyhow::Result<Vec<UnifiedParserEvent>> {
-        self.buffer.push_str(chunk);
-        self.drain(false)
+        let mut out = Vec::new();
+        self.push_ordered_into(chunk, &mut out)?;
+        Ok(out)
     }
 
     pub(crate) fn finish_ordered(&mut self) -> anyhow::Result<Vec<UnifiedParserEvent>> {
-        self.drain(true)
+        let mut out = Vec::new();
+        self.finish_ordered_into(&mut out)?;
+        Ok(out)
+    }
+
+    /// Drain one advance directly into the caller's sink.
+    ///
+    /// Preferred over [`Self::push_ordered`] on any fallible path: events reach the
+    /// caller as they are committed, so an `Err` later in the same advance leaves the
+    /// earlier ones in place instead of dropping them with the returned vector.
+    pub(crate) fn push_ordered_into<S: EventSink + ?Sized>(
+        &mut self,
+        chunk: &str,
+        out: &mut S,
+    ) -> anyhow::Result<()> {
+        self.buffer.push_str(chunk);
+        self.drain(false, out)
+    }
+
+    pub(crate) fn finish_ordered_into<S: EventSink + ?Sized>(
+        &mut self,
+        out: &mut S,
+    ) -> anyhow::Result<()> {
+        self.drain(true, out)
     }
 
     /// Position and length of the reasoning opener in the buffer, if configured.
@@ -333,9 +422,9 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// Returns `true` once the reasoning span yielded (closer seen, tool opener
     /// reached, or promoted at EOF) and the caller should keep draining; `false`
     /// means more input is needed.
-    fn drain_reasoning(
+    fn drain_reasoning<S: EventSink + ?Sized>(
         &mut self,
-        out: &mut Vec<UnifiedParserEvent>,
+        out: &mut S,
         flush: bool,
     ) -> anyhow::Result<bool> {
         let Some(reasoning) = self.reasoning else {
@@ -443,16 +532,14 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         carried
     }
 
-    fn drain(&mut self, flush: bool) -> anyhow::Result<Vec<UnifiedParserEvent>> {
-        let mut out: Vec<UnifiedParserEvent> = Vec::new();
-
+    fn drain<S: EventSink + ?Sized>(&mut self, flush: bool, out: &mut S) -> anyhow::Result<()> {
         loop {
             // Reasoning yields to tool structure: while a thought is open, its
             // closer OR a nested tool opener ends the current reasoning run (see
             // `drain_reasoning`), so a call emitted inside a thought is extracted
             // and the thought resumes after it.
             if self.in_reasoning {
-                if self.drain_reasoning(&mut out, flush)? {
+                if self.drain_reasoning(out, flush)? {
                     continue;
                 }
                 break;
@@ -518,10 +605,16 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     self.suppress_normal_text = false;
                     continue;
                 }
-                let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
-                self.buffer.drain(..end + self.spec.invoke_end.len());
-                if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
-                    out.push(UnifiedParserEvent::ToolCall(delta));
+                let invoke_len = end + self.spec.invoke_end.len();
+                let invoke = self.buffer[..invoke_len].to_string();
+                // Emit BEFORE consuming. `parse_invoke` is fallible, and draining first
+                // meant a failing emitter destroyed the invoke bytes: they were gone from
+                // the buffer, so `reset_stream` could no longer hand them back and the
+                // documented recovery contract was false for the only shipped family.
+                let emitted = self.emitter.parse_invoke(&invoke, self.next_index)?;
+                self.buffer.drain(..invoke_len);
+                if let Some(delta) = emitted {
+                    out.push_call(delta);
                     self.next_index += 1;
                     if self.spec.invoke_latch == InvokeLatch::IfEmitted {
                         self.suppress_normal_text = true;
@@ -550,7 +643,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     .min();
                 if next_open.is_none_or(|open| pos < open) {
                     if !self.suppress_normal_text && pos > 0 {
-                        push_run(&mut out, Kind::Text, &self.buffer[..pos]);
+                        push_run(out, Kind::Text, &self.buffer[..pos]);
                     }
                     self.buffer.drain(..pos + len);
                     self.suppress_normal_text = false;
@@ -584,7 +677,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let emit_len = self.buffer.len().saturating_sub(keep);
                 if emit_len > 0 {
                     if !self.suppress_normal_text {
-                        push_run(&mut out, Kind::Text, &self.buffer[..emit_len]);
+                        push_run(out, Kind::Text, &self.buffer[..emit_len]);
                     }
                     self.buffer.drain(..emit_len);
                 }
@@ -593,7 +686,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
 
             if start > 0 {
                 if !self.suppress_normal_text {
-                    push_run(&mut out, Kind::Text, &self.buffer[..start]);
+                    push_run(out, Kind::Text, &self.buffer[..start]);
                 }
                 self.buffer.drain(..start);
             }
@@ -626,15 +719,18 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         }
                         break;
                     };
-                    let invoke = self.buffer[..end + self.spec.invoke_end.len()].to_string();
-                    self.buffer.drain(..end + self.spec.invoke_end.len());
-                    if let Some(delta) = self.emitter.parse_invoke(&invoke, self.next_index)? {
+                    let invoke_len = end + self.spec.invoke_end.len();
+                    let invoke = self.buffer[..invoke_len].to_string();
+                    // Emit before consuming — same recovery contract as the wrapped site.
+                    let emitted = self.emitter.parse_invoke(&invoke, self.next_index)?;
+                    self.buffer.drain(..invoke_len);
+                    if let Some(delta) = emitted {
                         tracing::warn!(
                             why = %format!("{}_bare_invoke_recovery", self.spec.family),
                             tool_index = delta.tool_index,
                             "stream recovered a complete bare invoke"
                         );
-                        out.push(UnifiedParserEvent::ToolCall(delta));
+                        out.push_call(delta);
                         self.next_index += 1;
                         self.suppress_normal_text =
                             self.spec.bare_recovery_latch == BareRecoveryLatch::Set;
@@ -649,6 +745,90 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             }
         }
 
-        Ok(out)
+        Ok(())
+    }
+}
+
+/// Test-only: an emitter that fails partway through a stream, so the recovery contract
+/// can be exercised from every surface that drives a scanner.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Succeeds until it sees `boom`, then fails — the shape of any real emitter whose
+    /// arguments fail to type-check partway through a stream.
+    pub(crate) struct FailOnBoom;
+
+    impl InvokeEmitter for FailOnBoom {
+        fn parse_invoke(
+            &self,
+            invoke: &str,
+            tool_index: usize,
+        ) -> anyhow::Result<Option<ToolCallDelta>> {
+            if invoke.contains("boom") {
+                anyhow::bail!("injected emitter failure");
+            }
+            Ok(Some(ToolCallDelta {
+                tool_index,
+                name: Some("ok".to_string()),
+                arguments: "{}".to_string(),
+            }))
+        }
+    }
+
+    pub(crate) fn failing_scanner() -> WrappedBlockScanner<FailOnBoom> {
+        WrappedBlockScanner::new(
+            WrappedBlockSpec {
+                family: "test",
+                block_starts: vec!["<tool_call>".into()],
+                block_ends: vec!["</tool_call>".into()],
+                invoke_start: "<function=".into(),
+                invoke_end: "</function>".into(),
+                orphan_markers: vec!["</tool_call>".into()],
+                holdback_markers: vec!["<tool_call>".into(), "</tool_call>".into()],
+                bare_recovery_latch: BareRecoveryLatch::Set,
+                invoke_latch: InvokeLatch::IfEmitted,
+                drop_invoke_crossing_block_end: false,
+                preserve_special_tokens: true,
+            },
+            FailOnBoom,
+        )
+    }
+}
+
+#[cfg(test)]
+mod recovery_tests {
+    use super::test_support::*;
+    use super::*;
+
+    /// Scanner-level contract: on an emitter error the failed invoke stays in the buffer,
+    /// so `reset_stream` can hand it back. Pre-fix this drained before the fallible call.
+    #[test]
+    fn wrapped_emitter_error_leaves_invoke_recoverable() {
+        let mut s = failing_scanner();
+        let mut out: Vec<UnifiedParserEvent> = Vec::new();
+        let r = s.push_ordered_into(
+            "prefix<tool_call><function=ok></function><function=boom></function></tool_call>suffix",
+            &mut out,
+        );
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            s.reset_stream(),
+            "<function=boom></function></tool_call>suffix",
+            "the failed invoke and everything after it must remain recoverable"
+        );
+    }
+
+    #[test]
+    fn bare_emitter_error_leaves_invoke_recoverable() {
+        let mut s = failing_scanner();
+        let mut out: Vec<UnifiedParserEvent> = Vec::new();
+        let r = s.push_ordered_into("prefix<function=boom></function>suffix", &mut out);
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            s.reset_stream(),
+            "<function=boom></function>suffix",
+            "the failed bare invoke and everything after it must remain recoverable"
+        );
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -338,9 +338,19 @@ impl<'a> IntoIterator for &'a UnifiedParserOutput {
 
 impl FromIterator<UnifiedParserEvent> for UnifiedParserOutput {
     fn from_iter<T: IntoIterator<Item = UnifiedParserEvent>>(iter: T) -> Self {
-        Self {
-            events: iter.into_iter().collect(),
+        // Through the helpers, like every other way of building this type. A plain
+        // `collect()` bypassed the merge, so `collect()`ing two adjacent `Text` events
+        // produced a different event stream than pushing the same bytes — the same
+        // defect `append` had, one constructor over.
+        let mut out = Self::default();
+        for event in iter {
+            match event {
+                UnifiedParserEvent::Text(t) => out.push_text(t),
+                UnifiedParserEvent::Reasoning(t) => out.push_reasoning(t),
+                UnifiedParserEvent::ToolCall(c) => out.push_call(c),
+            }
         }
+        out
     }
 }
 
@@ -483,9 +493,11 @@ impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
     }
 
     fn finish(&mut self) -> Result<UnifiedParserOutput> {
-        Ok(UnifiedParserOutput {
-            events: self.scanner.finish_ordered()?,
-        })
+        // Direct into the output, matching `parse_into`: no intermediate vector, and the
+        // events reach the caller through the same coalescing helpers.
+        let mut out = UnifiedParserOutput::default();
+        self.scanner.finish_ordered_into(&mut out)?;
+        Ok(out)
     }
 }
 
@@ -968,5 +980,66 @@ mod parse_into_recovery_tests {
             "an event already committed cannot be retracted by a later error"
         );
         assert_eq!(p.reset(), "<function=boom></function>suffix");
+    }
+}
+
+/// Every way of BUILDING this type must agree, not just the push helpers.
+///
+/// `append` was fixed to coalesce and `FromIterator` was not, so `collect()` still
+/// produced a different event stream than pushing the same bytes. These pin every
+/// constructor to the one merge rule so the next one cannot drift alone.
+#[cfg(test)]
+mod construction_parity_tests {
+    use super::*;
+
+    fn adjacent() -> Vec<UnifiedParserEvent> {
+        vec![
+            UnifiedParserEvent::Text("hel".to_string()),
+            UnifiedParserEvent::Text("lo".to_string()),
+            UnifiedParserEvent::Reasoning("thin".to_string()),
+            UnifiedParserEvent::Reasoning("king".to_string()),
+        ]
+    }
+
+    fn pushed() -> UnifiedParserOutput {
+        let mut out = UnifiedParserOutput::default();
+        for e in adjacent() {
+            match e {
+                UnifiedParserEvent::Text(t) => out.push_text(t),
+                UnifiedParserEvent::Reasoning(t) => out.push_reasoning(t),
+                UnifiedParserEvent::ToolCall(c) => out.push_call(c),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn collect_agrees_with_pushing_the_same_events() {
+        let collected: UnifiedParserOutput = adjacent().into_iter().collect();
+        assert_eq!(
+            collected,
+            pushed(),
+            "`collect()` must apply the same merge rule as the push helpers"
+        );
+        assert_eq!(
+            collected.events,
+            vec![
+                UnifiedParserEvent::Text("hello".to_string()),
+                UnifiedParserEvent::Reasoning("thinking".to_string()),
+            ],
+            "adjacent same-kind events must merge when collected"
+        );
+    }
+
+    #[test]
+    fn append_agrees_with_pushing_the_same_events() {
+        let mut joined = UnifiedParserOutput::default();
+        let mut src: UnifiedParserOutput = adjacent().into_iter().collect();
+        joined.append(&mut src);
+        assert_eq!(
+            joined,
+            pushed(),
+            "`append` must apply the same merge rule as the push helpers"
+        );
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -221,6 +221,16 @@ pub trait UnifiedParser: Send {
 ///   exception: it routes every event through these same helpers, so joining two
 ///   independently-built buffers gives the same result as accumulating straight through.
 ///
+/// # This is a CONVENTION, not an enforced invariant
+///
+/// `events` is public — matching the peer type, which is the point of this surface — so
+/// nothing stops a caller writing `UnifiedParserOutput { events: vec![Text("hel"), Text("lo")] }`
+/// or `out.events.extend(..)` and holding a value that breaks the merge rule. Every
+/// route this crate owns (the push helpers, [`Self::append`], `FromIterator`, and the
+/// scanner's sink) does apply it; direct field access does not, and cannot be made to
+/// without diverging from the peer shape. So: build through the helpers. A value that
+/// did not come through them may carry adjacent same-kind events.
+///
 /// [`assemble`] performs the same fold, so a caller that coalesces here and one that
 /// folds afterwards agree on the assembled result either way.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -184,9 +184,16 @@ pub trait UnifiedParser: Send {
     /// `parse_into`/`finish` is what makes stream/batch parity (`I6`) structural
     /// instead of a property two code paths have to agree on.
     fn parse_complete(&mut self, output: &str) -> Result<Vec<UnifiedEvent>> {
-        let mut deltas = self.push(output)?;
-        deltas.append(&mut self.finish()?.events);
-        Ok(assemble(&deltas))
+        // Joined through `UnifiedParserOutput::append`, not a raw `Vec::append` on the
+        // event vectors: this is exactly the push/finish seam that rule exists for, and
+        // the crate should not violate its own documented merge semantics here. The
+        // assembled result is unchanged either way, since `assemble` performs the same
+        // fold — but the pre-fold event stream now agrees with every other spelling.
+        let mut acc = UnifiedParserOutput {
+            events: self.push(output)?,
+        };
+        acc.append(&mut self.finish()?);
+        Ok(assemble(&acc.events))
     }
 }
 
@@ -210,8 +217,9 @@ pub trait UnifiedParser: Send {
 ///   the new bytes may have merged into `events[n - 1]`. Use [`UnifiedParser::push`],
 ///   which returns exactly one advance's events, when that is the question.
 /// - **Append through the helpers, not `events.extend`.** `extend` bypasses the merge
-///   and yields a different event vector for identical bytes. Only [`Self::append`],
-///   which joins two independently-built buffers, is exempt.
+///   and yields a different event vector for identical bytes. [`Self::append`] is NOT an
+///   exception: it routes every event through these same helpers, so joining two
+///   independently-built buffers gives the same result as accumulating straight through.
 ///
 /// [`assemble`] performs the same fold, so a caller that coalesces here and one that
 /// folds afterwards agree on the assembled result either way.
@@ -221,14 +229,37 @@ pub struct UnifiedParserOutput {
     pub events: Vec<UnifiedParserEvent>,
 }
 
+impl crate::tool_calling::scan::EventSink for UnifiedParserOutput {
+    fn push_text(&mut self, text: &str) {
+        UnifiedParserOutput::push_text(self, text);
+    }
+
+    fn push_reasoning(&mut self, text: &str) {
+        UnifiedParserOutput::push_reasoning(self, text);
+    }
+
+    fn push_call(&mut self, call: ToolCallDelta) {
+        UnifiedParserOutput::push_call(self, call);
+    }
+}
+
 impl UnifiedParserOutput {
     /// Append another advance's updates, preserving order.
     ///
-    /// Concatenates WITHOUT coalescing across the seam: two independently-built buffers
-    /// keep their own boundaries. The merge rule applies to `push_text`/`push_reasoning`,
-    /// which add to one buffer.
+    /// Coalesces ACROSS the seam, matching the peer helper: routing every event through
+    /// `push_text`/`push_reasoning`/`push_call` means two buffers joined here produce the
+    /// same events as one buffer accumulated straight through. A plain `Vec::append` left
+    /// `Text("hello") + Text(" world")` as two events where the peer yields one, so the
+    /// same bytes described a different event stream depending on how the caller batched
+    /// them.
     pub fn append(&mut self, other: &mut Self) {
-        self.events.append(&mut other.events);
+        for event in std::mem::take(&mut other.events) {
+            match event {
+                UnifiedParserEvent::Text(t) => self.push_text(t),
+                UnifiedParserEvent::Reasoning(t) => self.push_reasoning(t),
+                UnifiedParserEvent::ToolCall(c) => self.push_call(c),
+            }
+        }
     }
 
     // --- Accumulation helpers, aligned with the peer traits in name and semantics.
@@ -422,10 +453,16 @@ pub(crate) struct ScannerUnified<E: InvokeEmitter> {
 }
 
 impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
-    // No `preserve_special_tokens` override here: the trait METHOD is the peer surface
-    // and belongs to this change, but whether a given family's markers ARE special
-    // tokens is family behaviour, exercised by the request-mode work. Overriding it
-    // without a test that can observe the difference would be an unmeasured claim.
+    /// Whether decoding must preserve special tokens, delegated to the shared grammar.
+    ///
+    /// NOT the trait default. Inheriting `false` here while the tool-only adapter over
+    /// this same scanner returned `true` meant two surfaces reported contradictory
+    /// decoding requirements for identical markup. The value now lives on the grammar and
+    /// both surfaces read it, so they cannot disagree.
+    fn preserve_special_tokens(&self) -> bool {
+        self.scanner.preserve_special_tokens()
+    }
+
     /// The trait default returns an empty string and leaves state untouched, which
     /// would tell a caller nothing was buffered while the scanner still held a partial
     /// marker, `in_block`, and a used `next_index`. A caller following the documented
@@ -436,17 +473,13 @@ impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
     }
 
     fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
-        // Through the helpers, NOT `events.extend`: the helpers coalesce into a trailing
-        // same-kind event and `extend` does not, so extending made the only shipped
-        // family disagree with the documented vendor contract for identical bytes.
-        for event in self.scanner.push_ordered(delta)? {
-            match event {
-                UnifiedParserEvent::Text(t) => output.push_text(t),
-                UnifiedParserEvent::Reasoning(t) => output.push_reasoning(t),
-                UnifiedParserEvent::ToolCall(c) => output.push_call(c),
-            }
-        }
-        Ok(())
+        // Straight into the caller's output, with no vector in between. Two reasons, and
+        // the first is a correctness one: an event written here is COMMITTED, so a later
+        // error in the same advance cannot retract it. Collecting into a local vector and
+        // copying at the end meant `?` dropped everything already emitted. It also drops
+        // the second allocation per advance. Coalescing is unchanged: the sink routes
+        // through these same `push_*` helpers.
+        self.scanner.push_ordered_into(delta, output)
     }
 
     fn finish(&mut self) -> Result<UnifiedParserOutput> {
@@ -484,15 +517,15 @@ static VENDOR_PARSERS: std::sync::LazyLock<
 ///
 /// # Startup-only
 ///
-/// Register during startup, BEFORE serving. Concurrent registration and parser
-/// construction is not supported and is not linearizable: the lookup copies the
-/// factory and releases the registry lock before calling it, so a construction
-/// already in flight can still build a parser that a concurrent `unregister` has
-/// just removed, and a lookup that observed no vendor can build the built-in after
-/// a concurrent `register` returned. Neither races memory — the registry itself is
-/// lock-guarded — but which implementation a request gets is undefined while the
-/// table is being mutated. A parser already constructed always keeps what it was
-/// built with, so a request in progress never changes implementation mid-stream.
+/// Register during startup, BEFORE serving. Every access is guarded by one `RwLock`,
+/// and a create linearizes at the moment it reads the table — so the outcome is always
+/// SOME well-defined selection, never undefined behaviour or a torn read. What is not
+/// guaranteed is ORDERING against an overlapping mutation: the lookup copies the factory
+/// and releases the lock before calling it, so a create that read the table first can
+/// finish building after a concurrent `unregister` returns. Registering at startup
+/// avoids having to reason about that window at all. A parser already constructed keeps
+/// what it was built with, so a request in progress never changes implementation
+/// mid-stream.
 pub fn register_unified_parser(
     family: &str,
     factory: UnifiedParserFactory,
@@ -524,9 +557,9 @@ pub fn register_unified_parser(
 /// reachable again.
 ///
 /// Accepts any alias of the family, matching [`register_unified_parser`], and
-/// inherits its STARTUP-ONLY restriction: unregistering while requests are being
-/// served is not linearizable, so a construction already in flight can still build
-/// the parser this call removes.
+/// inherits its STARTUP-ONLY guidance: a create that read the table before this call
+/// can still finish building the parser it removes, so the returned factory may be used
+/// once more after this returns.
 pub fn unregister_unified_parser(family: &str) -> Option<UnifiedParserFactory> {
     let key = canonical_unified_family(family).unwrap_or(family);
     VENDOR_PARSERS
@@ -605,9 +638,11 @@ macro_rules! unified_registry {
         /// Create the unified parser for a family.
         ///
         /// A vendor registration wins over the built-in of the same name — see
-        /// [`register_unified_parser`]. Vendor parsers are wrapped by the debug
-        /// wrapper on the same terms as built-ins, so switching to one does not
-        /// silently change what instrumentation reports.
+        /// [`register_unified_parser`]. Both branches return the parser directly:
+        /// there is no unified debug wrapper (the only `DebugToolParser` wraps the
+        /// separate tool-only trait). Selection is observable through the
+        /// `tracing::debug!` event emitted here, and it reports vendor and built-in
+        /// on the same terms.
         pub fn create_unified_parser_for_family(
             family: &str,
             tools: &[Tool],
@@ -776,5 +811,162 @@ mod tests {
                 UnifiedEvent::Text { text: "b".into() },
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod append_seam_tests {
+    use super::*;
+
+    /// The peer's regression: joining two buffers must yield the same events as
+    /// accumulating straight through, so the same bytes cannot describe a different
+    /// event stream depending on how the caller batched them.
+    /// The peer's exact seam regression: a multi-buffer join must produce the same
+    /// events as one buffer accumulated straight through, across two appends and both
+    /// text and reasoning runs.
+    #[test]
+    fn append_coalesces_adjacent_same_kind_events_across_the_seam() {
+        let mut acc = UnifiedParserOutput::default();
+        acc.push_text("hello");
+
+        let mut second = UnifiedParserOutput::default();
+        second.push_text(" world");
+        second.push_reasoning("think");
+        acc.append(&mut second);
+
+        let mut third = UnifiedParserOutput::default();
+        third.push_reasoning("ing");
+        third.push_text("!");
+        acc.append(&mut third);
+
+        assert_eq!(
+            acc.events,
+            vec![
+                UnifiedParserEvent::Text("hello world".to_string()),
+                UnifiedParserEvent::Reasoning("thinking".to_string()),
+                UnifiedParserEvent::Text("!".to_string()),
+            ],
+            "same-kind runs must merge across every seam, different kinds must not"
+        );
+        assert!(
+            second.events.is_empty(),
+            "append must consume the source events"
+        );
+        assert!(
+            third.events.is_empty(),
+            "append must consume the source events"
+        );
+    }
+
+    /// Different kinds must NOT merge, and calls never merge with anything.
+    #[test]
+    fn append_keeps_distinct_kinds_separate() {
+        let mut a = UnifiedParserOutput::default();
+        a.push_text("visible");
+        let mut b = UnifiedParserOutput::default();
+        b.push_reasoning("thought");
+        a.append(&mut b);
+
+        assert_eq!(
+            a.events.len(),
+            2,
+            "text and reasoning must stay distinct: {:?}",
+            a.events
+        );
+    }
+}
+
+/// The recovery contract through the PUBLIC surface a caller actually uses:
+/// `UnifiedParser::parse_into` with a caller-owned `UnifiedParserOutput`.
+///
+/// The scanner-level tests in `scan::recovery_tests` prove drain-after-success. They do
+/// NOT prove this: they drive a `Vec` sink directly, so reverting `parse_into` to collect
+/// into a local vector and copy at the end would leave them green while the caller's
+/// committed events were silently dropped by `?`. These tests are that missing control.
+#[cfg(test)]
+mod parse_into_recovery_tests {
+    use super::*;
+    use crate::tool_calling::scan::test_support::{FailOnBoom, failing_scanner};
+
+    fn parser() -> ScannerUnified<FailOnBoom> {
+        ScannerUnified {
+            scanner: failing_scanner(),
+        }
+    }
+
+    fn call(index: usize) -> UnifiedParserEvent {
+        UnifiedParserEvent::ToolCall(ToolCallDelta {
+            tool_index: index,
+            name: Some("ok".to_string()),
+            arguments: "{}".to_string(),
+        })
+    }
+
+    /// A failure on the FIRST wrapped invoke: text committed before it survives.
+    #[test]
+    fn first_wrapped_failure_keeps_committed_text_and_recovers_the_invoke() {
+        let mut p = parser();
+        let mut out = UnifiedParserOutput::default();
+        let r = p.parse_into(
+            "prefix<tool_call><function=boom></function></tool_call>suffix",
+            &mut out,
+        );
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            out.events,
+            vec![UnifiedParserEvent::Text("prefix".to_string())],
+            "text committed before the failure belongs to the caller"
+        );
+        assert_eq!(p.reset(), "<function=boom></function></tool_call>suffix");
+    }
+
+    /// A failure on a LATER wrapped invoke: the call that already succeeded survives too.
+    /// This is the case that a local-vector implementation loses entirely.
+    #[test]
+    fn later_wrapped_failure_keeps_the_call_that_already_succeeded() {
+        let mut p = parser();
+        let mut out = UnifiedParserOutput::default();
+        let r = p.parse_into(
+            "prefix<tool_call><function=ok></function><function=boom></function></tool_call>suffix",
+            &mut out,
+        );
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            out.events,
+            vec![UnifiedParserEvent::Text("prefix".to_string()), call(0)],
+            "an event already committed cannot be retracted by a later error"
+        );
+        assert_eq!(p.reset(), "<function=boom></function></tool_call>suffix");
+    }
+
+    #[test]
+    fn first_bare_failure_keeps_committed_text_and_recovers_the_invoke() {
+        let mut p = parser();
+        let mut out = UnifiedParserOutput::default();
+        let r = p.parse_into("prefix<function=boom></function>suffix", &mut out);
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            out.events,
+            vec![UnifiedParserEvent::Text("prefix".to_string())],
+            "text committed before the failure belongs to the caller"
+        );
+        assert_eq!(p.reset(), "<function=boom></function>suffix");
+    }
+
+    #[test]
+    fn later_bare_failure_keeps_the_call_that_already_succeeded() {
+        let mut p = parser();
+        let mut out = UnifiedParserOutput::default();
+        let r = p.parse_into(
+            "prefix<function=ok></function><function=boom></function>suffix",
+            &mut out,
+        );
+        assert!(r.is_err(), "the injected emitter must surface its error");
+        assert_eq!(
+            out.events,
+            vec![UnifiedParserEvent::Text("prefix".to_string()), call(0)],
+            "an event already committed cannot be retracted by a later error"
+        );
+        assert_eq!(p.reset(), "<function=boom></function>suffix");
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -31,8 +31,8 @@
 //!
 //! # Shape
 //!
-//! [`UnifiedParserEvent`] is the streaming vocabulary — what one `push` produced, in
-//! order. [`UnifiedEvent`] is the assembled view: adjacent same-kind deltas
+//! [`UnifiedParserEvent`] is the streaming vocabulary — what one parser advance
+//! produced, in order. [`UnifiedEvent`] is the assembled view: adjacent same-kind deltas
 //! coalesced and per-call argument fragments joined into one typed object
 //! (`I8`). [`assemble`] is the single implementation of that fold, so callers
 //! and conformance harnesses never reimplement it and drift.
@@ -92,9 +92,10 @@ pub enum UnifiedEvent {
 
 /// A parser that owns reasoning + content + tool calls for one stream.
 ///
-/// Streaming-first, like [`crate::ToolParser`]: `push` per decoded delta,
-/// `finish` once at end of stream. One instance parses exactly one choice of
-/// one request, which is what gives per-stream isolation (`I4`) by construction.
+/// Streaming-first, like [`crate::ToolParser`]: [`Self::parse_into`] per decoded
+/// delta, [`Self::finish`] once at end of stream. One instance parses exactly one
+/// choice of one request, which is what gives per-stream isolation (`I4`) by
+/// construction.
 pub trait UnifiedParser: Send {
     /// Initialize parser state from prompt token IDs before output deltas arrive.
     ///
@@ -108,17 +109,17 @@ pub trait UnifiedParser: Send {
 
     /// Feed one decoded text delta, appending committed events into `output`.
     ///
-    /// THE required method, matching the peer traits. Everything else that advances
-    /// the parser — [`UnifiedParser::push`], [`UnifiedParser::parse_complete`] — is
-    /// defined in terms of this one, so there is a single advance implementation per
-    /// family and no second path to drift.
+    /// THE required method, matching the peer traits. It is the only method that
+    /// advances the parser; [`UnifiedParserExt::push`] and
+    /// [`UnifiedParserExt::parse_complete`] are non-overridable conveniences defined
+    /// in terms of it, so every family has one advance implementation.
     ///
     /// Error contract, aligned with the peer traits: on `Err`, whatever was already
     /// appended to `output` stays committed and the parser's uncommitted buffer is
     /// intact, so the caller can recover it with [`UnifiedParser::reset`].
     ///
     /// This guarantee is specific to `parse_into`, because the caller owns `output` and
-    /// can still read it after an error. [`UnifiedParser::push`] owns its buffer and
+    /// can still read it after an error. [`UnifiedParserExt::push`] owns its buffer and
     /// returns `Result<Vec<_>>`, which has nowhere to carry partial output — a parser
     /// that may commit events and THEN fail must be driven through `parse_into`.
     fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()>;
@@ -134,26 +135,6 @@ pub trait UnifiedParser: Send {
     /// would silently drop the tail of every stream, and that is not a failure worth
     /// inheriting for symmetry's sake.
     fn finish(&mut self) -> Result<UnifiedParserOutput>;
-
-    /// Feed one decoded text delta; returns the events it committed, in order.
-    ///
-    /// Additive convenience over [`UnifiedParser::parse_into`] — allocates a fresh
-    /// vector per advance, which is why a serving loop prefers `parse_into`. The
-    /// conformance corpus asserts against this spelling.
-    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedParserEvent>> {
-        let mut out = UnifiedParserOutput::default();
-        match self.parse_into(chunk, &mut out) {
-            Ok(()) => Ok(out.events),
-            // On `Err` the committed events are UNRECOVERABLE through this spelling: the
-            // buffer is owned here, and `Result<Vec<_>>` has nowhere to carry it. The
-            // stay-committed guarantee therefore belongs to `parse_into`, whose buffer the
-            // CALLER owns and can still read after an error. Said plainly rather than left
-            // implied, because the trait doc and `CUSTOM_PARSERS.md` previously stated the
-            // guarantee without qualifying which spelling honours it — and a vendor doing
-            // exactly what those docs describe would have silently lost output here.
-            Err(e) => Err(e),
-        }
-    }
 
     /// Return the parser to a FRESH-STREAM state and hand back any unconsumed text.
     ///
@@ -177,25 +158,38 @@ pub trait UnifiedParser: Send {
     fn tool_call_id(&self, _tool_index: usize) -> Option<&str> {
         None
     }
+}
 
-    /// Parse complete output through the incremental lifecycle, then assemble.
+/// Allocation conveniences over the required [`UnifiedParser`] lifecycle.
+///
+/// These methods live in a blanket extension trait so parser implementations cannot
+/// override them and create a second advance path. Import this trait to call them.
+pub trait UnifiedParserExt: UnifiedParser {
+    /// Feed one decoded text delta; returns the events it committed, in order.
     ///
-    /// Additive: the peer traits have no batch entry point. Routing batch through
-    /// `parse_into`/`finish` is what makes stream/batch parity (`I6`) structural
-    /// instead of a property two code paths have to agree on.
-    fn parse_complete(&mut self, output: &str) -> Result<Vec<UnifiedEvent>> {
-        // Joined through `UnifiedParserOutput::append`, not a raw `Vec::append` on the
-        // event vectors: this is exactly the push/finish seam that rule exists for, and
-        // the crate should not violate its own documented merge semantics here. The
-        // assembled result is unchanged either way, since `assemble` performs the same
-        // fold — but the pre-fold event stream now agrees with every other spelling.
-        let mut acc = UnifiedParserOutput {
-            events: self.push(output)?,
-        };
-        acc.append(&mut self.finish()?);
-        Ok(assemble(&acc.events))
+    /// This allocates a fresh output per advance, which is why a serving loop prefers
+    /// [`UnifiedParser::parse_into`]. On `Err`, committed events in that local output
+    /// cannot be recovered through `Result<Vec<_>>`; use `parse_into` when partial
+    /// committed output must survive an error.
+    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedParserEvent>> {
+        let mut out = UnifiedParserOutput::default();
+        self.parse_into(chunk, &mut out)?;
+        Ok(out.events)
+    }
+
+    /// Parse complete output through `parse_into` + `finish`, then assemble.
+    ///
+    /// The fixed lifecycle makes stream/batch parity (`I6`) structural instead of a
+    /// property two independently overridable paths have to agree on.
+    fn parse_complete(&mut self, text: &str) -> Result<Vec<UnifiedEvent>> {
+        let mut out = UnifiedParserOutput::default();
+        self.parse_into(text, &mut out)?;
+        out.append(&mut self.finish()?);
+        Ok(assemble(&out.events))
     }
 }
+
+impl<T: UnifiedParser + ?Sized> UnifiedParserExt for T {}
 
 /// Ordered updates committed by one parser advance.
 ///
@@ -214,7 +208,7 @@ pub trait UnifiedParser: Send {
 ///
 /// - **Do not index a "what did this advance produce" window.** A watermark loop —
 ///   record `len()`, advance, read `events[n..]` — can legally observe NOTHING, because
-///   the new bytes may have merged into `events[n - 1]`. Use [`UnifiedParser::push`],
+///   the new bytes may have merged into `events[n - 1]`. Use [`UnifiedParserExt::push`],
 ///   which returns exactly one advance's events, when that is the question.
 /// - **Append through the helpers, not `events.extend`.** `extend` bypasses the merge
 ///   and yields a different event vector for identical bytes. [`Self::append`] is NOT an

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -31,7 +31,7 @@
 //!
 //! # Shape
 //!
-//! [`UnifiedDelta`] is the streaming vocabulary — what one `push` produced, in
+//! [`UnifiedParserEvent`] is the streaming vocabulary — what one `push` produced, in
 //! order. [`UnifiedEvent`] is the assembled view: adjacent same-kind deltas
 //! coalesced and per-call argument fragments joined into one typed object
 //! (`I8`). [`assemble`] is the single implementation of that fold, so callers
@@ -56,12 +56,16 @@ use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
 /// This is the streaming vocabulary shared by the whole crate: the marker-scan
 /// core emits it, tool-only parsers project it down to [`ToolParseResult`], and
 /// unified parsers hand it to the caller as-is.
+///
+/// Name, variant order and payload shapes are aligned with the peer streaming-parser
+/// traits, so the two translate variant-for-variant under a compiler rather than by a
+/// reader's judgement.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum UnifiedDelta {
-    /// Private chain-of-thought.
-    Reasoning { text: String },
-    /// User-visible content.
-    Text { text: String },
+pub enum UnifiedParserEvent {
+    /// Normal assistant-visible text.
+    Text(String),
+    /// Reasoning text hidden from the normal content stream.
+    Reasoning(String),
     /// A tool-call update. Carries the tool-only [`ToolCallDelta`] verbatim so
     /// the two surfaces cannot drift in how a call is described.
     ToolCall(ToolCallDelta),
@@ -92,24 +96,220 @@ pub enum UnifiedEvent {
 /// `finish` once at end of stream. One instance parses exactly one choice of
 /// one request, which is what gives per-stream isolation (`I4`) by construction.
 pub trait UnifiedParser: Send {
-    /// Feed one decoded text delta; returns the updates it completed, in order.
-    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>>;
+    /// Initialize parser state from prompt token IDs before output deltas arrive.
+    ///
+    /// This is the peer traits' `initialize` signature, so a caller written against
+    /// them reaches the same method with the same argument here. The default detects
+    /// nothing, matching the peer default; a family whose prompt can end mid-channel
+    /// overrides it and reads the tokens.
+    fn initialize(&mut self, _prompt_token_ids: &[u32]) -> Result<()> {
+        Ok(())
+    }
+
+    /// Feed one decoded text delta, appending committed events into `output`.
+    ///
+    /// THE required method, matching the peer traits. Everything else that advances
+    /// the parser — [`UnifiedParser::push`], [`UnifiedParser::parse_complete`] — is
+    /// defined in terms of this one, so there is a single advance implementation per
+    /// family and no second path to drift.
+    ///
+    /// Error contract, aligned with the peer traits: on `Err`, whatever was already
+    /// appended to `output` stays committed and the parser's uncommitted buffer is
+    /// intact, so the caller can recover it with [`UnifiedParser::reset`].
+    ///
+    /// This guarantee is specific to `parse_into`, because the caller owns `output` and
+    /// can still read it after an error. [`UnifiedParser::push`] owns its buffer and
+    /// returns `Result<Vec<_>>`, which has nowhere to carry partial output — a parser
+    /// that may commit events and THEN fail must be driven through `parse_into`.
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()>;
 
     /// Flush buffered partial state at end of stream.
     ///
-    /// Open reasoning is promoted here rather than dropped or leaked as text,
-    /// and an unrecoverable partial tool call is dropped without erroring
-    /// (policy P2 — best-effort recovery).
-    fn finish(&mut self) -> Result<Vec<UnifiedDelta>>;
+    /// Open reasoning is promoted here rather than dropped or leaked as text, and an
+    /// unrecoverable partial tool call is dropped without erroring (policy P2 —
+    /// best-effort recovery).
+    ///
+    /// The peer traits give this a default that returns nothing. It is REQUIRED here:
+    /// the signature a caller sees is identical, but a family that forgets to flush
+    /// would silently drop the tail of every stream, and that is not a failure worth
+    /// inheriting for symmetry's sake.
+    fn finish(&mut self) -> Result<UnifiedParserOutput>;
+
+    /// Feed one decoded text delta; returns the events it committed, in order.
+    ///
+    /// Additive convenience over [`UnifiedParser::parse_into`] — allocates a fresh
+    /// vector per advance, which is why a serving loop prefers `parse_into`. The
+    /// conformance corpus asserts against this spelling.
+    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedParserEvent>> {
+        let mut out = UnifiedParserOutput::default();
+        match self.parse_into(chunk, &mut out) {
+            Ok(()) => Ok(out.events),
+            // On `Err` the committed events are UNRECOVERABLE through this spelling: the
+            // buffer is owned here, and `Result<Vec<_>>` has nowhere to carry it. The
+            // stay-committed guarantee therefore belongs to `parse_into`, whose buffer the
+            // CALLER owns and can still read after an error. Said plainly rather than left
+            // implied, because the trait doc and `CUSTOM_PARSERS.md` previously stated the
+            // guarantee without qualifying which spelling honours it — and a vendor doing
+            // exactly what those docs describe would have silently lost output here.
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Return the parser to a FRESH-STREAM state and hand back any unconsumed text.
+    ///
+    /// This is not a mid-turn continuation hook. Everything restarts, including the
+    /// tool index, so the returned text must be re-parsed as a NEW stream and any
+    /// calls already emitted belong to the abandoned one — feeding the remainder back
+    /// into the same turn would re-number from index 0 and collide with them.
+    fn reset(&mut self) -> String {
+        String::new()
+    }
+
+    /// Whether decoded output must keep tokenizer special tokens.
+    ///
+    /// A family whose markers ARE special tokens cannot be parsed from text that
+    /// dropped them.
+    fn preserve_special_tokens(&self) -> bool {
+        false
+    }
+
+    /// The model-emitted id for a tool call, when the grammar carries one.
+    fn tool_call_id(&self, _tool_index: usize) -> Option<&str> {
+        None
+    }
 
     /// Parse complete output through the incremental lifecycle, then assemble.
     ///
-    /// Routing batch through `push`/`finish` is what makes stream/batch parity
-    /// (`I6`) structural instead of a property two code paths have to agree on.
+    /// Additive: the peer traits have no batch entry point. Routing batch through
+    /// `parse_into`/`finish` is what makes stream/batch parity (`I6`) structural
+    /// instead of a property two code paths have to agree on.
     fn parse_complete(&mut self, output: &str) -> Result<Vec<UnifiedEvent>> {
         let mut deltas = self.push(output)?;
-        deltas.append(&mut self.finish()?);
+        deltas.append(&mut self.finish()?.events);
         Ok(assemble(&deltas))
+    }
+}
+
+/// Ordered updates committed by one parser advance.
+///
+/// Aligned with the peer traits' output type: a vector, not a bundle of parallel
+/// channel fields. That is the whole point — a bundle cannot say whether text came
+/// before or after a call, which is the ordering this surface exists to pin.
+///
+/// # The buffer is CUMULATIVE, and appending COALESCES
+///
+/// One buffer may be driven through many advances. `push_text` and `push_reasoning`
+/// merge into a trailing event of the same kind, so two advances carrying `"hel"`
+/// then `"lo"` produce ONE `Text("hello")`, not two events.
+///
+/// Two consequences a caller must know, because they were previously unstated and the
+/// shipped implementations answered them differently:
+///
+/// - **Do not index a "what did this advance produce" window.** A watermark loop —
+///   record `len()`, advance, read `events[n..]` — can legally observe NOTHING, because
+///   the new bytes may have merged into `events[n - 1]`. Use [`UnifiedParser::push`],
+///   which returns exactly one advance's events, when that is the question.
+/// - **Append through the helpers, not `events.extend`.** `extend` bypasses the merge
+///   and yields a different event vector for identical bytes. Only [`Self::append`],
+///   which joins two independently-built buffers, is exempt.
+///
+/// [`assemble`] performs the same fold, so a caller that coalesces here and one that
+/// folds afterwards agree on the assembled result either way.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UnifiedParserOutput {
+    /// Updates in the order the model produced them.
+    pub events: Vec<UnifiedParserEvent>,
+}
+
+impl UnifiedParserOutput {
+    /// Append another advance's updates, preserving order.
+    ///
+    /// Concatenates WITHOUT coalescing across the seam: two independently-built buffers
+    /// keep their own boundaries. The merge rule applies to `push_text`/`push_reasoning`,
+    /// which add to one buffer.
+    pub fn append(&mut self, other: &mut Self) {
+        self.events.append(&mut other.events);
+    }
+
+    // --- Accumulation helpers, aligned with the peer traits in name and semantics.
+    // These COALESCE: appending text onto a trailing text event extends it rather than
+    // adding a second one. `assemble` performs the same fold, so a caller that
+    // accumulates through these and one that folds afterwards agree.
+
+    /// Append one visible text event if `delta` is non-empty.
+    pub fn push_text(&mut self, delta: impl AsRef<str> + Into<String>) {
+        if delta.as_ref().is_empty() {
+            return;
+        }
+        if let Some(UnifiedParserEvent::Text(last)) = self.events.last_mut() {
+            last.push_str(delta.as_ref());
+            return;
+        }
+        self.events.push(UnifiedParserEvent::Text(delta.into()));
+    }
+
+    /// Append one reasoning text event if `delta` is non-empty.
+    pub fn push_reasoning(&mut self, delta: impl AsRef<str> + Into<String>) {
+        if delta.as_ref().is_empty() {
+            return;
+        }
+        if let Some(UnifiedParserEvent::Reasoning(last)) = self.events.last_mut() {
+            last.push_str(delta.as_ref());
+            return;
+        }
+        self.events
+            .push(UnifiedParserEvent::Reasoning(delta.into()));
+    }
+
+    /// Append one tool-call event.
+    pub fn push_call(&mut self, call: ToolCallDelta) {
+        self.events.push(UnifiedParserEvent::ToolCall(call));
+    }
+
+    /// Whether this advance committed nothing.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Number of committed events.
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// Borrowing iterator over the committed events, in order.
+    pub fn iter(&self) -> std::slice::Iter<'_, UnifiedParserEvent> {
+        self.events.iter()
+    }
+
+    /// Collapse into assembled events (see [`assemble`]).
+    pub fn assembled(&self) -> Vec<UnifiedEvent> {
+        assemble(&self.events)
+    }
+}
+
+// Additive ergonomics: the type carries a single `events` field, so these cannot
+// change what is emitted — they only spare every caller an explicit `.events`.
+impl IntoIterator for UnifiedParserOutput {
+    type Item = UnifiedParserEvent;
+    type IntoIter = std::vec::IntoIter<UnifiedParserEvent>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.events.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a UnifiedParserOutput {
+    type Item = &'a UnifiedParserEvent;
+    type IntoIter = std::slice::Iter<'a, UnifiedParserEvent>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.events.iter()
+    }
+}
+
+impl FromIterator<UnifiedParserEvent> for UnifiedParserOutput {
+    fn from_iter<T: IntoIterator<Item = UnifiedParserEvent>>(iter: T) -> Self {
+        Self {
+            events: iter.into_iter().collect(),
+        }
     }
 }
 
@@ -120,14 +320,14 @@ pub trait UnifiedParser: Send {
 /// call's position at its FIRST delta so order survives fragmentation. Empty or
 /// unparseable arguments become `{}` (policy P3) rather than an error, because a
 /// malformed argument payload must not take down the rest of the turn.
-pub fn assemble(deltas: &[UnifiedDelta]) -> Vec<UnifiedEvent> {
+pub fn assemble(deltas: &[UnifiedParserEvent]) -> Vec<UnifiedEvent> {
     // Coalesce adjacent same-kind runs with the SAME helper the scan core uses, so
     // `I8` has exactly ONE implementation instead of one per type.
-    let mut merged: Vec<UnifiedDelta> = Vec::new();
+    let mut merged: Vec<UnifiedParserEvent> = Vec::new();
     for delta in deltas {
         match delta {
-            UnifiedDelta::Reasoning { text } => push_run(&mut merged, Kind::Reasoning, text),
-            UnifiedDelta::Text { text } => push_run(&mut merged, Kind::Text, text),
+            UnifiedParserEvent::Reasoning(text) => push_run(&mut merged, Kind::Reasoning, text),
+            UnifiedParserEvent::Text(text) => push_run(&mut merged, Kind::Text, text),
             call => merged.push(call.clone()),
         }
     }
@@ -139,9 +339,9 @@ pub fn assemble(deltas: &[UnifiedDelta]) -> Vec<UnifiedEvent> {
     let mut calls: BTreeMap<usize, (usize, String)> = BTreeMap::new();
     for delta in merged {
         match delta {
-            UnifiedDelta::Reasoning { text } => out.push(UnifiedEvent::Reasoning { text }),
-            UnifiedDelta::Text { text } => out.push(UnifiedEvent::Text { text }),
-            UnifiedDelta::ToolCall(call) => {
+            UnifiedParserEvent::Reasoning(text) => out.push(UnifiedEvent::Reasoning { text }),
+            UnifiedParserEvent::Text(text) => out.push(UnifiedEvent::Text { text }),
+            UnifiedParserEvent::ToolCall(call) => {
                 let (pos, raw) = calls.entry(call.tool_index).or_insert_with(|| {
                     out.push(UnifiedEvent::ToolCall {
                         name: String::new(),
@@ -196,14 +396,14 @@ impl ToolParseResult {
     /// occurred — which is what a reasoning-unaware tool parser sees anyway.
     /// This projection is the ONLY place the two surfaces are bridged, so the
     /// scan core can emit ordered deltas without changing tool-only behavior.
-    pub fn from_deltas(deltas: Vec<UnifiedDelta>) -> Self {
+    pub fn from_deltas(deltas: Vec<UnifiedParserEvent>) -> Self {
         let mut out = Self::default();
         for delta in deltas {
             match delta {
-                UnifiedDelta::Reasoning { text } | UnifiedDelta::Text { text } => {
+                UnifiedParserEvent::Reasoning(text) | UnifiedParserEvent::Text(text) => {
                     out.normal_text.push_str(&text)
                 }
-                UnifiedDelta::ToolCall(call) => out.calls.push(call),
+                UnifiedParserEvent::ToolCall(call) => out.calls.push(call),
             }
         }
         out
@@ -222,40 +422,250 @@ pub(crate) struct ScannerUnified<E: InvokeEmitter> {
 }
 
 impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
-    fn push(&mut self, chunk: &str) -> Result<Vec<UnifiedDelta>> {
-        self.scanner.push_ordered(chunk)
+    // No `preserve_special_tokens` override here: the trait METHOD is the peer surface
+    // and belongs to this change, but whether a given family's markers ARE special
+    // tokens is family behaviour, exercised by the request-mode work. Overriding it
+    // without a test that can observe the difference would be an unmeasured claim.
+    /// The trait default returns an empty string and leaves state untouched, which
+    /// would tell a caller nothing was buffered while the scanner still held a partial
+    /// marker, `in_block`, and a used `next_index`. A caller following the documented
+    /// recovery path after a `parse_into` error would then resume on stale state and
+    /// mis-number tool indices. The only shipped family must honour the contract.
+    fn reset(&mut self) -> String {
+        self.scanner.reset_stream()
     }
 
-    fn finish(&mut self) -> Result<Vec<UnifiedDelta>> {
-        self.scanner.finish_ordered()
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        // Through the helpers, NOT `events.extend`: the helpers coalesce into a trailing
+        // same-kind event and `extend` does not, so extending made the only shipped
+        // family disagree with the documented vendor contract for identical bytes.
+        for event in self.scanner.push_ordered(delta)? {
+            match event {
+                UnifiedParserEvent::Text(t) => output.push_text(t),
+                UnifiedParserEvent::Reasoning(t) => output.push_reasoning(t),
+                UnifiedParserEvent::ToolCall(c) => output.push_call(c),
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        Ok(UnifiedParserOutput {
+            events: self.scanner.finish_ordered()?,
+        })
     }
 }
 
-/// Every family `create_unified_parser_for_family` accepts, one entry per match
-/// arm. Tests iterate this so a family registered here without conformance
-/// coverage fails the suite instead of silently skipping.
-pub const REGISTERED_UNIFIED_FAMILIES: &[&str] = &["qwen3", "qwen3_coder"];
+/// How a vendor supplies a parser: given the request's tools, build one parser for
+/// one stream.
+///
+/// A plain `fn` pointer, not a boxed closure, so registering is `const`-friendly and
+/// a factory cannot capture per-request state by accident — the per-stream state
+/// belongs in the parser the factory returns (`I4`).
+pub type UnifiedParserFactory = fn(&[Tool]) -> Result<Box<dyn UnifiedParser>>;
 
-/// Create the Dynamo unified parser for a conformance family.
-pub fn create_unified_parser_for_family(
+/// Vendor-supplied families, consulted BEFORE the built-in table.
+///
+/// Checking this first is what makes "implement your own version of a family we
+/// already ship" work: registering `qwen3` shadows the built-in `qwen3` for the
+/// whole process, and unregistering restores it. An add-only registry would force a
+/// vendor who disagrees with one of our families to fork the crate.
+static VENDOR_PARSERS: std::sync::LazyLock<
+    std::sync::RwLock<std::collections::HashMap<String, UnifiedParserFactory>>,
+> = std::sync::LazyLock::new(|| std::sync::RwLock::new(std::collections::HashMap::new()));
+
+/// Register `factory` for `family`, returning whatever it displaced.
+///
+/// Returns `Some(previous)` if this replaced an earlier VENDOR registration, and
+/// `None` otherwise — including when it shadows a built-in, since the built-in is
+/// still there and returns as soon as this registration is removed. Callers that
+/// care whether they are shadowing should ask
+/// [`builtin_unified_families`] first.
+///
+/// # Startup-only
+///
+/// Register during startup, BEFORE serving. Concurrent registration and parser
+/// construction is not supported and is not linearizable: the lookup copies the
+/// factory and releases the registry lock before calling it, so a construction
+/// already in flight can still build a parser that a concurrent `unregister` has
+/// just removed, and a lookup that observed no vendor can build the built-in after
+/// a concurrent `register` returned. Neither races memory — the registry itself is
+/// lock-guarded — but which implementation a request gets is undefined while the
+/// table is being mutated. A parser already constructed always keeps what it was
+/// built with, so a request in progress never changes implementation mid-stream.
+pub fn register_unified_parser(
     family: &str,
-    tools: &[Tool],
-) -> Result<Box<dyn UnifiedParser>> {
-    match family {
-        // The conformance corpus calls this family `qwen3`; the tool-only
-        // registry calls the same XML grammar `qwen3_coder`. Accept both so
-        // callers do not have to know which registry they came from.
-        "qwen3" | "qwen3_coder" => Ok(qwen3::qwen3_unified(tools)),
-        other => anyhow::bail!("no Dynamo unified parser for family '{other}'"),
-    }
+    factory: UnifiedParserFactory,
+) -> Option<UnifiedParserFactory> {
+    // Register under the CANONICAL name. A built-in family can be reached by more
+    // than one routing name (`qwen3` and `qwen3_coder` are one grammar), and keying
+    // on the caller's spelling shadowed only the spelling they happened to use:
+    // `register_unified_parser("qwen3", ..)` left `qwen3_coder` on the built-in, so
+    // the same family silently ran two different parsers depending on how the
+    // request was routed. Canonicalizing on both sides is what makes "replace a
+    // family this crate ships" true for every name that family answers to.
+    let key = canonical_unified_family(family).unwrap_or(family);
+    let previous = VENDOR_PARSERS
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(key.to_string(), factory);
+    tracing::info!(
+        target: "dynamo_parsers_v2",
+        family = key,
+        requested = family,
+        shadows_builtin = canonical_unified_family(family).is_some(),
+        replaced_vendor = previous.is_some(),
+        "unified parser registered"
+    );
+    previous
+}
+
+/// Remove a vendor registration, returning it. A shadowed built-in becomes
+/// reachable again.
+///
+/// Accepts any alias of the family, matching [`register_unified_parser`], and
+/// inherits its STARTUP-ONLY restriction: unregistering while requests are being
+/// served is not linearizable, so a construction already in flight can still build
+/// the parser this call removes.
+pub fn unregister_unified_parser(family: &str) -> Option<UnifiedParserFactory> {
+    let key = canonical_unified_family(family).unwrap_or(family);
+    VENDOR_PARSERS
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(key)
+}
+
+/// Families currently registered by a vendor, sorted.
+pub fn vendor_unified_families() -> Vec<String> {
+    let mut v: Vec<String> = VENDOR_PARSERS
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .keys()
+        .cloned()
+        .collect();
+    v.sort();
+    v
+}
+
+/// Look up a vendor factory without constructing anything.
+///
+/// Canonicalizes first, so every alias of a built-in family resolves to the same
+/// vendor registration.
+fn vendor_factory(family: &str) -> Option<UnifiedParserFactory> {
+    let key = canonical_unified_family(family).unwrap_or(family);
+    VENDOR_PARSERS
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(key)
+        .copied()
+}
+
+/// THE built-in registry. One line per family — adding a family is adding a line
+/// here and nothing else in this crate.
+///
+/// It used to be two things that had to agree: a `match` in the constructor and a
+/// `REGISTERED_UNIFIED_FAMILIES` const the tests iterate. Adding a family meant
+/// editing both, and a family added to one but not the other either failed to
+/// construct or silently skipped its coverage. The macro generates both from this
+/// single list, so they cannot disagree.
+///
+/// A family may carry aliases: the conformance corpus calls the Qwen XML grammar
+/// `qwen3` while the tool-only registry calls it `qwen3_coder`, and callers should
+/// not have to know which name they arrived with.
+macro_rules! unified_registry {
+    ($($family:literal $(| $alias:literal)* => $ctor:path),+ $(,)?) => {
+        /// Every family `create_unified_parser_for_family` accepts, aliases included.
+        /// Tests iterate this, so a family here without conformance coverage fails the
+        /// suite instead of silently skipping.
+        pub const REGISTERED_UNIFIED_FAMILIES: &[&str] = &[$($family, $($alias,)*)+];
+
+        /// Every family built INTO this crate, aliases included.
+        ///
+        /// Deliberately excludes vendor registrations: the conformance suite
+        /// iterates this, and a vendor parser has no corpus here to be measured
+        /// against. Ask [`vendor_unified_families`] for those.
+        pub fn builtin_unified_families() -> &'static [&'static str] {
+            REGISTERED_UNIFIED_FAMILIES
+        }
+
+        /// The canonical name of a built-in family, given any of its aliases.
+        ///
+        /// `None` for a name this crate does not ship, which is how a vendor family
+        /// keeps its own spelling. Generated from the same list as the constructor,
+        /// so an alias cannot exist for dispatch but be invisible to the vendor
+        /// registry — that split is exactly what made `register_unified_parser`
+        /// shadow one routing name and not its sibling.
+        pub fn canonical_unified_family(family: &str) -> Option<&'static str> {
+            match family {
+                $($family $(| $alias)* => Some($family),)+
+                _ => None,
+            }
+        }
+
+        /// Create the unified parser for a family.
+        ///
+        /// A vendor registration wins over the built-in of the same name — see
+        /// [`register_unified_parser`]. Vendor parsers are wrapped by the debug
+        /// wrapper on the same terms as built-ins, so switching to one does not
+        /// silently change what instrumentation reports.
+        pub fn create_unified_parser_for_family(
+            family: &str,
+            tools: &[Tool],
+        ) -> Result<Box<dyn UnifiedParser>> {
+            if let Some(factory) = vendor_factory(family) {
+                let key = canonical_unified_family(family).unwrap_or(family);
+                let parser = factory(tools)?;
+                tracing::debug!(
+                    target: "dynamo_parsers_v2",
+                    family = key,
+                    requested = family,
+                    source = "vendor",
+                    "v2 UNIFIED parser active"
+                );
+                return Ok(parser);
+            }
+
+            let parser = match family {
+                $($family $(| $alias)* => $ctor(tools),)+
+                other => anyhow::bail!(
+                    "no unified parser for family '{other}'. Built-in: {:?}. \
+                     Vendor-registered: {:?}. To supply your own, call \
+                     dynamo_parsers_v2::register_unified_parser(\"{other}\", your_factory) \
+                     before serving.",
+                    REGISTERED_UNIFIED_FAMILIES,
+                    vendor_unified_families(),
+                ),
+            };
+            // Same helper the vendor branch above uses. A second generated match cost an
+            // arm per family plus an `unreachable!` that existed only because the compiler
+            // cannot see that the `bail!` above already returned.
+            let canonical = canonical_unified_family(family).unwrap_or(family);
+
+            // Parser construction happens per request, so keep the selection signal
+            // at debug level. Operators can enable the target when diagnosing routing
+            // without adding one production info line for every generation.
+            tracing::debug!(
+                target: "dynamo_parsers_v2",
+                family = canonical,
+                requested = family,
+                "v2 UNIFIED parser active"
+            );
+
+            Ok(parser)
+        }
+    };
+}
+
+unified_registry! {
+    "qwen3" | "qwen3_coder" => qwen3::qwen3_unified,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn call(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedDelta {
-        UnifiedDelta::ToolCall(ToolCallDelta {
+    fn call(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedParserEvent {
+        UnifiedParserEvent::ToolCall(ToolCallDelta {
             tool_index,
             name: name.map(str::to_string),
             arguments: arguments.to_string(),
@@ -274,12 +684,10 @@ mod tests {
     #[test]
     fn assemble_coalesces_adjacent_same_kind() {
         let out = assemble(&[
-            UnifiedDelta::Reasoning {
-                text: "think".into(),
-            },
-            UnifiedDelta::Reasoning { text: "ing".into() },
-            UnifiedDelta::Text { text: "he".into() },
-            UnifiedDelta::Text { text: "llo".into() },
+            UnifiedParserEvent::Reasoning("think".into()),
+            UnifiedParserEvent::Reasoning("ing".into()),
+            UnifiedParserEvent::Text("he".into()),
+            UnifiedParserEvent::Text("llo".into()),
         ]);
         assert_eq!(
             out,
@@ -299,9 +707,9 @@ mod tests {
         // The whole point of the surface: two thoughts separated by a call stay
         // two thoughts, in position.
         let out = assemble(&[
-            UnifiedDelta::Reasoning { text: "a".into() },
+            UnifiedParserEvent::Reasoning("a".into()),
             call(0, Some("f"), r#"{"x":"1"}"#),
-            UnifiedDelta::Reasoning { text: "b".into() },
+            UnifiedParserEvent::Reasoning("b".into()),
         ]);
         assert_eq!(out.len(), 3);
         assert_eq!(out[0], UnifiedEvent::Reasoning { text: "a".into() });
@@ -312,7 +720,7 @@ mod tests {
     fn assemble_joins_argument_fragments_at_the_first_position() {
         let out = assemble(&[
             call(0, Some("f"), r#"{"x":"#),
-            UnifiedDelta::Text { text: "mid".into() },
+            UnifiedParserEvent::Text("mid".into()),
             call(0, None, r#""1"}"#),
         ]);
         assert_eq!(
@@ -343,9 +751,9 @@ mod tests {
     #[test]
     fn tool_only_projection_drops_order_but_not_bytes() {
         let result = ToolParseResult::from_deltas(vec![
-            UnifiedDelta::Reasoning { text: "a".into() },
+            UnifiedParserEvent::Reasoning("a".into()),
             call(0, Some("f"), "{}"),
-            UnifiedDelta::Text { text: "b".into() },
+            UnifiedParserEvent::Text("b".into()),
         ]);
         assert_eq!(result.normal_text, "ab");
         assert_eq!(result.calls.len(), 1);

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -55,7 +55,7 @@ pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::unified::{UnifiedEvent, assemble};
+    use crate::unified::{UnifiedEvent, UnifiedParserExt, assemble};
 
     fn weather_tools() -> Vec<Tool> {
         vec![Tool {

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -46,6 +46,8 @@ pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
             // Qwen3 emits its own `<think>`; the template does not pre-fill one,
             // so the stream starts in visible content (policy P5).
             forced_start: false,
+            // `<think>` is not a special token for this family; the OR comes from the grammar.
+            preserve_special_tokens: false,
         }),
     })
 }

--- a/parsers/v2/tests/vendor_parser_example.rs
+++ b/parsers/v2/tests/vendor_parser_example.rs
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The worked example from `CUSTOM_PARSERS.md`, compiled.
+//!
+//! This is an INTEGRATION test on purpose: it sees exactly what a vendor crate sees
+//! — the public API of `dynamo_parsers_v2` and nothing else. If a symbol stops being
+//! re-exported, or the trait's required set changes, this fails to compile and the
+//! documented instructions are known to be wrong before a vendor discovers it.
+//!
+//! Keep this file and the code blocks in `CUSTOM_PARSERS.md` in step.
+
+use anyhow::Result;
+use dynamo_parsers_v2::{Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput};
+
+/// The smallest complete vendor parser: one required method plus the flush.
+#[derive(Default)]
+struct AcmeParser {
+    /// Anything not yet safe to emit. A real parser holds a partial marker here.
+    buffered: String,
+}
+
+impl UnifiedParser for AcmeParser {
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        // A real grammar decides per byte. This one keeps a trailing '<' back,
+        // standing in for "might be the start of a marker", so the example exercises
+        // buffering and the flush rather than pretending neither exists.
+        self.buffered.push_str(delta);
+        if let Some(cut) = self.buffered.rfind('<') {
+            let emit: String = self.buffered[..cut].to_string();
+            self.buffered = self.buffered[cut..].to_string();
+            output.push_text(emit);
+        } else {
+            let all = std::mem::take(&mut self.buffered);
+            output.push_text(all);
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        let mut out = UnifiedParserOutput::default();
+        // Whatever is still held back is ordinary text once the stream has ended.
+        out.push_text(std::mem::take(&mut self.buffered));
+        Ok(out)
+    }
+}
+
+/// Removes a registration on drop, including while unwinding from a panic, so a
+/// failing test cannot leave a global override installed for the next one.
+struct Restore(&'static str);
+impl Drop for Restore {
+    fn drop(&mut self) {
+        dynamo_parsers_v2::unregister_unified_parser(self.0);
+    }
+}
+
+fn acme_factory(_tools: &[Tool]) -> Result<Box<dyn UnifiedParser>> {
+    Ok(Box::new(AcmeParser::default()))
+}
+
+/// A vendor registers a NEW family and it is selected by name.
+#[test]
+fn vendor_family_is_selected_through_the_public_registry() {
+    dynamo_parsers_v2::register_unified_parser("acme_doc_example", acme_factory);
+    let _restore = Restore("acme_doc_example");
+
+    let mut parser = dynamo_parsers_v2::create_unified_parser_for_family("acme_doc_example", &[])
+        .expect("registered family must construct");
+    let mut events = parser.push("hello ").unwrap();
+    events.extend(parser.push("world").unwrap());
+    events.extend(parser.finish().unwrap().events);
+
+    let text: String = events
+        .iter()
+        .map(|e| match e {
+            UnifiedParserEvent::Text(t) => t.as_str(),
+            _ => "",
+        })
+        .collect();
+    assert_eq!(text, "hello world");
+}
+
+/// Nothing is lost across an arbitrary split — the property the contract section of
+/// `CUSTOM_PARSERS.md` asks a vendor to test, demonstrated on the example itself.
+#[test]
+fn example_parser_is_split_invariant() {
+    let input = "alpha <not-a-marker> beta";
+    let whole = {
+        let mut p = AcmeParser::default();
+        let mut out = UnifiedParserOutput::default();
+        p.parse_into(input, &mut out).unwrap();
+        let mut tail = p.finish().unwrap();
+        out.append(&mut tail);
+        out.assembled()
+    };
+
+    for cut in 1..input.len() {
+        if !input.is_char_boundary(cut) {
+            continue;
+        }
+        let mut p = AcmeParser::default();
+        let mut out = UnifiedParserOutput::default();
+        p.parse_into(&input[..cut], &mut out).unwrap();
+        p.parse_into(&input[cut..], &mut out).unwrap();
+        let mut tail = p.finish().unwrap();
+        out.append(&mut tail);
+        assert_eq!(
+            out.assembled(),
+            whole,
+            "split at {cut} produced a different result than the whole input"
+        );
+    }
+}
+
+/// A vendor replaces a family this crate ships, then gives it back.
+#[test]
+fn vendor_can_shadow_a_builtin_family() {
+    let family = "qwen3";
+    assert!(dynamo_parsers_v2::builtin_unified_families().contains(&family));
+
+    let builtin = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+        .unwrap()
+        .push("<think>hi</think>")
+        .unwrap();
+
+    dynamo_parsers_v2::register_unified_parser(family, acme_factory);
+    let restore = Restore(family);
+    let shadowed = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+        .unwrap()
+        .push("<think>hi</think>")
+        .unwrap();
+    assert_ne!(
+        shadowed, builtin,
+        "the vendor parser must be the one that ran"
+    );
+
+    drop(restore);
+    let restored = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+        .unwrap()
+        .push("<think>hi</think>")
+        .unwrap();
+    assert_eq!(restored, builtin, "unregistering must restore the built-in");
+}
+
+/// The Markdown example and this file must be the SAME implementation.
+///
+/// `CUSTOM_PARSERS.md` claimed that if its instructions stopped being true "the build
+/// fails here first". That claim was false: the documented example double-emitted its
+/// buffer (`push("hello") + finish()` produced `hellohello`) while this file buffered
+/// differently, so nothing compared the two and nothing failed. Matching them by hand
+/// restores the invariant but leaves it resting on the manual comparison that already
+/// failed once. This is the comparison, as a test.
+#[test]
+fn doc_example_matches_compiled_example() {
+    const DOC: &str = include_str!("../CUSTOM_PARSERS.md");
+    const SRC: &str = include_str!("vendor_parser_example.rs");
+
+    /// First fenced ```rust block in the doc.
+    fn first_rust_block(md: &str) -> &str {
+        let start = md
+            .find("```rust")
+            .expect("CUSTOM_PARSERS.md has no rust block");
+        let after = start + "```rust".len();
+        let end = md[after..].find("```").expect("unterminated rust block") + after;
+        &md[after..end]
+    }
+
+    /// Body of `fn <name>` up to the matching close brace, whitespace- and
+    /// comment-insensitive so formatting or a reworded comment cannot fail this.
+    fn body(src: &str, name: &str) -> String {
+        let sig = format!("fn {name}(");
+        let at = src.find(&sig).unwrap_or_else(|| panic!("no `{sig}` found"));
+        let open = src[at..].find('{').expect("no body") + at;
+        let (mut depth, mut end) = (0usize, open);
+        for (i, c) in src[open..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = open + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        src[open + 1..end]
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty() && !l.starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    let doc = first_rust_block(DOC);
+    for f in ["parse_into", "finish"] {
+        assert_eq!(
+            body(doc, f),
+            body(SRC, f),
+            "CUSTOM_PARSERS.md and vendor_parser_example.rs disagree on `{f}`. \
+             The documented example is what a vendor copies; keep them identical."
+        );
+    }
+}

--- a/parsers/v2/tests/vendor_parser_example.rs
+++ b/parsers/v2/tests/vendor_parser_example.rs
@@ -149,7 +149,7 @@ fn vendor_can_shadow_a_builtin_family() {
     assert_eq!(restored, builtin, "unregistering must restore the built-in");
 }
 
-/// The Markdown example and this file must be the SAME implementation.
+/// The Markdown example and this file must implement the same TRAIT METHODS, identically.
 ///
 /// `CUSTOM_PARSERS.md` claimed that if its instructions stopped being true "the build
 /// fails here first". That claim was false: the documented example double-emitted its
@@ -157,8 +157,15 @@ fn vendor_can_shadow_a_builtin_family() {
 /// differently, so nothing compared the two and nothing failed. Matching them by hand
 /// restores the invariant but leaves it resting on the manual comparison that already
 /// failed once. This is the comparison, as a test.
+///
+/// SCOPE, stated because the name used to promise more than the oracle delivers: this
+/// compares the method SET and each method BODY inside `impl UnifiedParser for
+/// AcmeParser`. It does NOT compile the Markdown block, and it does not compare imports,
+/// the struct definition, derives, the factory, or the registration snippet — renaming a
+/// struct field in the doc alone would break the documented example while this stays
+/// green. Compiling the extracted block is the real fix and is not done here.
 #[test]
-fn doc_example_matches_compiled_example() {
+fn doc_trait_method_bodies_match_compiled_example() {
     const DOC: &str = include_str!("../CUSTOM_PARSERS.md");
     const SRC: &str = include_str!("vendor_parser_example.rs");
 

--- a/parsers/v2/tests/vendor_parser_example.rs
+++ b/parsers/v2/tests/vendor_parser_example.rs
@@ -43,6 +43,13 @@ impl UnifiedParser for AcmeParser {
         out.push_text(std::mem::take(&mut self.buffered));
         Ok(out)
     }
+
+    fn reset(&mut self) -> String {
+        // MANDATORY for a parser that buffers: the default returns an empty string and
+        // clears nothing, so a caller recovering after an error would resume on this
+        // parser's stale held-back bytes. Hand them back and return to a fresh stream.
+        std::mem::take(&mut self.buffered)
+    }
 }
 
 /// Removes a registration on drop, including while unwinding from a panic, so a
@@ -193,8 +200,36 @@ fn doc_example_matches_compiled_example() {
             .join("")
     }
 
+    // Derive the method set from the sources instead of hardcoding it. A hardcoded
+    // ["parse_into", "finish"] let `reset` diverge between the two copies with the test
+    // still green — the guide's own MANDATORY rule was violated in the doc for exactly
+    // as long as this loop decided what counted.
     let doc = first_rust_block(DOC);
-    for f in ["parse_into", "finish"] {
+    // Scope to the trait impl: the compiled file also holds the tests themselves.
+    let impl_block = |src: &str| -> String {
+        let start = src
+            .find("impl UnifiedParser for AcmeParser {")
+            .expect("the example must implement UnifiedParser for AcmeParser");
+        let rest = &src[start..];
+        let end = rest.find("\n}").expect("unterminated impl block");
+        rest[..end].to_string()
+    };
+    let methods = |src: &str| -> Vec<String> {
+        impl_block(src)
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("fn "))
+            .filter_map(|l| l.split('(').next())
+            .map(str::to_string)
+            .collect()
+    };
+    assert_eq!(
+        methods(doc),
+        methods(SRC),
+        "CUSTOM_PARSERS.md and vendor_parser_example.rs implement different methods. \
+         A vendor copies the doc, so a method present in only one is a trap."
+    );
+    for f in methods(doc) {
+        let f = f.as_str();
         assert_eq!(
             body(doc, f),
             body(SRC, f),
@@ -202,4 +237,30 @@ fn doc_example_matches_compiled_example() {
              The documented example is what a vendor copies; keep them identical."
         );
     }
+}
+
+/// The example must obey the rule the guide states as MANDATORY: a parser that buffers
+/// overrides `reset`. It held a trailing `<` back with no override, so a vendor copying
+/// it would inherit the default that clears nothing and silently resume on stale bytes.
+#[test]
+fn the_worked_example_honours_the_reset_rule_it_documents() {
+    let mut p = AcmeParser::default();
+    let mut out = UnifiedParserOutput::default();
+    p.parse_into("visible<par", &mut out).expect("parse");
+
+    assert_eq!(
+        out.events,
+        vec![UnifiedParserEvent::Text("visible".to_string())],
+        "the partial marker must be held back, not emitted"
+    );
+    assert_eq!(
+        p.reset(),
+        "<par",
+        "reset must hand back the held-back bytes, not the default empty string"
+    );
+    assert_eq!(
+        p.reset(),
+        "",
+        "after reset the parser is a fresh stream and holds nothing"
+    );
 }

--- a/parsers/v2/tests/vendor_parser_example.rs
+++ b/parsers/v2/tests/vendor_parser_example.rs
@@ -11,7 +11,9 @@
 //! Keep this file and the code blocks in `CUSTOM_PARSERS.md` in step.
 
 use anyhow::Result;
-use dynamo_parsers_v2::{Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput};
+use dynamo_parsers_v2::{
+    Tool, UnifiedEvent, UnifiedParser, UnifiedParserEvent, UnifiedParserExt, UnifiedParserOutput,
+};
 
 /// The smallest complete vendor parser: one required method plus the flush.
 #[derive(Default)]
@@ -63,6 +65,43 @@ impl Drop for Restore {
 
 fn acme_factory(_tools: &[Tool]) -> Result<Box<dyn UnifiedParser>> {
     Ok(Box::new(AcmeParser::default()))
+}
+
+struct ConflictingPushParser;
+
+impl UnifiedParser for ConflictingPushParser {
+    fn parse_into(&mut self, _delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        output.push_text("A");
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        Ok(UnifiedParserOutput::default())
+    }
+}
+
+impl ConflictingPushParser {
+    fn push(&mut self, _chunk: &str) -> Result<Vec<UnifiedParserEvent>> {
+        Ok(vec![UnifiedParserEvent::Text("B".to_string())])
+    }
+}
+
+#[test]
+fn parse_complete_cannot_bypass_the_required_advance_method() {
+    let mut concrete = ConflictingPushParser;
+    assert_eq!(
+        concrete.push("ignored").unwrap(),
+        vec![UnifiedParserEvent::Text("B".to_string())]
+    );
+
+    let mut parser: Box<dyn UnifiedParser> = Box::new(ConflictingPushParser);
+
+    assert_eq!(
+        parser.parse_complete("ignored").unwrap(),
+        vec![UnifiedEvent::Text {
+            text: "A".to_string()
+        }]
+    );
 }
 
 /// A vendor registers a NEW family and it is selected by name.

--- a/parsers/v2/tests/vendor_registry.rs
+++ b/parsers/v2/tests/vendor_registry.rs
@@ -190,3 +190,39 @@ fn unknown_family_error_explains_how_to_register() {
     assert!(err.contains("register_unified_parser"), "{err}");
     assert!(err.contains("no_such_family"), "{err}");
 }
+
+/// The two surfaces over one Qwen scanner must report the SAME decoding requirement.
+/// They disagreed before: tool-only said `true`, unified inherited the trait default
+/// `false`, so a decoder honouring the flag could hand the two adapters different bytes
+/// for identical markup.
+mod preserve_special_tokens_parity {
+    use dynamo_parsers_v2::tool_calling::create_tool_parser_for_family;
+    use dynamo_parsers_v2::unified::create_unified_parser_for_family;
+
+    fn tool_only_value() -> bool {
+        create_tool_parser_for_family("qwen3_coder", &[])
+            .expect("qwen3_coder tool parser")
+            .preserve_special_tokens()
+    }
+
+    #[test]
+    fn canonical_family_matches_the_tool_only_adapter() {
+        let unified = create_unified_parser_for_family("qwen3", &[]).expect("qwen3 unified");
+        assert_eq!(
+            unified.preserve_special_tokens(),
+            tool_only_value(),
+            "unified and tool-only must not report different decoding requirements"
+        );
+    }
+
+    #[test]
+    fn alias_matches_the_tool_only_adapter() {
+        let unified =
+            create_unified_parser_for_family("qwen3_coder", &[]).expect("qwen3_coder unified");
+        assert_eq!(
+            unified.preserve_special_tokens(),
+            tool_only_value(),
+            "the alias must agree with the canonical family and the tool-only adapter"
+        );
+    }
+}

--- a/parsers/v2/tests/vendor_registry.rs
+++ b/parsers/v2/tests/vendor_registry.rs
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Vendor registry behaviour, in a binary of its own.
+//!
+//! These tests mutate PROCESS-GLOBAL state: registering a parser changes what
+//! `create_unified_parser_for_family` returns for every other caller in the same
+//! process. They lived in the lib test binary and a comment claimed that was safe
+//! because unrelated tests "never look up these family names". That was false —
+//! the override test replaces `qwen3`, and ordinary parser tests construct `qwen3`
+//! through the same registry, so with `--test-threads` high enough an unrelated
+//! test could observe the vendor's parser and fail. It was reproduced at 1-in-~33
+//! runs at 32 threads.
+//!
+//! A separate integration binary is a separate PROCESS, so the global here cannot
+//! reach the lib tests at all. Within this file the mutex still serializes, and
+//! `Restore` puts the registry back even if a test panics — an early `?` or failed
+//! assertion must not leave a global override installed for the tests that follow.
+
+use anyhow::Result;
+use dynamo_parsers_v2::{Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput};
+
+static SERIALIZE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Removes a registration on drop, including while unwinding from a panic.
+struct Restore(&'static str);
+impl Drop for Restore {
+    fn drop(&mut self) {
+        dynamo_parsers_v2::unregister_unified_parser(self.0);
+    }
+}
+
+/// The smallest possible vendor parser: every byte is visible text.
+#[derive(Default)]
+struct VendorEverythingIsText;
+
+impl UnifiedParser for VendorEverythingIsText {
+    fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()> {
+        output.push_text(delta);
+        Ok(())
+    }
+    fn finish(&mut self) -> Result<UnifiedParserOutput> {
+        Ok(UnifiedParserOutput::default())
+    }
+}
+
+fn vendor_factory(_tools: &[Tool]) -> Result<Box<dyn UnifiedParser>> {
+    Ok(Box::new(VendorEverythingIsText))
+}
+
+/// A vendor can implement `UnifiedParser` from outside and have it selected.
+#[test]
+fn vendor_can_register_a_new_family() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    assert!(dynamo_parsers_v2::create_unified_parser_for_family("acme_v1", &[]).is_err());
+
+    dynamo_parsers_v2::register_unified_parser("acme_v1", vendor_factory);
+    let _restore = Restore("acme_v1");
+    assert!(dynamo_parsers_v2::vendor_unified_families().contains(&"acme_v1".to_string()));
+
+    let events = dynamo_parsers_v2::create_unified_parser_for_family("acme_v1", &[])
+        .expect("registered family must construct")
+        .push("<think>hi</think>")
+        .unwrap();
+    assert_eq!(
+        events,
+        vec![UnifiedParserEvent::Text("<think>hi</think>".into())],
+        "the VENDOR parser must run, not a built-in that happens to know <think>"
+    );
+}
+
+/// THE case the registry exists for: replace a family this crate already ships.
+#[test]
+fn vendor_can_override_a_builtin_and_restore_it() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    let family = "qwen3";
+    assert!(dynamo_parsers_v2::builtin_unified_families().contains(&family));
+
+    let baseline = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+        .unwrap()
+        .push("<think>hi</think>")
+        .unwrap();
+    assert!(
+        baseline
+            .iter()
+            .any(|e| matches!(e, UnifiedParserEvent::Reasoning(_))),
+        "built-in qwen3 should emit reasoning, got {baseline:?}"
+    );
+
+    {
+        dynamo_parsers_v2::register_unified_parser(family, vendor_factory);
+        let _restore = Restore(family);
+        let overridden = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+            .unwrap()
+            .push("<think>hi</think>")
+            .unwrap();
+        assert_eq!(
+            overridden,
+            vec![UnifiedParserEvent::Text("<think>hi</think>".into())],
+            "the vendor override must win over the built-in of the same name"
+        );
+    }
+
+    let restored = dynamo_parsers_v2::create_unified_parser_for_family(family, &[])
+        .unwrap()
+        .push("<think>hi</think>")
+        .unwrap();
+    assert_eq!(
+        restored, baseline,
+        "removing the override must restore the built-in exactly"
+    );
+}
+
+/// Registering ONE name of a family must shadow EVERY name that family answers to.
+///
+/// `qwen3` and `qwen3_coder` are one grammar with two routing names. Keying the
+/// registry on the caller's spelling shadowed only that spelling, so the same
+/// family silently ran the vendor's parser or ours depending on how the request
+/// happened to be routed — the advertised "replace a family we ship" contract was
+/// true for one name and false for its sibling.
+#[test]
+fn registering_one_alias_shadows_every_alias_of_that_family() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    let (name, alias) = ("qwen3", "qwen3_coder");
+    assert!(dynamo_parsers_v2::builtin_unified_families().contains(&alias));
+
+    dynamo_parsers_v2::register_unified_parser(name, vendor_factory);
+    let _restore = Restore(name);
+
+    let by_name = dynamo_parsers_v2::create_unified_parser_for_family(name, &[])
+        .unwrap()
+        .push("<think>x</think>")
+        .unwrap();
+    let by_alias = dynamo_parsers_v2::create_unified_parser_for_family(alias, &[])
+        .unwrap()
+        .push("<think>x</think>")
+        .unwrap();
+    assert_eq!(
+        by_name, by_alias,
+        "registering {name} must also shadow {alias}; they are one family"
+    );
+    assert_eq!(
+        by_alias,
+        vec![UnifiedParserEvent::Text("<think>x</think>".into())]
+    );
+}
+
+/// ...and unregistering by either spelling must remove it for both.
+#[test]
+fn unregistering_by_alias_removes_the_registration() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    dynamo_parsers_v2::register_unified_parser("qwen3", vendor_factory);
+    assert!(dynamo_parsers_v2::unregister_unified_parser("qwen3_coder").is_some());
+
+    let after = dynamo_parsers_v2::create_unified_parser_for_family("qwen3", &[])
+        .unwrap()
+        .push("<think>x</think>")
+        .unwrap();
+    assert!(
+        after
+            .iter()
+            .any(|e| matches!(e, UnifiedParserEvent::Reasoning(_))),
+        "unregistering via the alias must restore the built-in for the canonical name too"
+    );
+}
+
+/// The built-in list is what conformance iterates, so a vendor registration must
+/// not silently enrol itself into a corpus that has no cases for it.
+#[test]
+fn registering_does_not_change_the_builtin_list() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    let before = dynamo_parsers_v2::builtin_unified_families().to_vec();
+    dynamo_parsers_v2::register_unified_parser("acme_not_in_corpus", vendor_factory);
+    let _restore = Restore("acme_not_in_corpus");
+    assert_eq!(
+        dynamo_parsers_v2::builtin_unified_families().to_vec(),
+        before
+    );
+}
+
+/// An unknown family must tell the caller how to supply one.
+#[test]
+fn unknown_family_error_explains_how_to_register() {
+    let _g = SERIALIZE.lock().unwrap_or_else(|e| e.into_inner());
+    // `Box<dyn UnifiedParser>` is not `Debug`, so `unwrap_err` is unavailable.
+    let err = match dynamo_parsers_v2::create_unified_parser_for_family("no_such_family", &[]) {
+        Ok(_) => panic!("an unregistered family must not construct"),
+        Err(e) => e.to_string(),
+    };
+    assert!(err.contains("register_unified_parser"), "{err}");
+    assert!(err.contains("no_such_family"), "{err}");
+}

--- a/parsers/v2/tests/vendor_registry.rs
+++ b/parsers/v2/tests/vendor_registry.rs
@@ -18,7 +18,9 @@
 //! assertion must not leave a global override installed for the tests that follow.
 
 use anyhow::Result;
-use dynamo_parsers_v2::{Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserOutput};
+use dynamo_parsers_v2::{
+    Tool, UnifiedParser, UnifiedParserEvent, UnifiedParserExt, UnifiedParserOutput,
+};
 
 static SERIALIZE: std::sync::Mutex<()> = std::sync::Mutex::new(());
 


### PR DESCRIPTION
#### Overview:

This PR aligns the unified parser's ordered-event and incremental-parse surface with the peer traits, and lets a third party supply their own unified parser — including replacing one this crate ships — without forking.

Two peer capabilities are deliberately NOT in this PR, so "aligned" should not be read as "drop-in adoptable": the peer's `create` takes a tokenizer as well as the tools, while the vendor factory here takes only tools, so a peer parser that resolves its markers from a tokenizer cannot be constructed through this registry yet; and `structural_tag_model`, which constrains generation for strict tool calling, has no type or consumer in this crate. Both need a design, and neither is closed by the follow-up request-mode PR — that one selects between native markup and guided JSON in already-generated bytes, which is a different question. It also fixes hover popups in the conformance report, which had stopped opening entirely.

Split out of [DIS-2544](https://linear.app/nvidia/issue/DIS-2544) / #174, which bundled several unrelated concerns into ~7k lines across 56 files and stalled in review. This half does **not** depend on qwen3 request modes, so it lands on its own; the request modes follow stacked on top in #174.

**No corpus change.** The unified golden feed is byte-identical to `main`.

<!-- stack-graph -->
#### Where this sits

```mermaid
flowchart TB
    M["main &nbsp;·&nbsp; 99 golden cases"]
    A["#178 &nbsp;·&nbsp; THE SURFACE &nbsp;·&nbsp; UnifiedParser trait + output type + vendor registry"]
    B["#174 &nbsp;·&nbsp; REQUEST MODES &nbsp;·&nbsp; StartingState + ToolOutputMode &nbsp;·&nbsp; corpus 99 → 237"]
    C["#166 &nbsp;·&nbsp; SECOND FAMILY &nbsp;·&nbsp; gemma4 on the surface, graded by #174's corpus"]
    M --> A --> B --> C
    classDef here fill:#fff4ce,stroke:#b06000,stroke-width:3px,color:#000
    classDef other fill:#f6f8fa,stroke:#8c959f,color:#000
    classDef base fill:#eef1f4,stroke:#8c959f,color:#000
    class M base
    class A here
    class B,C other
```

The full graph — every trait, type and registry entry each layer adds, and which layer consumes it — is in [DIS-2644](https://linear.app/nvidia/issue/DIS-2644/v2-align-the-unified-parser-surface-with-peer-traits-and-let-vendors), kept there because it is too wide to read inline on GitHub.
<!-- stack-graph -->

<!-- review-aids -->
#### Review aid: the lifecycle this PR pins down

```mermaid
stateDiagram-v2
    direction LR
    [*] --> Fresh
    Fresh --> Streaming : parse_into
    Streaming --> Streaming : parse_into
    Streaming --> Errored : Err
    Errored --> Fresh : reset()
    Streaming --> Ended : finish()
    Ended --> [*]
```

What each edge guarantees, and where to check it in the diff:

| edge | guarantee | where |
|---|---|---|
| `parse_into` | committed events land in the **caller's** output, so a later `Err` in the same advance cannot retract them | `ScannerUnified::parse_into` writes straight through `EventSink` |
| `Err` | the failing invoke was **never consumed** — buffer intact, `next_index` not advanced | both invoke sites call the emitter *before* `buffer.drain(..)` |
| `reset()` | returns the unconsumed text and clears **every** field carrying stream position: `in_block`, `in_reasoning`, `resume_reasoning`, `suppress_normal_text`, `next_index` | `reset_stream` in `scan.rs` |
| `finish()` | flushes into a fresh output; open reasoning is promoted rather than leaked | `ScannerUnified::finish` |

`push()` is the one spelling that CANNOT honour the first row — it owns its buffer and returns `Result<Vec<_>>`, which has nowhere to carry partial output. A parser that may commit and then fail must be driven through `parse_into`.

#### Review aid: what goes in, what comes out

Every line below is marked with where it comes from. Verified against the vLLM Rust parser crate at `rust/src/parser/src/unified/mod.rs` (v0.26.0).

```rust
// ---- IN ----
// (FROM vLLM — identical signature)
fn parse_into(&mut self, delta: &str, output: &mut UnifiedParserOutput) -> Result<()>;
// (FROM vLLM — identical signature)
fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()>;

// ---- OUT, streaming ----
// (FROM vLLM — identical struct, identical public field)
pub struct UnifiedParserOutput { pub events: Vec<UnifiedParserEvent> }

// (FROM vLLM — identical variants, identical tuple shapes)
pub enum UnifiedParserEvent {
    Text(String),
    Reasoning(String),
    ToolCall(ToolCallDelta),
}

// (FROM vLLM — identical fields)
pub struct ToolCallDelta { pub tool_index: usize, pub name: Option<String>, pub arguments: String }

// ---- OUT, assembled ----
// (NOT vLLM — ours. vLLM has no assembled-event type and no assemble().)
pub enum UnifiedEvent {
    Reasoning { text: String },
    Text      { text: String },
    ToolCall  { name: String, arguments: serde_json::Value },
}
```

**Provenance of every trait method:**

| method | provenance |
|---|---|
| `parse_into` · `initialize` · `reset` · `preserve_special_tokens` · `tool_call_id` | **FROM vLLM** — identical signatures |
| `finish` | **FROM vLLM**, one deliberate difference: vLLM gives it a default, we make it REQUIRED. A family that forgets to flush silently drops the tail of every stream, which is not a failure worth inheriting for symmetry |
| `push(chunk) -> Result<Vec<UnifiedParserEvent>>` | **NOT vLLM** — ours, additive convenience. The conformance corpus asserts against this spelling |
| `parse_complete(output) -> Result<Vec<UnifiedEvent>>` | **NOT vLLM** — ours. vLLM has no batch entry point; routing batch through `parse_into`/`finish` makes stream/batch parity structural |
| `register_unified_parser` / `unregister` / aliases | **NOT vLLM** — ours. vLLM has no vendor registry for unified parsers |

**Accumulation helpers** `push_text` · `push_reasoning` · `push_call` · `append` are **FROM vLLM** by name and semantics, including that `append` coalesces across the seam. One difference: vLLM's `append(other: Self)` consumes; ours takes `&mut Self`.

**In vLLM, deliberately NOT here:** `create(tools, tokenizer)` — their construction takes a tokenizer, ours takes only `&[Tool]`, so a peer parser that resolves markers from a tokenizer cannot be built through this registry yet. `structural_tag_model()` — constrains generation for strict tool calling; no type or consumer in this crate. `append_tool_output()` — bridges their separate tool-only output type.

**Why a flat `Vec` and not `{reasoning_text, content, tool_calls}`.** A bundle of parallel fields physically cannot say whether text came before or after a call — that is why the split path today hoists every thought to the front and merges them. Ordering is not a field you can add; it has to be the shape. This is the part vLLM already got right, and the reason aligning to it was worth doing.

Two distinctions that are easy to misread in the diff:

- `ToolCallDelta.arguments` is a **`String` fragment** that concatenates across deltas; `UnifiedEvent::ToolCall.arguments` is a **parsed `serde_json::Value`**. `assemble()` is the single fold between them — and both the fold and the assembled type are ours, not vLLM's.
- `UnifiedParserEvent` uses **tuple variants** (vLLM's shape); `UnifiedEvent` uses **struct variants with a serde tag**, because it serializes to the golden-corpus schema.

`Result` is `anyhow::Result` throughout.

#### Review aid: what an emitter failure costs, after this PR

The ordering below is the fix. Before it, the buffer was drained *before* the fallible call and the drain loop collected into a local vector that `?` dropped — so this same input lost `prefix`, the `ok` call that had already succeeded, and both invoke bodies, leaving `reset()` with only `</tool_call>suffix`.

```mermaid
sequenceDiagram
    autonumber
    participant C as Caller (owns output)
    participant S as Scanner drain loop
    participant E as Emitter (fallible)

    C->>S: parse_into("prefix<tool_call>ok…boom…</tool_call>suffix")
    S-->>C: push_text("prefix") — COMMITTED
    S->>E: parse_invoke(ok)
    E-->>S: Ok(ToolCall)
    S-->>C: push_call(ok) — COMMITTED
    S->>S: drain the ok bytes (only after success)
    S->>E: parse_invoke(boom)
    E-->>S: Err
    Note over S: boom bytes were NOT drained
    S-->>C: Err
    C->>S: reset()
    S-->>C: "<function=boom></function></tool_call>suffix"
```
<!-- review-aids -->


#### Example (before → after):

Hovering a cell in the conformance report opened nothing on a normal desktop:

```
before:  (hover: hover) reports false -> pointerenter listener never registered
         browser delivers real hover, cell matches CSS :hover, popup never opens
         keyboard focus also dead, because focusin sat behind the same gate
after:   listeners always registered; only tap-to-pin consults PointerEvent.pointerType
         real mouse, media queries false -> popup with 1334 chars, opacity 1, on top
```

#### Details:

- **Peer alignment** — `UnifiedParserEvent` in peer variant order and payload shapes, `parse_into` as the required method, `finish -> UnifiedParserOutput`, `initialize(&[u32])`, plus `reset` / `preserve_special_tokens` / `tool_call_id` and the peer accumulation helpers. `parse_complete` and the assembled `UnifiedEvent` view stay additive, so a peer-shaped caller never sees them.
- **Vendor registry** — `register_unified_parser` / `unregister_unified_parser`, keyed on the **canonical** family name so registering `qwen3` also shadows its `qwen3_coder` alias. Shadowing is non-destructive; unregistering restores the built-in exactly. `builtin_unified_families()` excludes vendor entries, because the conformance suite iterates it and a vendor family has no cases here. `CUSTOM_PARSERS.md` documents the contract, and its worked example exists as a compiled integration test (`tests/vendor_parser_example.rs`) using only the public API, with a guard asserting the guide's `impl UnifiedParser` methods match that file's. The guard is scoped to those method bodies — it does not compile the Markdown block, so a doc-only change to imports or struct fields would still slip past it.
- **GUI + tooling** — hover listeners no longer gated on a media query, capture-result semantics, ORDER/MERGE sequence display, render fixes.

#### Verification:

```
cargo test --workspace --all-targets --locked   1386 passed, 33 suites, 0 failed
python3 -m pytest conformance/utils/tests/      125 passed
cargo clippy --workspace --all-targets          0 warnings
piece-1 coupling gate                           PASS
golden.tar.gz / inputs.tar.gz                   43db2838… / 70fda09d… unchanged
```

`conformance/utils/piece1_coupling_gate.sh` is the falsifiable proof that no request-mode work leaked in: it rejects every request-mode symbol from the diff, proves `conformance/fixtures` and the manifest are byte-identical to `main`, pins both LFS pointers, and confirms the generator still emits main's 33 scenarios / 99 cases. It was negative-controlled against the combined branch, where it fails for eight independent reasons.

#### Where should the reviewer start?

`parsers/v2/src/unified/mod.rs` (the trait and registry), then `parsers/v2/CUSTOM_PARSERS.md`.

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom unified parsers, including registration, overrides, lifecycle controls, and vendor family management.
  * Improved conformance views with clearer event-order comparisons, compact tables, formatted tooltips, and sequence-divergence indicators.
  * Enhanced tooltip interactions across mouse, keyboard, touch, and pen input.

* **Bug Fixes**
  * Updated parser output handling for consistent reasoning, text, and tool-call events.

* **Documentation**
  * Added guidance for implementing, registering, testing, and integrating custom unified parsers.

* **Tests**
  * Expanded browser, parser, registry, and layout coverage for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







