### PR TITLE
chore: bump minijinja to 2.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
 dependencies = [
  "indexmap 2.14.0",
  "memo-map",
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.21.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85342f6fac0be8ccd5bd00d9066be538f34f393f577b75d81b17c8398a6b43bb"
+checksum = "fd6e279dc925840c2d9ebc1e9f85410611d01292561297463ba3e516c3ad94dd"
 dependencies = [
  "minijinja",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ either = { version = "1.13", features = ["serde"] }
 fastokens = "0.3.1"
 futures = "0.3"
 hf-hub = { version = "1.0", default-features = false, features = ["rustls-tls"] }
-minijinja = { version = "2.21.0" }
-minijinja-contrib = { version = "2.21.0" }
+minijinja = { version = "2.22.0" }
+minijinja-contrib = { version = "2.22.0" }
 moka = { version = "0.12" }
 num-traits = "0.2"
 openai-harmony = "0.0.8"


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This bumps `minijinja` and `minijinja-contrib` from 2.21.0 to 2.22.0. The release fixes loop-local assignments leaking into later iterations, aligning GLM-5.2 chat-template rendering with Python Jinja2.

### How This Was Implemented
- Updated both workspace dependency pins together.
- Refreshed only their Cargo lockfile versions and checksums.

<details>
<summary>Walkthrough</summary>

#### Mental model

All renderer chat templates continue through the existing MiniJinja environment. Version 2.22.0 changes the engine's loop scoping so assignments from one iteration do not affect subsequent iterations; no renderer code or public API changes.

#### Boundaries and limitations

This PR does not change template preprocessing, model detection, or renderer configuration.

</details>

### Validation
- `cargo test -p dynamo-renderer` (134 passed, 1 ignored).
<!-- codex-pr-description:end -->
