### PR TITLE
feat(parsers): shared scanner params, and guided tool-call fragment streaming

### DIFF
--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -72,6 +72,7 @@ fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
         drop_invoke_crossing_block_end: true,
         // Every wrapped family's markers are special tokens today.
         preserve_special_tokens: true,
+        ..Default::default()
     }
 }
 

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -76,6 +76,7 @@ fn spec() -> WrappedBlockSpec {
         drop_invoke_crossing_block_end: false,
         // Every wrapped family's markers are special tokens today.
         preserve_special_tokens: true,
+        ..Default::default()
     }
 }
 

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -63,6 +63,7 @@ fn spec() -> WrappedBlockSpec {
         drop_invoke_crossing_block_end: false,
         // Every wrapped family's markers are special tokens today.
         preserve_special_tokens: true,
+        ..Default::default()
     }
 }
 

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -53,6 +53,7 @@ fn spec() -> WrappedBlockSpec {
         drop_invoke_crossing_block_end: false,
         // Every wrapped family's markers are special tokens today.
         preserve_special_tokens: true,
+        ..Default::default()
     }
 }
 

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -77,20 +77,42 @@ use crate::unified::{Kind, UnifiedParserEvent};
 /// guarantee by construction is now only guaranteed by
 /// `guided_and_native_agree_on_the_same_reasoning_bytes` in `unified/qwen3.rs`.
 /// That test is what stops the two drifting; this helper no longer can.
+///
+/// A second copy of this rule is how the two modes drift apart (`I6`).
+pub(crate) fn reasoning_opener_len(
+    start: &str,
+    label: Option<&str>,
+    after_start: &str,
+    flush: bool,
+) -> Option<usize> {
+    let len = start.len();
+    let Some(label) = label else {
+        return Some(len);
+    };
+    if after_start.starts_with(label) {
+        return Some(len + label.len());
+    }
+    if !flush && after_start.len() < label.len() && label.starts_with(after_start) {
+        return None;
+    }
+    Some(len)
+}
+
 pub(crate) fn stray_in_reasoning(
     haystack: &str,
-    start: &str,
+    opener: Option<(usize, usize)>,
     end: &str,
     orphan_markers: &[String],
 ) -> Option<(usize, usize)> {
-    std::iter::once(start)
+    opener
+        .into_iter()
         .chain(
             orphan_markers
                 .iter()
                 .map(String::as_str)
-                .filter(|m| *m != end),
+                .filter(|m| *m != end)
+                .filter_map(|m| haystack.find(m).map(|pos| (pos, m.len()))),
         )
-        .filter_map(|m| haystack.find(m).map(|pos| (pos, m.len())))
         .min_by_key(|(pos, _)| *pos)
 }
 
@@ -151,12 +173,13 @@ pub(crate) fn reorder_arguments(arguments: &str, source_names: &[String]) -> Str
 
 /// What happens to the normal-text suppression latch after a bare-invoke
 /// recovery emits a call.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum BareRecoveryLatch {
     /// Clear the latch: when the optional outer close is absent, later
     /// narration must still reach normal_text (MiniMax M2 semantics; a stray
     /// close that DOES follow is stripped by the orphan-close handling).
     Clear,
+    #[default]
     /// Keep the latch set: trailing markup around the recovered invoke is
     /// dropped until an orphan close ends the markup context
     /// (MiniMax M3 / Qwen3-Coder / Kimi K2 semantics).
@@ -164,15 +187,34 @@ pub(crate) enum BareRecoveryLatch {
 }
 
 /// When the in-block invoke latch engages after parsing a complete invoke.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum InvokeLatch {
+    #[default]
     /// Only when the invoke produced a call delta (XML families).
     IfEmitted,
     /// Always — even when the invoke parsed to nothing (Kimi K2).
     Always,
 }
 
+/// Grammar-aware overrides for locating invokes when marker-only scanning is
+/// insufficient.
+///
+/// Gemma 4 needs all three answers because its string-delimited values may
+/// contain both `call:` and `<tool_call|>` as data. Keeping them on one hook
+/// prevents opener, end, and holdback ownership from drifting apart.
+#[derive(Clone, Copy)]
+pub(crate) struct InvokeScan {
+    /// End of the invoke that begins at byte zero, just past its closer. `flush`
+    /// allows a family to recover a balanced body whose closer never arrived.
+    pub end: fn(text: &str, flush: bool) -> Option<usize>,
+    /// Whether the `invoke_start` occurrence at `at` opens a real invoke.
+    pub opens: fn(text: &str, at: usize) -> bool,
+    /// Additional trailing bytes to retain while an opener is still arriving.
+    pub holdback: fn(text: &str) -> usize,
+}
+
 /// Declarative description of one wrapped-invoke grammar.
+#[derive(Default)]
 pub(crate) struct WrappedBlockSpec {
     /// Family name used in tracing `why` diagnostics.
     pub family: &'static str,
@@ -195,6 +237,8 @@ pub(crate) struct WrappedBlockSpec {
     /// the `invoke_end` means the call is malformed — drop it and close the
     /// block (Kimi K2's mismatched-fences rule).
     pub drop_invoke_crossing_block_end: bool,
+    /// Grammar-aware invoke location; `None` uses the marker-only rules.
+    pub invoke_scan: Option<InvokeScan>,
     /// Whether a decoder must keep tokenizer special tokens so this grammar's
     /// markers survive to the parser.
     ///
@@ -211,7 +255,7 @@ pub(crate) struct WrappedBlockSpec {
 /// `&'static str`: every family's markers are compile-time constants, so
 /// `drain_reasoning` copies two pointers per push instead of allocating two
 /// `String`s on the hot path.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub(crate) struct ReasoningSpec {
     /// Opener, e.g. `<think>`.
     pub start: &'static str,
@@ -223,6 +267,11 @@ pub(crate) struct ReasoningSpec {
     pub forced_start: bool,
     /// Whether the reasoning markers require special-token preservation.
     pub preserve_special_tokens: bool,
+    /// Role label the tokenizer writes immediately after `start`, e.g. gemma4's
+    /// `thought\n` in `<|channel>thought\n`. Structural, and stripped from the
+    /// thought rather than emitted as reasoning text. `None` for families whose
+    /// opener carries no label.
+    pub start_label: Option<&'static str>,
 }
 
 /// Per-family hook: parse one complete invoke (opener..closer inclusive) into
@@ -429,6 +478,14 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         &self.spec.invoke_end
     }
 
+    pub(crate) fn invoke_start(&self) -> &str {
+        &self.spec.invoke_start
+    }
+
+    pub(crate) fn invoke_scan(&self) -> Option<InvokeScan> {
+        self.spec.invoke_scan
+    }
+
     /// Select whether this stream interprets reasoning markers, without
     /// rebuilding the scanner or cloning its tool schemas.
     pub(crate) fn set_reasoning_mode(&mut self, enabled: bool, forced_start: Option<bool>) {
@@ -520,14 +577,56 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         pending
     }
 
+    /// Whether one invoke closer also closes the surrounding block.
+    fn invoke_closes_block(&self) -> bool {
+        self.spec.block_ends.contains(&self.spec.invoke_end)
+    }
+
+    /// Find the next real invoke opener, applying the family hook when present.
+    fn find_invoke_start(&self, text: &str) -> Option<usize> {
+        let Some(scan) = self.spec.invoke_scan else {
+            return text.find(self.spec.invoke_start.as_str());
+        };
+        let mut cursor = 0;
+        while let Some(relative) = text[cursor..].find(self.spec.invoke_start.as_str()) {
+            let at = cursor + relative;
+            if (scan.opens)(text, at) {
+                return Some(at);
+            }
+            cursor = at + self.spec.invoke_start.len();
+        }
+        None
+    }
+
+    /// Offset just past the closer of the invoke beginning at byte zero.
+    fn invoke_end_at(&self, text: &str, flush: bool) -> Option<usize> {
+        match self.spec.invoke_scan {
+            Some(scan) => (scan.end)(text, flush),
+            None => text
+                .find(self.spec.invoke_end.as_str())
+                .map(|position| position + self.spec.invoke_end.len()),
+        }
+    }
+
+    /// Bytes a reasoning opener occupies at `at`, structural label included.
+    fn opener_len_at(&self, at: usize, flush: bool) -> Option<usize> {
+        let reasoning = self.reasoning.as_ref()?;
+        reasoning_opener_len(
+            reasoning.start,
+            reasoning.start_label,
+            &self.buffer[at + reasoning.start.len()..],
+            flush,
+        )
+    }
+
     /// Position and length of the reasoning opener in the buffer, if configured.
-    fn find_reasoning_start(&self) -> Option<(usize, usize)> {
+    fn find_reasoning_start(&self, flush: bool) -> Option<(usize, usize)> {
         if !self.reasoning_enabled {
             return None;
         }
         let reasoning = self.reasoning.as_ref()?;
         let pos = self.buffer.find(reasoning.start)?;
-        Some((pos, reasoning.start.len()))
+        Some((pos, self.opener_len_at(pos, flush)?))
     }
 
     /// Position and length of the earliest malformed close outside a block.
@@ -562,7 +661,35 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 marker_prefix_suffix_len(&self.buffer, [reasoning.start, reasoning.end])
             })
             .unwrap_or_default();
-        regular.max(reasoning)
+        let invoke = self
+            .spec
+            .invoke_scan
+            .map(|scan| (scan.holdback)(&self.buffer))
+            .unwrap_or_default();
+        regular
+            .max(reasoning)
+            .max(self.pending_label_len())
+            .max(invoke)
+    }
+
+    /// Retain a complete reasoning opener while its optional role label is only
+    /// partially buffered.
+    fn pending_label_len(&self) -> usize {
+        let Some(reasoning) = self.reasoning.as_ref().filter(|_| self.reasoning_enabled) else {
+            return 0;
+        };
+        let Some(label) = reasoning.start_label else {
+            return 0;
+        };
+        let Some(at) = self.buffer.rfind(reasoning.start) else {
+            return 0;
+        };
+        let rest = &self.buffer[at + reasoning.start.len()..];
+        if rest.len() < label.len() && label.starts_with(rest) {
+            self.buffer.len() - at
+        } else {
+            0
+        }
     }
 
     /// Consume buffered reasoning up to its closer, or as far as is safe.
@@ -598,9 +725,18 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         let tool_open = find_first(&self.buffer, &self.spec.block_starts)
             .map(|(pos, _)| pos)
             .into_iter()
-            .chain(self.buffer.find(self.spec.invoke_start.as_str()))
+            .chain(self.find_invoke_start(&self.buffer))
             .min();
