### PR TITLE
fix: Fix kimi K2 structural tag issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "7.1.1"
+version = "8.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 clap = "4"
 derive_builder = "0.20"
-dynamo-parsers = { path = "parsers/v1", version = "7.1.1" }
+dynamo-parsers = { path = "parsers/v1", version = "8.0.0" }
 dynamo-protocols = { path = "protocols", version = "5.3.1" }
 dynamo-renderer = { path = "renderer", version = "5.0.2" }
 dynamo-tokenizers = { path = "tokenizers", version = "1.8.0" }

--- a/parsers/v1/CHANGELOG.md
+++ b/parsers/v1/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [8.0.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-parsers-v7.1.1...dynamo-parsers-v8.0.0) - 2026-08-14
+
+### Features
+
+- *(parsers)* Add native Kimi K2 structural-tag generation for required and named tool choices ([#188](https://github.com/ai-dynamo/frontend-crates/pull/188))
+
 ## [7.1.1](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-parsers-v7.1.0...dynamo-parsers-v7.1.1) - 2026-08-08
 
 ### Miscellaneous

--- a/parsers/v1/CHANGELOG.md
+++ b/parsers/v1/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- *(parsers)* Add native Kimi K2 structural-tag generation for required and named tool choices ([#188](https://github.com/ai-dynamo/frontend-crates/pull/188))
+- *(parsers)* [**breaking**] Add native Kimi K2 structural-tag generation and make `StructuralTagBuilder` non-exhaustive ([#188](https://github.com/ai-dynamo/frontend-crates/pull/188))
 
 ## [7.1.1](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-parsers-v7.1.0...dynamo-parsers-v7.1.1) - 2026-08-08
 

--- a/parsers/v1/Cargo.toml
+++ b/parsers/v1/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "dynamo-parsers"
 readme = "README.md"
-version = "7.1.1"
+version = "8.0.0"
 edition.workspace = true
 description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
 authors.workspace = true

--- a/parsers/v1/src/tool_calling/config.rs
+++ b/parsers/v1/src/tool_calling/config.rs
@@ -853,7 +853,7 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
         Self {
             parser_config: ParserConfig::KimiK2(KimiK2ParserConfig::default()),
-            structural_tag_builder: None,
+            structural_tag_builder: Some(StructuralTagBuilder::KimiK2),
         }
     }
 

--- a/parsers/v1/src/tool_calling/structural_tag/builder.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/builder.rs
@@ -122,7 +122,8 @@ pub enum StructuralTagBuilder {
     ///
     /// When generation starts in a prompt-injected reasoning block, this
     /// builder assumes the K2.5/K2.6 `kimi_k25` `</think>` terminator. Original
-    /// K2-Thinking, which emits its own `◁think▷` markers, is not supported.
+    /// K2-Thinking is not supported because its chat template leaves the
+    /// opening `<think>` for the model to generate.
     KimiK2,
 
     /// Kimi K3's native XTML response/tools channel format.
@@ -223,7 +224,7 @@ impl StructuralTagBuilder {
             Self::TriggeredTags(config) => config.reasoning_end.as_deref(),
             Self::DsmlToolCalls(config) => config.reasoning_end.as_deref(),
             // K2.5/K2.6 `kimi_k25` reasoning terminator. Original K2-Thinking
-            // uses different markers and must not be routed to this builder.
+            // generates the opening `<think>` itself and needs a separate path.
             Self::KimiK2 => Some("</think>"),
             Self::KimiK3 => Some("<|close|>think<|sep|>"),
         }

--- a/parsers/v1/src/tool_calling/structural_tag/builder.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/builder.rs
@@ -82,7 +82,11 @@ pub(crate) fn resolve_tools_to_include<'a>(
     }
 }
 
-/// Resolve one tool's argument schema for structural tag generation.
+/// Resolve one tool's argument schema using Dynamo's generic schema policy.
+///
+/// In [`StructuralTagSchemaMode::Auto`], only `strict: true` selects the
+/// declared schema. Model-native builders may intentionally follow different
+/// upstream semantics and should use a model-specific policy helper.
 pub(crate) fn resolve_tool_schema(tool: &ToolDefinition, strict_schema: bool) -> Value {
     // xgrammar uses `true` for syntactically valid but schema-unconstrained JSON.
     let default_schema = json!(true);
@@ -95,6 +99,16 @@ pub(crate) fn resolve_tool_schema(tool: &ToolDefinition, strict_schema: bool) ->
     }
 }
 
+/// Whether Kimi's vLLM/xgrammar-compatible format should use the declared
+/// parameter schema.
+///
+/// Kimi treats only an explicit `strict: false` as an opt-out. An omitted
+/// `strict` value therefore uses the declared schema, unlike Dynamo's generic
+/// [`StructuralTagSchemaMode::Auto`] policy.
+pub(crate) fn kimi_uses_declared_tool_schema(tool: &ToolDefinition, strict_schema: bool) -> bool {
+    strict_schema || tool.strict != Some(false)
+}
+
 /// Builder for model-family-specific tool-call structural tags.
 #[derive(Debug, Clone)]
 pub enum StructuralTagBuilder {
@@ -105,6 +119,10 @@ pub enum StructuralTagBuilder {
     DsmlToolCalls(DsmlToolCallsConfig),
 
     /// Kimi K2's native special-token tool-call section format.
+    ///
+    /// When generation starts in a prompt-injected reasoning block, this
+    /// builder assumes the K2.5/K2.6 `kimi_k25` `</think>` terminator. Original
+    /// K2-Thinking, which emits its own `◁think▷` markers, is not supported.
     KimiK2,
 
     /// Kimi K3's native XTML response/tools channel format.
@@ -204,6 +222,8 @@ impl StructuralTagBuilder {
         match self {
             Self::TriggeredTags(config) => config.reasoning_end.as_deref(),
             Self::DsmlToolCalls(config) => config.reasoning_end.as_deref(),
+            // K2.5/K2.6 `kimi_k25` reasoning terminator. Original K2-Thinking
+            // uses different markers and must not be routed to this builder.
             Self::KimiK2 => Some("</think>"),
             Self::KimiK3 => Some("<|close|>think<|sep|>"),
         }

--- a/parsers/v1/src/tool_calling/structural_tag/builder.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/builder.rs
@@ -12,6 +12,7 @@ use super::dsml::{self, DsmlToolCallsConfig};
 use super::format::{
     AnyTextFormat, AnyTokensFormat, Format, SequenceFormat, StructuralTag, TagFormat,
 };
+use super::kimi_k2;
 use super::kimi_k3;
 use super::triggered_tags::{self, TriggeredTagsConfig};
 
@@ -103,6 +104,9 @@ pub enum StructuralTagBuilder {
     /// DeepSeek DSML format with a `triggered_tags` wrapper and invoke list.
     DsmlToolCalls(DsmlToolCallsConfig),
 
+    /// Kimi K2's native special-token tool-call section format.
+    KimiK2,
+
     /// Kimi K3's native XTML response/tools channel format.
     KimiK3,
 }
@@ -123,6 +127,7 @@ impl StructuralTagBuilder {
         let structural_tag = match self {
             Self::TriggeredTags(config) => triggered_tags::build_triggered_tags(config, ctx)?,
             Self::DsmlToolCalls(config) => dsml::build_dsml_tool_calls(config, ctx)?,
+            Self::KimiK2 => kimi_k2::build_kimi_k2(ctx)?,
             Self::KimiK3 => kimi_k3::build_kimi_k3(ctx)?,
         };
 
@@ -190,6 +195,7 @@ impl StructuralTagBuilder {
         match self {
             Self::TriggeredTags(config) => &config.tool_call_ban_tokens,
             Self::DsmlToolCalls(config) => &config.tool_call_ban_tokens,
+            Self::KimiK2 => &[],
             Self::KimiK3 => &[],
         }
     }
@@ -198,6 +204,7 @@ impl StructuralTagBuilder {
         match self {
             Self::TriggeredTags(config) => config.reasoning_end.as_deref(),
             Self::DsmlToolCalls(config) => config.reasoning_end.as_deref(),
+            Self::KimiK2 => Some("</think>"),
             Self::KimiK3 => Some("<|close|>think<|sep|>"),
         }
     }

--- a/parsers/v1/src/tool_calling/structural_tag/builder.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/builder.rs
@@ -111,6 +111,7 @@ pub(crate) fn kimi_uses_declared_tool_schema(tool: &ToolDefinition, strict_schem
 
 /// Builder for model-family-specific tool-call structural tags.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum StructuralTagBuilder {
     /// Simple `triggered_tags` format with one tag template per tool.
     TriggeredTags(TriggeredTagsConfig),

--- a/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
@@ -7,9 +7,10 @@
 //! JSON array used by the legacy forced-tool path. The numeric suffix belongs
 //! to the model-generated call ID and must remain dynamic for parallel calls.
 //!
-//! This builder supports K2-Instruct and K2.5/K2.6 reasoning prompts that use
-//! the `kimi_k25` `</think>` terminator. It does not support original
-//! K2-Thinking prompts, where the model emits its own `◁think▷` markers.
+//! This builder supports K2-Instruct and K2.5/K2.6 reasoning prompts. The
+//! K2.5/K2.6 chat template injects `<think>` into the generation prompt, and
+//! the model later emits `</think>`. It does not support original K2-Thinking,
+//! whose chat template leaves the opening `<think>` for the model to generate.
 
 use serde_json::{Value, json};
 

--- a/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kimi K2 native structural-tag generation.
+//!
+//! K2 emits tool calls inside a special-token section rather than as the raw
+//! JSON array used by the legacy forced-tool path. The numeric suffix belongs
+//! to the model-generated call ID and must remain dynamic for parallel calls.
+
+use serde_json::{Value, json};
+
+use super::builder::{ToolCallFormatBuildContext, resolve_tools_to_include};
+use super::format::{
+    ConstStringFormat, Format, JsonSchemaFormat, JsonSchemaStyle, RegexFormat, SequenceFormat,
+    StructuralTag, TagFormat, TagsWithSeparatorFormat, TriggeredTagsFormat,
+};
+use crate::tool_calling::{ToolChoice, ToolDefinition};
+
+const TOOL_CALL_BEGIN_PREFIX: &str = "<|tool_call_begin|>functions.";
+const TOOL_CALL_ARGUMENT_BEGIN: &str = "<|tool_call_argument_begin|>";
+const TOOL_CALL_END: &str = "<|tool_call_end|>";
+const TOOL_CALLS_SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
+const TOOL_CALLS_SECTION_END: &str = "<|tool_calls_section_end|>";
+
+fn tool_schema(tool: &ToolDefinition, strict_schema: bool) -> Value {
+    // Match vLLM/xgrammar: use the declared parameters unless the request
+    // explicitly opts out with strict=false. Global strict mode overrides the
+    // opt-out. Xgrammar uses `true` for unconstrained but valid JSON.
+    if strict_schema || tool.strict != Some(false) {
+        tool.parameters.clone().unwrap_or_else(|| json!(true))
+    } else {
+        json!(true)
+    }
+}
+
+fn call_tag(tool: &ToolDefinition, strict_schema: bool) -> TagFormat {
+    TagFormat {
+        begin: format!("{TOOL_CALL_BEGIN_PREFIX}{}:", tool.name),
+        content: Box::new(Format::Sequence(SequenceFormat {
+            elements: vec![
+                Format::Regex(RegexFormat {
+                    pattern: r"\d+".to_string(),
+                }),
+                Format::ConstString(ConstStringFormat {
+                    value: TOOL_CALL_ARGUMENT_BEGIN.to_string(),
+                }),
+                Format::JsonSchema(JsonSchemaFormat {
+                    json_schema: tool_schema(tool, strict_schema),
+                    style: JsonSchemaStyle::Json,
+                }),
+            ],
+        })),
+        end: TOOL_CALL_END.to_string(),
+    }
+}
+
+/// Build Kimi K2's native tool-call section.
+pub(crate) fn build_kimi_k2(
+    ctx: &ToolCallFormatBuildContext<'_>,
+) -> anyhow::Result<Option<StructuralTag>> {
+    let (tools, outer_at_least_one) = resolve_tools_to_include(ctx)?;
+    if tools.is_empty() {
+        return Ok(None);
+    }
+
+    let mut calls: Vec<TagFormat> = tools
+        .into_iter()
+        .map(|tool| call_tag(tool, ctx.strict_schema()))
+        .collect();
+
+    let calls_format = if matches!(ctx.tool_choice, ToolChoice::Named(_)) {
+        Format::Tag(calls.pop().expect("named tool choice resolves one tool"))
+    } else {
+        Format::TagsWithSeparator(TagsWithSeparatorFormat {
+            tags: calls,
+            separator: String::new(),
+            at_least_one: true,
+            stop_after_first: ctx.stop_after_first(),
+        })
+    };
+
+    let format = if matches!(ctx.tool_choice, ToolChoice::Auto) {
+        Format::TriggeredTags(TriggeredTagsFormat {
+            triggers: vec![TOOL_CALLS_SECTION_BEGIN.to_string()],
+            tags: vec![TagFormat {
+                begin: TOOL_CALLS_SECTION_BEGIN.to_string(),
+                content: Box::new(calls_format),
+                end: TOOL_CALLS_SECTION_END.to_string(),
+            }],
+            at_least_one: outer_at_least_one,
+            stop_after_first: ctx.stop_after_first(),
+        })
+    } else {
+        Format::Sequence(SequenceFormat {
+            elements: vec![
+                Format::ConstString(ConstStringFormat {
+                    value: TOOL_CALLS_SECTION_BEGIN.to_string(),
+                }),
+                calls_format,
+                Format::ConstString(ConstStringFormat {
+                    value: TOOL_CALLS_SECTION_END.to_string(),
+                }),
+            ],
+        })
+    };
+
+    Ok(Some(StructuralTag { format }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::tool_calling::structural_tag::StructuralTagSchemaMode;
+
+    fn tools() -> Vec<ToolDefinition> {
+        vec![
+            ToolDefinition {
+                name: "get_weather".to_string(),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"]
+                })),
+                strict: None,
+            },
+            ToolDefinition {
+                name: "get_time".to_string(),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {"timezone": {"type": "string"}}
+                })),
+                strict: Some(false),
+            },
+        ]
+    }
+
+    fn context<'a>(
+        tool_choice: &'a ToolChoice,
+        tools: &'a [ToolDefinition],
+        parallel_tool_calls: Option<bool>,
+        starts_in_reasoning: bool,
+        schema_mode: StructuralTagSchemaMode,
+    ) -> ToolCallFormatBuildContext<'a> {
+        ToolCallFormatBuildContext {
+            tool_choice,
+            tools,
+            parallel_tool_calls,
+            schema_mode,
+            starts_in_reasoning,
+        }
+    }
+
+    #[test]
+    fn required_uses_native_section_dynamic_ids_and_vllm_schema_semantics() {
+        let tools = tools();
+        let ctx = context(
+            &ToolChoice::Required,
+            &tools,
+            None,
+            false,
+            StructuralTagSchemaMode::Auto,
+        );
+        let value = serde_json::to_value(build_kimi_k2(&ctx).unwrap().unwrap()).unwrap();
+        let elements = value["format"]["elements"].as_array().unwrap();
+
+        assert_eq!(elements[0]["value"], TOOL_CALLS_SECTION_BEGIN);
+        assert_eq!(elements[1]["type"], "tags_with_separator");
+        assert_eq!(elements[1]["at_least_one"], true);
+        assert_eq!(elements[1]["tags"].as_array().unwrap().len(), 2);
+        assert_eq!(elements[2]["value"], TOOL_CALLS_SECTION_END);
+
+        let weather = &elements[1]["tags"][0];
+        assert_eq!(
+            weather["begin"],
+            "<|tool_call_begin|>functions.get_weather:"
+        );
+        assert_eq!(weather["content"]["elements"][0]["pattern"], r"\d+");
+        assert_eq!(
+            weather["content"]["elements"][1]["value"],
+            TOOL_CALL_ARGUMENT_BEGIN
+        );
+        assert_eq!(
+            weather["content"]["elements"][2]["json_schema"],
+            tools[0].parameters.clone().unwrap()
+        );
+        assert_eq!(weather["end"], TOOL_CALL_END);
+
+        // Unlike the omitted strict flag above, explicit strict=false opts out.
+        assert_eq!(
+            elements[1]["tags"][1]["content"]["elements"][2]["json_schema"],
+            true
+        );
+    }
+
+    #[test]
+    fn named_choice_includes_only_the_selected_tool() {
+        let tools = tools();
+        let choice = ToolChoice::Named("get_time".to_string());
+        let ctx = context(&choice, &tools, None, false, StructuralTagSchemaMode::Auto);
+        let value = serde_json::to_value(build_kimi_k2(&ctx).unwrap().unwrap()).unwrap();
+        let call = &value["format"]["elements"][1];
+
+        assert_eq!(call["type"], "tag");
+        assert_eq!(call["begin"], "<|tool_call_begin|>functions.get_time:");
+        assert_eq!(call["content"]["elements"][2]["json_schema"], true);
+    }
+
+    #[test]
+    fn auto_is_triggered_but_inner_section_requires_a_call() {
+        let tools = tools();
+        let ctx = context(
+            &ToolChoice::Auto,
+            &tools,
+            None,
+            false,
+            StructuralTagSchemaMode::Auto,
+        );
+        let value = serde_json::to_value(build_kimi_k2(&ctx).unwrap().unwrap()).unwrap();
+
+        assert_eq!(value["format"]["type"], "triggered_tags");
+        assert_eq!(value["format"]["at_least_one"], false);
+        assert_eq!(value["format"]["triggers"][0], TOOL_CALLS_SECTION_BEGIN);
+        assert_eq!(value["format"]["tags"][0]["content"]["at_least_one"], true);
+    }
+
+    #[test]
+    fn required_honors_single_call_and_reasoning_prefix() {
+        let tools = tools();
+        let ctx = context(
+            &ToolChoice::Required,
+            &tools,
+            Some(false),
+            true,
+            StructuralTagSchemaMode::Strict,
+        );
+        let builder = crate::tool_calling::StructuralTagBuilder::KimiK2;
+        let value = builder.build_tool_call_format(&ctx).unwrap().unwrap();
+
+        assert_eq!(value["format"]["type"], "sequence");
+        assert_eq!(value["format"]["elements"][0]["end"], "</think>");
+        let native = &value["format"]["elements"][1];
+        assert_eq!(
+            native["elements"][1]["stop_after_first"], true,
+            "parallel_tool_calls=false must stop after the first native call"
+        );
+        assert_eq!(
+            native["elements"][1]["tags"][1]["content"]["elements"][2]["json_schema"],
+            tools[1].parameters.clone().unwrap(),
+            "global strict mode overrides explicit strict=false"
+        );
+    }
+}

--- a/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs
@@ -6,10 +6,16 @@
 //! K2 emits tool calls inside a special-token section rather than as the raw
 //! JSON array used by the legacy forced-tool path. The numeric suffix belongs
 //! to the model-generated call ID and must remain dynamic for parallel calls.
+//!
+//! This builder supports K2-Instruct and K2.5/K2.6 reasoning prompts that use
+//! the `kimi_k25` `</think>` terminator. It does not support original
+//! K2-Thinking prompts, where the model emits its own `◁think▷` markers.
 
 use serde_json::{Value, json};
 
-use super::builder::{ToolCallFormatBuildContext, resolve_tools_to_include};
+use super::builder::{
+    ToolCallFormatBuildContext, kimi_uses_declared_tool_schema, resolve_tools_to_include,
+};
 use super::format::{
     ConstStringFormat, Format, JsonSchemaFormat, JsonSchemaStyle, RegexFormat, SequenceFormat,
     StructuralTag, TagFormat, TagsWithSeparatorFormat, TriggeredTagsFormat,
@@ -26,7 +32,7 @@ fn tool_schema(tool: &ToolDefinition, strict_schema: bool) -> Value {
     // Match vLLM/xgrammar: use the declared parameters unless the request
     // explicitly opts out with strict=false. Global strict mode overrides the
     // opt-out. Xgrammar uses `true` for unconstrained but valid JSON.
-    if strict_schema || tool.strict != Some(false) {
+    if kimi_uses_declared_tool_schema(tool, strict_schema) {
         tool.parameters.clone().unwrap_or_else(|| json!(true))
     } else {
         json!(true)
@@ -63,13 +69,18 @@ pub(crate) fn build_kimi_k2(
         return Ok(None);
     }
 
-    let mut calls: Vec<TagFormat> = tools
+    let calls: Vec<TagFormat> = tools
         .into_iter()
         .map(|tool| call_tag(tool, ctx.strict_schema()))
         .collect();
 
     let calls_format = if matches!(ctx.tool_choice, ToolChoice::Named(_)) {
-        Format::Tag(calls.pop().expect("named tool choice resolves one tool"))
+        Format::Tag(
+            calls
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("named tool choice resolved no tool"))?,
+        )
     } else {
         Format::TagsWithSeparator(TagsWithSeparatorFormat {
             tags: calls,

--- a/parsers/v1/src/tool_calling/structural_tag/kimi_k3.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/kimi_k3.rs
@@ -197,7 +197,7 @@ fn arguments_block(parameters: Option<&Value>) -> Format {
 fn call_tag(tool: &ToolDefinition, strict_schema: bool) -> TagFormat {
     // Match vLLM's K3 behavior: use the declared schema unless the caller
     // explicitly sets strict=false. Global strict mode overrides that opt-out.
-    let parameters = if strict_schema || tool.strict != Some(false) {
+    let parameters = if super::builder::kimi_uses_declared_tool_schema(tool, strict_schema) {
         tool.parameters.as_ref()
     } else {
         None

--- a/parsers/v1/src/tool_calling/structural_tag/mod.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/mod.rs
@@ -12,11 +12,13 @@
 //! - [`builder`] — public builder API used by the preprocessor
 //! - [`triggered_tags`] — `triggered_tags` format implementation
 //! - [`dsml`] — DeepSeek V3.2+ DSML tool-call format implementation
+//! - [`kimi_k2`] — Kimi K2 native tool-call section format
 //! - [`kimi_k3`] — Kimi K3 native XTML channel format
 
 pub mod builder;
 pub mod dsml;
 pub mod format;
+pub mod kimi_k2;
 pub mod kimi_k3;
 pub mod triggered_tags;
 

--- a/parsers/v1/src/tool_calling/structural_tag/tests.rs
+++ b/parsers/v1/src/tool_calling/structural_tag/tests.rs
@@ -4,7 +4,10 @@
 use serde_json::{Value, json};
 
 use super::TOOL_NAME_PLACEHOLDER;
-use super::builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext};
+use super::builder::{
+    StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext,
+    kimi_uses_declared_tool_schema,
+};
 use super::dsml::DsmlToolCallsConfig;
 use super::format::JsonSchemaStyle;
 use super::triggered_tags::TriggeredTagsConfig;
@@ -286,6 +289,21 @@ fn strict_schema_mode_uses_real_schema_for_all() {
     let tags = parsed["format"]["tags"].as_array().unwrap();
     assert!(tags[0]["content"]["json_schema"]["properties"]["a"].is_object());
     assert!(tags[1]["content"]["json_schema"]["properties"]["location"].is_object());
+}
+
+#[test]
+fn kimi_schema_policy_matches_vllm_xgrammar() {
+    let mut tool = sample_tools().remove(0);
+
+    tool.strict = None;
+    assert!(kimi_uses_declared_tool_schema(&tool, false));
+
+    tool.strict = Some(true);
+    assert!(kimi_uses_declared_tool_schema(&tool, false));
+
+    tool.strict = Some(false);
+    assert!(!kimi_uses_declared_tool_schema(&tool, false));
+    assert!(kimi_uses_declared_tool_schema(&tool, true));
 }
 
 #[test]
@@ -603,6 +621,7 @@ fn parser_map_structural_tag_smoke() {
         "qwen3_coder",
         "deepseek_v3_2",
         "deepseek_v4",
+        "kimi_k2",
         "kimi_k3",
         "inkling",
     ];


### PR DESCRIPTION
## Overview:

Adds native Kimi K2 structural-tag generation so guided decoding uses the same tool-call format that the Kimi K2 parser understands.

## Root cause:

Dynamo could parse Kimi K2's native, marker-delimited tool calls, but `frontend-crates` did not have a structural-tag builder for that same format. When Dynamo had to enforce a `required` or named tool call, it therefore fell back to constraining the output as a generic JSON array.

This created a format mismatch: Kimi K2 is trained to produce its native tool-call markers, while guided decoding required raw JSON and the response parser expected the native markers. Some prompts happened to complete the generic JSON and passed. With other prompts, the grammar accepted the opening `[` but rejected the model's preferred continuation. Whitespace remained valid, so generation could continue with whitespace until `max_tokens` without producing a tool call.

## Details:

- Registers a structural-tag builder for the `kimi_k2` parser.
- Builds Kimi K2's native tool-call envelope, including dynamic call IDs and request tool schemas.
- Supports `required`, named, and `auto` choices while preserving parallel-call behavior.
- Matches vLLM/xgrammar schema semantics for Kimi: an omitted or `true` per-tool `strict` value uses the declared schema, while an explicit `strict: false` permits unconstrained valid JSON unless global strict mode overrides it.
- Shares that Kimi-specific schema policy with the existing Kimi K3 builder while leaving Dynamo's generic schema policy unchanged.
- Supports K2-Instruct and K2.5/K2.6 reasoning prompts that use the `kimi_k25` `</think>` terminator. Original K2-Thinking prompts using `◁think▷` markers are explicitly outside this builder's scope.
- Adds focused coverage for tool choices, schema modes, reasoning-prefix handling, and real parser-map registration.
- Bumps `dynamo-parsers` from `7.1.1` to `8.0.0`. Adding `KimiK2` to the public `StructuralTagBuilder` enum can break downstream exhaustive matches, so this requires a major-version bump.

## Where should the reviewer start?

Start with `parsers/v1/src/tool_calling/structural_tag/kimi_k2.rs`. Then review the shared Kimi schema policy and public builder registration in `parsers/v1/src/tool_calling/structural_tag/builder.rs`, followed by the parser registration in `parsers/v1/src/tool_calling/config.rs`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to the Kimi forced-tool issue [ai-dynamo/dynamo#13231](https://github.com/ai-dynamo/dynamo/issues/13231); the complete behavior fix spans this and the companion Dynamo PR.
