### PR TITLE
chore: bump minijinja to 2.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.22.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
 dependencies = [
  "indexmap 2.14.0",
  "memo-map",
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.22.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6e279dc925840c2d9ebc1e9f85410611d01292561297463ba3e516c3ad94dd"
+checksum = "bd3e5f077bc2379f0f7d911e7cfdd921114ed99fc884533dca502944cb355b11"
 dependencies = [
  "minijinja",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ either = { version = "1.13", features = ["serde"] }
 fastokens = "0.3.1"
 futures = "0.3"
 hf-hub = { version = "1.0", default-features = false, features = ["rustls-tls"] }
-minijinja = { version = "2.22.0" }
-minijinja-contrib = { version = "2.22.0" }
+minijinja = { version = "2.24.0" }
+minijinja-contrib = { version = "2.24.0" }
 moka = { version = "0.12" }
 num-traits = "0.2"
 openai-harmony = "0.0.8"


### PR DESCRIPTION
## Overview

Bumps `minijinja` and `minijinja-contrib` from 2.22.0 to 2.24.0 (workspace pins + lockfile).

minijinja 2.24.0 fixes conditional expressions in keyword-argument values (`namespace(name=x if x else 'd')`), which Jinja2 accepts but earlier minijinja rejected with `syntax error: unexpected identifier, expected ','` (mitsuhiko/minijinja#921). Meta's Muse-Glimmer-30B chat template uses this construct, so the frontend failed to materialize the model (prompt-formatter retry loop) with the stock template.

## Details

- Workspace pins for `minijinja` / `minijinja-contrib` move to 2.24.0 together; mixing versions does not compile (contrib 2.2x against a newer core).
- Adds a renderer regression test that the kwarg-conditional construct parses and renders (`test_kwarg_conditional_expression_parses`), guarding the floor.

## Verification

- `cargo test -p dynamo-renderer`: 135 passed.
- Workspace builds clean, fmt clean.
- E2e: dynamo main with this bump serves Muse-Glimmer-30B using the stock HF chat template (model materializes in ~2 min, multi-turn tool history renders; previously an infinite materialization-retry loop).