-        let stray = stray_in_reasoning(&self.buffer, start, end, &self.spec.orphan_markers);
+        let duplicate_start = self
+            .buffer
+            .find(start)
+            .and_then(|pos| Some((pos, self.opener_len_at(pos, flush)?)));
+        let stray = stray_in_reasoning(
+            &self.buffer,
+            duplicate_start,
+            end,
+            &self.spec.orphan_markers,
+        );
 
         if let Some((at, what)) = earliest([
             self.buffer.find(end).map(|pos| (pos, InReasoning::Close)),
@@ -663,7 +799,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             }
 
             if self.in_block {
-                let invoke_start = self.buffer.find(self.spec.invoke_start.as_str());
+                let invoke_start = self.find_invoke_start(&self.buffer);
 
                 // Close the block once no more complete invokes precede its end.
                 if let Some((end_pos, end_len)) = find_first(&self.buffer, &self.spec.block_ends) {
@@ -698,7 +834,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     self.uncommitted_block.push_str(&self.buffer[..start]);
                     self.buffer.drain(..start);
                 }
-                let Some(end) = self.buffer.find(self.spec.invoke_end.as_str()) else {
+                let Some(end) = self.invoke_end_at(&self.buffer, flush) else {
                     if flush {
                         tracing::warn!(
                             why = %format!("{}_incomplete_invoke", self.spec.family),
@@ -727,14 +863,13 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     self.suppress_normal_text = false;
                     continue;
                 }
-                let invoke_len = end + self.spec.invoke_end.len();
-                let invoke = self.buffer[..invoke_len].to_string();
+                let invoke = self.buffer[..end].to_string();
                 // Emit BEFORE consuming. `parse_invoke` is fallible, and draining first
                 // meant a failing emitter destroyed the invoke bytes: they were gone from
                 // the buffer, so `reset` could no longer hand them back and the
                 // documented recovery contract was false for the only shipped family.
                 let emitted = self.emitter.parse_invoke(&invoke, self.next_index)?;
-                self.buffer.drain(..invoke_len);
+                self.buffer.drain(..end);
                 if let Some(delta) = emitted {
                     out.push_call(delta);
                     self.next_index += 1;
@@ -748,6 +883,12 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 if self.spec.invoke_latch == InvokeLatch::Always {
                     self.suppress_normal_text = true;
                 }
+                if self.invoke_closes_block() {
+                    self.uncommitted_block.clear();
+                    self.in_block = false;
+                    self.suppress_normal_text = false;
+                    self.in_reasoning = std::mem::take(&mut self.resume_reasoning);
+                }
                 continue;
             }
 
@@ -760,11 +901,11 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 let next_open = find_first(&self.buffer, &self.spec.block_starts)
                     .map(|(p, _)| p)
                     .into_iter()
-                    .chain(self.buffer.find(self.spec.invoke_start.as_str()))
+                    .chain(self.find_invoke_start(&self.buffer))
                     // A reasoning opener counts as an opener here, so the
                     // matching closer in `<think>a</think>` is not mistaken for
                     // an orphan and stripped.
-                    .chain(self.find_reasoning_start().map(|(p, _)| p))
+                    .chain(self.find_reasoning_start(flush).map(|(p, _)| p))
                     .min();
                 if next_open.is_none_or(|open| pos < open) {
                     if !self.suppress_normal_text && pos > 0 {
@@ -781,10 +922,9 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
             let next_marker = earliest([
                 find_first(&self.buffer, &self.spec.block_starts)
                     .map(|(pos, len)| (pos, Marker::Block(len))),
-                self.buffer
-                    .find(self.spec.invoke_start.as_str())
+                self.find_invoke_start(&self.buffer)
                     .map(|pos| (pos, Marker::BareInvoke)),
-                self.find_reasoning_start()
+                self.find_reasoning_start(flush)
                     .map(|(pos, len)| (pos, Marker::ReasoningStart(len))),
             ]);
 
@@ -828,7 +968,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 Marker::BareInvoke => {
                     // A bare invoke (no wrapper) is recovered only once its close
                     // has streamed; otherwise wait for more input.
-                    let Some(end) = self.buffer.find(self.spec.invoke_end.as_str()) else {
+                    let Some(end) = self.invoke_end_at(&self.buffer, flush) else {
                         if flush {
                             tracing::warn!(
                                 why = %format!("{}_incomplete_bare_invoke", self.spec.family),
@@ -838,11 +978,10 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                         }
                         break;
                     };
-                    let invoke_len = end + self.spec.invoke_end.len();
-                    let invoke = self.buffer[..invoke_len].to_string();
+                    let invoke = self.buffer[..end].to_string();
                     // Emit before consuming — same recovery contract as the wrapped site.
                     let emitted = self.emitter.parse_invoke(&invoke, self.next_index)?;
-                    self.buffer.drain(..invoke_len);
+                    self.buffer.drain(..end);
                     if let Some(delta) = emitted {
                         tracing::warn!(
                             why = %format!("{}_bare_invoke_recovery", self.spec.family),
@@ -908,6 +1047,7 @@ pub(crate) mod test_support {
                 bare_recovery_latch: BareRecoveryLatch::Set,
                 invoke_latch: InvokeLatch::IfEmitted,
                 drop_invoke_crossing_block_end: false,
+                invoke_scan: None,
                 preserve_special_tokens: true,
             },
             FailOnBoom,
@@ -1025,6 +1165,7 @@ mod tests {
             start: "<think>",
             end: "</think>",
             forced_start: true,
+            start_label: None,
             preserve_special_tokens: false,
         });
 

--- a/parsers/v2/src/unified/guided_cursor.rs
+++ b/parsers/v2/src/unified/guided_cursor.rs
@@ -1,0 +1,712 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Incremental lexer over one guided `required` tool-call payload.
+//!
+//! # Why this is one type
+//!
+//! Streaming a call before its payload has closed needs four facts that only a
+//! JSON lexer can answer: which call element the scan is inside, that element's
+//! decoded `name`, where its argument OBJECT begins, and which bytes of that
+//! object are safe to release. An earlier revision answered them with three
+//! independent `str::find` helpers, and each one was wrong in its own way —
+//! `"name"` was matched anywhere in the payload (so `{"x":"name","arguments":…}`
+//! emitted a call named `arguments`), `_` decoded to the literal characters
+//! `u005f`, the `parameters` alias was not recognised at all, and every helper
+//! rescanned the whole accumulated buffer on every push, making a
+//! character-at-a-time stream quadratic.
+//!
+//! Those are not four bugs, they are one: lexical state with no owner. This type
+//! is that owner. It holds the string/escape state, the brace depth, the current
+//! element index, the decoded name, and the released-byte offset in one place, and
+//! it advances strictly FORWARD — each call consumes only the bytes appended since
+//! the last one, so driving a payload one character at a time costs O(n) total.
+//!
+//! # What it deliberately does not do
+//!
+//! It does not validate. `parse_required_guided_calls` remains the only judge of
+//! whether a payload is a legal call set, and the completion path still runs it.
+//! The cursor's single question is narrower: *has enough arrived that a name and
+//! an argument OBJECT can no longer turn into something else?* Requiring the
+//! argument value to open with `{` is what makes that safe — a `null`, a string,
+//! a number or an array never reaches the commit point, so the shapes the
+//! contract voids are never put on the wire in the first place.
+
+use crate::tool_calling::traits::ToolCallDelta;
+
+/// The two spellings a required-choice call may use for its argument object.
+///
+/// Both are accepted by `parse_required_guided_calls`; a call carrying BOTH is
+/// ambiguous and that function voids it. The cursor has to know both spellings for
+/// the same reason — recognising only `arguments` silently streamed nothing for a
+/// `parameters` call, and the assembled result arrived with empty arguments.
+const ARGUMENT_ALIASES: [&str; 2] = ["arguments", "parameters"];
+
+/// Where the scanner sits inside a call object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Slot {
+    /// Between `{` or `,` and the next key.
+    Key,
+    /// A key literal closed; waiting for its `:`.
+    Colon,
+    /// Past the `:`; the next token is that key's value.
+    Value,
+}
+
+/// A call the cursor has already put on the wire.
+///
+/// `released` is a byte count into the call's RAW argument object — the same bytes
+/// `parse_required_guided_calls` will later hand back as that call's arguments — so
+/// the completion path can emit exactly the remainder without re-deriving spans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommittedCall {
+    pub index: usize,
+    pub name: String,
+    pub released: usize,
+    /// A second argument alias appeared AFTER this call was committed.
+    ///
+    /// `parse_required_guided_calls` voids an ambiguous call, but this one is
+    /// already on the wire and a fragment cannot be unsaid. The completion path
+    /// warns rather than pretending it can retract.
+    pub ambiguous: bool,
+}
+
+/// Per-element scan state, reset at every call boundary.
+#[derive(Debug, Default, Clone)]
+struct Element {
+    name: Option<String>,
+    /// Offset of the `{` opening the argument object.
+    args_start: Option<usize>,
+    /// Offset just past the argument object's `}`, once it closed.
+    args_end: Option<usize>,
+    /// The scan is inside the argument object right now.
+    in_args: bool,
+    /// Both aliases appeared.
+    ambiguous: bool,
+    /// An alias appeared whose value was not an object.
+    ///
+    /// Blocks the commit even if the OTHER alias later supplies a good object:
+    /// that shape is ambiguous too, and the buffered path voids it correctly.
+    non_object_alias: bool,
+    committed: bool,
+    /// Bytes of the argument object already released, relative to `args_start`.
+    released: usize,
+}
+
+/// Forward-only lexer over one guided payload.
+#[derive(Debug)]
+pub(crate) struct GuidedJsonCursor {
+    /// Bytes already lexed. The scan never revisits them.
+    scanned: usize,
+    depth: i32,
+    in_string: bool,
+    escaped: bool,
+    /// Opening quote of a key or name literal the cursor needs. The raw slice is
+    /// decoded once, when its closing quote arrives; JSON escape semantics stay
+    /// owned by `serde_json`.
+    literal_start: Option<usize>,
+    /// Depth at which a call object's keys sit: 2 under an array root, 1 under a
+    /// bare object root.
+    key_depth: i32,
+    root_seen: bool,
+    /// The payload does not open as a call shape, so nothing may ever commit.
+    disabled: bool,
+    slot: Slot,
+    pending_key: Option<String>,
+    element: Element,
+    index: usize,
+    committed: Vec<CommittedCall>,
+}
+
+impl Default for GuidedJsonCursor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GuidedJsonCursor {
+    pub(crate) fn new() -> Self {
+        Self {
+            scanned: 0,
+            depth: 0,
+            in_string: false,
+            escaped: false,
+            literal_start: None,
+            key_depth: 1,
+            root_seen: false,
+            disabled: false,
+            slot: Slot::Key,
+            pending_key: None,
+            element: Element::default(),
+            index: 0,
+            committed: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    /// Calls already on the wire, in emission order.
+    pub(crate) fn committed(&self) -> &[CommittedCall] {
+        &self.committed
+    }
+
+    pub(crate) fn has_committed(&self) -> bool {
+        !self.committed.is_empty()
+    }
+
+    /// Lex the bytes appended since the last advance, emitting whatever became
+    /// safe to commit.
+    ///
+    /// `payload` is the WHOLE accumulated payload, not just the new chunk — the
+    /// cursor slices it from `scanned`, so the caller does not have to track which
+    /// bytes it has already handed over.
+    pub(crate) fn advance(&mut self, payload: &str, out: &mut Vec<ToolCallDelta>) {
+        if self.disabled || payload.len() <= self.scanned {
+            // Truncation (a reset mid-stream) would make the retained offsets lie.
+            // The caller resets the cursor with the payload; nothing to do here.
+            return;
+        }
+
+        let mut cut = self.scanned;
+        for (relative, ch) in payload[self.scanned..].char_indices() {
+            let at = self.scanned + relative;
+            cut = at + ch.len_utf8();
+            self.step(payload, at, cut, ch, out);
+            if self.disabled {
+                break;
+            }
+        }
+        self.scanned = cut;
+        self.maybe_commit(out);
+        self.flush(payload, cut, out);
+    }
+
+    /// One character of the lex. `cut` is the offset just past `ch`, so a flush
+    /// triggered mid-advance still sees the bytes this character contributed.
+    fn step(
+        &mut self,
+        payload: &str,
+        at: usize,
+        cut: usize,
+        ch: char,
+        out: &mut Vec<ToolCallDelta>,
+    ) {
+        if self.in_string {
+            self.step_in_string(payload, at, ch);
+            return;
+        }
+
+        match ch {
+            '"' => {
+                if !self.root_seen {
+                    // A required payload opens with `[` or `{`; a bare string is not
+                    // a call shape and the buffered path owns it.
+                    self.disabled = true;
+                    return;
+                }
+                self.in_string = true;
+                // Capture only the literals the cursor needs: every key at call-key
+                // depth, and the `name` value. Capturing every string in the payload
+                // would allocate once per argument value for nothing.
+                let wanted = self.depth == self.key_depth
+                    && match self.slot {
+                        Slot::Key => true,
+                        Slot::Value => self.pending_key.as_deref() == Some("name"),
+                        Slot::Colon => false,
+                    };
+                self.literal_start = wanted.then_some(at);
+            }
+            '{' | '[' => {
+                if !self.root_seen {
+                    self.root_seen = true;
+                    self.key_depth = if ch == '[' { 2 } else { 1 };
+                }
+                let opening_args = ch == '{'
+                    && self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && self.is_alias(self.pending_key.as_deref());
+                let starts_element = self.depth == self.key_depth - 1 && ch == '{';
+                self.depth += 1;
+                if opening_args {
+                    if self.element.args_start.is_some() {
+                        self.element.ambiguous = true;
+                    } else {
+                        self.element.args_start = Some(at);
+                        self.element.in_args = true;
+                    }
+                } else if starts_element {
+                    self.slot = Slot::Key;
+                    self.pending_key = None;
+                } else if self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && self.pending_key.as_deref() == Some("name")
+                {
+                    // `"name"` bound to a non-string: never commits.
+                    self.element.non_object_alias = true;
+                }
+                self.maybe_commit(out);
+            }
+            '}' | ']' => {
+                let closing_args =
+                    self.element.in_args && self.depth == self.key_depth + 1 && ch == '}';
+                let closes_element = self.depth == self.key_depth && ch == '}';
+                self.depth -= 1;
+                if closing_args {
+                    self.element.args_end = Some(at + 1);
+                    self.element.in_args = false;
+                    self.maybe_commit(out);
+                    self.flush(payload, cut, out);
+                } else if closes_element {
+                    // A name that closed AFTER its arguments only becomes committable
+                    // here, so commit before the final flush or its bytes are lost
+                    // with the element.
+                    self.maybe_commit(out);
+                    self.flush(payload, at, out);
+                    self.finish_element();
+                }
+            }
+            ':' if self.depth == self.key_depth && self.slot == Slot::Colon => {
+                self.slot = Slot::Value;
+            }
+            ',' if self.depth == self.key_depth => {
+                self.slot = Slot::Key;
+                self.pending_key = None;
+            }
+            _ if ch.is_whitespace() => {}
+            _ => {
+                if !self.root_seen {
+                    self.disabled = true;
+                    return;
+                }
+                if self.depth == self.key_depth && self.slot == Slot::Value {
+                    // A bare literal (`null`, a number, `true`) bound to an argument
+                    // alias or to `name`: neither can ever become an object, so this
+                    // element must stay on the buffered path.
+                    if self.is_alias(self.pending_key.as_deref())
+                        || self.pending_key.as_deref() == Some("name")
+                    {
+                        self.element.non_object_alias = true;
+                    }
+                }
+            }
+        }
+    }
+
+    /// One character while inside a string literal.
+    fn step_in_string(&mut self, payload: &str, at: usize, ch: char) {
+        if self.escaped {
+            self.escaped = false;
+            return;
+        }
+        match ch {
+            '\\' => self.escaped = true,
+            '"' => {
+                self.in_string = false;
+                self.close_literal(payload, at);
+            }
+            _ => {}
+        }
+    }
+
+    /// A captured literal closed: it is either this element's key or its name.
+    fn close_literal(&mut self, payload: &str, end: usize) {
+        let Some(start) = self.literal_start.take() else {
+            return;
+        };
+        let Ok(literal) = serde_json::from_str::<String>(&payload[start..=end]) else {
+            return;
+        };
+        match self.slot {
+            Slot::Key => {
+                if self.is_alias(Some(literal.as_str())) && self.element.args_start.is_some() {
+                    self.element.ambiguous = true;
+                }
+                self.pending_key = Some(literal);
+                self.slot = Slot::Colon;
+            }
+            Slot::Value => {
+                if self.pending_key.as_deref() == Some("name") {
+                    self.element.name = Some(literal);
+                }
+            }
+            Slot::Colon => {}
+        }
+    }
+
+    fn is_alias(&self, key: Option<&str>) -> bool {
+        key.is_some_and(|key| ARGUMENT_ALIASES.contains(&key))
+    }
+
+    /// Put the current element on the wire once it can no longer change shape.
+    ///
+    /// Both facts are required: the name has closed, AND the argument value has
+    /// been seen to open with `{`. Committing on the name alone is what let a
+    /// `null`, a string and a non-object argument set reach the caller as calls the
+    /// contract says must become text.
+    fn maybe_commit(&mut self, out: &mut Vec<ToolCallDelta>) {
+        if self.element.committed
+            || self.element.ambiguous
+            || self.element.non_object_alias
+            || self.element.args_start.is_none()
+        {
+            return;
+        }
+        let Some(name) = self.element.name.clone() else {
+            return;
+        };
+        self.element.committed = true;
+        self.committed.push(CommittedCall {
+            index: self.index,
+            name: name.clone(),
+            released: 0,
+            ambiguous: false,
+        });
+        out.push(ToolCallDelta {
+            tool_index: self.index,
+            name: Some(name),
+            arguments: String::new(),
+        });
+    }
+
+    /// Release argument bytes the current element has accumulated since the last
+    /// fragment.
+    fn flush(&mut self, payload: &str, cut: usize, out: &mut Vec<ToolCallDelta>) {
+        if !self.element.committed {
+            return;
+        }
+        let Some(start) = self.element.args_start else {
+            return;
+        };
+        // Never past the argument object's own close: the bytes after it belong to
+        // the call envelope, not to the arguments.
+        let bound = self.element.args_end.unwrap_or(cut).min(cut);
+        let from = start + self.element.released;
+        if bound <= from {
+            return;
+        }
+        let fragment = payload[from..bound].to_string();
+        self.element.released = bound - start;
+        if let Some(record) = self.committed.last_mut() {
+            record.released = self.element.released;
+            record.ambiguous = self.element.ambiguous;
+        }
+        out.push(ToolCallDelta {
+            tool_index: self.index,
+            name: None,
+            arguments: fragment,
+        });
+    }
+
+    /// The current call object closed; move to the next element.
+    fn finish_element(&mut self) {
+        if self.element.committed
+            && let Some(record) = self.committed.last_mut()
+        {
+            record.ambiguous = self.element.ambiguous;
+        }
+        // ALWAYS advance, including for an element the cursor could not commit. The
+        // index is the element's position in the payload array, and the completion
+        // path matches committed records against `serde`'s element order — skipping
+        // an uncommittable element here would slide every later call onto the wrong
+        // index.
+        self.index += 1;
+        self.element = Element::default();
+        self.slot = Slot::Key;
+        self.pending_key = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a payload one character at a time and collect every delta.
+    fn stream(payload: &str) -> Vec<ToolCallDelta> {
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for ch in payload.chars() {
+            seen.push(ch);
+            cursor.advance(&seen, &mut out);
+        }
+        out
+    }
+
+    /// Names carried, in order.
+    fn names(deltas: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        deltas
+            .iter()
+            .filter_map(|d| d.name.clone().map(|n| (d.tool_index, n)))
+            .collect()
+    }
+
+    /// Argument bytes reassembled per tool index.
+    fn arguments(deltas: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        let mut joined: Vec<(usize, String)> = Vec::new();
+        for delta in deltas {
+            if delta.arguments.is_empty() {
+                continue;
+            }
+            match joined
+                .iter_mut()
+                .find(|(index, _)| *index == delta.tool_index)
+            {
+                Some((_, text)) => text.push_str(&delta.arguments),
+                None => joined.push((delta.tool_index, delta.arguments.clone())),
+            }
+        }
+        joined
+    }
+
+    #[test]
+    fn a_name_key_is_a_key_not_any_occurrence_of_the_word() {
+        // The old `str::find("\"name\"")` matched this VALUE and then read the next
+        // string as the function name, emitting a call named `arguments`.
+        let deltas = stream(r#"[{"x":"name","arguments":{"city":"Paris"}}]"#);
+        assert_eq!(names(&deltas), Vec::<(usize, String)>::new());
+        assert!(
+            arguments(&deltas).is_empty(),
+            "a nameless element must not stream"
+        );
+    }
+
+    #[test]
+    fn escaped_names_decode() {
+        // NOT a raw literal: the payload must carry the six characters
+        // `_`, which JSON decodes to `_`. The old decoder pushed the
+        // escape's payload characters verbatim and produced `getu005fweather`.
+        let payload = "[{\"name\":\"get\\u005fweather\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\u005f"),
+            "the escape must survive to the test"
+        );
+        assert_eq!(
+            names(&stream(payload)),
+            vec![(0, "get_weather".to_string())]
+        );
+
+        let deltas = stream(r#"[{"name":"a\"b\\c\nd","arguments":{}}]"#);
+        assert_eq!(names(&deltas), vec![(0, "a\"b\\c\nd".to_string())]);
+    }
+
+    #[test]
+    fn surrogate_pairs_decode_to_one_character() {
+        // Escaped, as a JSON encoder outside the BMP actually emits it. Decoding
+        // each half alone yields two replacement characters.
+        let payload = "[{\"name\":\"a\\ud83d\\ude00b\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\ud83d"),
+            "the escape must survive to the test"
+        );
+        assert_eq!(
+            names(&stream(payload)),
+            vec![(0, "a\u{1F600}b".to_string())]
+        );
+    }
+
+    #[test]
+    fn the_parameters_alias_streams_too() {
+        let deltas = stream(r#"[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Tokyo"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn parallel_calls_get_distinct_indices() {
+        let deltas =
+            stream(r#"[{"name":"a","arguments":{"x":1}},{"name":"b","arguments":{"y":2}}]"#);
+        assert_eq!(
+            names(&deltas),
+            vec![(0, "a".to_string()), (1, "b".to_string())]
+        );
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"x":1}"#.to_string()), (1, r#"{"y":2}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn arguments_reassemble_byte_for_byte_at_every_split() {
+        let payload = r#"[{"name":"f","arguments":{"a":"x y","b":[1,2],"c":{"d":"}"}}}]"#;
+        let expected = r#"{"a":"x y","b":[1,2],"c":{"d":"}"}}"#;
+        let deltas = stream(payload);
+        assert_eq!(arguments(&deltas), vec![(0, expected.to_string())]);
+    }
+
+    #[test]
+    fn a_brace_inside_an_argument_string_does_not_close_the_object() {
+        let deltas = stream(r#"[{"name":"f","arguments":{"s":"}}]"}}]"#);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"s":"}}]"}"#.to_string())]);
+    }
+
+    #[test]
+    fn non_object_arguments_never_commit() {
+        for payload in [
+            r#"[{"name":"f","arguments":"just a string"}]"#,
+            r#"[{"name":"f","arguments":null}]"#,
+            r#"[{"name":"f","arguments":[1,2]}]"#,
+            r#"[{"name":"f","arguments":7}]"#,
+        ] {
+            let deltas = stream(payload);
+            assert!(
+                deltas.is_empty(),
+                "{payload} committed a call the contract voids: {deltas:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_parameterless_call_stays_on_the_buffered_path() {
+        // No argument key at all means no arguments, which is VALID — but there is
+        // no object opener to commit on, so the buffered path emits it with `{}`.
+        let deltas = stream(r#"[{"name":"f"}]"#);
+        assert!(deltas.is_empty());
+    }
+
+    #[test]
+    fn both_aliases_present_never_commits() {
+        let deltas = stream(r#"[{"name":"f","arguments":{"a":1},"parameters":{"b":2}}]"#);
+        assert!(
+            names(&deltas).is_empty() || deltas.iter().all(|d| d.tool_index == 0),
+            "ambiguity must not produce a second call"
+        );
+    }
+
+    #[test]
+    fn a_name_after_its_arguments_still_commits() {
+        let deltas = stream(r#"[{"arguments":{"city":"Paris"},"name":"get_weather"}]"#);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn a_bare_object_payload_is_one_call() {
+        let deltas = stream(r#"{"name":"f","arguments":{"x":1}}"#);
+        assert_eq!(names(&deltas), vec![(0, "f".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"x":1}"#.to_string())]);
+    }
+
+    #[test]
+    fn a_non_call_payload_disables_the_cursor() {
+        assert!(stream(r#""just a string""#).is_empty());
+        assert!(stream("42").is_empty());
+    }
+
+    /// Byte at which the first name-carrying delta appeared, feeding one character
+    /// at a time.
+    fn name_arrives_at(payload: &str) -> usize {
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for (index, ch) in payload.char_indices() {
+            seen.push(ch);
+            let before = out.len();
+            cursor.advance(&seen, &mut out);
+            if out[before..].iter().any(|d| d.name.is_some()) {
+                return index;
+            }
+        }
+        panic!("no name delta for {payload:?}");
+    }
+
+    #[test]
+    fn the_name_lands_at_the_argument_opener_not_at_the_close() {
+        // The commit point IS the `{` that opens the arguments — that is what makes
+        // a non-object argument set unstreamable. So the win is not a fixed
+        // fraction of the payload; it is everything the model still has to generate
+        // AFTER that brace, which is the whole argument body.
+        let payload = r#"[{"name":"get_weather","arguments":{"city":"Paris"}}]"#;
+        let opener = payload
+            .find(r#""arguments":{"#)
+            .expect("an argument opener")
+            + r#""arguments":"#.len();
+        assert_eq!(name_arrives_at(payload), opener);
+        assert!(name_arrives_at(payload) < payload.len() - 1);
+    }
+
+    #[test]
+    fn a_large_argument_body_is_almost_entirely_streamed() {
+        // The reported shape: a call whose arguments take seconds to generate. The
+        // buffered path emits nothing until the final byte; here the name is out
+        // after the first few percent and the body follows as fragments.
+        let body: String = (0..200)
+            .map(|i| format!(r#""k{i}":"v{i}","#))
+            .collect::<String>();
+        let payload = format!(r#"[{{"name":"f","arguments":{{{body}"last":"x"}}}}]"#);
+        let at = name_arrives_at(&payload);
+        assert!(
+            at * 20 < payload.len(),
+            "name arrived at byte {at} of {} — over 5% of the payload",
+            payload.len()
+        );
+
+        // And the body really does arrive in pieces, not one burst.
+        let deltas = stream(&payload);
+        let frames = deltas.iter().filter(|d| !d.arguments.is_empty()).count();
+        assert!(frames > 100, "arguments arrived in {frames} frame(s)");
+    }
+
+    #[test]
+    fn multi_byte_argument_content_is_never_split_mid_character() {
+        let payload = r#"[{"name":"f","arguments":{"city":"東京","emoji":"😀"}}]"#;
+        let deltas = stream(payload);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"東京","emoji":"😀"}"#.to_string())]
+        );
+        for delta in &deltas {
+            assert!(std::str::from_utf8(delta.arguments.as_bytes()).is_ok());
+        }
+    }
+
+    #[test]
+    fn whole_input_and_every_split_agree() {
+        let payload = r#"[{"name":"a","arguments":{"x":"1"}},{"name":"b","arguments":{"y":"2"}}]"#;
+        let whole = {
+            let mut cursor = GuidedJsonCursor::new();
+            let mut out = Vec::new();
+            cursor.advance(payload, &mut out);
+            out
+        };
+        let per_char = stream(payload);
+        assert_eq!(names(&whole), names(&per_char));
+        assert_eq!(arguments(&whole), arguments(&per_char));
+
+        for split in 1..payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let mut cursor = GuidedJsonCursor::new();
+            let mut out = Vec::new();
+            cursor.advance(&payload[..split], &mut out);
+            cursor.advance(payload, &mut out);
+            assert_eq!(names(&out), names(&whole), "names differ at split {split}");
+            assert_eq!(
+                arguments(&out),
+                arguments(&whole),
+                "arguments differ at split {split}"
+            );
+        }
+    }
+
+    #[test]
+    fn committed_records_track_released_bytes() {
+        let payload = r#"[{"name":"f","arguments":{"x":1}}]"#;
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        let committed = cursor.committed();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].index, 0);
+        assert_eq!(committed[0].name, "f");
+        assert_eq!(committed[0].released, r#"{"x":1}"#.len());
+    }
+}

--- a/parsers/v2/src/unified/guided_cursor.rs
+++ b/parsers/v2/src/unified/guided_cursor.rs
@@ -116,6 +116,10 @@ pub(crate) struct GuidedJsonCursor {
     element: Element,
     index: usize,
     committed: Vec<CommittedCall>,
+    /// Absolute end, in the fed payload's coordinates, of the last byte released
+    /// as a call fragment. Recovery may only emit bytes at or after this offset:
+    /// anything before it is already on the wire and cannot be unsaid.
+    released_end: usize,
 }
 
 impl Default for GuidedJsonCursor {
@@ -140,6 +144,7 @@ impl GuidedJsonCursor {
             element: Element::default(),
             index: 0,
             committed: Vec::new(),
+            released_end: 0,
         }
     }
 
@@ -154,6 +159,12 @@ impl GuidedJsonCursor {
 
     pub(crate) fn has_committed(&self) -> bool {
         !self.committed.is_empty()
+    }
+
+    /// Absolute end of the bytes already released as call fragments, in the
+    /// coordinates of the payload passed to [`Self::advance`].
+    pub(crate) fn released_end(&self) -> usize {
+        self.released_end
     }
 
     /// Lex the bytes appended since the last advance, emitting whatever became
@@ -388,6 +399,7 @@ impl GuidedJsonCursor {
         }
         let fragment = payload[from..bound].to_string();
         self.element.released = bound - start;
+        self.released_end = self.released_end.max(bound);
         if let Some(record) = self.committed.last_mut() {
             record.released = self.element.released;
             record.ambiguous = self.element.ambiguous;

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -48,9 +48,12 @@
 //! adopted without a translation layer. Where it diverges from the peer shape, the
 //! divergence is stated at the item.
 
+mod guided_cursor;
 pub mod qwen3;
 
 use std::collections::BTreeMap;
+
+use guided_cursor::GuidedJsonCursor;
 
 use serde::{Deserialize, Serialize};
 
@@ -125,6 +128,29 @@ pub enum UnifiedToolOutputMode {
 }
 
 /// Caller policy when guided decoding violates the promised tool-call shape.
+///
+/// The three values are three different contracts, not three settings of one. Each
+/// states what the caller gets when the payload turns out malformed, and that
+/// answer is what decides whether the parser may stream:
+///
+/// | policy | malformed payload becomes | emits before the payload closes |
+/// |---|---|---|
+/// | [`Reject`](Self::Reject) | a typed error | no |
+/// | [`RecoverAsText`](Self::RecoverAsText) | text; an array voids ATOMICALLY | no |
+/// | [`StreamBestEffort`](Self::StreamBestEffort) | text, PER CALL | yes |
+///
+/// # Why streaming needed its own policy rather than a flag
+///
+/// A fragment cannot be unsaid. `Reject` promises an error, and that promise is
+/// only keepable while nothing has been emitted. `RecoverAsText` promises that if
+/// ANY element of a call array is invalid the WHOLE array surfaces as text — and
+/// nothing can know element one is safe until element N has arrived. Both promises
+/// are therefore incompatible with emitting early, and an earlier revision that
+/// streamed under `RecoverAsText` did not weaken it visibly; it simply started
+/// dispatching calls the contract says must become text.
+///
+/// So streaming is a THIRD contract that callers opt into, and the two existing
+/// ones behave exactly as they did before.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum InvalidGuidedPayloadPolicy {
     /// Return a typed error so the serving layer can reject or retry the output.
@@ -132,6 +158,20 @@ pub enum InvalidGuidedPayloadPolicy {
     Reject,
     /// Preserve the corpus' best-effort behavior by surfacing the bytes as text.
     RecoverAsText,
+    /// Stream each call as soon as its name and argument OBJECT are unambiguous.
+    ///
+    /// What the caller trades away, stated plainly:
+    ///
+    /// - A call already on the wire cannot later become recovery text. If a second
+    ///   argument alias appears after the call went out, it is logged, not undone.
+    /// - Recovery is PER CALL. One invalid element of an array surfaces as text on
+    ///   its own; the valid elements around it still dispatch. Under
+    ///   [`RecoverAsText`](Self::RecoverAsText) the whole array would have voided.
+    ///
+    /// What it keeps: the commit point requires the argument value to open with
+    /// `{`, so `null`, a string, a number, an array, and a parameterless call never
+    /// reach the wire early and are still judged by the buffered path.
+    StreamBestEffort,
 }
 
 /// Fully resolved request-scoped parser configuration.
@@ -895,6 +935,12 @@ struct GuidedState {
     /// Visible post-payload text has started. Structural whitespace immediately
     /// after JSON may be discarded, but whitespace after visible text is content.
     post_payload_text_started: bool,
+    /// The single owner of JSON lexical state for the streaming path.
+    ///
+    /// Idle unless [`InvalidGuidedPayloadPolicy::StreamBestEffort`] is in force —
+    /// the other two contracts buffer to completion, so under them this never
+    /// advances and the completion path below is unchanged.
+    cursor: GuidedJsonCursor,
     input: String,
     json: String,
 }
@@ -1199,6 +1245,7 @@ impl GuidedState {
                 == UnifiedParserStartingState::Reasoning,
             payload_emitted: false,
             post_payload_text_started: false,
+            cursor: GuidedJsonCursor::new(),
             input: String::new(),
             json: String::new(),
         }
@@ -1219,6 +1266,14 @@ impl GuidedState {
             self.input.push_str(chunk);
         }
         for event in self.drain(false) {
+            output.push_event(event);
+        }
+        // Release whatever the payload now lets us commit to, BEFORE the
+        // completion check: the name is usually knowable long before the closing
+        // brace, and holding it until then is the reported latency defect.
+        let mut incremental = Vec::new();
+        self.emit_incremental(&mut incremental);
+        for event in incremental {
             output.push_event(event);
         }
         for event in self.emit_completed_json()? {
@@ -1270,6 +1325,7 @@ impl GuidedState {
         self.stripped_markup = false;
         self.payload_emitted = false;
         self.post_payload_text_started = false;
+        self.cursor.reset();
         recovered
     }
 
@@ -1310,6 +1366,27 @@ impl GuidedState {
         let uncommitted_suffix = self.json[payload_end..].to_string();
         let tail = self.json[tail_start..].to_string();
         self.json.truncate(payload_end);
+        // Streaming already put one or more calls on the wire. Re-emitting them from
+        // the assembled path would duplicate the name and let `assemble` overwrite
+        // the streamed arguments with a second value, so this branch flushes the
+        // argument bytes still owed and then settles only what was NOT streamed.
+        if self.cursor.has_committed() {
+            let mut out = Vec::new();
+            self.emit_incremental(&mut out);
+            out.extend(self.finish_streamed_remainder());
+            // The buffered paths below all clear `json` before returning; this branch
+            // did not, so the payload stayed in the buffer and was emitted a SECOND
+            // time as visible text on the next advance.
+            self.json.clear();
+            // Same bookkeeping the assembled path does below: mark the payload done,
+            // leave guided-payload mode, and hand the tail back as ordinary input so
+            // trailing visible text is still emitted. Skipping this dropped the text
+            // after the call entirely.
+            self.payload_emitted = true;
+            self.mode = GuidedMode::OutsideReasoning;
+            self.input.push_str(&tail);
+            return Ok(out);
+        }
         let mut output = match self.finish_json() {
             Ok(output) => output,
             Err(error) => {
@@ -1683,6 +1760,119 @@ impl GuidedState {
         output
     }
 
+    /// Emit whatever the accumulated payload lets us commit to, incrementally.
+    ///
+    /// Policy A, the "commit point": the first thing released is the function name,
+    /// and only once its JSON string value has CLOSED — at that instant the name can
+    /// no longer change and the payload is known to be shaped like a call. Before
+    /// that nothing is emitted, so `InvalidGuidedPayloadPolicy::Reject` can still
+    /// fire on a payload that never gets there.
+    ///
+    /// After the name is committed, argument bytes are released as they arrive. Only
+    /// the bytes already accumulated are released, and only on a character boundary,
+    /// so a fragment is never half a UTF-8 codepoint and never has to be taken back.
+    /// Settle the elements streaming did NOT put on the wire.
+    ///
+    /// Recovery here is PER CALL, which is the difference
+    /// [`InvalidGuidedPayloadPolicy::StreamBestEffort`] declares: an element that is
+    /// not a legal call becomes its own recovery text, while the valid elements
+    /// around it still dispatch. The atomic contract would have voided all of them
+    /// together, and cannot be offered once a fragment is already out.
+    fn finish_streamed_remainder(&mut self) -> Vec<UnifiedParserEvent> {
+        let payload = self.json.trim().to_string();
+        let mut out = Vec::new();
+        let Some(elements) = parse_required_guided_elements(&payload) else {
+            // Not even splittable into elements. Whatever was streamed stays
+            // streamed; the rest is recovery text.
+            tracing::warn!(
+                why = "unified_guided_json_not_a_tool_call",
+                choice = "required",
+                payload_bytes = payload.len(),
+                payload_kind = json_payload_kind(&payload),
+                streamed_calls = self.cursor.committed().len(),
+                "guided output did not parse as a tool call after fragments were \
+                 already emitted; emitting the remainder as text"
+            );
+            out.push(UnifiedParserEvent::Text(payload));
+            return out;
+        };
+
+        for (index, element) in elements.into_iter().enumerate() {
+            let streamed = self
+                .cursor
+                .committed()
+                .iter()
+                .find(|committed| committed.index == index);
+            match (element.call, streamed) {
+                // Already on the wire; its fragments carried name and arguments.
+                (Some(_), Some(committed)) => {
+                    if committed.ambiguous {
+                        tracing::warn!(
+                            why = "unified_guided_call_became_ambiguous_after_commit",
+                            tool_index = index,
+                            name = %committed.name,
+                            "a second argument alias appeared after this call was \
+                             streamed; it cannot be withdrawn"
+                        );
+                    }
+                }
+                // Valid but never committed — a parameterless call, or one whose
+                // name closed too late to beat its own payload.
+                (Some(call), None) => {
+                    out.push(UnifiedParserEvent::ToolCall(ToolCallDelta {
+                        tool_index: index,
+                        name: Some(call.name),
+                        arguments: call.arguments,
+                    }));
+                }
+                // Invalid, and nothing went out for it: recover just this element.
+                (None, None) => {
+                    tracing::warn!(
+                        why = "unified_guided_element_is_not_a_tool_call",
+                        tool_index = index,
+                        element_bytes = element.raw.len(),
+                        "guided element is not a legal call; emitting it as text"
+                    );
+                    out.push(UnifiedParserEvent::Text(element.raw));
+                }
+                // Invalid, but already streamed. A fragment cannot be unsaid.
+                (None, Some(committed)) => {
+                    tracing::warn!(
+                        why = "unified_guided_streamed_call_failed_validation",
+                        tool_index = index,
+                        name = %committed.name,
+                        "this call was streamed before it could be judged invalid; \
+                         it stays on the wire"
+                    );
+                }
+            }
+        }
+        out
+    }
+
+    /// Drive the cursor over the payload accumulated so far.
+    ///
+    /// Under the two buffering contracts this is a no-op, so their behaviour is
+    /// byte-identical to before the streaming path existed.
+    fn emit_incremental(&mut self, output: &mut Vec<UnifiedParserEvent>) {
+        if self.invalid_payload != InvalidGuidedPayloadPolicy::StreamBestEffort {
+            return;
+        }
+        // A named choice's payload is BARE arguments: there is no
+        // `{"name": .., "arguments": ..}` envelope for the cursor to find a name or
+        // an object opener in. Its name is known from the request before any byte
+        // arrives, so it needs its own commit rule rather than this one, and until
+        // that exists it stays on the buffered path.
+        if self.named_tool.is_some() {
+            return;
+        }
+        let mut deltas = Vec::new();
+        self.cursor.advance(&self.json, &mut deltas);
+        for delta in deltas {
+            output.push(UnifiedParserEvent::ToolCall(delta));
+        }
+    }
+
     /// Parse the accumulated payload. Anything that does not parse as the
     /// expected call shape is surfaced as visible text rather than dropped
     /// (policy P2 — best-effort recovery, never silent loss).
@@ -1759,7 +1949,10 @@ impl GuidedState {
                         "named-choice payload carries `name` plus `arguments`/`parameters`; forwarding it verbatim as the argument set"
                     );
                 }
-                vec![(name.clone(), raw_payload.clone())]
+                vec![GuidedCall {
+                    name: name.clone(),
+                    arguments: raw_payload.clone(),
+                }]
             }),
             None => parse_required_guided_calls(payload),
         };
@@ -1811,61 +2004,104 @@ impl GuidedState {
         Ok(calls
             .into_iter()
             .enumerate()
-            .map(|(tool_index, (name, arguments))| {
+            .map(|(tool_index, call)| {
                 UnifiedParserEvent::ToolCall(ToolCallDelta {
                     tool_index,
-                    name: Some(name),
-                    arguments,
+                    name: Some(call.name),
+                    arguments: call.arguments,
                 })
             })
             .collect())
     }
 }
 
+/// One judged call: its decoded function name, and its argument object as raw JSON
+/// text (never re-serialized, so argument bytes reach the caller verbatim).
+struct GuidedCall {
+    name: String,
+    arguments: String,
+}
+
+/// One element of a required payload: the call it judges to (`None` when the
+/// element is not a legal call), paired with that element's raw bytes for recovery.
+struct GuidedElement {
+    call: Option<GuidedCall>,
+    raw: String,
+}
+
+/// Judge ONE required-choice call element.
+///
+/// The single implementation of what makes a call legal, shared by the atomic
+/// whole-array path ([`parse_required_guided_calls`]) and the per-call path the
+/// streaming contract uses ([`parse_required_guided_elements`]). Two copies of this
+/// judgement would let the two recovery modes disagree about the same bytes.
+fn convert_guided_call(call: GuidedToolCall) -> Option<GuidedCall> {
+    // No argument key means NO ARGUMENTS, not a malformed call. `UNIFIED.6.a`
+    // already fixes that semantic on the native path — same tool, no parameter
+    // block, golden `arguments: {}` — so voiding it here made guided disagree with
+    // native on an identical shape and made a parameterless tool uncallable. What
+    // makes an element invalid is a missing `name` (required on GuidedToolCall);
+    // that still voids the whole array, per `31.c` / `51.b`.
+    let arguments = match (call.parameters, call.arguments) {
+        // PRESENT but not an object is a malformed call, the same judgement the
+        // NAMED path makes on its whole payload: arguments that are a string or
+        // a number cannot bind to the tool's parameters, so emitting it would
+        // hand the tool a shape it cannot use. Absent is different — that means
+        // no arguments, and stays valid (see the note above).
+        (Some(raw), None) | (None, Some(raw)) => {
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get()).ok()?;
+            raw.get().to_string()
+        }
+        (None, None) => "{}".to_string(),
+        // The aliases are alternatives, not two independently meaningful
+        // argument sets. Choosing one silently can emit different bytes from
+        // what the backend intended, so reject the ambiguous call fail-closed.
+        (Some(_), Some(_)) => return None,
+    };
+    Some(GuidedCall {
+        name: call.name,
+        arguments,
+    })
+}
+
 /// A required (un-named) choice emits one call object or an array of them.
-fn parse_required_guided_calls(payload: &str) -> Option<Vec<(String, String)>> {
-    fn convert(call: GuidedToolCall) -> Option<(String, String)> {
-        // No argument key means NO ARGUMENTS, not a malformed call. `UNIFIED.6.a`
-        // already fixes that semantic on the native path — same tool, no parameter
-        // block, golden `arguments: {}` — so voiding it here made guided disagree with
-        // native on an identical shape and made a parameterless tool uncallable. What
-        // makes an element invalid is a missing `name` (required on GuidedToolCall);
-        // that still voids the whole array, per `31.c` / `51.b`.
-        let arguments = match (call.parameters, call.arguments) {
-            // PRESENT but not an object is a malformed call, the same judgement the
-            // NAMED path makes on its whole payload: arguments that are a string or
-            // a number cannot bind to the tool's parameters, so emitting it would
-            // hand the tool a shape it cannot use. Absent is different — that means
-            // no arguments, and stays valid (see the note above).
-            (Some(raw), None) | (None, Some(raw)) => {
-                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get())
-                    .ok()?;
-                raw.get().to_string()
-            }
-            (None, None) => "{}".to_string(),
-            // The aliases are alternatives, not two independently meaningful
-            // argument sets. Choosing one silently can emit different bytes from
-            // what the backend intended, so reject the ambiguous call fail-closed.
-            (Some(_), Some(_)) => return None,
-        };
-        Some((call.name, arguments))
-    }
+///
+/// ATOMIC: one invalid element voids the whole payload, which is what
+/// [`InvalidGuidedPayloadPolicy::RecoverAsText`] promises.
+fn parse_required_guided_calls(payload: &str) -> Option<Vec<GuidedCall>> {
+    parse_required_guided_elements(payload)?
+        .into_iter()
+        .map(|element| element.call)
+        .collect()
+}
 
+/// Per-element view of a required payload, paired with each element's raw bytes.
+///
+/// `None` in the first slot marks an element that is not a legal call. Only the
+/// streaming contract uses this shape, because only it recovers PER CALL; the
+/// atomic path folds the same elements into one all-or-nothing answer above, so
+/// both agree element for element by construction.
+fn parse_required_guided_elements(payload: &str) -> Option<Vec<GuidedElement>> {
     if let Ok(raw_calls) = serde_json::from_str::<Vec<Box<serde_json::value::RawValue>>>(payload) {
-        return raw_calls
-            .into_iter()
-            .map(|raw| {
-                serde_json::from_str::<GuidedToolCall>(raw.get())
-                    .ok()
-                    .and_then(convert)
-            })
-            .collect();
+        return Some(
+            raw_calls
+                .into_iter()
+                .map(|raw| {
+                    let element = raw.get().to_string();
+                    let call = serde_json::from_str::<GuidedToolCall>(raw.get())
+                        .ok()
+                        .and_then(convert_guided_call);
+                    GuidedElement { call, raw: element }
+                })
+                .collect(),
+        );
     }
 
-    serde_json::from_str::<GuidedToolCall>(payload)
-        .ok()
-        .and_then(convert)
-        .map(|call| vec![call])
+    let call = serde_json::from_str::<GuidedToolCall>(payload).ok()?;
+    Some(vec![GuidedElement {
+        call: convert_guided_call(call),
+        raw: payload.to_string(),
+    }])
 }
 
 /// How a vendor supplies a parser: given the request's tools, build one parser for

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -1780,6 +1780,11 @@ impl GuidedState {
     /// together, and cannot be offered once a fragment is already out.
     fn finish_streamed_remainder(&mut self) -> Vec<UnifiedParserEvent> {
         let payload = self.json.trim().to_string();
+        // Bytes already dispatched as call fragments may NOT come back as text.
+        // The cursor is fed `self.json`, so slice in THAT coordinate system before
+        // trimming, or a leading-whitespace offset silently re-emits committed bytes.
+        let released_end = self.cursor.released_end().min(self.json.len());
+        let remainder = self.json[released_end..].trim().to_string();
         let mut out = Vec::new();
         let Some(elements) = parse_required_guided_elements(&payload) else {
             // Not even splittable into elements. Whatever was streamed stays
@@ -1793,7 +1798,7 @@ impl GuidedState {
                 "guided output did not parse as a tool call after fragments were \
                  already emitted; emitting the remainder as text"
             );
-            out.push(UnifiedParserEvent::Text(payload));
+            out.push(UnifiedParserEvent::Text(remainder));
             return out;
         };
 
@@ -1996,8 +2001,19 @@ impl GuidedState {
             // answer — a marker leak (`I3`) on the one path that exists to recover
             // gracefully. `raw_payload` is already the tail-trimmed value, and it
             // stays byte-identical to the buffer when nothing was stripped (`I7`).
+            // Output conservation: bytes already dispatched as call fragments must
+            // NOT come back as visible text, or a client executes the tool and then
+            // renders its JSON as prose. `raw_payload` is `self.json`, the same
+            // coordinates the cursor lexes in, so the released prefix slices off
+            // directly. Emitting nothing is correct when the whole payload was
+            // already streamed.
+            let released_end = self.cursor.released_end().min(raw_payload.len());
+            let remainder = raw_payload[released_end..].to_string();
             self.json.clear();
-            return Ok(vec![UnifiedParserEvent::Text(raw_payload)]);
+            if remainder.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Ok(vec![UnifiedParserEvent::Text(remainder)]);
         };
 
         self.json.clear();

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -55,7 +55,8 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::tool_calling::scan::{
-    InvokeEmitter, ReasoningSpec, WrappedBlockScanner, marker_prefix_suffix_len, push_run,
+    InvokeEmitter, InvokeScan, ReasoningSpec, WrappedBlockScanner, marker_prefix_suffix_len,
+    push_run, reasoning_opener_len,
 };
 use crate::tool_calling::traits::{Result, Tool, ToolCallDelta, ToolParseResult};
 
@@ -722,8 +723,12 @@ impl<E: InvokeEmitter> ScannerUnified<E> {
             (UnifiedToolOutputMode::GuidedJson { named_tool }, Some(reasoning)) => {
                 Some(Box::new(GuidedState::new(
                     reasoning,
-                    self.scanner.control_markers().to_vec(),
-                    self.scanner.invoke_end().to_string(),
+                    GuidedGrammar {
+                        control_markers: self.scanner.control_markers().to_vec(),
+                        invoke_start: self.scanner.invoke_start().to_string(),
+                        invoke_end: self.scanner.invoke_end().to_string(),
+                        invoke_scan: self.scanner.invoke_scan(),
+                    },
                     named_tool,
                     starting_state,
                     invalid_guided_payload,
@@ -857,6 +862,13 @@ where
 /// reasoning markers, taken from the scanner's own [`ReasoningSpec`]. Guided
 /// decoding is a BACKEND feature — any family can be served with it — so this
 /// lives on the shared unified parser rather than in one family's module.
+struct GuidedGrammar {
+    control_markers: Vec<String>,
+    invoke_start: String,
+    invoke_end: String,
+    invoke_scan: Option<InvokeScan>,
+}
+
 struct GuidedState {
     /// Any control markup was stripped this turn. Used only to tell a turn that
     /// produced nothing because it was ALL markup from a model that genuinely said
@@ -867,9 +879,7 @@ struct GuidedState {
     /// declaration. One set, used for both lookup and chunk-boundary holdback, in
     /// both the inside-a-thought and outside-a-thought scopes. Assembling it
     /// per-site from openers and orphans is how those four uses drifted apart.
-    control_markers: Vec<String>,
-    /// Paired with a stripped prefix-form invoke opener; see `invoke_end()`.
-    invoke_end: String,
+    grammar: GuidedGrammar,
     named_tool: Option<String>,
     invalid_payload: InvalidGuidedPayloadPolicy,
     /// Response starting_state disables reasoning markers, but tool control markers
@@ -1020,6 +1030,8 @@ fn guided_holdback_len(
     reasoning_markers: &[&str],
     control: &[String],
     invoke_end: &str,
+    start_label: Option<(&str, &str)>,
+    invoke_control: Option<(&str, InvokeScan)>,
     flush: bool,
 ) -> usize {
     if flush {
@@ -1067,7 +1079,32 @@ fn guided_holdback_len(
         .map(|(at, _)| input.len() - at)
         .max()
         .unwrap_or(0);
-    split.max(pending_prefix_form)
+    let pending_label = start_label
+        .and_then(|(start, label)| {
+            let at = input.rfind(start)?;
+            let rest = &input[at + start.len()..];
+            (rest.len() < label.len() && label.starts_with(rest)).then_some(input.len() - at)
+        })
+        .unwrap_or(0);
+    let pending_invoke = invoke_control
+        .map(|(start, scan)| {
+            let partial = (scan.holdback)(input);
+            let body = input
+                .match_indices(start)
+                .filter_map(|(at, _)| {
+                    let suffix = &input[at..];
+                    ((scan.opens)(input, at) && (scan.end)(suffix, false).is_none())
+                        .then_some(input.len() - at)
+                })
+                .max()
+                .unwrap_or(0);
+            partial.max(body)
+        })
+        .unwrap_or(0);
+    split
+        .max(pending_prefix_form)
+        .max(pending_label)
+        .max(pending_invoke)
 }
 
 /// Whether a buffered guided run has opened a JSON value. Anything before the
@@ -1145,8 +1182,7 @@ fn guided_payload_syntax_boundary(
 impl GuidedState {
     fn new(
         reasoning: ReasoningSpec,
-        control_markers: Vec<String>,
-        invoke_end: String,
+        grammar: GuidedGrammar,
         named_tool: Option<String>,
         starting_state: UnifiedParserStartingState,
         invalid_payload: InvalidGuidedPayloadPolicy,
@@ -1154,8 +1190,7 @@ impl GuidedState {
         Self {
             stripped_markup: false,
             reasoning,
-            control_markers,
-            invoke_end,
+            grammar,
             named_tool,
             invalid_payload,
             reasoning_enabled: starting_state != UnifiedParserStartingState::Response,
@@ -1206,8 +1241,8 @@ impl GuidedState {
             if let Some(boundary) = guided_payload_syntax_boundary(
                 &self.json,
                 self.reasoning,
-                &self.control_markers,
-                &self.invoke_end,
+                &self.grammar.control_markers,
+                &self.grammar.invoke_end,
             ) {
                 let tail = self.json.split_off(boundary);
                 let payload_end = self.json.trim_end().len();
@@ -1262,8 +1297,8 @@ impl GuidedState {
         let syntax_at = guided_payload_syntax_boundary(
             &self.json,
             self.reasoning,
-            &self.control_markers,
-            &self.invoke_end,
+            &self.grammar.control_markers,
+            &self.grammar.invoke_end,
         );
         let (payload_end, tail_start) = if syntax_at == Some(whitespace_end) {
             // Whitespace separating the value from control syntax belongs to
@@ -1286,6 +1321,66 @@ impl GuidedState {
         self.mode = GuidedMode::OutsideReasoning;
         self.input.push_str(&tail);
         Ok(std::mem::take(&mut output))
+    }
+
+    fn opener_len_at(&self, at: usize, flush: bool) -> Option<usize> {
+        reasoning_opener_len(
+            self.reasoning.start,
+            self.reasoning.start_label,
+            &self.input[at + self.reasoning.start.len()..],
+            flush,
+        )
+    }
+
+    fn start_label(&self) -> Option<(&str, &str)> {
+        self.reasoning
+            .start_label
+            .map(|label| (self.reasoning.start, label))
+    }
+
+    fn invoke_control(&self) -> Option<(&str, InvokeScan)> {
+        self.grammar
+            .invoke_scan
+            .map(|scan| (self.grammar.invoke_start.as_str(), scan))
+    }
+
+    fn control_marker_at(
+        &self,
+        haystack: &str,
+        limit: Option<usize>,
+        competing: &[&str],
+        flush: bool,
+    ) -> Option<(usize, usize)> {
+        let regular = control_marker_at(
+            haystack,
+            &self.grammar.control_markers,
+            &self.grammar.invoke_end,
+            limit,
+            competing,
+            flush,
+        );
+        let Some(scan) = self.grammar.invoke_scan else {
+            return regular;
+        };
+
+        let mut cursor = 0;
+        while let Some(relative) = haystack[cursor..].find(&self.grammar.invoke_start) {
+            let at = cursor + relative;
+            let suffix = &haystack[at..];
+            if (scan.opens)(haystack, at) {
+                if let Some(len) = (scan.end)(suffix, flush) {
+                    return regular
+                        .filter(|(regular_at, _)| *regular_at < at)
+                        .or(Some((at, len)));
+                }
+                return regular.filter(|(regular_at, _)| *regular_at < at);
+            }
+            if !flush && (scan.holdback)(suffix) == suffix.len() {
+                return regular.filter(|(regular_at, _)| *regular_at < at);
+            }
+            cursor = at + self.grammar.invoke_start.len();
+        }
+        regular
     }
 
     /// Strip the reasoning markers wrapping the JSON payload. Once visible
@@ -1338,32 +1433,34 @@ impl GuidedState {
                         .reasoning_enabled
                         .then(|| self.input.find(start))
                         .flatten();
-                    let stray_close = control_marker_at(
-                        &self.input,
-                        &self.control_markers,
-                        &self.invoke_end,
-                        // Nor past the start of the payload itself.
-                        self.input.find(['{', '[']),
-                        // A thought marker ahead also ends the header: a stray
-                        // `<function=` must not borrow the `>` from `<think>` and
-                        // swallow the thought — that put private reasoning in the
-                        // user's answer.
-                        &[start, end],
-                        flush,
-                    )
-                    .into_iter()
-                    .chain(
-                        self.reasoning_enabled
-                            .then(|| self.input.find(end).map(|at| (at, end.len())))
-                            .flatten(),
-                    )
-                    .min_by_key(|(at, _)| *at);
+                    let stray_close = self
+                        .control_marker_at(
+                            &self.input,
+                            // Nor past the start of the payload itself.
+                            self.input.find(['{', '[']),
+                            // A thought marker ahead also ends the header: a stray
+                            // `<function=` must not borrow the `>` from `<think>` and
+                            // swallow the thought — that put private reasoning in the
+                            // user's answer.
+                            &[start, end],
+                            flush,
+                        )
+                        .into_iter()
+                        .chain(
+                            self.reasoning_enabled
+                                .then(|| self.input.find(end).map(|at| (at, end.len())))
+                                .flatten(),
+                        )
+                        .min_by_key(|(at, _)| *at);
                     let close_at = stray_close.map(|(at, _)| at);
                     let close_len = stray_close.map(|(_, l)| l).unwrap_or(end.len());
                     let closer_first = matches!((open_at, close_at), (Some(o), Some(c)) if c < o)
                         || (open_at.is_none() && close_at.is_some());
 
-                    if !closer_first && let Some(at) = open_at {
+                    if !closer_first
+                        && let Some(at) = open_at
+                        && let Some(open_len) = self.opener_len_at(at, flush)
+                    {
                         // Whatever was buffered as "payload so far", plus this prefix,
                         // was visible text after all — a thought is opening behind it.
                         let mut pending = std::mem::take(&mut self.json);
@@ -1378,7 +1475,7 @@ impl GuidedState {
                                 self.post_payload_text_started = true;
                             }
                         }
-                        self.input.drain(..at + start.len());
+                        self.input.drain(..at + open_len);
                         self.mode = GuidedMode::Reasoning;
                         self.accept_redundant_reasoning_start = false;
                         continue;
@@ -1423,8 +1520,10 @@ impl GuidedState {
                         guided_holdback_len(
                             &self.input,
                             reasoning_markers,
-                            &self.control_markers,
-                            &self.invoke_end,
+                            &self.grammar.control_markers,
+                            &self.grammar.invoke_end,
+                            self.start_label(),
+                            self.invoke_control(),
                             flush,
                         )
                     };
@@ -1477,9 +1576,11 @@ impl GuidedState {
                     if self.accept_redundant_reasoning_start {
                         let non_whitespace = self.input.trim_start();
                         let leading = self.input.len() - non_whitespace.len();
-                        if non_whitespace.starts_with(start) {
+                        if non_whitespace.starts_with(start)
+                            && let Some(open_len) = self.opener_len_at(leading, flush)
+                        {
                             push_run(&mut output, Kind::Reasoning, &self.input[..leading]);
-                            self.input.drain(..leading + start.len());
+                            self.input.drain(..leading + open_len);
                             self.accept_redundant_reasoning_start = false;
                             continue;
                         }
@@ -1514,20 +1615,23 @@ impl GuidedState {
                     // guided payload that followed and returned an empty response.
                     // The native scanner does treat it as structural, but it can: it
                     // opens a block and recovers the call from the markup itself.
-                    let stray = control_marker_at(
-                        &self.input,
-                        &self.control_markers,
-                        &self.invoke_end,
-                        // A narrated invoke lives INSIDE this thought, so its
-                        // terminator cannot be past the span's closer.
-                        self.input.find(end),
-                        &[end],
-                        flush,
-                    )
-                    .into_iter()
-                    .chain(self.input.find(start).map(|at| (at, start.len())))
-                    .min_by_key(|(at, _)| *at)
-                    .map(|(at, len)| (at, len, false));
+                    let stray = self
+                        .control_marker_at(
+                            &self.input,
+                            // A narrated invoke lives INSIDE this thought, so its
+                            // terminator cannot be past the span's closer.
+                            self.input.find(end),
+                            &[end],
+                            flush,
+                        )
+                        .into_iter()
+                        .chain(
+                            self.input
+                                .find(start)
+                                .and_then(|at| Some((at, self.opener_len_at(at, flush)?))),
+                        )
+                        .min_by_key(|(at, _)| *at)
+                        .map(|(at, len)| (at, len, false));
                     if let Some((at, consume, closes)) = [close, stray]
                         .into_iter()
                         .flatten()
@@ -1560,8 +1664,10 @@ impl GuidedState {
                         guided_holdback_len(
                             &self.input,
                             &[start, end],
-                            &self.control_markers,
-                            &self.invoke_end,
+                            &self.grammar.control_markers,
+                            &self.grammar.invoke_end,
+                            self.start_label(),
+                            self.invoke_control(),
                             flush,
                         )
                     };
@@ -2100,6 +2206,7 @@ mod tests {
             start: "<think>",
             end: "</think>",
             forced_start: false,
+            start_label: None,
             preserve_special_tokens: false,
         };
 
@@ -2130,10 +2237,15 @@ mod tests {
                 start: "<think>",
                 end: "</think>",
                 forced_start: false,
+                start_label: None,
                 preserve_special_tokens: false,
             },
-            vec!["<tool_call>".into(), "</tool_call>".into()],
-            "</function>".into(),
+            GuidedGrammar {
+                control_markers: vec!["<tool_call>".into(), "</tool_call>".into()],
+                invoke_start: "<function=".into(),
+                invoke_end: "</function>".into(),
+                invoke_scan: None,
+            },
             None,
             UnifiedParserStartingState::None,
             InvalidGuidedPayloadPolicy::RecoverAsText,

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1565,6 +1565,444 @@ mod tests {
             }
         }
     }
+
+    use crate::tool_calling::traits::ToolCallDelta;
+
+    /// Init selecting the streaming contract.
+    fn stream_init(mode: UnifiedToolOutputMode) -> UnifiedParserInit {
+        UnifiedParserInit {
+            prompt_token_ids: Vec::new(),
+            starting_state: UnifiedParserStartingState::None,
+            tool_output_mode: mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
+        }
+    }
+
+    /// Every delta produced by feeding `payload` in `chunks`, push order preserved.
+    fn streamed(payload: &str, chunks: &[&str]) -> (Vec<ToolCallDelta>, Vec<UnifiedParserEvent>) {
+        let _ = payload;
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                named_tool: None,
+            }))
+            .expect("required guided init");
+        let mut calls = Vec::new();
+        let mut all = Vec::new();
+        for chunk in chunks {
+            for event in parser.push(chunk).expect("push") {
+                if let UnifiedParserEvent::ToolCall(delta) = &event {
+                    calls.push(delta.clone());
+                }
+                all.push(event);
+            }
+        }
+        for event in parser.finish().expect("finish").events {
+            if let UnifiedParserEvent::ToolCall(delta) = &event {
+                calls.push(delta.clone());
+            }
+            all.push(event);
+        }
+        (calls, all)
+    }
+
+    /// One chunk per character.
+    fn per_char(payload: &str) -> Vec<&str> {
+        payload
+            .char_indices()
+            .map(|(i, ch)| &payload[i..i + ch.len_utf8()])
+            .collect()
+    }
+
+    /// Byte span of the first argument OBJECT in `payload`, tolerating any
+    /// whitespace the fixture uses between the key, the colon and the brace.
+    fn argument_object(payload: &str) -> (usize, usize) {
+        let key = payload.find("\"arguments\"").expect("fixture shape");
+        let open = payload[key..].find('{').expect("fixture shape") + key;
+        let mut depth = 0i32;
+        let mut in_string = false;
+        let mut escaped = false;
+        for (offset, ch) in payload[open..].char_indices() {
+            if in_string {
+                match ch {
+                    _ if escaped => escaped = false,
+                    '\\' => escaped = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
+                continue;
+            }
+            match ch {
+                '"' => in_string = true,
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return (open, open + offset + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unterminated argument object in {payload:?}");
+    }
+
+    /// Arguments reassembled per tool index, in first-seen index order.
+    fn joined_arguments(calls: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        let mut out: Vec<(usize, String)> = Vec::new();
+        for delta in calls {
+            match out.iter_mut().find(|(index, _)| *index == delta.tool_index) {
+                Some((_, text)) => text.push_str(&delta.arguments),
+                None => out.push((delta.tool_index, delta.arguments.clone())),
+            }
+        }
+        out
+    }
+
+    /// The defect a downstream user reported: with `tool_choice="required"`,
+    /// streaming on and thinking disabled, nothing reaches the wire until the whole
+    /// call has been generated. Their vanilla-vLLM deployment starts streaming in
+    /// ~0.2s; this path took ~10s and then arrived in one burst.
+    ///
+    /// The assertion is ORDERING, not wall-clock: a name-carrying event must exist
+    /// before the parser has been handed the bytes that complete the call. A timing
+    /// assertion would pass on a fast machine, fail on a slow one, and say nothing
+    /// about emission granularity.
+    #[test]
+    fn required_guided_emits_the_name_before_the_call_completes() {
+        // Cut just after the arguments object opens - the commit point - which is
+        // still well before the arguments close.
+        let cut = argument_object(GUIDED_CALL).0 + 1;
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                named_tool: None,
+            }))
+            .expect("required guided init");
+
+        let early = parser.push(&GUIDED_CALL[..cut]).expect("push prefix");
+        let named = early.iter().any(|e| {
+            matches!(e, UnifiedParserEvent::ToolCall(c) if c.name.as_deref() == Some("get_weather"))
+        });
+
+        assert!(
+            named,
+            "no name-carrying frame before the call completed; got {early:?}. \
+             The function name is unambiguous at byte {cut} - everything after it is \
+             arguments - so a consumer could already have started rendering the call."
+        );
+    }
+
+    /// Streaming must be INCREMENTAL, not merely "earlier", and the fragments must
+    /// reassemble BYTE FOR BYTE.
+    ///
+    /// An earlier version of this test asserted only that the join `contains("Paris")`,
+    /// which a parser that mangled every other byte would still pass. The assertion
+    /// is now equality against the exact argument object.
+    #[test]
+    fn required_guided_streams_arguments_in_multiple_fragments() {
+        let (calls, events) = streamed(GUIDED_CALL, &per_char(GUIDED_CALL));
+
+        let names: Vec<&str> = calls.iter().filter_map(|c| c.name.as_deref()).collect();
+        assert_eq!(names, vec!["get_weather"], "exactly one decoded name");
+        assert!(
+            calls.iter().all(|c| c.tool_index == 0),
+            "one call must not spread across indices: {calls:?}"
+        );
+
+        let frames = calls.iter().filter(|c| !c.arguments.is_empty()).count();
+        assert!(
+            frames >= 2,
+            "arguments arrived in {frames} frame(s) - that is a burst, not a stream"
+        );
+
+        let (start, end) = argument_object(GUIDED_CALL);
+        let expected = GUIDED_CALL[start..end].to_string();
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, expected)],
+            "fragments must reassemble the argument object byte for byte"
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+            "a valid streamed call must not also produce recovery text: {events:?}"
+        );
+    }
+
+    /// The `parameters` spelling is as legal as `arguments`, and recognising only
+    /// one of them streamed NOTHING for the other - the call then assembled with
+    /// empty arguments, which is worse than the latency it was fixing.
+    #[test]
+    fn required_guided_streams_the_parameters_alias_too() {
+        let payload = r#"[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#;
+        let (calls, _) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, r#"{"city":"Tokyo"}"#.to_string())]
+        );
+        // Assert it STREAMED, not merely that it assembled. The buffered path
+        // produces the identical assembled result, so an outcome-only assertion
+        // passes with the alias unrecognised - which is exactly the bug.
+        let frames = calls.iter().filter(|c| !c.arguments.is_empty()).count();
+        assert!(
+            frames >= 2,
+            "the parameters alias assembled correctly but never streamed: \
+             {frames} argument frame(s)"
+        );
+    }
+
+    /// A `\uXXXX` escape in the function name must decode. The old scanner pushed
+    /// the escape's payload characters verbatim and produced `getu005fweather`.
+    #[test]
+    fn required_guided_decodes_escaped_names() {
+        let payload = "[{\"name\":\"get\\u005fweather\",\"arguments\":{\"city\":\"Paris\"}}]";
+        assert!(
+            payload.contains("\\u005f"),
+            "the escape must survive to the test"
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+    }
+
+    /// Parallel calls keep distinct indices and stay in payload order. Hardcoding
+    /// index 0 collapsed both calls into one.
+    #[test]
+    fn required_guided_streams_parallel_calls_on_distinct_indices() {
+        let payload = concat!(
+            r#"[{"name":"get_weather","arguments":{"city":"Paris"}},"#,
+            r#"{"name":"get_weather","arguments":{"city":"Tokyo"}}]"#
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        let named: Vec<(usize, &str)> = calls
+            .iter()
+            .filter_map(|c| c.name.as_deref().map(|n| (c.tool_index, n)))
+            .collect();
+        assert_eq!(named, vec![(0, "get_weather"), (1, "get_weather")]);
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![
+                (0, r#"{"city":"Paris"}"#.to_string()),
+                (1, r#"{"city":"Tokyo"}"#.to_string()),
+            ]
+        );
+    }
+
+    /// PER-CALL recovery, the guarantee `StreamBestEffort` trades the atomic one
+    /// for: a malformed second element becomes its own text and the valid first
+    /// element still dispatches.
+    #[test]
+    fn required_guided_recovers_only_the_invalid_element() {
+        let payload = concat!(
+            r#"[{"name":"get_weather","arguments":{"city":"Paris"}},"#,
+            r#"{"arguments":{"city":"Tokyo"}}]"#
+        );
+        let (calls, events) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"],
+            "the valid element must still dispatch"
+        );
+        let texts: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            texts,
+            vec![r#"{"arguments":{"city":"Tokyo"}}"#],
+            "only the nameless element recovers as text"
+        );
+    }
+
+    /// Shapes the contract voids must never reach the wire early, because a
+    /// fragment cannot be withdrawn. The commit point requires an argument OBJECT
+    /// opener, so each of these stays on the buffered path.
+    #[test]
+    fn required_guided_never_streams_a_shape_the_contract_voids() {
+        for payload in [
+            r#"[{"name":"get_weather","arguments":"just a string"}]"#,
+            r#"[{"name":"get_weather","arguments":null}]"#,
+            r#"[{"name":"get_weather","arguments":[1,2]}]"#,
+        ] {
+            let (calls, events) = streamed(payload, &per_char(payload));
+            assert!(
+                calls.is_empty(),
+                "{payload} streamed a call the contract voids: {calls:?}"
+            );
+            assert!(
+                events
+                    .iter()
+                    .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+                "{payload} should have recovered as text; got {events:?}"
+            );
+        }
+    }
+
+    /// The ONE guarantee `StreamBestEffort` genuinely cannot keep, pinned so it
+    /// stays a documented loss rather than a surprise.
+    ///
+    /// A call carrying BOTH argument aliases is ambiguous and the buffered
+    /// contracts void it. Streaming cannot: the second alias only appears after the
+    /// first has already supplied an object opener, which is the commit point, so
+    /// the call is on the wire before the ambiguity exists to be seen. It stays,
+    /// carrying the alias that arrived first, and the parser says so in a warning.
+    #[test]
+    fn ambiguity_discovered_after_the_commit_cannot_be_withdrawn() {
+        let payload = r#"[{"name":"get_weather","arguments":{"a":1},"parameters":{"b":2}}]"#;
+        let (calls, events) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"],
+            "the call was committed before the second alias arrived"
+        );
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, r#"{"a":1}"#.to_string())],
+            "it carries the alias that opened first"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+            "recovery text here would DUPLICATE the streamed call: {events:?}"
+        );
+    }
+
+    /// A parameterless call has no argument object to commit on, so it settles on
+    /// the buffered path - and must still arrive with `{}`, not an empty string,
+    /// and must not disturb a streamed sibling.
+    #[test]
+    fn required_guided_parameterless_call_keeps_its_empty_argument_set() {
+        let payload = concat!(
+            r#"[{"name":"get_weather"},"#,
+            r#"{"name":"get_weather","arguments":{"city":"Paris"}}]"#
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        let mut assembled = joined_arguments(&calls);
+        // Deltas for call 0 arrive AFTER call 1's, and that is inherent: a
+        // parameterless call has no argument object to commit on, so it can only be
+        // settled once the payload closes, by which time its streamed sibling has
+        // long been on the wire. Consumers key by `tool_index` (`assemble` does), so
+        // the wire order is not the call order.
+        assembled.sort_by_key(|(index, _)| *index);
+        assert_eq!(
+            assembled,
+            vec![
+                (0, "{}".to_string()),
+                (1, r#"{"city":"Paris"}"#.to_string())
+            ]
+        );
+    }
+
+    /// Truncation mid-payload: whatever was streamed stays streamed, and nothing
+    /// is invented for the part that never arrived.
+    #[test]
+    fn required_guided_truncation_after_commit_does_not_invent_arguments() {
+        let cut = GUIDED_CALL.find("\"city\"").expect("fixture shape");
+        let (calls, _) = streamed(&GUIDED_CALL[..cut], &per_char(&GUIDED_CALL[..cut]));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+        let joined = joined_arguments(&calls);
+        let released = joined.first().map(|(_, text)| text.as_str()).unwrap_or("");
+        assert!(
+            GUIDED_CALL[cut - released.len()..].starts_with(released) || released.len() <= 1,
+            "released bytes must be a prefix of the real arguments; got {released:?}"
+        );
+    }
+
+    /// Reuse: a second request on the same parser must not inherit the first
+    /// request's cursor offsets, or the new payload is lexed from the wrong place.
+    #[test]
+    fn required_guided_streaming_state_does_not_leak_across_requests() {
+        let mut parser = qwen3_unified(&weather_tools());
+        let mut seen = Vec::new();
+        for request in 0..2 {
+            if request > 0 {
+                parser.reset();
+            }
+            parser
+                .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                    named_tool: None,
+                }))
+                .expect("required guided init");
+            let mut calls = Vec::new();
+            for chunk in per_char(GUIDED_CALL) {
+                for event in parser.push(chunk).expect("push") {
+                    if let UnifiedParserEvent::ToolCall(delta) = event {
+                        calls.push(delta);
+                    }
+                }
+            }
+            for event in parser.finish().expect("finish").events {
+                if let UnifiedParserEvent::ToolCall(delta) = event {
+                    calls.push(delta);
+                }
+            }
+            seen.push(joined_arguments(&calls));
+        }
+        assert_eq!(
+            seen[0], seen[1],
+            "the second request diverged from the first"
+        );
+    }
+
+    /// Whole-input and every valid split must assemble identically, and the split
+    /// runs must show intermediate progress rather than one terminal burst.
+    #[test]
+    fn required_guided_streaming_is_split_invariant() {
+        let whole = streamed(GUIDED_CALL, &[GUIDED_CALL]).0;
+        let baseline = joined_arguments(&whole);
+        let names: Vec<&str> = whole.iter().filter_map(|c| c.name.as_deref()).collect();
+
+        for split in 1..GUIDED_CALL.len() {
+            if !GUIDED_CALL.is_char_boundary(split) {
+                continue;
+            }
+            let (calls, _) = streamed(GUIDED_CALL, &[&GUIDED_CALL[..split], &GUIDED_CALL[split..]]);
+            assert_eq!(
+                joined_arguments(&calls),
+                baseline,
+                "arguments differ at split {split}"
+            );
+            assert_eq!(
+                calls
+                    .iter()
+                    .filter_map(|c| c.name.as_deref())
+                    .collect::<Vec<_>>(),
+                names,
+                "names differ at split {split}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -48,6 +48,7 @@ pub(crate) fn qwen3_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
             forced_start: false,
             // `<think>` is not a special token for this family; the OR comes from the grammar.
             preserve_special_tokens: false,
+            ..Default::default()
         },
     )))
 }

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1918,6 +1918,118 @@ mod tests {
         );
     }
 
+    /// Output conservation: bytes already dispatched as a tool call must NOT come
+    /// back as visible text. When a later array element leaves the payload
+    /// unsplittable, the recovery path may only emit the UN-streamed remainder --
+    /// re-emitting the whole buffer makes a client execute the tool and then render
+    /// its JSON as prose.
+    #[test]
+    fn required_guided_truncation_does_not_duplicate_a_streamed_call_as_text() {
+        // One complete call, then a second element truncated right after its
+        // `"arguments":` key, so the payload can no longer be split into elements.
+        let payload = concat!(
+            r#"[{"name": "get_weather", "arguments": {"city": "Paris"}},"#,
+            r#"{"name": "get_weather", "arguments":"#
+        );
+        let (calls, all) = streamed(payload, &per_char(payload));
+
+        // The first call must have streamed.
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.name.as_deref() == Some("get_weather")),
+            "expected the complete first call to stream: {calls:?}"
+        );
+        let streamed_args: String = calls
+            .iter()
+            .filter(|c| c.tool_index == 0)
+            .map(|c| c.arguments.as_str())
+            .collect();
+        assert!(
+            !streamed_args.is_empty(),
+            "expected argument fragments for call 0"
+        );
+
+        let text: String = all
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            !text.contains(&streamed_args),
+            "recovery text re-emitted bytes already dispatched as call 0.\n               streamed args: {streamed_args:?}\n  recovery text: {text:?}"
+        );
+    }
+
+    /// The conservation invariant must hold at EVERY chunk boundary, not just the
+    /// per-char one: the split decides how much streamed before truncation, so a
+    /// single split size can pass while others duplicate.
+    #[test]
+    fn required_guided_truncation_conserves_output_at_every_split() {
+        let payload = concat!(
+            r#"[{"name": "get_weather", "arguments": {"city": "Paris"}},"#,
+            r#"{"name": "get_weather", "arguments":"#
+        );
+        for split in 0..=payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let chunks = vec![&payload[..split], &payload[split..]];
+            let (calls, all) = streamed(payload, &chunks);
+            let streamed_args: String = calls
+                .iter()
+                .filter(|c| c.tool_index == 0)
+                .map(|c| c.arguments.as_str())
+                .collect();
+            if streamed_args.is_empty() {
+                continue; // nothing committed at this split, nothing to conserve
+            }
+            let text: String = all
+                .iter()
+                .filter_map(|e| match e {
+                    UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                !text.contains(&streamed_args),
+                "split {split}: recovery text re-emitted dispatched bytes\n                   streamed: {streamed_args:?}\n  text: {text:?}"
+            );
+        }
+    }
+
+    /// The single-call case: one call commits, then the stream ends mid-arguments.
+    /// There is no second element to make the payload unsplittable, so this
+    /// exercises the other recovery branch.
+    #[test]
+    fn required_guided_single_committed_call_truncated_conserves_output() {
+        let cut = GUIDED_CALL.find("Paris").expect("fixture shape") + 2;
+        let payload = &GUIDED_CALL[..cut];
+        let (calls, all) = streamed(payload, &per_char(payload));
+        let streamed_args: String = calls
+            .iter()
+            .filter(|c| c.tool_index == 0)
+            .map(|c| c.arguments.as_str())
+            .collect();
+        if streamed_args.is_empty() {
+            return; // nothing committed, nothing to conserve
+        }
+        let text: String = all
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !text.contains(&streamed_args),
+            "single-call truncation re-emitted dispatched bytes\n               streamed: {streamed_args:?}\n  text: {text:?}"
+        );
+    }
+
     /// Truncation mid-payload: whatever was streamed stays streamed, and nothing
     /// is invented for the part that never arrived.
     #[test]


### PR DESCRIPTION
#### Overview:

This PR makes the qwen3 guided tool-call path emit the function name and argument fragments as the model generates them, instead of one delta once the call is complete. Affects **guided requests only** (`tool_choice="required"` or a named tool), and only for callers that opt in — native markup and every existing caller are byte-identical. Also groups the shared scanner params into one struct so a new field stops costing every parser an edit; no behavior change.

#### Example (before -> after):

A `required` payload arriving in four pushes. `->` shows the events that push emits.

```
before -- nothing until the JSON value closes:

  push 1  [{"name":"get_weather","arguments":{     ->  (no events)
  push 2  "city":"Par                              ->  (no events)
  push 3  is"}                                     ->  (no events)
  push 4  ]                                        ->  ToolCall{ name:"get_weather",
                                                                 arguments:{"city":"Paris"} }

after -- the name lands on the push that makes it unambiguous:

  push 1  [{"name":"get_weather","arguments":{     ->  ToolCall{ name:"get_weather", arguments:"" }
                                                       ToolCall{ name:None, arguments:"{" }
  push 2  "city":"Par                              ->  ToolCall{ name:None, arguments:"\"city\":\"Par" }
  push 3  is"}                                     ->  ToolCall{ name:None, arguments:"is\"}" }
  push 4  ]                                        ->  (no events)
```

Exactly one event carries `name`; the `arguments` fragments concatenate to the original bytes, so `assemble` produces the identical call either way. A caller left on `Reject` or `RecoverAsText` still sees the `before` column.

#### Details:

- Adds `InvalidGuidedPayloadPolicy::StreamBestEffort` as a third contract, not a loosened one: a fragment cannot be unsaid, and neither `Reject` (typed error) nor `RecoverAsText` (array voids atomically) survives emitting early. Both are unchanged.
- The commit point is the argument OBJECT opener, not the closed name, so `null`, a bare string, an array and a parameterless call never reach the wire early and are still judged on the buffered path.
- `GuidedGrammar` groups the grammar-owned params and the specs gain a `Default`. Verified by construction: a probe field broke 4 parsers before, 0 after.

#### Verification:

`cargo test --locked --workspace` 1495 passed, 80/80 unified golden cases, clippy `-D warnings` and `fmt --check` clean; stacked #166 and #191 replay on this head at their baselines with no source edits.

#### Where should the reviewer start?

`parsers/v2/src/unified/guided_cursor.rs`, then `parsers/v2/src/unified/mod.rs`, then `parsers/v2/src/tool_calling/scan.rs`

/coderabbit profile chill
