### PR TITLE
feat(parsers): port kimi_k2 to the v2 parser

### DIFF
--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,9 +1,9 @@
 {
-  "snapshot": "20260820_170413",
-  "created_pt": "2026-08-20 17:04:13 America/Los_Angeles",
+  "snapshot": "20260823_234750",
+  "created_pt": "2026-08-23 23:47:50 America/Los_Angeles",
   "crates": {
-    "dynamo-parsers": "8.0.0",
-    "dynamo-parsers-v2": "0.3.1"
+    "dynamo-parsers": "8.1.0",
+    "dynamo-parsers-v2": "0.3.2"
   },
   "peers": {
     "vllm": "0.26.0",
@@ -214,6 +214,11 @@
       "path": "unified/dynamo_v2-0.3.1.tar.gz",
       "sha256": "2d146a67e5da2d74a7726d0c53e2d8c23389a3941c6df140b6141980439800c1",
       "size": 12317
+    },
+    {
+      "path": "unified/dynamo_v2-0.3.2.tar.gz",
+      "sha256": "9a6ba4a5553408fdb2c881a41db3097640f48c95ee496e055825620fb3dc2145",
+      "size": 12234
     },
     {
       "path": "unified/golden.tar.gz",

--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -201,6 +201,16 @@
       "size": 10039
     },
     {
+      "path": "unified/dynamo_v2-0.2.1.tar.gz",
+      "sha256": "c4744205651226a62e1595f13d2a889adbca8b6dfe06838b306300e2bc5d78e5",
+      "size": 9999
+    },
+    {
+      "path": "unified/dynamo_v2-0.3.0+pr191.tar.gz",
+      "sha256": "35bb831633c50d3ee99e8c95adeb69b908247c501387e1d4b8f82be2d6681c65",
+      "size": 9989
+    },
+    {
       "path": "unified/dynamo_v2-0.3.1.tar.gz",
       "sha256": "2d146a67e5da2d74a7726d0c53e2d8c23389a3941c6df140b6141980439800c1",
       "size": 12317

--- a/conformance/fixtures/unified/dynamo_v2-0.2.1.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.2.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4744205651226a62e1595f13d2a889adbca8b6dfe06838b306300e2bc5d78e5
+size 9999

--- a/conformance/fixtures/unified/dynamo_v2-0.3.0+pr191.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.3.0+pr191.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35bb831633c50d3ee99e8c95adeb69b908247c501387e1d4b8f82be2d6681c65
+size 9989

--- a/conformance/fixtures/unified/dynamo_v2-0.3.2.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.3.2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a6ba4a5553408fdb2c881a41db3097640f48c95ee496e055825620fb3dc2145
+size 12234

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -9,6 +9,7 @@
 //! fine (hence the allow).
 #![allow(dead_code)]
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Recursively collect `*.yaml` fixture files under `dir` into `out`.
@@ -46,35 +47,150 @@ pub fn ensure_fixtures() -> PathBuf {
         return PathBuf::from(r);
     }
 
-    let cache_root = std::env::var("XDG_CACHE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            PathBuf::from(std::env::var("HOME").expect("HOME not set")).join(".cache")
-        })
-        .join("dynamo/conformance-fixtures");
-
     let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("utils/src/extract_fixtures.py");
 
     // flock serializes parallel test binaries so only one extraction runs.
-    let status = std::process::Command::new("flock")
+    let output = std::process::Command::new("flock")
         .args([
             "/tmp/dynamo-conformance-extract.lock",
             "python3",
             script.to_str().expect("non-UTF-8 script path"),
         ])
-        .status()
+        .output()
         .expect("flock/python3 not found — ensure python3 is in PATH");
 
-    if !status.success() {
+    // `.output()` captures stderr instead of inheriting it (needed to also
+    // capture stdout below) -- forward it so extraction progress ("Extracting
+    // N shard(s)...", "Cache hit: ...") is still visible in the test run,
+    // not silently swallowed. A failure writing to this process's own
+    // stderr is itself unusual enough to fail fast on rather than ignore.
+    std::io::stderr()
+        .write_all(&output.stderr)
+        .expect("failed to forward extract_fixtures.py stderr to this process's stderr");
+
+    if !output.status.success() {
         panic!(
             "fixture extraction failed (exit {}). If the shards are git-lfs \
              pointers, run:\n  git lfs install && git lfs pull\nthen retry:\n  python3 {}",
-            status.code().unwrap_or(-1),
+            output.status.code().unwrap_or(-1),
             script.display()
         );
     }
 
-    cache_root
+    // `extract_fixtures.py` prints its resolved, content-addressed snapshot
+    // dir as the last stdout line. Return THAT, not `cache_root` (the
+    // directory holding the mutable `toolcalling`/`reasoning`/`unified`
+    // symlinks): every caller does `ensure_fixtures().join("<family>/...")`
+    // and then reads many files under it over the test's lifetime, and
+    // `Path::join` never touches the filesystem — the OS re-resolves any
+    // symlink component on EVERY subsequent file access. A concurrent
+    // sibling checkout publishing a different manifest's identity and
+    // retargeting the symlink mid-test would silently switch which
+    // snapshot later reads in the SAME test see, even though extraction
+    // itself is now race-free (`fixtures_identity`-keyed, atomically
+    // published). Resolving to the immutable identity dir once, up front,
+    // matches the same fix `_common.sh` already applies for the identical
+    // reason (see its `FIXTURES_SNAP` comment) — one shared pattern, not two.
+    let stdout = String::from_utf8(output.stdout).expect("extract_fixtures.py stdout is not UTF-8");
+    match resolve_snap_dir(&stdout) {
+        Ok(snap_dir) => snap_dir,
+        // A missing, malformed, or non-directory printed path is NOT
+        // recovered by falling back to `cache_root` — that fallback is
+        // exactly the mutable, racy path this function exists to stop
+        // returning. Fail loudly with the full captured output instead, so a
+        // broken contract is caught here, not silently downgraded back to
+        // the old ownership model.
+        Err(reason) => panic!(
+            "extract_fixtures.py did not print a valid resolved snapshot directory as its \
+             last stdout line: {reason}.\nfull stdout: {stdout:?}\nstderr: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    }
+}
+
+/// Pure parsing/validation of `ensure_fixtures`'s subprocess contract,
+/// split out so the failure shapes (empty output, a non-existent path, a
+/// malformed line, extra noisy lines) are directly unit-testable without a
+/// real `flock`/`python3` subprocess.
+fn resolve_snap_dir(stdout: &str) -> Result<PathBuf, String> {
+    let printed = stdout.lines().next_back().unwrap_or("").trim();
+    if printed.is_empty() {
+        return Err("stdout was empty (or only blank lines)".to_string());
+    }
+    let snap_dir = PathBuf::from(printed);
+    if !snap_dir.is_dir() {
+        return Err(format!(
+            "printed path {printed:?} is not an existing directory"
+        ));
+    }
+    Ok(snap_dir)
+}
+
+#[cfg(test)]
+mod resolve_snap_dir_tests {
+    use super::resolve_snap_dir;
+
+    #[test]
+    fn accepts_a_real_directory_on_the_last_line() {
+        let dir = std::env::temp_dir().join(format!(
+            "dynamo-resolve-snap-dir-test-{}-{}",
+            std::process::id(),
+            "ok"
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let stdout = format!("Extracting 3 shard(s) into ...\n{}\n", dir.display());
+        assert_eq!(resolve_snap_dir(&stdout), Ok(dir.clone()));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_stdout() {
+        assert!(resolve_snap_dir("").is_err());
+        assert!(resolve_snap_dir("\n\n").is_err());
+    }
+
+    #[test]
+    fn rejects_a_malformed_or_missing_path() {
+        let err = resolve_snap_dir("not a real path at all\n").unwrap_err();
+        assert!(err.contains("not an existing directory"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_path_that_does_not_exist_on_disk() {
+        let err = resolve_snap_dir("/definitely/does/not/exist/anywhere\n").unwrap_err();
+        assert!(err.contains("not an existing directory"), "{err}");
+    }
+
+    #[test]
+    fn uses_only_the_last_line_ignoring_noisy_progress_output() {
+        let dir = std::env::temp_dir().join(format!(
+            "dynamo-resolve-snap-dir-test-{}-{}",
+            std::process::id(),
+            "noisy"
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let stdout = format!(
+            "Extracting 47 shard(s) into {}\n  [extract] a.tar.gz -> ...\n  [extract] b.tar.gz -> ...\n{}\n",
+            dir.display(),
+            dir.display()
+        );
+        assert_eq!(resolve_snap_dir(&stdout), Ok(dir.clone()));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_directory_that_is_actually_a_file() {
+        let file = std::env::temp_dir().join(format!(
+            "dynamo-resolve-snap-dir-test-{}-{}",
+            std::process::id(),
+            "file"
+        ));
+        std::fs::write(&file, b"not a directory").unwrap();
+        let stdout = format!("{}\n", file.display());
+        let err = resolve_snap_dir(&stdout).unwrap_err();
+        assert!(err.contains("not an existing directory"), "{err}");
+        std::fs::remove_file(&file).unwrap();
+    }
 }
 
 /// Ensures the authored unified golden spec exists and returns its directory.

--- a/conformance/utils/src/_common.sh
+++ b/conformance/utils/src/_common.sh
@@ -24,7 +24,6 @@ TOOLS="$ROOT/conformance/utils/src"
 # not only when the cache is empty: it exits instantly on a cache hit, and it
 # re-extracts when the committed manifest pin moved — otherwise a render after
 # pulling new shards would silently use a stale snapshot.
-FIXTURES_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/dynamo/conformance-fixtures"
 # extract_fixtures prints THIS manifest's snapshot dir on stdout. Point readers at
 # that exact dir, NOT the shared `<cache>/toolcalling` symlink: sibling checkouts
 # pinning a different snapshot race to repoint that symlink, so a render could read
@@ -32,12 +31,8 @@ FIXTURES_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/dynamo/conformance-fixtures"
 # pinned snapshot dir directly is immune to that race.
 FIXTURES_SNAP=$(python3 "$TOOLS/extract_fixtures.py" 2>/dev/null | tail -1)
 if [ -z "$FIXTURES_SNAP" ] || [ ! -d "$FIXTURES_SNAP/toolcalling" ]; then
-  # Fall back to a plain extract (and the symlink) if the snapshot path is unusable.
-  python3 "$TOOLS/extract_fixtures.py" >/dev/null || {
-    echo "[conformance] fixture extraction failed. If shards are LFS pointers, run:" >&2
-    echo "  git lfs install && git lfs pull" >&2
-    exit 1
-  }
+  echo "[conformance] extract_fixtures.py did not return a usable immutable snapshot" >&2
+  exit 1
 else
   FIXTURES_ROOT="$FIXTURES_SNAP"
 fi
@@ -177,6 +172,7 @@ build_stage_conformance() {
   \cp -f "$TOOLS/generate_conformance_table.py" "$STAGE/tests/parity/generate_conformance_table.py"
   # impls.py + markers.py are staged in _build_stage_base.
   \cp -f "$TOOLS/fixtures.py" "$STAGE/tests/parity/fixtures.py"
+  \cp -f "$TOOLS/fixture_snapshot.py" "$STAGE/tests/parity/fixture_snapshot.py"
   \cp -f "$TOOLS/conformance_table.html.j2" "$STAGE/tests/parity/conformance_table.html.j2"
   # Shared CSS/JS assets are staged in _build_stage_base.
   _copy_toolcalling_v2_fixtures

--- a/conformance/utils/src/extract_fixtures.py
+++ b/conformance/utils/src/extract_fixtures.py
@@ -28,6 +28,7 @@ Usage:
 
 import argparse
 import errno
+import fcntl
 import hashlib
 import json
 import os
@@ -35,6 +36,7 @@ import secrets
 import shutil
 import sys
 import tarfile
+from contextlib import contextmanager
 from pathlib import Path
 
 # The only errnos `Path.rename()` onto an existing directory is expected to
@@ -45,11 +47,12 @@ from pathlib import Path
 RENAME_DEST_EXISTS_ERRNOS = (errno.ENOTEMPTY, errno.EEXIST)
 
 # Bound on retrying a `.refreshN` publish name after a collision with a
-# concurrent `--full-refresh` run (see the retry loop in `main()`). A bounded
+# concurrent `--full-refresh` run (see `publish_refresh_generation`). A bounded
 # retry, not a `while .exists()` probe-then-rename: the probe alone is
 # check-then-act and a genuine concurrent racer can occupy the exact name
 # between the check and the rename.
 REFRESH_RENAME_RETRY_LIMIT = 20
+CACHE_PUBLISH_LOCK = ".publish.lock"
 
 # conformance/utils/src/extract_fixtures.py -> repo root: 4 .parent calls
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -70,6 +73,18 @@ def sha256_file(path):
 def get_cache_root():
     xdg = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
     return Path(xdg) / "dynamo" / "conformance-fixtures"
+
+
+@contextmanager
+def cache_publish_lock(cache_root):
+    """Serialize generation selection, publication, and link retargeting."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    with (cache_root / CACHE_PUBLISH_LOCK).open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 def shard_hash_map(shards):
@@ -151,6 +166,96 @@ def resolve_current_generation(cache_root, pin, fid, pinned_shards):
     return best_dir, best_n
 
 
+def publish_refresh_generation(tmp_dir, cache_root, pin, fid, pinned_shards):
+    """Publish ``tmp_dir`` at the next immutable refresh generation.
+
+    A forced rebuild never renames or deletes a previously published path:
+    a reader may still be using it. The highest valid generation owns
+    recency even when generation 0 has been removed, and rename collisions
+    advance to the next number so concurrent refreshers cannot overwrite one
+    another.
+    """
+    _, current_n = resolve_current_generation(cache_root, pin, fid, pinned_shards)
+    refresh_n = max(current_n, 0) + 1
+    for _attempt in range(REFRESH_RENAME_RETRY_LIMIT):
+        candidate = cache_root / f"{pin}-{fid}.refresh{refresh_n}"
+        try:
+            tmp_dir.rename(candidate)
+            print(
+                f"  --full-refresh: identity {fid} already published; built a new "
+                f"generation at {candidate} instead of mutating the existing one "
+                "(a reader still using the prior generation is unaffected)",
+                file=sys.stderr,
+            )
+            return candidate
+        except OSError as exc:
+            if exc.errno not in RENAME_DEST_EXISTS_ERRNOS:
+                raise
+            refresh_n += 1
+    raise OSError(
+        f"could not publish a --full-refresh generation for identity "
+        f"{fid} in {cache_root} after {REFRESH_RENAME_RETRY_LIMIT} "
+        "name collisions -- persistent concurrent refreshers?"
+    )
+
+
+def publish_extracted_snapshot(
+    tmp_dir, cache_root, pin, fid, pinned_shards, full_refresh, verbose=False
+):
+    """Publish one completed build and point readers at the newest generation."""
+    base_dir = cache_root / f"{pin}-{fid}"
+    with cache_publish_lock(cache_root):
+        current_dir, _current_n = resolve_current_generation(
+            cache_root, pin, fid, pinned_shards
+        )
+        if full_refresh and current_dir is not None:
+            publish_refresh_generation(tmp_dir, cache_root, pin, fid, pinned_shards)
+        elif current_dir is not None:
+            print(
+                f"  identity {fid} already published by a concurrent extraction, "
+                f"discarding redundant build",
+                file=sys.stderr,
+            )
+            shutil.rmtree(str(tmp_dir))
+        else:
+            try:
+                tmp_dir.rename(base_dir)
+            except OSError as exc:
+                # A non-cooperating older publisher may still win generation 0.
+                # Accept it only when its state proves the same identity.
+                if exc.errno not in RENAME_DEST_EXISTS_ERRNOS:
+                    raise
+                published = read_state(base_dir)
+                if not (base_dir.is_dir() and published.get("shards") == pinned_shards):
+                    raise OSError(
+                        exc.errno,
+                        f"{base_dir} is occupied but is not a valid published extraction "
+                        f"for identity {fid} (state mismatch) -- refusing to treat it as "
+                        "authoritative or overwrite it",
+                    ) from exc
+                if full_refresh:
+                    publish_refresh_generation(tmp_dir, cache_root, pin, fid, pinned_shards)
+                else:
+                    print(
+                        f"  identity {fid} already published by a concurrent extraction, "
+                        f"discarding redundant build",
+                        file=sys.stderr,
+                    )
+                    shutil.rmtree(str(tmp_dir))
+
+        # Prefer any higher generation already published before this writer
+        # retargets the compatibility links. Correctness-critical consumers
+        # use the immutable path returned below, because an older checkout
+        # that does not know this lock can still overwrite those links later.
+        newest_dir, _newest_n = resolve_current_generation(
+            cache_root, pin, fid, pinned_shards
+        )
+        if newest_dir is None:
+            raise OSError(f"published fixture identity {fid} has no valid generation")
+        update_symlinks(cache_root, newest_dir, verbose=verbose)
+        return newest_dir
+
+
 def write_state(snap_dir, snapshot, shards):
     state = {
         "snapshot": snapshot,
@@ -205,7 +310,7 @@ def shard_file(shard):
 
 
 def update_symlinks(cache_root, snap_dir, verbose=False):
-    """Create/retarget relative symlinks cache_root/{toolcalling,reasoning} -> snap_dir/..."""
+    """Retarget compatibility links; readers use the returned immutable snapshot path."""
     for name in ("toolcalling", "reasoning", "unified"):
         src = snap_dir / name
         if not src.exists():
@@ -313,22 +418,18 @@ def main():
     # function's docstring).
     snap_dir = cache_root / f"{pin}-{fid}"
 
-    current_dir, current_n = resolve_current_generation(cache_root, pin, fid, pinned_shards)
-    if current_dir and not args.full_refresh:
-        # A directory only ever exists at this exact content-addressed name
-        # once it is fully built (see the atomic publish below), so its
-        # presence alone is already sufficient; `resolve_current_generation`'s
-        # state-file check is a cheap extra sanity check against out-of-band
-        # interference, not the thing establishing correctness.
-        #
-        # Retarget the stable symlinks even on a hit: switching between two
-        # already-cached identities/generations (e.g. a pin rollback) must
-        # repoint toolcalling/ + reasoning/ or readers keep using the other
-        # snapshot.
-        update_symlinks(cache_root, current_dir, verbose=args.verbose)
-        print(f"Cache hit: {current_dir}", file=sys.stderr)
-        print(current_dir)
-        return
+    if not args.full_refresh:
+        with cache_publish_lock(cache_root):
+            current_dir, _current_n = resolve_current_generation(
+                cache_root, pin, fid, pinned_shards
+            )
+            if current_dir:
+                # Retarget while holding the same lock as publishers: a cache
+                # hit must not restore an older identity after a newer publish.
+                update_symlinks(cache_root, current_dir, verbose=args.verbose)
+                print(f"Cache hit: {current_dir}", file=sys.stderr)
+                print(current_dir)
+                return
 
     if args.dry_run:
         for s in shards:
@@ -367,98 +468,15 @@ def main():
         extract_tarball(shard_file(s), tmp_dir, verbose=args.verbose)
     write_state(tmp_dir, pin, shards)
 
-    try:
-        tmp_dir.rename(snap_dir)
-    except OSError as exc:
-        # Only "the destination already exists" may mean a concurrent process
-        # published the SAME identity first (two uncoordinated first-time
-        # builds of one new identity, e.g. via the unlocked `_common.sh`
-        # path). Any other errno -- permission, I/O, disk full, cross-device
-        # EXDEV -- is a real failure with nothing to reconcile against and
-        # must propagate with its original cause, not be swallowed here.
-        if exc.errno not in RENAME_DEST_EXISTS_ERRNOS:
-            raise
-        # Even a "destination exists" error must be verified, not trusted:
-        # the directory occupying this name could be a stray/partial one
-        # from manual intervention or a bug, not a genuine prior publish.
-        published = read_state(snap_dir)
-        if not (snap_dir.is_dir() and published.get("shards") == pinned_shards):
-            raise OSError(
-                exc.errno,
-                f"{snap_dir} is occupied but is not a valid published extraction "
-                f"for identity {fid} (state mismatch) -- refusing to treat it as "
-                "authoritative or overwrite it",
-            ) from exc
-        if args.full_refresh:
-            # `--full-refresh` means "rebuild regardless of cache validity" --
-            # e.g. to recover from local corruption that doesn't change the
-            # shard-source hash this identity is keyed on (state only records
-            # the shard SOURCES' hashes, never the extracted output content).
-            # Silently discarding the rebuild here (the plain branch below)
-            # defeats the flag's purpose. But renaming/deleting the EXISTING
-            # `snap_dir` to make room -- an earlier version of this fix did
-            # exactly that -- reopens the identical hazard the rest of this
-            # function exists to close: a reader that resolved a symlink
-            # pointing at `snap_dir` before this run started may still be
-            # reading files through that exact path for the rest of ITS OWN
-            # lifetime, with no bound on how long that takes. There is no
-            # safe moment to rename or delete a path a reader might still be
-            # using -- "briefly" is still unsafe.
-            #
-            # So a forced rebuild of an identity that already exists NEVER
-            # touches `snap_dir` at all. It publishes to a new, disambiguated
-            # generation path instead; `snap_dir` itself is simply
-            # abandoned, exactly like any other published directory (see the
-            # "no orphan sweep, never delete a published dir" decision
-            # above) -- a reader already using it keeps working, unaffected,
-            # for its entire lifetime. The symlinks (the one mutable
-            # "current" locator, already updated via its own atomic
-            # temp-then-rename) retarget to the new generation for whoever
-            # resolves them AFTER this run.
-            # `resolve_current_generation` (not a fresh `.exists()` probe loop
-            # from 1) picks the starting number: another concurrent
-            # `--full-refresh` racing on the SAME base identity could have
-            # already published `.refresh1`, and starting from 1 again would
-            # just re-collide. The `.exists()` check on the next candidate is
-            # still check-then-act, so the actual rename below is wrapped in
-            # the same narrowed-errno retry as the generation-0 publish path
-            # above -- two runs computing the identical candidate name is a
-            # real, reachable race, not a hypothetical one.
-            _, current_n = resolve_current_generation(cache_root, pin, fid, pinned_shards)
-            refresh_n = max(current_n, 0) + 1
-            published_refresh = False
-            for _attempt in range(REFRESH_RENAME_RETRY_LIMIT):
-                candidate = cache_root / f"{pin}-{fid}.refresh{refresh_n}"
-                try:
-                    tmp_dir.rename(candidate)
-                    published_refresh = True
-                    break
-                except OSError as exc2:
-                    if exc2.errno not in RENAME_DEST_EXISTS_ERRNOS:
-                        raise
-                    refresh_n += 1
-            if not published_refresh:
-                raise OSError(
-                    f"could not publish a --full-refresh generation for identity "
-                    f"{fid} in {cache_root} after {REFRESH_RENAME_RETRY_LIMIT} "
-                    "name collisions -- persistent concurrent refreshers?"
-                )
-            snap_dir = candidate
-            print(
-                f"  --full-refresh: identity {fid} already published; built a new "
-                f"generation at {snap_dir} instead of mutating the existing one "
-                "(a reader still using the prior generation is unaffected)",
-                file=sys.stderr,
-            )
-        else:
-            print(
-                f"  identity {fid} already published by a concurrent extraction, "
-                f"discarding redundant build",
-                file=sys.stderr,
-            )
-            shutil.rmtree(str(tmp_dir))
-
-    update_symlinks(cache_root, snap_dir, verbose=args.verbose)
+    snap_dir = publish_extracted_snapshot(
+        tmp_dir,
+        cache_root,
+        pin,
+        fid,
+        pinned_shards,
+        full_refresh=args.full_refresh,
+        verbose=args.verbose,
+    )
 
     print(snap_dir)
 

--- a/conformance/utils/src/extract_fixtures.py
+++ b/conformance/utils/src/extract_fixtures.py
@@ -27,13 +27,29 @@ Usage:
 """
 
 import argparse
+import errno
 import hashlib
 import json
 import os
+import secrets
 import shutil
 import sys
 import tarfile
 from pathlib import Path
+
+# The only errnos `Path.rename()` onto an existing directory is expected to
+# raise for "the destination is already occupied" -- confirmed ENOTEMPTY on
+# ext4; EEXIST kept for portability to other POSIX filesystems/kernels. Any
+# other errno (permission, I/O, cross-device EXDEV, disk full, ...) is a real
+# failure and must propagate, never be treated as "someone published first."
+RENAME_DEST_EXISTS_ERRNOS = (errno.ENOTEMPTY, errno.EEXIST)
+
+# Bound on retrying a `.refreshN` publish name after a collision with a
+# concurrent `--full-refresh` run (see the retry loop in `main()`). A bounded
+# retry, not a `while .exists()` probe-then-rename: the probe alone is
+# check-then-act and a genuine concurrent racer can occupy the exact name
+# between the check and the rename.
+REFRESH_RENAME_RETRY_LIMIT = 20
 
 # conformance/utils/src/extract_fixtures.py -> repo root: 4 .parent calls
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -56,6 +72,35 @@ def get_cache_root():
     return Path(xdg) / "dynamo" / "conformance-fixtures"
 
 
+def shard_hash_map(shards):
+    """The one owner of `{shard path: sha256}` -- `write_state`, the cache-hit
+    check, and `fixtures_identity` all need the exact same map, and a second
+    independent construction of it is exactly the divergent-copy class that
+    caused the prior stale-check bug this file already documents (see the
+    `fixtures_identity` docstring below)."""
+    return {s["path"]: s["sha256"] for s in shards}
+
+
+def fixtures_identity(shards):
+    """Content identity for a shard set: sha256 of the canonical (sorted)
+    shard-hash map, truncated to 16 hex chars.
+
+    NOT the same thing as `snapshot`/`pin`: `pin` is a human-readable stamp
+    that can stay fixed while the shards under it are re-pinned in place
+    (it happened once, to fixtures-batch-on-stream-v2 -- see the comment in
+    `main()`). Naming the cache directory by `pin` alone let two DIFFERENT
+    shard-hash sets collide on one path; whichever extraction ran second
+    called `shutil.rmtree()` on the directory a concurrent reader (a test in
+    another git worktree, or `_common.sh`, which has no lock at all) could
+    still be reading through the `toolcalling`/`reasoning`/`unified`
+    symlinks -- a real, reproduced `ENOENT` race. Keying the directory name
+    by this identity instead means two different shard sets simply never
+    share a path, so nothing is ever deleted out from under a live reader.
+    """
+    pinned = sorted(shard_hash_map(shards).items())
+    return hashlib.sha256(json.dumps(pinned).encode()).hexdigest()[:16]
+
+
 def read_state(snap_dir):
     state_file = snap_dir / ".fixtures-state.json"
     if state_file.exists():
@@ -66,10 +111,50 @@ def read_state(snap_dir):
     return {}
 
 
+def resolve_current_generation(cache_root, pin, fid, pinned_shards):
+    """The one owner of "which published directory is current for this
+    identity" -- generation 0 is the bare `{pin}-{fid}`, and `--full-refresh`
+    publishes later generations at `{pin}-{fid}.refresh{N}` (N >= 1) without
+    ever touching an earlier one (see the `--full-refresh` branch in
+    `main()`). A caller that reconstructs the bare `{pin}-{fid}` path
+    directly instead of calling this function is blind to every refresh: it
+    treats the abandoned original generation as the cache hit forever,
+    silently undoing what `--full-refresh` was run to fix. `main()`'s
+    cache-hit check and `package_fixtures.py`'s `_extracted_snapshot_dir()`
+    both route through this one function for exactly that reason.
+
+    Returns `(path, generation)` for the highest-generation directory whose
+    recorded state still matches `pinned_shards`, or `(None, -1)` if none
+    does.
+    """
+    if not cache_root.exists():
+        return None, -1
+    base = f"{pin}-{fid}"
+    best_dir, best_n = None, -1
+    for d in cache_root.iterdir():
+        if not d.is_dir():
+            continue
+        if d.name == base:
+            n = 0
+        elif d.name.startswith(base + ".refresh"):
+            suffix = d.name[len(base + ".refresh") :]
+            if not suffix.isdigit():
+                continue
+            n = int(suffix)
+        else:
+            continue
+        if n <= best_n:
+            continue
+        if read_state(d).get("shards") != pinned_shards:
+            continue
+        best_dir, best_n = d, n
+    return best_dir, best_n
+
+
 def write_state(snap_dir, snapshot, shards):
     state = {
         "snapshot": snapshot,
-        "shards": {s["path"]: s["sha256"] for s in shards},
+        "shards": shard_hash_map(shards),
     }
     tmp = snap_dir / ".fixtures-state.json.tmp"
     tmp.write_text(json.dumps(state, indent=2) + "\n")
@@ -163,9 +248,24 @@ def show_info(manifest, cache_root):
 
     cached = list_cached_snapshots(cache_root)
     if cached:
+        fid = fixtures_identity(shards)
+        pinned_shards = shard_hash_map(shards)
+        current_dir, _ = resolve_current_generation(cache_root, pin, fid, pinned_shards)
         print(f"\nCached snapshots in {cache_root}:")
         for d in cached:
-            marker = "  <- current pin" if d.name == pin else ""
+            # Cached dirs are named `{pin}-{fid}` or `{pin}-{fid}.refreshN`
+            # (see `fixtures_identity` / `resolve_current_generation`), never
+            # bare `pin` -- an exact-equality check here always missed. A
+            # `startswith(f"{pin}-")` check marks EVERY generation of the
+            # current pin, not just the one readers actually resolve through
+            # the symlinks -- route through `resolve_current_generation`, the
+            # same single owner `main()`'s cache-hit check uses, instead.
+            if d == current_dir:
+                marker = "  <- current pin (active generation)"
+            elif d.name.startswith(f"{pin}-"):
+                marker = "  <- current pin (older generation)"
+            else:
+                marker = ""
             print(f"  {d.name}{marker}")
     else:
         print(f"\nNo cached snapshots in {cache_root}")
@@ -197,32 +297,32 @@ def main():
         show_info(manifest, cache_root)
         return
 
-    snap_dir = cache_root / pin
+    pinned_shards = shard_hash_map(shards)
+    fid = fixtures_identity(shards)
+    # `{pin}-{fid}`, not bare `pin`: two different shard-hash sets under the
+    # SAME pin (a re-pin in place) must never share a directory name -- see
+    # `fixtures_identity`'s docstring for the race this closes. This is only
+    # the generation-0 build target; a cache HIT must check every generation
+    # via `resolve_current_generation`, not just this bare name, or a prior
+    # `--full-refresh` becomes invisible to every later plain run (see that
+    # function's docstring).
+    snap_dir = cache_root / f"{pin}-{fid}"
 
-    # Clean up an incomplete partial extraction (snap_dir present but no state marker)
-    if snap_dir.exists() and not (snap_dir / ".fixtures-state.json").exists():
-        print(f"  incomplete extraction at {snap_dir}, removing", file=sys.stderr)
-        shutil.rmtree(str(snap_dir))
-
-    state = read_state(snap_dir)
-
-    pinned_shards = {s["path"]: s["sha256"] for s in shards}
-    if (
-        state
-        and state.get("snapshot") == pin
-        # Compare the full shard-hash map, not just the stamp: a shard can be
-        # re-pinned IN PLACE under an unchanged snapshot (it happened to
-        # fixtures-batch-on-stream-v2), and a stamp-only check would keep
-        # serving the stale extracted tree forever.
-        and state.get("shards") == pinned_shards
-        and not args.full_refresh
-    ):
+    current_dir, current_n = resolve_current_generation(cache_root, pin, fid, pinned_shards)
+    if current_dir and not args.full_refresh:
+        # A directory only ever exists at this exact content-addressed name
+        # once it is fully built (see the atomic publish below), so its
+        # presence alone is already sufficient; `resolve_current_generation`'s
+        # state-file check is a cheap extra sanity check against out-of-band
+        # interference, not the thing establishing correctness.
+        #
         # Retarget the stable symlinks even on a hit: switching between two
-        # already-cached snapshots (e.g. a pin rollback) must repoint
-        # toolcalling/ + reasoning/ or readers keep using the other snapshot.
-        update_symlinks(cache_root, snap_dir, verbose=args.verbose)
-        print(f"Cache hit: {snap_dir}", file=sys.stderr)
-        print(snap_dir)
+        # already-cached identities/generations (e.g. a pin rollback) must
+        # repoint toolcalling/ + reasoning/ or readers keep using the other
+        # snapshot.
+        update_symlinks(cache_root, current_dir, verbose=args.verbose)
+        print(f"Cache hit: {current_dir}", file=sys.stderr)
+        print(current_dir)
         return
 
     if args.dry_run:
@@ -232,17 +332,127 @@ def main():
         print(snap_dir)
         return
 
-    if snap_dir.exists():
-        # Reaching here means the cache-hit check failed for this dir (forced
-        # refresh, or the manifest's shard pins moved under the same stamp) —
-        # the extraction is stale either way.
-        print(f"  stale extraction at {snap_dir}, re-extracting", file=sys.stderr)
-        shutil.rmtree(str(snap_dir))
+    # No orphaned-`.tmp.*`-dir sweep here (deliberately removed after review):
+    # an mtime-based age gate only reflects a directory's own DIRECT children
+    # changing, not writes deep inside an already-created subtree, so a
+    # genuinely still-running long build (or one with a large gap between
+    # its last top-level entry and its last file write) could be swept by a
+    # CONCURRENT process's own sweep step. `extract_tarball`'s unconditional
+    # `mkdir(parents=True, exist_ok=True)` means the victim wouldn't even
+    # notice -- it would silently recreate the directory, keep writing, and
+    # ultimately publish a `.fixtures-state.json` claiming completeness over
+    # data that was actually wiped mid-build. A leftover `.tmp.*` dir is
+    # never referenced by any symlink and can never be mistaken for a valid
+    # cache (see `list_cached_snapshots`'s state-file check), so leaving
+    # orphans in place is purely a disk-hygiene cost, not a correctness one
+    # -- not worth trading for that failure mode. Clean up manually if disk
+    # usage becomes a real problem.
 
-    print(f"Extracting {len(shards)} shard(s) into {snap_dir}", file=sys.stderr)
+    # Build into a private, unique temp dir -- never referenced by any
+    # symlink, so a concurrent reader can never observe it, and a crash here
+    # only ever corrupts this process's own scratch directory. Publish with a
+    # single atomic rename once the build (including the state file) is
+    # complete, so `snap_dir` is either fully absent or fully populated —
+    # never observed mid-extraction by a concurrent reader.
+    tmp_dir = cache_root / f".tmp.{fid}.{os.getpid()}.{secrets.token_hex(4)}"
+    if tmp_dir.exists():
+        shutil.rmtree(str(tmp_dir))
+    print(f"Extracting {len(shards)} shard(s) into {tmp_dir}", file=sys.stderr)
     for s in shards:
-        extract_tarball(shard_file(s), snap_dir, verbose=args.verbose)
-    write_state(snap_dir, pin, shards)
+        extract_tarball(shard_file(s), tmp_dir, verbose=args.verbose)
+    write_state(tmp_dir, pin, shards)
+
+    try:
+        tmp_dir.rename(snap_dir)
+    except OSError as exc:
+        # Only "the destination already exists" may mean a concurrent process
+        # published the SAME identity first (two uncoordinated first-time
+        # builds of one new identity, e.g. via the unlocked `_common.sh`
+        # path). Any other errno -- permission, I/O, disk full, cross-device
+        # EXDEV -- is a real failure with nothing to reconcile against and
+        # must propagate with its original cause, not be swallowed here.
+        if exc.errno not in RENAME_DEST_EXISTS_ERRNOS:
+            raise
+        # Even a "destination exists" error must be verified, not trusted:
+        # the directory occupying this name could be a stray/partial one
+        # from manual intervention or a bug, not a genuine prior publish.
+        published = read_state(snap_dir)
+        if not (snap_dir.is_dir() and published.get("shards") == pinned_shards):
+            raise OSError(
+                exc.errno,
+                f"{snap_dir} is occupied but is not a valid published extraction "
+                f"for identity {fid} (state mismatch) -- refusing to treat it as "
+                "authoritative or overwrite it",
+            ) from exc
+        if args.full_refresh:
+            # `--full-refresh` means "rebuild regardless of cache validity" --
+            # e.g. to recover from local corruption that doesn't change the
+            # shard-source hash this identity is keyed on (state only records
+            # the shard SOURCES' hashes, never the extracted output content).
+            # Silently discarding the rebuild here (the plain branch below)
+            # defeats the flag's purpose. But renaming/deleting the EXISTING
+            # `snap_dir` to make room -- an earlier version of this fix did
+            # exactly that -- reopens the identical hazard the rest of this
+            # function exists to close: a reader that resolved a symlink
+            # pointing at `snap_dir` before this run started may still be
+            # reading files through that exact path for the rest of ITS OWN
+            # lifetime, with no bound on how long that takes. There is no
+            # safe moment to rename or delete a path a reader might still be
+            # using -- "briefly" is still unsafe.
+            #
+            # So a forced rebuild of an identity that already exists NEVER
+            # touches `snap_dir` at all. It publishes to a new, disambiguated
+            # generation path instead; `snap_dir` itself is simply
+            # abandoned, exactly like any other published directory (see the
+            # "no orphan sweep, never delete a published dir" decision
+            # above) -- a reader already using it keeps working, unaffected,
+            # for its entire lifetime. The symlinks (the one mutable
+            # "current" locator, already updated via its own atomic
+            # temp-then-rename) retarget to the new generation for whoever
+            # resolves them AFTER this run.
+            # `resolve_current_generation` (not a fresh `.exists()` probe loop
+            # from 1) picks the starting number: another concurrent
+            # `--full-refresh` racing on the SAME base identity could have
+            # already published `.refresh1`, and starting from 1 again would
+            # just re-collide. The `.exists()` check on the next candidate is
+            # still check-then-act, so the actual rename below is wrapped in
+            # the same narrowed-errno retry as the generation-0 publish path
+            # above -- two runs computing the identical candidate name is a
+            # real, reachable race, not a hypothetical one.
+            _, current_n = resolve_current_generation(cache_root, pin, fid, pinned_shards)
+            refresh_n = max(current_n, 0) + 1
+            published_refresh = False
+            for _attempt in range(REFRESH_RENAME_RETRY_LIMIT):
+                candidate = cache_root / f"{pin}-{fid}.refresh{refresh_n}"
+                try:
+                    tmp_dir.rename(candidate)
+                    published_refresh = True
+                    break
+                except OSError as exc2:
+                    if exc2.errno not in RENAME_DEST_EXISTS_ERRNOS:
+                        raise
+                    refresh_n += 1
+            if not published_refresh:
+                raise OSError(
+                    f"could not publish a --full-refresh generation for identity "
+                    f"{fid} in {cache_root} after {REFRESH_RENAME_RETRY_LIMIT} "
+                    "name collisions -- persistent concurrent refreshers?"
+                )
+            snap_dir = candidate
+            print(
+                f"  --full-refresh: identity {fid} already published; built a new "
+                f"generation at {snap_dir} instead of mutating the existing one "
+                "(a reader still using the prior generation is unaffected)",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"  identity {fid} already published by a concurrent extraction, "
+                f"discarding redundant build",
+                file=sys.stderr,
+            )
+            shutil.rmtree(str(tmp_dir))
+
     update_symlinks(cache_root, snap_dir, verbose=args.verbose)
 
     print(snap_dir)

--- a/conformance/utils/src/extract_fixtures.py
+++ b/conformance/utils/src/extract_fixtures.py
@@ -213,11 +213,16 @@ def update_symlinks(cache_root, snap_dir, verbose=False):
         link = cache_root / name
         # Relative target: <snapshot>/<name>  (e.g. 20260707_215709/toolcalling)
         target = Path(snap_dir.name) / name
-        tmp = cache_root / f".{name}.tmp"
-        if tmp.is_symlink() or tmp.exists():
-            tmp.unlink()
-        tmp.symlink_to(target)
-        tmp.rename(link)
+        # Every publisher owns a distinct temporary link. A shared
+        # `.{name}.tmp` is a check-then-act race: one publisher can rename
+        # another's temp link, leaving the second with FileNotFoundError.
+        tmp = cache_root / f".{name}.tmp.{os.getpid()}.{secrets.token_hex(8)}"
+        try:
+            tmp.symlink_to(target)
+            tmp.replace(link)
+        finally:
+            if tmp.is_symlink() or tmp.exists():
+                tmp.unlink()
         if verbose:
             print(f"  [symlink] {link} -> {target}", file=sys.stderr)
 

--- a/conformance/utils/src/fixture_snapshot.py
+++ b/conformance/utils/src/fixture_snapshot.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve the immutable fixture snapshot used by Python conformance tools."""
+
+import os
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache
+def fixture_snapshot_root() -> Path:
+    """Return one immutable snapshot path, never the mutable cache symlinks."""
+    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
+    root = Path(env) if env else None
+    if root is None or any((root / name).is_symlink() for name in ("toolcalling", "reasoning", "unified")):
+        script = Path(__file__).resolve().parent / "extract_fixtures.py"
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        printed = proc.stdout.strip().splitlines()
+        if not printed:
+            raise RuntimeError("extract_fixtures.py returned no snapshot path")
+        root = Path(printed[-1])
+    if not root.is_dir():
+        raise RuntimeError(f"fixture snapshot path is not a directory: {root}")
+    return root

--- a/conformance/utils/src/fixtures.py
+++ b/conformance/utils/src/fixtures.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import yaml
 
+from fixture_snapshot import fixture_snapshot_root
 from impls import IMPL_DISPLAY, IMPL_KEYS, PEER_IMPL_KEYS
 from markers import (
     VLLM_RUST_UNAVAILABLE,
@@ -29,24 +30,17 @@ FIXTURES = REPO_ROOT / "tests/parity/toolcalling/fixtures"
 RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
 
 # The versioned fixture source (inputs/ + per-impl <impl>-<version>/ dirs) lives in
-# the fixture extraction cache (from the in-repo LFS store). `_common.sh` exports
-# CONFORMANCE_FIXTURES_ROOT (the cache root); fall back to the standard cache path for
-# standalone runs. Powers the per-impl version radios: the generator resolves each
+# an immutable fixture extraction snapshot (from the in-repo LFS store). `_common.sh`
+# exports CONFORMANCE_FIXTURES_ROOT; standalone runs resolve the exact snapshot printed
+# by `extract_fixtures.py`. Powers the per-impl version radios: the generator resolves each
 # version snapshot and re-runs the load path so cell keys align exactly with the
 # rendered (pinned) table.
 _FRONTEND_CRATES_ROOT = Path(os.environ.get("FRONTEND_CRATES_ROOT", str(REPO_ROOT)))
 
 
 def _fixtures_cache_root() -> Path:
-    """Fixture extraction cache root (`~/.cache/dynamo/conformance-fixtures`
-    or `$XDG_CACHE_HOME/...`). `_common.sh` exports CONFORMANCE_FIXTURES_ROOT pointing
-    here; honor it first so staged renders and standalone runs agree."""
-    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "dynamo/conformance-fixtures"
+    """Immutable manifest-pinned snapshot used by all fixture readers."""
+    return fixture_snapshot_root()
 
 
 _SRC_FIXTURES = _fixtures_cache_root() / "toolcalling/fixtures-batch-v1"

--- a/conformance/utils/src/package_fixtures.py
+++ b/conformance/utils/src/package_fixtures.py
@@ -34,6 +34,8 @@ import tarfile
 import tempfile
 from pathlib import Path
 
+import extract_fixtures  # sibling script, same dir on sys.path (matches capture_driver's import pattern)
+
 # conformance/utils/src/ -> repo root: 4 .parent calls (strip filename, then 3 dirs)
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MANIFEST_REL = Path("conformance") / "fixtures-manifest.json"
@@ -124,15 +126,36 @@ def stage_fixtures(conformance_root, tmpdir):
 
 def _extracted_snapshot_dir():
     """The current extracted snapshot in the fixture cache, or None. Used to
-    protect whole-tree shards from partial local capture trees."""
-    xdg = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
-    cache_root = Path(xdg) / "dynamo" / "conformance-fixtures"
+    protect whole-tree shards from partial local capture trees.
+
+    Same directory-naming contract as `extract_fixtures.py`: cached
+    extractions are keyed by `{pin}-{fixtures_identity(shards)}`, not bare
+    `pin` (a shard set can be re-pinned in place under an unchanged pin) --
+    reusing `fixtures_identity` here instead of a second, independent
+    identity computation keeps the two scripts from silently drifting apart
+    on what "the same content" means.
+
+    Resolution itself routes through `extract_fixtures.resolve_current_generation`
+    -- the same single owner `extract_fixtures.py`'s own cache-hit check
+    uses -- instead of reconstructing the bare `{pin}-{fid}` path directly.
+    A `--full-refresh` publishes later generations at `{pin}-{fid}.refreshN`
+    without ever touching the original; a direct reconstruction here would
+    keep resolving to the abandoned (possibly corrupted) original generation
+    forever, even after a refresh fixed it.
+    """
     manifest_path = ROOT / MANIFEST_REL
     if not manifest_path.exists():
         return None
-    snap = json.loads(manifest_path.read_text()).get("snapshot")
-    d = cache_root / snap if snap else None
-    return d if d and d.is_dir() else None
+    manifest = json.loads(manifest_path.read_text())
+    snap = manifest.get("snapshot")
+    shards = manifest.get("shards", [])
+    if not snap or not shards:
+        return None
+    cache_root = extract_fixtures.get_cache_root()
+    fid = extract_fixtures.fixtures_identity(shards)
+    pinned_shards = extract_fixtures.shard_hash_map(shards)
+    d, _generation = extract_fixtures.resolve_current_generation(cache_root, snap, fid, pinned_shards)
+    return d
 
 
 def build_shards(tmpdir, blobs_dir, prune=False):

--- a/conformance/utils/src/parser_families.yaml
+++ b/conformance/utils/src/parser_families.yaml
@@ -195,7 +195,7 @@ unified:
     leak_markers: ["thought\n"]
   kimi_k2:
     registry: kimi_k2
-    native: false
+    native: true
     reasoning_parser: kimi_k25
     tool_parser: kimi_k2
     golden_spec: kimi.yaml

--- a/conformance/utils/src/refresh_dynamo_captures.py
+++ b/conformance/utils/src/refresh_dynamo_captures.py
@@ -21,8 +21,8 @@ Modes (any subset; default all):
 
 The tree is the working copy that package_and_publish.py packages
 (conformance/toolcalling/...). If a fixture tree is missing there, it is first
-copied from the fixture cache (CONFORMANCE_FIXTURES_ROOT or
-~/.cache/dynamo/conformance-fixtures) so peer data carries over unchanged.
+copied from the immutable snapshot resolved by `extract_fixtures.py` so peer data
+carries over unchanged.
 
 Usage:
   python3 refresh_dynamo_captures.py                # all three modes
@@ -31,7 +31,6 @@ Usage:
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -41,6 +40,7 @@ from pathlib import Path
 import yaml
 
 from dynamo_version import crate_version, dynamo_v2_label
+from fixture_snapshot import fixture_snapshot_root
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent.parent.parent  # conformance/utils/src -> repo root
@@ -58,20 +58,11 @@ _FAMILIES = yaml.safe_load((HERE / "parser_families.yaml").read_text())["familie
 V2_FAMILIES = sorted(f for f, s in _FAMILIES.items() if s.get("dynamo_v2"))
 
 
-def cache_root() -> Path:
-    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-    if env:
-        return Path(env)
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "dynamo" / "conformance-fixtures"
-
-
 def ensure_tree(name: str) -> Path:
     """Return TREE/<name>, copying it from the fixture cache on first use."""
     dst = TREE / name
     if not (dst / "inputs").is_dir() and not any(dst.glob("*/*.yaml")):
-        src = cache_root() / "toolcalling" / name
+        src = fixture_snapshot_root() / "toolcalling" / name
         if not src.is_dir():
             raise SystemExit(f"{src} not cached — run extract_fixtures.py first")
         print(f"[refresh] copying {src} -> {dst}")

--- a/conformance/utils/src/tables/common.py
+++ b/conformance/utils/src/tables/common.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from fixture_snapshot import fixture_snapshot_root
+
 
 # ---------------------------------------------------------------------------
 # Destination-aware link resolution for the conformance generator. The generator
@@ -58,20 +60,15 @@ def _hrefs_for_output(output_path: Path, artifact_root: Path) -> dict[str, str]:
 
 
 # Fixture YAMLs aren't loose in the repo — they're LFS tarballs under
-# conformance/fixtures/, extracted into the local cache
-# (~/.cache/dynamo/conformance-fixtures/, or $CONFORMANCE_FIXTURES_ROOT). The store
+# conformance/fixtures/, extracted into an immutable snapshot selected through
+# $CONFORMANCE_FIXTURES_ROOT or `extract_fixtures.py`. The store
 # holds only the tarballs (no per-file URL), so a
 # per-cell YAML link points at the extracted file in that cache via file://. The
 # rendered `__fixture_path` is the flat resolved-tree path the readers use; remap it to
 # the versioned cache layout (the shared `inputs/` tree carries the model_text /
 # description a viewer wants to see).
 def _fixtures_cache_root() -> str:
-    env = os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-    if env:
-        return env.rstrip("/")
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return str(base / "dynamo/conformance-fixtures")
+    return str(fixture_snapshot_root())
 
 
 def _fixture_cache_relpath(rel: str) -> str:

--- a/conformance/utils/src/validate.py
+++ b/conformance/utils/src/validate.py
@@ -144,6 +144,7 @@ def run_container(impl: str, container: str, cases: list[dict]) -> dict[str, dic
     """Ship the adapter + a worker into ``container`` and run all cases there."""
     dest = "/tmp/conformance_validate"
     bundle = {
+        "fixture_snapshot.py": PH / "fixture_snapshot.py",
         "tables/__init__.py": PKG / "__init__.py",
         "tables/common.py": PKG / "common.py",
         "tables/toolcalling/__init__.py": PKG / "toolcalling" / "__init__.py",

--- a/conformance/utils/tests/test_browser_popup_compare.py
+++ b/conformance/utils/tests/test_browser_popup_compare.py
@@ -12,8 +12,8 @@ test_browser_smoke.py).
 """
 from __future__ import annotations
 
-import os
 import shutil
+import sys
 import time
 from pathlib import Path
 
@@ -22,6 +22,13 @@ import pytest
 selenium = pytest.importorskip("selenium")
 from selenium import webdriver  # noqa: E402
 from selenium.webdriver.chrome.options import Options  # noqa: E402
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from fixture_snapshot import fixture_snapshot_root  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     not any(
@@ -35,11 +42,7 @@ def _dynamo_key(impl: str) -> str:
     """Candidate key of the LATEST stream capture dir for a Dynamo impl
     (`dynamo_v1` = jail reference, `dynamo_v2` = stream parser); older version
     dirs are capture history and render as extra candidates."""
-    root = Path(
-        os.environ.get("CONFORMANCE_FIXTURES_ROOT")
-        or Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
-        / "dynamo/conformance-fixtures"
-    )
+    root = fixture_snapshot_root()
     import re as _re
 
     dirs = [

--- a/conformance/utils/tests/test_extract_fixtures_identity.py
+++ b/conformance/utils/tests/test_extract_fixtures_identity.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -68,6 +69,44 @@ def _run_main(tmp_path, monkeypatch, manifest, argv=()):
     monkeypatch.setattr(extract_fixtures, "MANIFEST_PATH", manifest_path)
     monkeypatch.setattr(sys, "argv", ["extract_fixtures.py", *argv])
     extract_fixtures.main()
+
+
+def test_concurrent_symlink_publishers_do_not_share_a_temp_path(tmp_path, monkeypatch):
+    """Two publishers may race on the stable link, but each must own its temporary link until the atomic replace."""
+    cache = tmp_path / "cache"
+    snapshots = [cache / "snap-a", cache / "snap-b"]
+    for snapshot in snapshots:
+        (snapshot / "toolcalling").mkdir(parents=True)
+
+    real_symlink_to = Path.symlink_to
+    both_temps_created = threading.Barrier(2)
+
+    def synchronized_symlink_to(path, target, target_is_directory=False):
+        real_symlink_to(path, target, target_is_directory)
+        if path.name.startswith(".toolcalling.tmp"):
+            both_temps_created.wait(timeout=5)
+
+    monkeypatch.setattr(Path, "symlink_to", synchronized_symlink_to)
+    errors = []
+
+    def publish(snapshot):
+        try:
+            extract_fixtures.update_symlinks(cache, snapshot)
+        except Exception as error:
+            errors.append(error)
+
+    threads = [threading.Thread(target=publish, args=(snapshot,)) for snapshot in snapshots]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert not errors
+    assert os.readlink(cache / "toolcalling") in {
+        "snap-a/toolcalling",
+        "snap-b/toolcalling",
+    }
 
 
 def test_two_shard_sets_under_the_same_pin_do_not_collide(cache_root, tmp_path, monkeypatch, capsys):

--- a/conformance/utils/tests/test_extract_fixtures_identity.py
+++ b/conformance/utils/tests/test_extract_fixtures_identity.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for the content-addressed fixture-cache publish contract.
+
+`extract_fixtures.py` used to name its extraction directory by `manifest["snapshot"]`
+(a human-readable pin) alone. Shard content is not uniquely determined by that pin --
+a shard set can be re-pinned in place under an unchanged pin (it happened once, to
+fixtures-batch-on-stream-v2). When that happened, the stale-check failed and the code
+ran `shutil.rmtree()` directly on the live, previously-published directory, then
+re-extracted in place -- while a concurrent, unlocked reader (a test in another git
+worktree, or `_common.sh`, which never acquires the flock at all) could still be
+reading files through the `toolcalling`/`reasoning`/`unified` symlinks. This was
+reproduced for real: a concurrent reader hit `FileNotFoundError` after 103/3345
+fixture files were successfully opened.
+
+The fix: key the cache directory by `fixtures_identity(shards)` (content, not pin),
+build every extraction into a private `.tmp.*` directory, and publish with ONE atomic
+rename. These tests exercise that contract directly, with mocked/tiny extraction and
+no real concurrency or timing -- the correctness property is about ORDERING (build
+under tmp, one rename at the end), so a mocked mid-build failure exercises the exact
+code path a real SIGKILL would leave behind.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+UTILS = Path(__file__).resolve().parents[1]
+SRC = UTILS / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import extract_fixtures  # noqa: E402
+
+
+def _shard(path, sha256, size=1):
+    return {"path": path, "sha256": sha256, "size": size}
+
+
+def _fake_extract_tarball(_tarball_path, dest_dir, verbose=False):
+    """Stand-in for the real tar extraction: writes one marker file so the
+    directory is non-empty and distinguishable, without needing a real
+    tarball on disk."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "marker.txt").write_text(str(dest_dir))
+
+
+@pytest.fixture
+def cache_root(tmp_path, monkeypatch):
+    root = tmp_path / "cache"
+    monkeypatch.setattr(extract_fixtures, "get_cache_root", lambda: root)
+    monkeypatch.setattr(extract_fixtures, "shard_file", lambda s: Path(f"/fake/{s['path']}"))
+    monkeypatch.setattr(extract_fixtures, "extract_tarball", _fake_extract_tarball)
+    return root
+
+
+def _run_main(tmp_path, monkeypatch, manifest, argv=()):
+    # A real file on disk, not a global Path.exists/read_text monkeypatch:
+    # patching a method on the Path CLASS itself is process-wide, and calling
+    # through to "the real" Path.exists/read_text from inside the patched
+    # version just calls the patched version again -- infinite recursion.
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    monkeypatch.setattr(extract_fixtures, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(sys, "argv", ["extract_fixtures.py", *argv])
+    extract_fixtures.main()
+
+
+def test_two_shard_sets_under_the_same_pin_do_not_collide(cache_root, tmp_path, monkeypatch, capsys):
+    """(A) A re-pin in place -- same `snapshot` stamp, different shard hashes --
+    must produce two distinct, coexisting directories, not one rmtree-ing the
+    other. The first directory's own content must be untouched afterward."""
+    manifest_v1 = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest_v1)
+    out_v1 = capsys.readouterr().out.strip()
+    dir_v1 = Path(out_v1)
+    assert dir_v1.is_dir()
+    marker_v1 = (dir_v1 / "marker.txt").read_text()
+
+    manifest_v2 = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash2")]}
+    _run_main(tmp_path, monkeypatch, manifest_v2)
+    out_v2 = capsys.readouterr().out.strip()
+    dir_v2 = Path(out_v2)
+
+    assert dir_v1 != dir_v2, "different shard content under the same pin must get different directories"
+    assert dir_v1.is_dir(), "the first identity's directory must survive the second extraction untouched"
+    assert (dir_v1 / "marker.txt").read_text() == marker_v1
+
+
+def test_interrupted_build_never_appears_at_the_published_name(cache_root, tmp_path, monkeypatch):
+    """(B) A failure partway through extraction must leave NO directory at the
+    content-addressed published name -- only a `.tmp.*` remnant, proving the
+    SIGKILL-safety property: nothing is published except via the final
+    single-rename step."""
+
+    def _boom(_tarball_path, dest_dir, verbose=False):
+        # Mirror the real extract_tarball's mkdir-then-populate ordering (it
+        # creates dest_dir before writing any content) so the crash leaves a
+        # realistic partial `.tmp.*` directory on disk to assert against,
+        # not an early raise that never touches the filesystem at all.
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        raise RuntimeError("simulated crash mid-extraction")
+
+    monkeypatch.setattr(extract_fixtures, "extract_tarball", _boom)
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    fid = extract_fixtures.fixtures_identity(manifest["shards"])
+    published = cache_root / f"20260101_000000-{fid}"
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        _run_main(tmp_path, monkeypatch, manifest)
+
+    assert not published.exists(), "a failed build must never appear at the published identity name"
+    leftovers = list(cache_root.glob(".tmp.*")) if cache_root.exists() else []
+    assert leftovers, "the partial build should be visible only under a .tmp.* scratch name"
+
+
+def test_identical_identity_is_a_cache_hit_not_a_rebuild(cache_root, tmp_path, monkeypatch, capsys):
+    """(C) A second call with the identical shard content is a cache hit --
+    `extract_tarball` must not run again."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    capsys.readouterr()
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("extract_tarball must not be called on a cache hit")
+
+    monkeypatch.setattr(extract_fixtures, "extract_tarball", _fail_if_called)
+    _run_main(tmp_path, monkeypatch, manifest)
+    out = capsys.readouterr()
+    assert "Cache hit" in out.err
+
+
+def test_full_refresh_builds_a_new_generation_without_touching_the_old_one(cache_root, tmp_path, monkeypatch, capsys):
+    """Reviewer-caught regression, then a reviewer-caught regression IN the
+    first fix: `--full-refresh` against an already-published identity used to
+    (1) silently discard the rebuild (defeating the flag), then a first fix
+    attempt (2) renamed the existing published directory out of the way to
+    make room for the rebuild -- which reintroduces the EXACT mutation-under
+    -a-live-reader hazard this whole module exists to close. A reader that
+    resolved the OLD generation's path before `--full-refresh` ran must keep
+    working, unaffected, for as long as it keeps reading -- there is no safe
+    moment to rename or delete a path a reader might still be using.
+
+    The correct contract: `--full-refresh` against an already-published
+    identity NEVER touches the existing directory. It publishes a NEW,
+    disambiguated generation (`{identity}.refresh1`, `.refresh2`, ...) and
+    only the symlinks (the one mutable "current" locator) retarget to it.
+    """
+    call_count = {"n": 0}
+
+    def _counting_extract_tarball(_tarball_path, dest_dir, verbose=False):
+        call_count["n"] += 1
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "marker.txt").write_text(f"build #{call_count['n']}")
+
+    monkeypatch.setattr(extract_fixtures, "extract_tarball", _counting_extract_tarball)
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    out_v1 = capsys.readouterr().out.strip()
+    old_dir = Path(out_v1)
+    old_marker = old_dir / "marker.txt"
+    assert old_marker.read_text() == "build #1"
+
+    _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    out_v2 = capsys.readouterr()
+    new_dir = Path(out_v2.out.strip())
+
+    assert call_count["n"] == 2, "extract_tarball must actually run again under --full-refresh"
+    assert "built a new generation" in out_v2.err
+    assert new_dir != old_dir, "the refresh must publish to a NEW path, never reuse the old one"
+    assert new_dir.name.endswith(".refresh1"), new_dir.name
+    assert (new_dir / "marker.txt").read_text() == "build #2"
+    # The old generation's directory and content are byte-for-byte untouched --
+    # this is the property a concurrent reader's continued access depends on.
+    assert old_dir.is_dir(), "the OLD generation must still exist -- a reader may still be reading it"
+    assert old_marker.read_text() == "build #1", "the OLD generation's content must be completely unchanged"
+
+
+def test_plain_run_after_full_refresh_resolves_to_the_new_generation(cache_root, tmp_path, monkeypatch, capsys):
+    """MUST finding (blind audit of the `--full-refresh` redesign): a plain
+    (no-flag) run must resolve to whatever generation `--full-refresh` most
+    recently published, never silently fall back to the abandoned original.
+    `_common.sh` runs this script with no flags before every conformance
+    test/render, so an invisible refresh means the fix `--full-refresh` was
+    run to apply never actually takes effect for anything downstream --
+    reproduced against the unmodified module before this fix: the very next
+    plain run flipped the symlink straight back to the corrupted original.
+    """
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    capsys.readouterr()
+    _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    refreshed_dir = Path(capsys.readouterr().out.strip())
+    assert refreshed_dir.name.endswith(".refresh1")
+
+    _run_main(tmp_path, monkeypatch, manifest)  # plain run, no flag
+    out = capsys.readouterr()
+    plain_dir = Path(out.out.strip())
+
+    assert plain_dir == refreshed_dir, (
+        "a plain run after --full-refresh must resolve to the refreshed "
+        f"generation, not the abandoned original; got {plain_dir}"
+    )
+    assert "Cache hit" in out.err
+
+
+def test_extracted_snapshot_dir_resolves_to_the_new_generation_after_full_refresh(
+    cache_root, tmp_path, monkeypatch, capsys
+):
+    """Same MUST finding, the other consumer the audit specifically asked to
+    be hunted for: `package_fixtures.py`'s `_extracted_snapshot_dir()` used
+    to reconstruct the bare `{pin}-{fid}` path directly instead of following
+    `resolve_current_generation`, so it also kept resolving to the abandoned
+    (possibly corrupted) generation after a refresh."""
+    package_fixtures_src = SRC
+    if str(package_fixtures_src) not in sys.path:
+        sys.path.insert(0, str(package_fixtures_src))
+    import package_fixtures  # noqa: E402  (sibling module, same sys.path entry as extract_fixtures)
+
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    capsys.readouterr()
+    _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    refreshed_dir = Path(capsys.readouterr().out.strip())
+    assert refreshed_dir.name.endswith(".refresh1")
+
+    manifest_path = tmp_path / "package_fixtures_manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    monkeypatch.setattr(package_fixtures, "ROOT", tmp_path)
+    monkeypatch.setattr(package_fixtures, "MANIFEST_REL", manifest_path.relative_to(tmp_path))
+
+    resolved = package_fixtures._extracted_snapshot_dir()
+    assert resolved == refreshed_dir, (
+        "_extracted_snapshot_dir() must resolve to the refreshed generation, "
+        f"not the abandoned original; got {resolved}"
+    )
+
+
+def test_refresh_publish_retries_past_a_colliding_generation_name(cache_root, tmp_path, monkeypatch, capsys):
+    """MUST finding (blind audit): the `.refreshN` candidate picked by
+    `resolve_current_generation` is check-then-act -- a second, genuinely
+    concurrent `--full-refresh` run can occupy that exact name between the
+    check and this process's own rename. The loser must retry the next
+    generation number via the same narrowed-errno handling the generation-0
+    publish path already uses, not raise an unhandled `OSError`.
+
+    A first version of this test injected the competitor on the FIRST call
+    to `resolve_current_generation` -- but `main()`'s `--full-refresh` path
+    calls it TWICE: once for the cache-hit check near the top (which still
+    runs even when `--full-refresh` is set, before the flag is even
+    consulted), and once inside this retry loop, right before computing
+    `refresh_n`. Injecting on the first call means the SECOND call already
+    observes the competitor and correctly picks `.refresh2` on its very
+    first attempt -- the retry-on-collision branch this test exists to
+    cover never actually runs, even though the assertions still pass (a
+    coverage gap a later audit caught: the test's own docstring claimed to
+    reproduce the race but did not). This version counts calls and injects
+    strictly AFTER the SECOND call returns its own (pre-injection) result,
+    so `refresh_n` is computed as if no competitor exists yet, and the
+    injected competitor is only on disk by the time the loop's own
+    `tmp_dir.rename(candidate)` actually runs -- a genuine collision.
+    """
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    fid = extract_fixtures.fixtures_identity(manifest["shards"])
+    _run_main(tmp_path, monkeypatch, manifest)  # publish generation 0
+    capsys.readouterr()
+
+    real_resolve = extract_fixtures.resolve_current_generation
+    real_write_state = extract_fixtures.write_state
+    call_count = {"n": 0}
+
+    def _resolve_then_inject_competitor_after_the_second_call(cache_root_, pin_, fid_, pinned_shards_):
+        call_count["n"] += 1
+        result = real_resolve(cache_root_, pin_, fid_, pinned_shards_)
+        if call_count["n"] == 2:
+            # Call #1 was the cache-hit check near the top of main() (runs
+            # even under --full-refresh); call #2 is the one inside the
+            # retry loop, immediately before `refresh_n` is computed from
+            # its result. Injecting AFTER this call returns means `result`
+            # (and therefore `refresh_n`) reflects the pre-competitor state,
+            # but the competitor is on disk before the loop's own rename
+            # attempt -- the exact check-to-rename race window.
+            competitor = cache_root_ / f"{pin_}-{fid_}.refresh1"
+            competitor.mkdir(parents=True)
+            (competitor / "marker.txt").write_text("sentinel-from-a-competing-refresh")
+            real_write_state(competitor, pin_, manifest["shards"])
+        return result
+
+    monkeypatch.setattr(
+        extract_fixtures, "resolve_current_generation", _resolve_then_inject_competitor_after_the_second_call
+    )
+
+    _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    out = capsys.readouterr()
+    new_dir = Path(out.out.strip())
+
+    assert call_count["n"] == 2, "sanity: --full-refresh must call resolve_current_generation exactly twice"
+    assert new_dir.name.endswith(".refresh2"), (
+        f"the retry must land on the next free generation after the collision, got {new_dir.name}"
+    )
+    competitor = cache_root / f"20260101_000000-{fid}.refresh1"
+    assert (
+        competitor / "marker.txt"
+    ).read_text() == "sentinel-from-a-competing-refresh", "the competitor's generation must survive completely untouched"
+
+
+def test_refresh_publish_collision_retry_negative_control(cache_root, tmp_path, monkeypatch, capsys):
+    """Negative control for the test above: prove it can actually fail. The
+    retry loop's collision handling is disabled -- but ONLY from the moment
+    the SAME real collision the positive test exercises would occur, not
+    from the start of the run. Disabling `RENAME_DEST_EXISTS_ERRNOS` before
+    `_run_main` even starts (a first draft of this control did that) also
+    breaks the unrelated, pre-existing generation-0 collision check earlier
+    in `main()`, so the run fails there instead -- a real failure, but not
+    evidence the RETRY loop's own handling matters. Instead the errno tuple
+    is flipped from inside the `resolve_current_generation` wrapper, exactly
+    when the positive test's competitor is injected: the first (pre-existing)
+    collision check has already run and succeeded by that point, so only the
+    retry loop's own narrowed catch is disabled. With it disabled, the
+    identical race must surface as an unhandled `OSError` instead of a
+    successful `.refresh2` publish -- proving the positive test's green
+    result actually depends on this code, not on some other path."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)  # publish generation 0
+    capsys.readouterr()
+
+    real_resolve = extract_fixtures.resolve_current_generation
+    real_write_state = extract_fixtures.write_state
+    call_count = {"n": 0}
+
+    def _resolve_then_inject_competitor_and_disable_retry_handling(cache_root_, pin_, fid_, pinned_shards_):
+        call_count["n"] += 1
+        result = real_resolve(cache_root_, pin_, fid_, pinned_shards_)
+        if call_count["n"] == 2:
+            competitor = cache_root_ / f"{pin_}-{fid_}.refresh1"
+            competitor.mkdir(parents=True)
+            (competitor / "marker.txt").write_text("sentinel-from-a-competing-refresh")
+            real_write_state(competitor, pin_, manifest["shards"])
+            monkeypatch.setattr(extract_fixtures, "RENAME_DEST_EXISTS_ERRNOS", ())
+        return result
+
+    monkeypatch.setattr(
+        extract_fixtures, "resolve_current_generation", _resolve_then_inject_competitor_and_disable_retry_handling
+    )
+
+    with pytest.raises(OSError):
+        _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    assert call_count["n"] == 2, "sanity: the race must still reach the same collision point as the positive test"
+
+
+def test_concurrent_double_publish_of_one_identity_is_a_safe_noop(cache_root, tmp_path, monkeypatch, capsys):
+    """(D) Simulates a genuine concurrent double-publish: a SECOND process
+    finishes and publishes the identical identity while THIS process is still
+    mid-build, so this process's own final rename genuinely collides with a
+    valid, freshly-published directory. Pre-creating the "competitor" before
+    `main()` even starts would just take the ordinary cache-hit path (no
+    rename ever attempted) -- the race only exists at the rename step, so the
+    competitor has to appear there, injected via the same `write_state` hook
+    `main()` calls right before its own rename."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    shards = manifest["shards"]
+    fid = extract_fixtures.fixtures_identity(shards)
+    published = cache_root / f"20260101_000000-{fid}"
+
+    real_write_state = extract_fixtures.write_state
+
+    def _write_state_then_let_a_competitor_publish_first(snap_dir, snapshot, shards_):
+        real_write_state(snap_dir, snapshot, shards_)
+        # `snap_dir` here is THIS process's own tmp_dir, about to be renamed.
+        # Publish the "other process's" identical-identity result at the real
+        # published name right now, simulating it winning the race.
+        published.mkdir(parents=True)
+        (published / "toolcalling").mkdir()
+        (published / "toolcalling" / "marker.txt").write_text("sentinel-from-the-other-publisher")
+        real_write_state(published, snapshot, shards_)
+
+    monkeypatch.setattr(extract_fixtures, "write_state", _write_state_then_let_a_competitor_publish_first)
+
+    _run_main(tmp_path, monkeypatch, manifest)
+    out = capsys.readouterr()
+
+    assert "already published" in out.err
+    assert (published / "toolcalling" / "marker.txt").read_text() == "sentinel-from-the-other-publisher"
+    assert not list(cache_root.glob(".tmp.*")), "the redundant temp build must be discarded, not left behind"
+
+
+def test_rejects_an_untrusted_directory_occupying_the_identity_name(cache_root, tmp_path, monkeypatch):
+    """A directory at the identity name with NO valid state file (or a
+    mismatched one) must not be silently trusted as an authoritative prior
+    publish -- the rename failure must propagate instead of discarding a
+    verified fresh build in favor of unknown content."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    fid = extract_fixtures.fixtures_identity(manifest["shards"])
+    stray = cache_root / f"20260101_000000-{fid}"
+    stray.mkdir(parents=True)
+    (stray / "not_a_real_state_file.txt").write_text("garbage")
+
+    with pytest.raises(OSError):
+        _run_main(tmp_path, monkeypatch, manifest)
+
+
+def test_extraction_never_touches_an_older_published_directory(cache_root, tmp_path, monkeypatch):
+    """A published, content-addressed directory (never named `.tmp.*`) is
+    never touched by ANY later extraction, regardless of its age. There is
+    deliberately no orphan-cleanup sweep of any kind (removed after review:
+    an mtime-based age gate could delete a directory a different,
+    genuinely-still-running extraction is actively building into, since
+    `extract_tarball`'s `mkdir(exist_ok=True)` means the victim wouldn't
+    even notice and would go on to publish a corrupted "complete" state).
+    Leftover `.tmp.*` dirs are an accepted disk-hygiene cost, not a
+    correctness concern -- never referenced by any symlink, never mistaken
+    for a valid cache."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    published = [d for d in cache_root.iterdir() if not d.name.startswith(".")]
+    assert len(published) == 1
+    marker = published[0] / "marker.txt"  # _fake_extract_tarball writes it at the extraction root
+    old_time = 0  # 1970 -- as old as an mtime can be
+    os.utime(published[0], (old_time, old_time))
+
+    # A second extraction (different identity) must not disturb the first.
+    manifest2 = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash2")]}
+    _run_main(tmp_path, monkeypatch, manifest2)
+
+    assert published[0].is_dir(), "an old PUBLISHED directory must survive a later, unrelated extraction"
+    assert marker.is_file()
+
+
+def test_extraction_never_removes_any_tmp_dir_of_any_age(cache_root, tmp_path, monkeypatch):
+    """No sweep exists at all: a `.tmp.*` dir -- fresh (may belong to a
+    genuinely still-running concurrent extraction; `_common.sh` has no lock
+    at all) or old (a leftover from a past crash) -- is left alone by a
+    later extraction either way. This is the intentional post-review design,
+    not a gap: age-based cleanup was removed rather than made more precise,
+    since it has no correctness value and the corruption risk it introduced
+    outweighed the disk-hygiene benefit."""
+    fresh_tmp = cache_root / ".tmp.somebody-else.999.deadbeef"
+    fresh_tmp.mkdir(parents=True)
+    (fresh_tmp / "in_progress.txt").write_text("still building")
+
+    old_tmp = cache_root / ".tmp.orphaned.111.cafebabe"
+    old_tmp.mkdir(parents=True)
+    os.utime(old_tmp, (0, 0))
+
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+
+    assert fresh_tmp.is_dir(), "a recent .tmp.* dir must be left alone -- it may be a live concurrent build"
+    assert old_tmp.is_dir(), "an old .tmp.* dir must also be left alone -- no sweep exists to remove it"
+
+
+def test_show_info_marks_the_current_pin_under_the_new_naming(cache_root, tmp_path, monkeypatch, capsys):
+    """`show_info`'s `d.name == pin` check always misses once directories are
+    named `{pin}-{fid}`; must use a prefix match instead."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    _run_main(tmp_path, monkeypatch, manifest)
+    capsys.readouterr()
+
+    extract_fixtures.show_info(manifest, cache_root)
+    out = capsys.readouterr().out
+    assert "<- current pin" in out

--- a/conformance/utils/tests/test_extract_fixtures_identity.py
+++ b/conformance/utils/tests/test_extract_fixtures_identity.py
@@ -26,6 +26,7 @@ import json
 import os
 import sys
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -36,6 +37,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 import extract_fixtures  # noqa: E402
+import fixture_snapshot  # noqa: E402
 
 
 def _shard(path, sha256, size=1):
@@ -107,6 +109,121 @@ def test_concurrent_symlink_publishers_do_not_share_a_temp_path(tmp_path, monkey
         "snap-a/toolcalling",
         "snap-b/toolcalling",
     }
+
+
+def test_concurrent_refreshers_cannot_retarget_links_to_an_older_generation(
+    cache_root, monkeypatch
+):
+    """Generation publication and stable-link retargeting are one serialized transition."""
+    pin = "20260101_000000"
+    shards = [_shard("toolcalling/a.tar.gz", "hash1")]
+    pinned_shards = extract_fixtures.shard_hash_map(shards)
+    fid = extract_fixtures.fixtures_identity(shards)
+    base = cache_root / f"{pin}-{fid}"
+    (base / "toolcalling").mkdir(parents=True)
+    extract_fixtures.write_state(base, pin, shards)
+
+    tmp_dirs = [cache_root / ".tmp.first", cache_root / ".tmp.second"]
+    for tmp_dir in tmp_dirs:
+        (tmp_dir / "toolcalling").mkdir(parents=True)
+        extract_fixtures.write_state(tmp_dir, pin, shards)
+
+    real_update_symlinks = extract_fixtures.update_symlinks
+    first_update_started = threading.Event()
+    release_first_update = threading.Event()
+    second_finished = threading.Event()
+    second_lock_attempted = threading.Event()
+    errors = []
+
+    real_cache_publish_lock = extract_fixtures.cache_publish_lock
+
+    @contextmanager
+    def observed_cache_publish_lock(cache_root_):
+        if threading.current_thread().name == "second-publisher":
+            second_lock_attempted.set()
+        with real_cache_publish_lock(cache_root_):
+            yield
+
+    def ordered_update_symlinks(cache_root_, snap_dir, verbose=False):
+        if snap_dir.name.endswith(".refresh1"):
+            first_update_started.set()
+            assert release_first_update.wait(timeout=5)
+        real_update_symlinks(cache_root_, snap_dir, verbose=verbose)
+
+    monkeypatch.setattr(extract_fixtures, "cache_publish_lock", observed_cache_publish_lock)
+    monkeypatch.setattr(extract_fixtures, "update_symlinks", ordered_update_symlinks)
+
+    def publish(tmp_dir, finished=None):
+        try:
+            extract_fixtures.publish_extracted_snapshot(
+                tmp_dir,
+                cache_root,
+                pin,
+                fid,
+                pinned_shards,
+                full_refresh=True,
+            )
+        except Exception as error:
+            errors.append(error)
+        finally:
+            if finished is not None:
+                finished.set()
+
+    first = threading.Thread(target=publish, args=(tmp_dirs[0],))
+    first.start()
+    assert first_update_started.wait(timeout=5)
+
+    second = threading.Thread(
+        target=publish,
+        args=(tmp_dirs[1], second_finished),
+        name="second-publisher",
+    )
+    second.start()
+    assert second_lock_attempted.wait(timeout=5)
+    assert not second_finished.is_set(), "the second publisher crossed the locked transition"
+    release_first_update.set()
+
+    first.join(timeout=5)
+    second.join(timeout=5)
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+
+    current, generation = extract_fixtures.resolve_current_generation(
+        cache_root, pin, fid, pinned_shards
+    )
+    assert generation == 2
+    assert os.readlink(cache_root / "toolcalling") == f"{current.name}/toolcalling"
+
+
+def test_python_consumers_resolve_an_immutable_snapshot_instead_of_stable_links(
+    cache_root, monkeypatch
+):
+    stale = cache_root / "stale"
+    current = cache_root / "current"
+    (stale / "toolcalling").mkdir(parents=True)
+    (current / "toolcalling").mkdir(parents=True)
+    (stale / "toolcalling" / "marker.txt").write_text("stale")
+    (current / "toolcalling" / "marker.txt").write_text("current")
+    (cache_root / "toolcalling").symlink_to(stale / "toolcalling")
+
+    monkeypatch.delenv("CONFORMANCE_FIXTURES_ROOT", raising=False)
+    monkeypatch.setattr(
+        fixture_snapshot.subprocess,
+        "run",
+        lambda *args, **kwargs: fixture_snapshot.subprocess.CompletedProcess(
+            args=args[0], returncode=0, stdout=f"{current}\n", stderr=""
+        ),
+    )
+    fixture_snapshot.fixture_snapshot_root.cache_clear()
+    try:
+        resolved = fixture_snapshot.fixture_snapshot_root()
+    finally:
+        fixture_snapshot.fixture_snapshot_root.cache_clear()
+
+    assert resolved == current
+    assert (resolved / "toolcalling" / "marker.txt").read_text() == "current"
+    assert (cache_root / "toolcalling" / "marker.txt").read_text() == "stale"
 
 
 def test_two_shard_sets_under_the_same_pin_do_not_collide(cache_root, tmp_path, monkeypatch, capsys):
@@ -247,6 +364,28 @@ def test_plain_run_after_full_refresh_resolves_to_the_new_generation(cache_root,
     assert "Cache hit" in out.err
 
 
+@pytest.mark.parametrize("current_generation", [1, 3])
+def test_full_refresh_with_missing_base_advances_past_the_current_generation(
+    cache_root, tmp_path, monkeypatch, capsys, current_generation
+):
+    """A missing generation-0 directory must not make a later refresh publish
+    an older generation number than the one readers already resolve."""
+    manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
+    fid = extract_fixtures.fixtures_identity(manifest["shards"])
+    current = cache_root / f"20260101_000000-{fid}.refresh{current_generation}"
+    (current / "toolcalling").mkdir(parents=True)
+    (current / "marker.txt").write_text("current")
+    extract_fixtures.write_state(current, manifest["snapshot"], manifest["shards"])
+
+    _run_main(tmp_path, monkeypatch, manifest, argv=["--full-refresh"])
+    refreshed = Path(capsys.readouterr().out.strip())
+    assert refreshed.name.endswith(f".refresh{current_generation + 1}"), refreshed.name
+
+    _run_main(tmp_path, monkeypatch, manifest)
+    plain = Path(capsys.readouterr().out.strip())
+    assert plain == refreshed
+
+
 def test_extracted_snapshot_dir_resolves_to_the_new_generation_after_full_refresh(
     cache_root, tmp_path, monkeypatch, capsys
 ):
@@ -287,21 +426,9 @@ def test_refresh_publish_retries_past_a_colliding_generation_name(cache_root, tm
     generation number via the same narrowed-errno handling the generation-0
     publish path already uses, not raise an unhandled `OSError`.
 
-    A first version of this test injected the competitor on the FIRST call
-    to `resolve_current_generation` -- but `main()`'s `--full-refresh` path
-    calls it TWICE: once for the cache-hit check near the top (which still
-    runs even when `--full-refresh` is set, before the flag is even
-    consulted), and once inside this retry loop, right before computing
-    `refresh_n`. Injecting on the first call means the SECOND call already
-    observes the competitor and correctly picks `.refresh2` on its very
-    first attempt -- the retry-on-collision branch this test exists to
-    cover never actually runs, even though the assertions still pass (a
-    coverage gap a later audit caught: the test's own docstring claimed to
-    reproduce the race but did not). This version counts calls and injects
-    strictly AFTER the SECOND call returns its own (pre-injection) result,
-    so `refresh_n` is computed as if no competitor exists yet, and the
-    injected competitor is only on disk by the time the loop's own
-    `tmp_dir.rename(candidate)` actually runs -- a genuine collision.
+    The competitor is injected after `publish_refresh_generation` resolves
+    the current generation but before its rename. The final resolve after
+    publication adds a third call, after the collision has been handled.
     """
     manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
     fid = extract_fixtures.fixtures_identity(manifest["shards"])
@@ -316,13 +443,10 @@ def test_refresh_publish_retries_past_a_colliding_generation_name(cache_root, tm
         call_count["n"] += 1
         result = real_resolve(cache_root_, pin_, fid_, pinned_shards_)
         if call_count["n"] == 2:
-            # Call #1 was the cache-hit check near the top of main() (runs
-            # even under --full-refresh); call #2 is the one inside the
-            # retry loop, immediately before `refresh_n` is computed from
-            # its result. Injecting AFTER this call returns means `result`
-            # (and therefore `refresh_n`) reflects the pre-competitor state,
-            # but the competitor is on disk before the loop's own rename
-            # attempt -- the exact check-to-rename race window.
+            # Call #1 selects the current generation for the publication
+            # transition. Call #2 computes the refresh candidate, so an
+            # injection after this result occupies the chosen name before
+            # rename -- the exact check-to-rename race window.
             competitor = cache_root_ / f"{pin_}-{fid_}.refresh1"
             competitor.mkdir(parents=True)
             (competitor / "marker.txt").write_text("sentinel-from-a-competing-refresh")
@@ -337,7 +461,7 @@ def test_refresh_publish_retries_past_a_colliding_generation_name(cache_root, tm
     out = capsys.readouterr()
     new_dir = Path(out.out.strip())
 
-    assert call_count["n"] == 2, "sanity: --full-refresh must call resolve_current_generation exactly twice"
+    assert call_count["n"] == 3, "sanity: publication must select, publish, then resolve the final generation"
     assert new_dir.name.endswith(".refresh2"), (
         f"the retry must land on the next free generation after the collision, got {new_dir.name}"
     )
@@ -349,20 +473,9 @@ def test_refresh_publish_retries_past_a_colliding_generation_name(cache_root, tm
 
 def test_refresh_publish_collision_retry_negative_control(cache_root, tmp_path, monkeypatch, capsys):
     """Negative control for the test above: prove it can actually fail. The
-    retry loop's collision handling is disabled -- but ONLY from the moment
-    the SAME real collision the positive test exercises would occur, not
-    from the start of the run. Disabling `RENAME_DEST_EXISTS_ERRNOS` before
-    `_run_main` even starts (a first draft of this control did that) also
-    breaks the unrelated, pre-existing generation-0 collision check earlier
-    in `main()`, so the run fails there instead -- a real failure, but not
-    evidence the RETRY loop's own handling matters. Instead the errno tuple
-    is flipped from inside the `resolve_current_generation` wrapper, exactly
-    when the positive test's competitor is injected: the first (pre-existing)
-    collision check has already run and succeeded by that point, so only the
-    retry loop's own narrowed catch is disabled. With it disabled, the
-    identical race must surface as an unhandled `OSError` instead of a
-    successful `.refresh2` publish -- proving the positive test's green
-    result actually depends on this code, not on some other path."""
+    retry loop's collision handling is disabled at the same moment the
+    positive test injects its competitor. The identical race must surface as
+    an `OSError` instead of a successful `.refresh2` publish."""
     manifest = {"snapshot": "20260101_000000", "shards": [_shard("toolcalling/a.tar.gz", "hash1")]}
     _run_main(tmp_path, monkeypatch, manifest)  # publish generation 0
     capsys.readouterr()

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -19,7 +19,6 @@ so the guards keep working across version bumps.
 """
 import copy
 import json
-import os
 import re
 import subprocess
 import sys
@@ -32,23 +31,13 @@ REPO = UTILS.parents[1]
 if str(UTILS / "src") not in sys.path:
     sys.path.insert(0, str(UTILS / "src"))
 
-import check_family_coverage as _cfc  # noqa: E402
+from fixture_snapshot import fixture_snapshot_root  # noqa: E402
 import model as model_mod  # noqa: E402
 
 
 def _resolve_cache_root() -> Path:
-    """Manifest-pinned snapshot dir — NEVER the shared `<cache>/toolcalling`
-    symlink, which sibling checkouts race to repoint mid-run (the peer-version
-    guards below flaked exactly that way; see conformance/README "Invariants").
-    Honors CONFORMANCE_FIXTURES_ROOT (exported by _common.sh). Falls back to the
-    symlink path when extraction is impossible so _HAVE_FIXTURES turns into a
-    clean skip instead of a collection error."""
-    try:
-        return _cfc.resolve_fixtures_root()
-    except (SystemExit, subprocess.CalledProcessError):
-        xdg = os.environ.get("XDG_CACHE_HOME")
-        base = Path(xdg) if xdg else Path.home() / ".cache"
-        return base / "dynamo/conformance-fixtures"
+    """Manifest-pinned snapshot dir, never the mutable compatibility links."""
+    return fixture_snapshot_root()
 
 
 _CACHE_ROOT = _resolve_cache_root()
@@ -480,7 +469,6 @@ def test_v2_no_verbose_todo_baked_in_cells(model_v2):
 
 def test_v2_reasoning_uses_current_peers(model_v2):
     # reasoning tab uses the same current peer versions as the toolcalling tabs.
-    tc = " ".join(c["label"] for c in _tab(model_v2, "tab-toolcalling-batch")["candidates"])
     peers = _peer_versions("reasoning/fixtures-v1")
     r = " ".join(c["label"] for c in _tab(model_v2, "tab-reasoning-batch")["candidates"])
     for impl in ("vllm_python", "sglang_python"):

--- a/conformance/utils/tests/test_render_invariants.py
+++ b/conformance/utils/tests/test_render_invariants.py
@@ -16,7 +16,6 @@ rendered stream cells depend on).
 """
 from __future__ import annotations
 
-import os
 import sys
 import tempfile
 from pathlib import Path
@@ -30,13 +29,9 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from resolve_stream_fixtures import resolve, version_key  # noqa: E402
+from fixture_snapshot import fixture_snapshot_root  # noqa: E402
 
-FIXTURES_ROOT = Path(
-    os.environ.get(
-        "CONFORMANCE_FIXTURES_ROOT",
-        os.path.expanduser("~/.cache/dynamo/conformance-fixtures"),
-    )
-)
+FIXTURES_ROOT = fixture_snapshot_root()
 STREAM_SRC = FIXTURES_ROOT / "toolcalling" / "fixtures-stream-v2"
 
 pytestmark = pytest.mark.skipif(

--- a/parsers/v1/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/parsers/v1/src/tool_calling/xml/kimi_k2_parser.rs
@@ -394,10 +394,31 @@ fn parse_section_block(
             .name("function_id")
             .map(|m| m.as_str().trim())
             .unwrap_or("");
-        let arguments_raw = cap
+        let lazy_arguments = cap
             .name("arguments")
             .map(|m| m.as_str().trim())
             .unwrap_or("{}");
+        // The lazy regex capture stops at the first literal `call_end`, even
+        // when that byte sequence belongs to a valid JSON string. Let the
+        // JSON parser own the payload boundary first, then require this
+        // call's real closer before any later call opener. Malformed JSON
+        // keeps the historical permissive raw-string fallback above.
+        let arguments_raw = cap
+            .name("arguments")
+            .and_then(|capture| {
+                let argument_region = &block[capture.start()..];
+                let mut values = serde_json::Deserializer::from_str(argument_region)
+                    .into_iter::<serde::de::IgnoredAny>();
+                values.next()?.ok()?;
+                let json_len = values.byte_offset();
+                let after_json = &argument_region[json_len..];
+                let call_end = after_json.find(config.call_end.as_str())?;
+                let next_call_start = after_json.find(config.call_start.as_str());
+                next_call_start
+                    .is_none_or(|next| call_end < next)
+                    .then(|| argument_region[..json_len].trim())
+            })
+            .unwrap_or(lazy_arguments);
 
         // Parse function ID
         let function_name = if let Some(id_cap) = id_regex.captures(function_id) {
@@ -513,6 +534,22 @@ mod tests {
 
         let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["location"], "NYC");
+    }
+
+    /// The v2 fixture corpus does not execute this separate v1 owner. Pin the
+    /// shared payload-ownership contract here: a marker-looking substring in
+    /// a valid JSON string is argument data, not the call boundary.
+    #[test]
+    fn test_parse_preserves_call_end_inside_a_json_string() {
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{"cmd":"echo <|tool_call_end|> literal"}<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, _) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"cmd":"echo <|tool_call_end|> literal"}"#
+        );
     }
 
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1, TOOLCALLING.batch.7.d in tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.yaml.

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -52,6 +52,13 @@ const CALL_START: &str = "<|tool_call_begin|>";
 const CALL_END: &str = "<|tool_call_end|>";
 const ARGUMENT_BEGIN: &str = "<|tool_call_argument_begin|>";
 
+// Mirrors `KimiK2ParserConfig::default().section_end_variants` for the same
+// reason as the consts above -- `kimi_invoke_end` needs to recognize a real
+// section close to distinguish it from genuine EOS truncation (see its use
+// below).
+const SECTION_END_PLURAL: &str = "<|tool_calls_section_end|>";
+const SECTION_END_SINGULAR: &str = "<|tool_call_section_end|>";
+
 const FUNCTIONS_PREFIX: &str = "functions.";
 
 /// Bytes valid in a `NAME:IDX` identifier, per `get_id_regex`'s `[\w.\-]+`.
@@ -124,7 +131,17 @@ fn native_id_len(text: &str, flush: bool) -> NativeId {
 ///   (`UNIFIED.5.b`, `tool_no_close`, the same best-effort-recovery contract
 ///   as policy P2) instead of being dropped as if it were genuinely
 ///   truncated. `K2Emitter` synthesizes the missing closer before typing it.
-fn kimi_invoke_end(text: &str, flush: bool) -> Option<usize> {
+///   BUT only for `tool_index == 0`: the captured batch contract
+///   (`TOOLCALLING.batch.5.d`/`TOOLCALLING.streamv2.5.d`, independently
+///   pinned against the real `parse_section_block` regex and its own
+///   streaming golden capture) drops a later call that never gets its own
+///   `call_end`, while still recovering an incomplete FIRST call at EOF
+///   (`TOOLCALLING.batch.5.a`/`UNIFIED.tool_no_close`). This mirrors that
+///   observed asymmetry; it is not a claim about model reliability beyond
+///   what these two fixtures establish. `tool_index` is the same monotonic
+///   per-stream counter `WrappedBlockScanner` already tracks for
+///   `tool_call_id`.
+fn kimi_invoke_end(text: &str, flush: bool, tool_index: usize) -> Option<usize> {
     // The first `argument_begin` in `text` only belongs to THIS invoke
     // (the one starting at byte 0) if nothing closes the invoke before it.
     // Model output is probabilistic and can violate its own grammar --
@@ -267,7 +284,26 @@ fn kimi_invoke_end(text: &str, flush: bool) -> Option<usize> {
     // re-match a `call_end`-looking byte sequence still sitting inside the
     // not-yet-closed argument string.
     let after_args = &text[args_at..];
-    let Some(json_len) = json_value_end(after_args) else {
+    // `json_value_end` only proves bracket/quote NESTING is balanced, not
+    // that the bytes are valid JSON (`{not-json}` reads as "balanced" --
+    // braces match, zero quotes to mistrack -- but isn't a legal JSON
+    // value; likewise `{<|tool_calls_section_end|>}` balances even though
+    // its "content" is a section-end marker, not JSON). Every downstream
+    // branch below this point (the well-formed `call_end` search, the
+    // best-effort EOF recovery) assumed a `json_value_end` success meant
+    // "this is real JSON" and never re-checked -- a bracket-balanced-but-
+    // invalid body could still slip through, its embedded section-end
+    // marker never even scanned for, since the code trusted `json_len` as
+    // the argument's real boundary. Validating HERE, before any of those
+    // branches run, means an invalid body falls through to the SAME
+    // malformed/raw-string fallback below (with its own intervening-
+    // section-end guard) instead of taking the well-formed path at all --
+    // one owner for "is this argument actually usable as JSON", not a
+    // patchwork of per-branch checks.
+    let valid_json_len = json_value_end(after_args).filter(|&json_len| {
+        serde_json::from_str::<serde_json::Value>(&after_args[..json_len]).is_ok()
+    });
+    let Some(json_len) = valid_json_len else {
         // `json_value_end` returning `None` does NOT mean "malformed" --
         // most of the time it means "not balanced YET", e.g. a chunk split
         // lands mid-string with a `call_end`-looking byte sequence sitting
@@ -295,7 +331,26 @@ fn kimi_invoke_end(text: &str, flush: bool) -> Option<usize> {
             && let Some(rel) = after_args.find(CALL_END)
             && after_args.find(CALL_START).is_none_or(|next| rel < next)
         {
-            return Some(args_at + rel + CALL_END.len());
+            // Mirror the well-formed-JSON sibling's section-end guard
+            // below: a real section-end marker occurring before this
+            // literal `call_end` means the model explicitly closed the
+            // whole tool_calls section without ever giving THIS call its
+            // own `call_end` ("mismatched fences"), same as the sibling
+            // case, just discovered via the malformed/raw-string path
+            // instead of the well-formed-JSON path. Recovering here would
+            // swallow the section-end marker into this invoke's own
+            // malformed argument and hide the section boundary from every
+            // downstream check that trusts this returned position --
+            // reproduced directly: `{"location": "unterminated<section_end>`
+            // followed by a literal `call_end` recovered a call whose raw
+            // argument absorbed the section-end marker as text.
+            let before_call_end = &after_args[..rel];
+            let section_end_intervenes = [SECTION_END_PLURAL, SECTION_END_SINGULAR]
+                .iter()
+                .any(|marker| before_call_end.contains(marker));
+            if !section_end_intervenes {
+                return Some(args_at + rel + CALL_END.len());
+            }
         }
         return None;
     };
@@ -316,7 +371,33 @@ fn kimi_invoke_end(text: &str, flush: bool) -> Option<usize> {
     // Best-effort recovery (`UNIFIED.5.b`, policy P2 sibling): the argument
     // body is syntactically complete but the model stopped before emitting
     // the closer. Only at true EOF -- otherwise wait for more input.
-    flush.then_some(json_end)
+    //
+    // But NOT when a real section-end marker follows instead of more input
+    // running out: that's not truncation, it's the model explicitly closing
+    // the whole tool_calls section without ever giving THIS call its own
+    // `call_end` -- "mismatched fences" (`TOOLCALLING.batch.4.d`, sourced
+    // from vLLM's own kimi_k2 parser tests). `parse_section_block`'s regex
+    // (the batch-mode typing layer this module promises byte-parity with)
+    // has no fallback for a missing `call_end` regardless of what follows
+    // it, so recovering here would ship a call batch mode drops -- exactly
+    // the divergence `conformance_toolcalling_batch_via_stream` caught.
+    if flush {
+        let trimmed_after_json = after_json.trim_start();
+        if [SECTION_END_PLURAL, SECTION_END_SINGULAR]
+            .iter()
+            .any(|marker| trimmed_after_json.starts_with(marker))
+        {
+            return None;
+        }
+    }
+    // `tool_index == 0` only (see the doc comment above): a later call with
+    // no evidence it ever closes is a malformed shape, not truncation, once
+    // an earlier call in the same response DID close correctly. `json_len`
+    // is already proven valid JSON at this point (the hoisted
+    // `serde_json::from_str` check above `valid_json_len` covers this
+    // whole function, not just this one branch), so no separate
+    // JSON-validity check is needed here.
+    (flush && tool_index == 0).then_some(json_end)
 }
 
 /// Kimi's `call_start` marker is unambiguous wherever it appears; every
@@ -515,6 +596,61 @@ mod tests {
     }
 
     #[test]
+    fn hardcoded_markers_mirror_the_config_default() {
+        // `CALL_START`/`CALL_END`/`ARGUMENT_BEGIN`/`SECTION_END_PLURAL`/
+        // `SECTION_END_SINGULAR` all exist only because `InvokeScan`'s hooks
+        // are plain `fn` pointers and cannot borrow a per-instance config
+        // (see the comment on `CALL_START` above). `KimiK2ParserConfig::
+        // default()` is the one real owner of these strings; this test is
+        // the parity check that fails loudly if a future config change
+        // silently stops matching these mirrors, instead of `kimi_invoke_end`
+        // quietly scanning for the wrong bytes.
+        let config = KimiK2ParserConfig::default();
+        assert_eq!(config.call_start, CALL_START);
+        assert_eq!(config.call_end, CALL_END);
+        assert_eq!(config.argument_begin, ARGUMENT_BEGIN);
+        assert_eq!(
+            config.section_end_variants,
+            vec![
+                SECTION_END_PLURAL.to_string(),
+                SECTION_END_SINGULAR.to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn section_end_marker_embedded_in_a_string_argument_is_data_not_a_boundary() {
+        // A well-formed call whose own JSON string argument happens to
+        // contain the literal bytes of the section-end marker (e.g. echoing
+        // a shell command) must NOT be mistaken for the real block boundary.
+        // The shared `drop_invoke_crossing_block_end` safety net used a raw,
+        // non-string-aware search that matched this embedded copy and
+        // dropped the whole call, leaking its JSON tail as garbage text and
+        // corrupting the `tool_index` of the following call (`next_index`
+        // never advanced for the dropped one).
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>",
+                "{\"cmd\":\"echo <|tool_calls_section_end|>\"}<|tool_call_end|>",
+                "<|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"location\":\"NYC\"}<|tool_call_end|><|tool_calls_section_end|>",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 2);
+        assert_eq!(merged.calls[0].tool_index, 0);
+        assert_eq!(merged.calls[0].name.as_deref(), Some("run"));
+        assert_eq!(
+            merged.calls[0].arguments,
+            r#"{"cmd":"echo <|tool_calls_section_end|>"}"#
+        );
+        assert_eq!(merged.calls[1].tool_index, 1);
+        assert_eq!(merged.calls[1].name.as_deref(), Some("get_weather"));
+        assert_eq!(merged.calls[1].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    #[test]
     fn emits_complete_call_on_close() {
         let out = parse_chunks(
             &weather_tools(),
@@ -552,7 +688,7 @@ mod tests {
         // on its own, without ever needing the native-id path below it.
         let bare_invoke_with_own_close = "<|tool_call_begin|>functions.run:0<|tool_call_end|>";
         assert_eq!(
-            kimi_invoke_end(text, true),
+            kimi_invoke_end(text, true, 0),
             Some(bare_invoke_with_own_close.len()),
             "must bound to the bare invoke's own close, not span through the second invoke's call_end"
         );
@@ -572,7 +708,7 @@ mod tests {
         let text = "<|tool_call_begin|>functions.run:0<|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|>";
         let bare_invoke_id_only = "<|tool_call_begin|>functions.run:0";
         assert_eq!(
-            kimi_invoke_end(text, true),
+            kimi_invoke_end(text, true, 0),
             Some(bare_invoke_id_only.len()),
             "must bound to the bare invoke's id alone (it has no close of its own), \
              not span through the second invoke's call_end"
@@ -702,6 +838,136 @@ mod tests {
         );
         assert_eq!(out.normal_text, "");
         assert!(out.calls.is_empty());
+    }
+
+    #[test]
+    fn mismatched_fences_drop_the_call_instead_of_recovering_it() {
+        // `TOOLCALLING.batch.4.d` (sourced from vLLM's own kimi_k2 parser
+        // tests): the JSON body is syntactically complete, but the model
+        // closes the whole tool_calls section (`section_end`) without ever
+        // giving this call its own `call_end`. This is NOT the same as
+        // running out of tokens mid-call (`suppresses_truncated_call_at_eof`)
+        // or completing right at EOF with nothing else following
+        // (`UNIFIED.tool_no_close`, `TOOLCALLING.streamv2.5.a`) -- a real
+        // section-end marker DOES follow, so the model had more to say and
+        // chose not to close this call. Batch mode's regex requires a
+        // literal `call_end` unconditionally and drops it; streaming must
+        // match, or `conformance_toolcalling_batch_via_stream` diverges.
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>",
+                "{\"location\":\"NYC\"}<|tool_calls_section_end|>",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        assert!(out.calls.is_empty());
+    }
+
+    /// Reviewer-caught regression: a bracket-balanced but JSON-GRAMMAR-INVALID
+    /// body (`{not-json}` -- braces match, but it's not legal JSON: no
+    /// quoted key, no colon, no value) with NO `call_end` anywhere in the
+    /// buffer used to still recover a call at EOF, because `json_value_end`
+    /// only proves bracket/quote nesting is balanced, not that the bytes
+    /// parse as JSON. `parse_section_block`'s regex (batch mode) requires a
+    /// literal `call_end` to match anything at all and so drops this input
+    /// outright -- reproduced directly: streaming shipped a call with
+    /// `arguments: "{not-json}"` while batch mode produced zero calls.
+    #[test]
+    fn eof_recovery_requires_actually_valid_json_not_just_balanced_brackets() {
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{not-json}";
+        assert_eq!(
+            kimi_invoke_end(text, true, 0),
+            None,
+            "a bracket-balanced but grammatically invalid body with no call_end evidence \
+             at all must not be recovered -- batch mode's regex can never match it either"
+        );
+    }
+
+    /// Sibling positive control: the SAME shape but with genuinely valid
+    /// JSON still recovers normally -- this fix must not regress the
+    /// existing `UNIFIED.5.b`/`tool_no_close` best-effort recovery contract.
+    #[test]
+    fn eof_recovery_still_recovers_genuinely_valid_json_with_no_call_end() {
+        let text =
+            "<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}";
+        assert_eq!(
+            kimi_invoke_end(text, true, 0),
+            Some(text.len()),
+            "valid JSON with no call_end at true EOF must still be recovered"
+        );
+    }
+
+    /// Reviewer-caught regression: a malformed (odd quote count) argument
+    /// followed by a real section-end marker, with a literal `call_end`
+    /// only appearing AFTER that section-end, used to still recover a call
+    /// whose raw-string argument swallowed the section-end marker as text
+    /// -- the same "mismatched fences" shape the well-formed-JSON path
+    /// already guards against (see the `flush` block above this function's
+    /// EOF-recovery gate), just reached through the malformed/raw-string
+    /// fallback instead, which was missing the equivalent guard.
+    #[test]
+    fn malformed_argument_recovery_also_respects_an_intervening_section_end() {
+        let text = "<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\": \"unterminated<|tool_calls_section_end|><|tool_call_end|>";
+        assert_eq!(
+            kimi_invoke_end(text, true, 0),
+            None,
+            "a real section-end marker occurring before the only available call_end \
+             means this call never got its own closer -- must drop, not swallow the \
+             section-end into a malformed raw-string argument"
+        );
+    }
+
+    /// Sibling positive control: the SAME malformed-argument raw-string
+    /// fallback still recovers normally when no section-end marker
+    /// intervenes -- this fix must not regress the raw-string recovery
+    /// contract `malformed_non_json_arguments_still_ship_the_call_instead_of_vanishing`
+    /// already covers end-to-end.
+    #[test]
+    fn malformed_argument_recovery_still_works_without_an_intervening_section_end() {
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>bad\"arg<|tool_call_end|>";
+        assert_eq!(
+            kimi_invoke_end(text, true, 0),
+            Some(text.len()),
+            "a malformed raw-string argument with its own real call_end and no \
+             intervening section-end must still be recovered"
+        );
+    }
+
+    #[test]
+    fn mismatched_fences_singular_section_variant_also_drops_the_call() {
+        // Same shape as above, through the singular `<|tool_call_section_end|>`
+        // variant -- the guard checks both `section_end_variants`, not just
+        // the plural default.
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"NYC\"}<|tool_call_section_end|>",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        assert!(out.calls.is_empty());
+    }
+
+    #[test]
+    fn multi_call_mismatched_fences_keeps_the_closed_call_drops_the_open_one() {
+        // `TOOLCALLING.batch.5.d`-adjacent shape: a properly closed first
+        // call followed by a second call whose JSON is complete but whose
+        // `call_end` is missing, with a real section_end right after (unlike
+        // `.5.d`, which has no section_end at all and is a genuine-truncation
+        // case handled by `known-divergences.yaml`, not this guard). The
+        // first call must still ship; only the malformed second is dropped.
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"Boston\"}<|tool_call_end|>",
+                "<|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"location\":\"New York\"}<|tool_calls_section_end|>",
+            ],
+        );
+        assert_eq!(out.normal_text, "");
+        let merged = out.coalesce_calls();
+        assert_eq!(merged.calls.len(), 1);
+        assert_eq!(merged.calls[0].arguments, r#"{"location":"Boston"}"#);
     }
 
     #[test]

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -35,13 +35,309 @@
 //! malformed payloads, which is exactly what the fixtures expect.
 
 use crate::tool_calling::scan::{
-    BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
+    BareRecoveryLatch, InvokeEmitter, InvokeLatch, InvokeScan, WrappedBlockScanner,
+    WrappedBlockSpec, json_value_end,
 };
 use crate::tool_calling::v1core::{
     KimiK2ParserConfig, ToolDefinition, try_tool_call_parse_kimi_k2,
 };
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
+
+// Mirror `KimiK2ParserConfig::default()` (the only config `kimi_k2_scanner`
+// ever builds). `InvokeScan`'s hooks are plain `fn` pointers, not closures, so
+// they cannot borrow a per-instance config; hardcoding the same defaults here
+// is the existing pattern other `invoke_scan` families (e.g. gemma4) follow.
+const CALL_START: &str = "<|tool_call_begin|>";
+const CALL_END: &str = "<|tool_call_end|>";
+const ARGUMENT_BEGIN: &str = "<|tool_call_argument_begin|>";
+
+const FUNCTIONS_PREFIX: &str = "functions.";
+
+/// Bytes valid in a `NAME:IDX` identifier, per `get_id_regex`'s `[\w.\-]+`.
+fn ident_char(c: char) -> bool {
+    c.is_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+/// Result of scanning for a `NAME:IDX` id at the start of a buffer.
+enum NativeId {
+    /// A complete id, with its length. At least one digit follows `:` --
+    /// more digits streaming in later would only extend it, and every
+    /// length already satisfies `\d+`, so there is no ambiguity to wait out.
+    Complete(usize),
+    /// What's buffered so far could still grow into a complete id (more
+    /// name bytes, the `:` itself, or its digits) with more input.
+    Pending,
+    /// Terminates in a way that rules out `NAME:IDX` ever matching here.
+    None,
+}
+
+/// Scan `text` for a complete `NAME:IDX` id (mirrors `get_id_regex`'s
+/// `[\w.\-]+:\d+`), distinguishing "never going to match" from "not
+/// determinable yet from what's buffered" -- the latter must wait for more
+/// input rather than being treated as a bare, unindexed name. The
+/// batch-path regex this mirrors is permissive by design (an unindexed name
+/// is still valid prose, not a malformed id), which is exactly why this
+/// cannot default to `None` just because a terminator hasn't streamed yet.
+fn native_id_len(text: &str, flush: bool) -> NativeId {
+    let ident_len = match text.find(|c: char| !ident_char(c)) {
+        Some(i) => i,
+        None if flush => text.len(),
+        None => return NativeId::Pending,
+    };
+    if ident_len == 0 {
+        return NativeId::None;
+    }
+    let rest = &text[ident_len..];
+    let Some(after_colon) = rest.strip_prefix(':') else {
+        return if !flush && rest.is_empty() {
+            NativeId::Pending
+        } else {
+            NativeId::None
+        };
+    };
+    match after_colon.find(|c: char| !c.is_ascii_digit()) {
+        Some(0) => NativeId::None, // `:` immediately followed by a non-digit
+        Some(d) => NativeId::Complete(ident_len + 1 + d),
+        None if after_colon.is_empty() => {
+            if flush {
+                NativeId::None
+            } else {
+                NativeId::Pending
+            }
+        }
+        None => NativeId::Complete(ident_len + 1 + after_colon.len()),
+    }
+}
+
+/// Locate the end of one Kimi invoke (`call_start .. call_end`) by finding
+/// where its JSON argument body actually closes first, rather than searching
+/// the raw buffer for `call_end` from byte zero.
+///
+/// Two things follow from that ordering:
+/// - A `call_end`-looking byte sequence embedded INSIDE the JSON string
+///   argument is data, not the real closer (`UNIFIED.7.b`,
+///   `arg_marker_in_string`) — the naive whole-buffer search matched the
+///   embedded copy first and truncated the argument there.
+/// - At true EOF (`flush`), a body whose JSON is syntactically complete but
+///   whose `call_end` never streamed (max_tokens / EOS) is recoverable
+///   (`UNIFIED.5.b`, `tool_no_close`, the same best-effort-recovery contract
+///   as policy P2) instead of being dropped as if it were genuinely
+///   truncated. `K2Emitter` synthesizes the missing closer before typing it.
+fn kimi_invoke_end(text: &str, flush: bool) -> Option<usize> {
+    // The first `argument_begin` in `text` only belongs to THIS invoke
+    // (the one starting at byte 0) if nothing closes the invoke before it.
+    // Model output is probabilistic and can violate its own grammar --
+    // a bare `NAME:IDX<|tool_call_end|>` with no argument section at all,
+    // immediately followed by a real second invoke that DOES have one. An
+    // unbounded search matched the second invoke's `argument_begin` to the
+    // first invoke's span, merging both into one string and silently
+    // dropping the first call. Already-buffered bytes before a found
+    // `argument_begin` can't be invalidated by more input streaming in
+    // later, so this bound is safe to apply immediately, not just at
+    // `flush`.
+    let args_at = text.find(ARGUMENT_BEGIN).and_then(|pos| {
+        // Either sibling marker before the found `argument_begin` proves it
+        // belongs to a LATER invoke, not this one: a `call_end` means this
+        // invoke already closed with no argument section; a second
+        // `call_start` means a new invoke opened before this one ever
+        // reached its own `argument_begin` (this one has neither a
+        // `call_end` NOR an `argument_begin` of its own). Checking only the
+        // `call_end` half left the `call_end`-less variant of the same
+        // malformed shape unguarded -- currently masked by the downstream
+        // regex's own forgiving `captures_iter` and the JSON-argument
+        // branch's `CALL_START` bound below, not by this check actually
+        // being correct, so a future change to either of those could silently
+        // revive the merge.
+        let belongs_to_later_invoke =
+            text[..pos].contains(CALL_END) || text[CALL_START.len()..pos].contains(CALL_START);
+        if belongs_to_later_invoke && flush {
+            // Logged only at `flush` (this check re-runs on every call while
+            // streaming, but the bare-close case can only finish resolving
+            // once no more input is coming -- see the `remainder` check
+            // below) so this fires exactly once per malformed invoke, not
+            // once per push.
+            tracing::warn!(
+                why = "kimi_k2_invoke_closed_before_argument_begin",
+                "stream dropped a bare invoke with no argument section of its own; \
+                 a later argument_begin belongs to a different invoke"
+            );
+        }
+        (!belongs_to_later_invoke).then_some(pos + ARGUMENT_BEGIN.len())
+    });
+    // No `argument_begin` at all: this isn't (yet, or ever) a well-formed
+    // `call_start .. argument_begin .. json .. call_end` invoke -- e.g. the
+    // guided-decoding native-markup-leak scenarios, where the buffer holds
+    // `call_start` grammar tokens but never a real argument section.
+    let Some(args_at) = args_at else {
+        // A `call_end` found here is NOT reliable evidence until `flush`:
+        // streaming only ever APPENDS bytes, so a legitimate `argument_begin`
+        // that hasn't arrived YET can still turn up later and take priority
+        // over this reading. Committing early made the result depend on
+        // where the chunk boundary happened to land -- the exact same bytes
+        // parsed to a dropped call in one push and a leaked raw-JSON `Text`
+        // in two, for identical final input. Only trust this reading once
+        // no more input is coming.
+        //
+        // Same bound as the `argument_begin` check above: a `call_end`
+        // preceded by a SECOND `call_start` belongs to a later invoke, not
+        // this one (this invoke never closed at all before the next one
+        // opened) -- trusting it merged both spans the same way an
+        // unbounded `argument_begin` search did.
+        if flush
+            && let Some(end) = text.find(CALL_END).map(|pos| pos + CALL_END.len())
+            && !text[CALL_START.len()..end].contains(CALL_START)
+        {
+            return Some(end);
+        }
+        // No `argument_begin` AND no `call_end` (or not `flush` yet): not a
+        // well-formed native invoke, and never going to become one from more
+        // `call_end` bytes arriving -- e.g. a narrated `<|tool_call_begin|>`
+        // header the model wrote while guided decoding actually constrained
+        // the payload, with
+        // nothing after it but bare JSON, a reasoning marker, or truncated
+        // header text (`guided_json_*_bare_opener`,
+        // `guided_json_narrated_prefix_inside_reasoning`,
+        // `guided_json_stray_prefix_before_reasoning`). Waiting forever for
+        // delimiters that will never come left the whole header + payload
+        // leaking as visible text.
+        //
+        // Bound the invoke to the STRUCTURAL part only: the literal
+        // `functions.` prefix, plus a complete `NAME:IDX` id when one
+        // actually follows it. A bare name with no index
+        // (`functions.get_weather` narrated inside a thought,
+        // `guided_json_narrated_prefix_inside_reasoning`) is prose the model
+        // wrote, not a real id -- swallowing it as control markup drops it
+        // from the reasoning text the golden oracle expects it to survive
+        // in. Whatever isn't consumed here -- JSON, `<think>`, a bare name,
+        // or nothing -- is scanned fresh on its own terms.
+        let after_start = &text[CALL_START.len()..];
+        let Some(after_prefix) = after_start.strip_prefix(FUNCTIONS_PREFIX) else {
+            // Not (yet) the literal `functions.` prefix. If what's buffered
+            // is a proper prefix of it, more input could still complete the
+            // match -- wait rather than deciding early.
+            if !flush
+                && after_start.len() < FUNCTIONS_PREFIX.len()
+                && FUNCTIONS_PREFIX.starts_with(after_start)
+            {
+                return None;
+            }
+            // Genuinely not the expected shape: nothing here is header
+            // markup, so bound the invoke to the bare opener marker itself.
+            return Some(CALL_START.len());
+        };
+        let end = match native_id_len(after_prefix, flush) {
+            NativeId::Complete(id_len) => CALL_START.len() + FUNCTIONS_PREFIX.len() + id_len,
+            NativeId::Pending => return None,
+            NativeId::None => CALL_START.len() + FUNCTIONS_PREFIX.len(),
+        };
+        // The byte right after `end` may be the start of a real
+        // `argument_begin` or `call_end` that just hasn't finished
+        // streaming (both begin with `<`, which never matches
+        // `functions.`/`ident_char`). Both searches above already proved
+        // neither marker exists in full yet, so a match here can only be a
+        // genuine partial -- wait for it rather than prematurely bounding
+        // the header.
+        let remainder = &text[end..];
+        // A COMPLETE `call_end` right here is the one case that is still
+        // NOT settled: it could be this invoke's own (no-args) close, or it
+        // could be a premature echo that a real `argument_begin` further
+        // downstream will supersede once more input streams in -- streaming
+        // only ever appends, so that later marker cannot be ruled out yet.
+        // Read this the same way the pure `call_end`-only branch above does:
+        // trust it only once nothing more is coming (`flush`). Same class of
+        // bug either commit destroyed -- reading it early made the outcome
+        // depend on the chunk boundary instead of the bytes.
+        if !flush && remainder.starts_with(CALL_END) {
+            return None;
+        }
+        if !flush
+            && [ARGUMENT_BEGIN, CALL_END]
+                .iter()
+                .any(|marker| remainder.len() < marker.len() && marker.starts_with(remainder))
+        {
+            return None;
+        }
+        return Some(end);
+    };
+    // From here the shape has a real `argument_begin`, so ownership of the
+    // closer search transfers to the JSON boundary (`I7`) when the argument
+    // body IS balanced JSON -- never fall back to a raw literal search of
+    // the (possibly still-streaming) buffer in that case, which would
+    // re-match a `call_end`-looking byte sequence still sitting inside the
+    // not-yet-closed argument string.
+    let after_args = &text[args_at..];
+    let Some(json_len) = json_value_end(after_args) else {
+        // `json_value_end` returning `None` does NOT mean "malformed" --
+        // most of the time it means "not balanced YET", e.g. a chunk split
+        // lands mid-string with a `call_end`-looking byte sequence sitting
+        // inside the still-open quote (`UNIFIED.7.b`, `arg_marker_in_string`).
+        // Falling back to a raw `call_end` search there re-matches that
+        // EMBEDDED fake closer and truncates the argument -- exactly the I7
+        // corruption this whole JSON-boundary approach exists to prevent.
+        // Only at true EOF, once no more input can possibly arrive to
+        // balance it, is "never resolves to JSON" a safe conclusion.
+        //
+        // At that point `parse_section_block` (the batch-mode typing layer
+        // this module's own doc promises byte-parity with) has a
+        // raw-string fallback for exactly this: when `serde_json::from_str`
+        // fails, it ships the raw text verbatim instead of rejecting the
+        // call. Propagating `None` unconditionally skipped that fallback
+        // entirely -- the whole invoke never reached the typing layer, so
+        // the SAME bytes that recover as a call with a raw-string argument
+        // in batch mode silently vanished in streaming mode. If the
+        // family's own literal `call_end` is already present, bound the
+        // invoke there (same `call_start` bound as every other closer
+        // search in this function) and let the raw text through to that
+        // fallback, rather than deciding here that it can never be
+        // recovered.
+        if flush
+            && let Some(rel) = after_args.find(CALL_END)
+            && after_args.find(CALL_START).is_none_or(|next| rel < next)
+        {
+            return Some(args_at + rel + CALL_END.len());
+        }
+        return None;
+    };
+    let json_end = args_at + json_len;
+    let after_json = &text[json_end..];
+    if let Some(rel) = after_json.find(CALL_END) {
+        // Bound the search: a new invoke opening before this one's own
+        // closer means this invoke never closed. Reaching past the new
+        // opener to grab some LATER invoke's `call_end` merged both calls'
+        // bytes into one corrupted invoke and silently dropped the second
+        // call entirely. Fall through to the same best-effort recovery the
+        // missing-closer case already uses, so the first call still ships
+        // (JSON is complete) and the second is scanned as its own invoke.
+        if after_json.find(CALL_START).is_none_or(|next| rel < next) {
+            return Some(json_end + rel + CALL_END.len());
+        }
+    }
+    // Best-effort recovery (`UNIFIED.5.b`, policy P2 sibling): the argument
+    // body is syntactically complete but the model stopped before emitting
+    // the closer. Only at true EOF -- otherwise wait for more input.
+    flush.then_some(json_end)
+}
+
+/// Kimi's `call_start` marker is unambiguous wherever it appears; every
+/// occurrence opens a real invoke (same effective behavior as the
+/// marker-only path this hook replaces).
+fn kimi_invoke_opens(_text: &str, _at: usize) -> bool {
+    true
+}
+
+/// No additional holdback beyond the generic marker holdback: `call_end` and
+/// `argument_begin` are already in `holdback_markers`, which already retains
+/// a partial marker split across a chunk boundary.
+fn kimi_invoke_holdback(_text: &str) -> usize {
+    0
+}
+
+const KIMI_INVOKE_SCAN: InvokeScan = InvokeScan {
+    end: kimi_invoke_end,
+    opens: kimi_invoke_opens,
+    holdback: kimi_invoke_holdback,
+};
 
 fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
     // Orphan markers: inner markers (`call_end`, `argument_begin`) and every
@@ -72,7 +368,7 @@ fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
         drop_invoke_crossing_block_end: true,
         // Every wrapped family's markers are special tokens today.
         preserve_special_tokens: true,
-        ..Default::default()
+        invoke_scan: Some(KIMI_INVOKE_SCAN),
     }
 }
 
@@ -80,17 +376,35 @@ fn spec(config: &KimiK2ParserConfig) -> WrappedBlockSpec {
 /// `<|tool_call_begin|>...<|tool_call_end|>` call in the section markers so
 /// the v1 parser takes its normal section path, then emits `name` + JSON
 /// `arguments` as one delta.
-struct K2Emitter {
+pub(crate) struct K2Emitter {
     config: KimiK2ParserConfig,
     tools: Vec<ToolDefinition>,
+    /// Native `functions.NAME:IDX` id per `tool_index`, for
+    /// [`InvokeEmitter::tool_call_id`]. The v1core parser already extracts
+    /// this id (`ToolCallResponse::id`) to resolve the function name; Kimi's
+    /// envelope is the only wrapped grammar that NAMES the call this way, so
+    /// this is the one family that needs to remember it past `parse_invoke`.
+    native_ids: Vec<Option<String>>,
 }
 
 impl InvokeEmitter for K2Emitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {
+        // `kimi_invoke_end` may hand back a call recovered at EOF whose JSON
+        // body is complete but whose `call_end` never streamed (`UNIFIED.5.b`).
+        // Normalize it here: the regex-based v1 parser requires the literal
+        // closer to delimit the arguments capture, so synthesize it rather
+        // than re-feeding the raw, still-unclosed bytes.
+        let synthesized;
+        let invoke = if invoke.ends_with(self.config.call_end.as_str()) {
+            invoke
+        } else {
+            synthesized = format!("{invoke}{}", self.config.call_end);
+            synthesized.as_str()
+        };
         let wrapped = format!(
             "{}{}{}",
             self.config.section_start, invoke, self.config.section_end
@@ -100,11 +414,27 @@ impl InvokeEmitter for K2Emitter {
         let Some(parsed) = calls.into_iter().next() else {
             return Ok(None);
         };
+        // `tool_index` is assigned by the caller in emission order (0, 1, 2,
+        // ...), so a plain positional slot is enough — pad rather than
+        // index-assign, since a dropped/malformed invoke ahead of this one
+        // (`Ok(None)` above) never reserves a slot for itself.
+        if self.native_ids.len() <= tool_index {
+            self.native_ids.resize(tool_index + 1, None);
+        }
+        self.native_ids[tool_index] = Some(parsed.id);
         Ok(Some(ToolCallDelta {
             tool_index,
             name: Some(parsed.function.name),
             arguments: parsed.function.arguments,
         }))
+    }
+
+    fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+        self.native_ids.get(tool_index)?.as_deref()
+    }
+
+    fn reset(&mut self) {
+        self.native_ids.clear();
     }
 }
 
@@ -113,17 +443,26 @@ pub struct KimiK2ToolStreamParser {
     scanner: WrappedBlockScanner<K2Emitter>,
 }
 
+/// Build the Kimi K2 marker scanner for one stream.
+///
+/// Extracted so the tool-only parser and the unified adapter share ONE scanner
+/// construction. Two constructions would be two grammars that drift.
+pub(crate) fn kimi_k2_scanner(tools: &[Tool]) -> WrappedBlockScanner<K2Emitter> {
+    let config = KimiK2ParserConfig::default();
+    WrappedBlockScanner::new(
+        spec(&config),
+        K2Emitter {
+            config,
+            tools: tools.iter().map(ToolDefinition::from).collect(),
+            native_ids: Vec::new(),
+        },
+    )
+}
+
 impl KimiK2ToolStreamParser {
     pub fn new(tools: &[Tool]) -> Self {
-        let config = KimiK2ParserConfig::default();
         Self {
-            scanner: WrappedBlockScanner::new(
-                spec(&config),
-                K2Emitter {
-                    config,
-                    tools: tools.iter().map(ToolDefinition::from).collect(),
-                },
-            ),
+            scanner: kimi_k2_scanner(tools),
         }
     }
 }
@@ -191,6 +530,53 @@ mod tests {
         assert_eq!(merged.calls[0].tool_index, 0);
         assert_eq!(merged.calls[0].name.as_deref(), Some("get_weather"));
         assert_eq!(merged.calls[0].arguments, r#"{"location":"NYC"}"#);
+    }
+
+    /// Direct unit test on the boundary finder itself, bypassing the
+    /// scanner/typing pipeline entirely -- the pipeline-level symptom of this
+    /// bug is easy to mask by accident (the downstream regex's own
+    /// `captures_iter` happens to skip a malformed prefix and still find the
+    /// valid second call on its own, and content between two invokes in one
+    /// section is suppressed by unrelated, correct `InvokeLatch::Always`
+    /// behavior regardless of this fix). The boundary VALUE is the actual
+    /// contract: a bare `NAME:IDX<|tool_call_end|>` invoke with no
+    /// `argument_begin` at all must bound to itself, not reach across a
+    /// second invoke's `call_start` to grab that invoke's `argument_begin`.
+    #[test]
+    fn invoke_end_does_not_reach_across_a_bare_close_to_a_later_argument_begin() {
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|>";
+        // The correct boundary is the bare invoke's OWN call_end, not just
+        // its id -- that call_end genuinely belongs to it, and stopping
+        // there (rather than reaching into the second invoke) is what makes
+        // `find(CALL_END)` in the fallback above correctly resolve this case
+        // on its own, without ever needing the native-id path below it.
+        let bare_invoke_with_own_close = "<|tool_call_begin|>functions.run:0<|tool_call_end|>";
+        assert_eq!(
+            kimi_invoke_end(text, true),
+            Some(bare_invoke_with_own_close.len()),
+            "must bound to the bare invoke's own close, not span through the second invoke's call_end"
+        );
+    }
+
+    /// Sibling of the test above: a bare invoke that has NEITHER its own
+    /// `argument_begin` NOR its own `call_end` -- its id text runs straight
+    /// into a second invoke's `call_start`. The `argument_begin` bound only
+    /// checked for an intervening `call_end`; this shape has none, so it was
+    /// unguarded and the second invoke's `argument_begin`/JSON/`call_end`
+    /// still got attributed to the first, merging both spans -- masked from
+    /// producing a visibly wrong result only by the downstream regex's
+    /// forgiving `captures_iter` and the JSON-argument branch's own
+    /// `CALL_START` bound, not by this check being correct.
+    #[test]
+    fn invoke_end_does_not_reach_across_a_bare_open_with_no_close_at_all() {
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|>";
+        let bare_invoke_id_only = "<|tool_call_begin|>functions.run:0";
+        assert_eq!(
+            kimi_invoke_end(text, true),
+            Some(bare_invoke_id_only.len()),
+            "must bound to the bare invoke's id alone (it has no close of its own), \
+             not span through the second invoke's call_end"
+        );
     }
 
     #[test]

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -256,6 +256,21 @@ fn kimi_invoke_end(text: &str, flush: bool, tool_index: usize) -> Option<usize> 
         // genuine partial -- wait for it rather than prematurely bounding
         // the header.
         let remainder = &text[end..];
+        // Reviewer-caught regression: the Kimi batch grammar permits `\s*`
+        // between `NAME:IDX` and `argument_begin` (the regex in
+        // `get_tool_call_regex` matches `\s*` there too), but the two
+        // holdback checks below used `remainder` verbatim -- a chunk split
+        // landing right after that permitted whitespace (`remainder == " "`)
+        // matched neither marker's prefix, so this function committed to
+        // `Some(end)` one push early, before `argument_begin` streamed in.
+        // The caller then bounds the invoke to a header-only span with no
+        // argument section at all, and the real call is silently lost
+        // (`K2Emitter` can't parse a header with no `argument_begin`).
+        // Deciding over the whitespace-trimmed view (never emitting or
+        // discarding that whitespace -- it stays buffered either way, since
+        // `end` doesn't move) closes this without weakening the check for
+        // any non-whitespace byte.
+        let structural_remainder = remainder.trim_start();
         // A COMPLETE `call_end` right here is the one case that is still
         // NOT settled: it could be this invoke's own (no-args) close, or it
         // could be a premature echo that a real `argument_begin` further
@@ -265,13 +280,14 @@ fn kimi_invoke_end(text: &str, flush: bool, tool_index: usize) -> Option<usize> 
         // trust it only once nothing more is coming (`flush`). Same class of
         // bug either commit destroyed -- reading it early made the outcome
         // depend on the chunk boundary instead of the bytes.
-        if !flush && remainder.starts_with(CALL_END) {
+        if !flush && structural_remainder.starts_with(CALL_END) {
             return None;
         }
         if !flush
-            && [ARGUMENT_BEGIN, CALL_END]
-                .iter()
-                .any(|marker| remainder.len() < marker.len() && marker.starts_with(remainder))
+            && [ARGUMENT_BEGIN, CALL_END].iter().any(|marker| {
+                structural_remainder.len() < marker.len()
+                    && marker.starts_with(structural_remainder)
+            })
         {
             return None;
         }
@@ -890,6 +906,28 @@ mod tests {
         );
         assert_eq!(out.normal_text, "");
         assert!(out.calls.is_empty());
+    }
+
+    /// Reviewer-caught regression, sibling of the test above: dropping a
+    /// call with mismatched fences is correct, but the ABOVE test ends
+    /// right after `section_end` and so cannot detect a different bug --
+    /// `WrappedBlockScanner::drain` used to treat `invoke_end_at`
+    /// returning `None` at flush as ALWAYS "genuinely incomplete", clearing
+    /// the entire remaining buffer including any real visible text that
+    /// followed the section-end marker. Batch mode's regex-based
+    /// extraction correctly preserves that trailing text; streaming
+    /// dropped it too. The correct result is an empty call list AND the
+    /// visible suffix preserved as `normal_text`.
+    #[test]
+    fn mismatched_fences_preserve_text_after_section_end() {
+        let out = parse_chunks(
+            &weather_tools(),
+            &[
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{}<|tool_calls_section_end|>Visible answer",
+            ],
+        );
+        assert!(out.calls.is_empty());
+        assert_eq!(out.normal_text, "Visible answer");
     }
 
     /// Reviewer-caught regression: a bracket-balanced but JSON-GRAMMAR-INVALID

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -36,7 +36,7 @@
 
 use crate::tool_calling::scan::{
     BareRecoveryLatch, InvokeEmitter, InvokeLatch, InvokeScan, WrappedBlockScanner,
-    WrappedBlockSpec, json_value_end,
+    WrappedBlockSpec, find_first_outside_strings, json_value_end,
 };
 use crate::tool_calling::v1core::{
     KimiK2ParserConfig, ToolDefinition, try_tool_call_parse_kimi_k2,
@@ -327,10 +327,30 @@ fn kimi_invoke_end(text: &str, flush: bool, tool_index: usize) -> Option<usize> 
         // search in this function) and let the raw text through to that
         // fallback, rather than deciding here that it can never be
         // recovered.
-        if flush
-            && let Some(rel) = after_args.find(CALL_END)
-            && after_args.find(CALL_START).is_none_or(|next| rel < next)
-        {
+        // In malformed input, quote state is not a trustworthy owner across
+        // invoke boundaries. An unmatched quote in this call can hide the
+        // next call's opener, then a second unmatched quote can restore the
+        // scanner state and make that later call's closer look structural.
+        // Treat the earliest raw opener as a hard damage boundary before
+        // accepting any quote-aware closer; valid JSON took the branch below
+        // and therefore keeps marker-looking bytes inside strings as data.
+        let next_call_start = after_args.find(CALL_START);
+        let structural_call_end = find_first_outside_strings(after_args, [CALL_END])
+            .map(|(position, _)| position)
+            .filter(|position| next_call_start.is_none_or(|next| *position < next));
+        let raw_call_end = after_args.find(CALL_END);
+        let bounded_raw_call_end =
+            raw_call_end.filter(|position| next_call_start.is_some_and(|next| *position < next));
+        let (rel, markers_are_structural) = match structural_call_end {
+            Some(position) => (position, true),
+            // A later raw opener makes the earlier raw closer stable before
+            // EOF: future bytes belong to the next invoke and cannot turn
+            // this closer into quoted data for the current one.
+            None if bounded_raw_call_end.is_some() => (bounded_raw_call_end?, false),
+            None if flush => (raw_call_end?, false),
+            None => return None,
+        };
+        if next_call_start.is_none_or(|next| rel < next) {
             // Mirror the well-formed-JSON sibling's section-end guard
             // below: a real section-end marker occurring before this
             // literal `call_end` means the model explicitly closed the
@@ -345,9 +365,17 @@ fn kimi_invoke_end(text: &str, flush: bool, tool_index: usize) -> Option<usize> 
             // followed by a literal `call_end` recovered a call whose raw
             // argument absorbed the section-end marker as text.
             let before_call_end = &after_args[..rel];
-            let section_end_intervenes = [SECTION_END_PLURAL, SECTION_END_SINGULAR]
-                .iter()
-                .any(|marker| before_call_end.contains(marker));
+            let section_end_intervenes = if markers_are_structural {
+                find_first_outside_strings(
+                    before_call_end,
+                    [SECTION_END_PLURAL, SECTION_END_SINGULAR],
+                )
+                .is_some()
+            } else {
+                [SECTION_END_PLURAL, SECTION_END_SINGULAR]
+                    .iter()
+                    .any(|marker| before_call_end.contains(marker))
+            };
             if !section_end_intervenes {
                 return Some(args_at + rel + CALL_END.len());
             }
@@ -932,6 +960,98 @@ mod tests {
             "a malformed raw-string argument with its own real call_end and no \
              intervening section-end must still be recovered"
         );
+    }
+
+    #[test]
+    fn closed_malformed_arguments_emit_on_the_closing_chunk() {
+        let mut parser = KimiK2ToolStreamParser::new(&weather_tools());
+        assert!(
+            parser
+                .push("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>")
+                .unwrap()
+                .calls
+                .is_empty()
+        );
+
+        let emitted = parser
+            .push("{\"location\":\"NYC\"<|tool_call_end|><|tool_calls_section_end|>")
+            .unwrap();
+        assert_eq!(emitted.calls.len(), 1);
+        assert_eq!(emitted.calls[0].arguments, r#"{"location":"NYC""#);
+        assert!(parser.finish().unwrap().calls.is_empty());
+    }
+
+    #[test]
+    fn closed_malformed_arguments_emit_before_finish_at_every_valid_utf8_split() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"München\"<|tool_call_end|><|tool_calls_section_end|>";
+        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+            let mut parser = KimiK2ToolStreamParser::new(&weather_tools());
+            let mut emitted = parser.push(&input[..split]).unwrap();
+            emitted.append(parser.push(&input[split..]).unwrap());
+            assert_eq!(
+                emitted.calls.len(),
+                1,
+                "split at byte {split} must emit once the closer is available"
+            );
+            assert_eq!(emitted.calls[0].arguments, r#"{"location":"München""#);
+            assert!(
+                parser.finish().unwrap().calls.is_empty(),
+                "split at byte {split} must not defer the call until finish"
+            );
+        }
+    }
+
+    fn assert_closed_malformed_quoted_marker_emits_on_the_closing_chunk(marker: &str) {
+        let arguments = format!(r#"{{"location" "München {marker} literal"}}"#);
+        let mut parser = KimiK2ToolStreamParser::new(&weather_tools());
+        assert!(
+            parser
+                .push("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>")
+                .unwrap()
+                .calls
+                .is_empty()
+        );
+
+        let emitted = parser
+            .push(&format!("{arguments}{CALL_END}{SECTION_END_PLURAL}"))
+            .unwrap();
+        assert_eq!(emitted.calls.len(), 1);
+        assert_eq!(emitted.calls[0].arguments, arguments);
+        assert!(parser.finish().unwrap().calls.is_empty());
+    }
+
+    #[test]
+    fn malformed_quoted_call_end_is_data_and_emits_on_the_closing_chunk() {
+        assert_closed_malformed_quoted_marker_emits_on_the_closing_chunk(CALL_END);
+    }
+
+    #[test]
+    fn malformed_quoted_section_end_is_data_and_emits_on_the_closing_chunk() {
+        assert_closed_malformed_quoted_marker_emits_on_the_closing_chunk(SECTION_END_PLURAL);
+    }
+
+    #[test]
+    fn closed_malformed_quoted_markers_emit_before_finish_at_every_valid_utf8_split() {
+        let header = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>";
+        for marker in [CALL_END, SECTION_END_PLURAL] {
+            let arguments = format!(r#"{{"location" "München {marker} literal"}}"#);
+            let input = format!("{header}{arguments}{CALL_END}{SECTION_END_PLURAL}");
+            for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+                let mut parser = KimiK2ToolStreamParser::new(&weather_tools());
+                let mut emitted = parser.push(&input[..split]).unwrap();
+                emitted.append(parser.push(&input[split..]).unwrap());
+                assert_eq!(
+                    emitted.calls.len(),
+                    1,
+                    "marker {marker:?}, split at byte {split} must emit once the closer is available"
+                );
+                assert_eq!(emitted.calls[0].arguments, arguments);
+                assert!(
+                    parser.finish().unwrap().calls.is_empty(),
+                    "marker {marker:?}, split at byte {split} must not defer the call until finish"
+                );
+            }
+        }
     }
 
     #[test]

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -90,7 +90,7 @@ struct M2Emitter {
 
 impl InvokeEmitter for M2Emitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -77,7 +77,7 @@ struct M3Emitter {
 
 impl InvokeEmitter for M3Emitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {

--- a/parsers/v2/src/tool_calling/muse_glimmer.rs
+++ b/parsers/v2/src/tool_calling/muse_glimmer.rs
@@ -281,7 +281,7 @@ pub(crate) struct MuseInvokeEmitter {
 
 impl InvokeEmitter for MuseInvokeEmitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -66,7 +66,7 @@ pub(crate) struct Qwen3Emitter {
 
 impl InvokeEmitter for Qwen3Emitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>> {

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -151,7 +151,17 @@ pub(crate) fn json_value_end(text: &str) -> Option<usize> {
     if first != '{' && first != '[' {
         return None;
     }
-    let mut depth = 1usize;
+    // A stack of the closer each opener actually requires -- not a numeric
+    // depth counter. A numeric counter treats `}` and `]` as interchangeable,
+    // so a mismatched-type input like `{]` or `[}` reads as balanced at
+    // depth 0 instead of being rejected. That's not just cosmetic: this
+    // function's whole purpose (see the doc comment above) is to find the
+    // structural end of the value so a literal closer search past it can't
+    // be fooled by a copy of that closer embedded in an still-open string
+    // (`I7`) -- a false "balanced" reading here can hand back a boundary
+    // BEFORE a string that legitimately belongs to the same value, reopening
+    // exactly that corruption.
+    let mut stack = vec![if first == '{' { '}' } else { ']' }];
     let mut in_string = false;
     let mut escape = false;
     for (idx, c) in chars {
@@ -167,10 +177,18 @@ pub(crate) fn json_value_end(text: &str) -> Option<usize> {
         }
         match c {
             '"' => in_string = true,
-            '{' | '[' => depth += 1,
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
             '}' | ']' => {
-                depth -= 1;
-                if depth == 0 {
+                // A closer that doesn't match the innermost opener's type
+                // can never be part of a well-formed JSON value from here --
+                // there is no future input that fixes a type mismatch, so
+                // this reading can never become balanced (unlike a plain
+                // depth shortfall, which just needs more input).
+                if stack.pop() != Some(c) {
+                    return None;
+                }
+                if stack.is_empty() {
                     return Some(idx + c.len_utf8());
                 }
             }
@@ -252,7 +270,10 @@ pub(crate) enum InvokeLatch {
 pub(crate) struct InvokeScan {
     /// End of the invoke that begins at byte zero, just past its closer. `flush`
     /// allows a family to recover a balanced body whose closer never arrived.
-    pub end: fn(text: &str, flush: bool) -> Option<usize>,
+    /// `tool_index` is the invoke's position in this stream (0 for the first
+    /// call) -- some best-effort recoveries are only justified for the first
+    /// call in a response (see `kimi_invoke_end`'s doc comment).
+    pub end: fn(text: &str, flush: bool, tool_index: usize) -> Option<usize>,
     /// Whether the `invoke_start` occurrence at `at` opens a real invoke.
     pub opens: fn(text: &str, at: usize) -> bool,
     /// Additional trailing bytes to retain while an opener is still arriving.
@@ -358,6 +379,46 @@ fn find_first(text: &str, markers: &[String]) -> Option<(usize, usize)> {
         .iter()
         .filter_map(|m| text.find(m.as_str()).map(|p| (p, m.len())))
         .min_by_key(|(p, _)| *p)
+}
+
+/// Same as [`find_first`], but a marker-looking byte sequence inside a
+/// double-quoted JSON string is data, not structure, and is skipped (`I7`,
+/// same escape-aware tracking as [`json_value_end`]). A raw `find_first`
+/// over a buffer that still contains an invoke's own JSON argument body can
+/// match a copy of a block-end marker the model happened to echo inside a
+/// string argument (e.g. a shell command echoing the exact closing tag) and
+/// mistake it for the real block boundary -- silently dropping a
+/// well-formed invoke and corrupting the `tool_index` of every call after
+/// it. Callers checking "did the block end before this invoke's own
+/// resolved close" need this variant; callers scanning plain narration
+/// (never inside an open JSON string) can keep using `find_first`.
+pub(crate) fn find_first_outside_strings(text: &str, markers: &[String]) -> Option<(usize, usize)> {
+    let mut in_string = false;
+    let mut escape = false;
+    for (idx, c) in text.char_indices() {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+            continue;
+        }
+        if let Some((_, len)) = markers
+            .iter()
+            .find(|m| text[idx..].starts_with(m.as_str()))
+            .map(|m| (idx, m.len()))
+        {
+            return Some((idx, len));
+        }
+    }
+    None
 }
 
 /// Earliest `(position, payload)` among the candidates.
@@ -676,7 +737,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
     /// Offset just past the closer of the invoke beginning at byte zero.
     fn invoke_end_at(&self, text: &str, flush: bool) -> Option<usize> {
         match self.spec.invoke_scan {
-            Some(scan) => (scan.end)(text, flush),
+            Some(scan) => (scan.end)(text, flush, self.next_index),
             None => text
                 .find(self.spec.invoke_end.as_str())
                 .map(|position| position + self.spec.invoke_end.len()),
@@ -924,8 +985,25 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 // Mismatched fences: a block close inside the invoke body means
                 // the invoke never closed. Drop it and close the block; narration
                 // after the close is the user's text again.
+                //
+                // `find_first_outside_strings`, not `find_first`: the search
+                // runs over `self.buffer` from the invoke's start, which can
+                // legitimately contain a block-end-looking byte sequence
+                // inside the invoke's own JSON string argument (a shell
+                // command echoing the closing tag). Safety only needs to
+                // hold for any match this call actually returns, which the
+                // `be_pos < end` filter below always bounds to inside the
+                // invoke (the scan is strictly left-to-right, so `in_string`
+                // at any returned `be_pos < end` depends only on bytes
+                // already known to belong to this invoke) -- not for the
+                // full buffer being scanned. A raw search there mistakes an
+                // embedded copy for the real boundary and drops a
+                // well-formed invoke -- also corrupting every later
+                // `tool_index`, since `next_index` never advances for a
+                // dropped call.
                 if self.spec.drop_invoke_crossing_block_end
-                    && let Some((be_pos, be_len)) = find_first(&self.buffer, &self.spec.block_ends)
+                    && let Some((be_pos, be_len)) =
+                        find_first_outside_strings(&self.buffer, &self.spec.block_ends)
                     && be_pos < end
                 {
                     tracing::warn!(
@@ -1171,6 +1249,69 @@ mod recovery_tests {
 mod tests {
     use super::test_support::failing_scanner;
     use super::*;
+
+    #[test]
+    fn json_value_end_rejects_mismatched_bracket_types() {
+        // A numeric depth counter treats `}`/`]` as interchangeable and
+        // would read these as balanced at the position of the mismatched
+        // closer -- e.g. `{]` closing at index 1. Neither can ever become
+        // valid JSON no matter what follows, so both must be `None`, not a
+        // false-positive boundary.
+        assert_eq!(json_value_end("{]"), None);
+        assert_eq!(json_value_end("[}"), None);
+        assert_eq!(json_value_end(r#"{"a":[1,2}}"#), None);
+        assert_eq!(json_value_end("[1,2}"), None);
+        // Negative control: the same shapes with correctly matched closers
+        // still resolve normally, proving the fix only rejects the type
+        // mismatch, not depth-nesting itself.
+        assert_eq!(json_value_end("{}"), Some(2));
+        assert_eq!(json_value_end(r#"{"a":[1,2]}"#), Some(11));
+    }
+
+    #[test]
+    fn find_first_outside_strings_skips_a_marker_inside_a_quoted_string() {
+        let markers = vec!["CLOSE".to_string()];
+        // A marker-looking sequence entirely inside a string is data, not
+        // structure -- must be skipped in favor of the real one afterward.
+        assert_eq!(
+            find_first_outside_strings(r#"{"a":"has CLOSE inside"}CLOSE"#, &markers),
+            Some((24, 5)),
+        );
+    }
+
+    #[test]
+    fn find_first_outside_strings_handles_an_escaped_quote_next_to_the_marker() {
+        let markers = vec!["CLOSE".to_string()];
+        // `\"` immediately before the embedded marker must not be misread as
+        // the string's real closing quote (which would wrongly un-toggle
+        // `in_string` one byte early and expose the embedded marker).
+        assert_eq!(
+            find_first_outside_strings(r#"{"a":"ends with \" then CLOSE inside"}CLOSE"#, &markers),
+            Some((38, 5)),
+        );
+    }
+
+    #[test]
+    fn find_first_outside_strings_returns_the_earliest_of_multiple_markers() {
+        let markers = vec!["BB".to_string(), "A".to_string()];
+        // Earliest BYTE POSITION wins regardless of which marker string it
+        // belongs to or the order markers are listed in.
+        assert_eq!(
+            find_first_outside_strings("xxAxxBBxx", &markers),
+            Some((2, 1))
+        );
+    }
+
+    #[test]
+    fn find_first_outside_strings_on_empty_or_no_match_is_none() {
+        let markers = vec!["CLOSE".to_string()];
+        assert_eq!(find_first_outside_strings("", &markers), None);
+        assert_eq!(find_first_outside_strings("no marker here", &markers), None);
+        assert_eq!(
+            find_first_outside_strings(r#""CLOSE only inside a string""#, &markers),
+            None
+        );
+    }
 
     #[test]
     fn reset_recovers_the_complete_push_after_an_emitter_error() {

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -976,6 +976,42 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 }
                 let Some(end) = self.invoke_end_at(&self.buffer, flush) else {
                     if flush {
+                        // Reviewer-caught regression: `invoke_end_at`
+                        // returning `None` at flush does NOT always mean
+                        // "genuinely incomplete, nothing left to salvage".
+                        // Kimi's own "mismatched fences" guard (in
+                        // `kimi_invoke_end`) also returns `None` when a
+                        // REAL block-end marker follows a call that never
+                        // got its own closer -- deliberately dropping just
+                        // that call while the section boundary itself is
+                        // still genuine. Unconditionally clearing the whole
+                        // buffer here discarded that boundary too, along
+                        // with any visible text genuinely following it --
+                        // batch mode's regex-based section extraction
+                        // preserves that trailing narration; streaming
+                        // didn't. Same string-aware search as the
+                        // `drop_invoke_crossing_block_end` check above
+                        // (safe for the identical reason): if a real
+                        // block-end marker is present, drop through it and
+                        // resume draining the suffix as ordinary text
+                        // instead of discarding everything after it.
+                        if self.spec.drop_invoke_crossing_block_end
+                            && let Some((be_pos, be_len)) = find_first_outside_strings(
+                                &self.buffer,
+                                self.spec.block_ends.iter().map(String::as_str),
+                            )
+                        {
+                            tracing::warn!(
+                                why = %format!("{}_incomplete_invoke", self.spec.family),
+                                "stream dropped invoke with no evidence it ever closed before the block end"
+                            );
+                            self.buffer.drain(..be_pos + be_len);
+                            self.uncommitted_block.clear();
+                            self.in_block = false;
+                            self.suppress_normal_text = false;
+                            self.in_reasoning = std::mem::take(&mut self.resume_reasoning);
+                            continue;
+                        }
                         tracing::warn!(
                             why = %format!("{}_incomplete_invoke", self.spec.family),
                             "stream dropped incomplete invoke at EOF"

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -134,6 +134,52 @@ where
         .unwrap_or(0)
 }
 
+/// Byte offset just past the first complete top-level JSON value (object or
+/// array) in `text`, skipping leading whitespace before it — or `None` if the
+/// value is absent, not object/array-shaped, or still open (unterminated
+/// string, unbalanced braces).
+///
+/// String contents are tracked with escape awareness, so a marker-looking
+/// byte sequence inside a quoted value is never mistaken for structure (`I7`).
+/// A family whose invoke body is `ARGUMENT_MARKER {json} CLOSE_MARKER` uses
+/// this to find where the json ends BEFORE searching for `CLOSE_MARKER`, so a
+/// copy of that marker embedded in a string argument cannot be mistaken for
+/// the real one (`WrappedBlockSpec::invoke_scan`).
+pub(crate) fn json_value_end(text: &str) -> Option<usize> {
+    let mut chars = text.char_indices();
+    let (_, first) = chars.find(|(_, c)| !c.is_whitespace())?;
+    if first != '{' && first != '[' {
+        return None;
+    }
+    let mut depth = 1usize;
+    let mut in_string = false;
+    let mut escape = false;
+    for (idx, c) in chars {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => in_string = true,
+            '{' | '[' => depth += 1,
+            '}' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx + c.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Re-serialize a v1core arguments JSON object in the model-emitted source
 /// order (`source_names`, extracted from the raw invoke body by the family).
 /// A repeated source name is emitted once (the v1 object holds one value per
@@ -276,12 +322,34 @@ pub(crate) struct ReasoningSpec {
 
 /// Per-family hook: parse one complete invoke (opener..closer inclusive) into
 /// a call delta. `None` means the invoke was malformed and is dropped.
+///
+/// `&mut self` (not `&self`): a family whose envelope names the call natively
+/// (Kimi's `functions.NAME:IDX`) needs somewhere to remember that id per
+/// `tool_index` for [`Self::tool_call_id`] to hand back later, and a plain
+/// owned field is the ordinary way to do that — no `RefCell` needed, since
+/// parsing and the later lookup never run at the same time.
 pub(crate) trait InvokeEmitter {
     fn parse_invoke(
-        &self,
+        &mut self,
         invoke: &str,
         tool_index: usize,
     ) -> anyhow::Result<Option<ToolCallDelta>>;
+
+    /// The model-emitted id for a call already parsed at `tool_index`, when
+    /// this family's grammar carries one. Mirrors
+    /// [`crate::unified::UnifiedParser::tool_call_id`] one layer down, so a
+    /// family overrides it in exactly one place regardless of whether it is
+    /// reached through the tool-only or unified adapter.
+    fn tool_call_id(&self, _tool_index: usize) -> Option<&str> {
+        None
+    }
+
+    /// Clear any per-stream state before [`WrappedBlockScanner::reset`] hands
+    /// the scanner back for a NEW stream at `tool_index` 0. A no-op default
+    /// is correct for every stateless emitter; an emitter that tracks ids per
+    /// `tool_index` (Kimi) must override this or a new stream's index 0
+    /// would read back the abandoned stream's id.
+    fn reset(&mut self) {}
 }
 
 /// First occurrence of any of `markers` in `text`: `(position, marker_len)`.
@@ -486,6 +554,12 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         self.spec.invoke_scan
     }
 
+    /// The model-emitted id for a call at `tool_index`, delegated to the
+    /// family's emitter. See [`InvokeEmitter::tool_call_id`].
+    pub(crate) fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+        self.emitter.tool_call_id(tool_index)
+    }
+
     /// Select whether this stream interprets reasoning markers, without
     /// rebuilding the scanner or cloning its tool schemas.
     pub(crate) fn set_reasoning_mode(&mut self, enabled: bool, forced_start: Option<bool>) {
@@ -574,6 +648,7 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
         self.resume_reasoning = false;
         self.suppress_normal_text = false;
         self.next_index = 0;
+        self.emitter.reset();
         pending
     }
 
@@ -1019,7 +1094,7 @@ pub(crate) mod test_support {
 
     impl InvokeEmitter for FailOnBoom {
         fn parse_invoke(
-            &self,
+            &mut self,
             invoke: &str,
             tool_index: usize,
         ) -> anyhow::Result<Option<ToolCallDelta>> {

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -392,7 +392,10 @@ fn find_first(text: &str, markers: &[String]) -> Option<(usize, usize)> {
 /// it. Callers checking "did the block end before this invoke's own
 /// resolved close" need this variant; callers scanning plain narration
 /// (never inside an open JSON string) can keep using `find_first`.
-pub(crate) fn find_first_outside_strings(text: &str, markers: &[String]) -> Option<(usize, usize)> {
+pub(crate) fn find_first_outside_strings<'a, I>(text: &str, markers: I) -> Option<(usize, usize)>
+where
+    I: Clone + IntoIterator<Item = &'a str>,
+{
     let mut in_string = false;
     let mut escape = false;
     for (idx, c) in text.char_indices() {
@@ -411,8 +414,9 @@ pub(crate) fn find_first_outside_strings(text: &str, markers: &[String]) -> Opti
             continue;
         }
         if let Some((_, len)) = markers
-            .iter()
-            .find(|m| text[idx..].starts_with(m.as_str()))
+            .clone()
+            .into_iter()
+            .find(|m| text[idx..].starts_with(m))
             .map(|m| (idx, m.len()))
         {
             return Some((idx, len));
@@ -1002,8 +1006,10 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                 // `tool_index`, since `next_index` never advances for a
                 // dropped call.
                 if self.spec.drop_invoke_crossing_block_end
-                    && let Some((be_pos, be_len)) =
-                        find_first_outside_strings(&self.buffer, &self.spec.block_ends)
+                    && let Some((be_pos, be_len)) = find_first_outside_strings(
+                        &self.buffer,
+                        self.spec.block_ends.iter().map(String::as_str),
+                    )
                     && be_pos < end
                 {
                     tracing::warn!(
@@ -1270,45 +1276,45 @@ mod tests {
 
     #[test]
     fn find_first_outside_strings_skips_a_marker_inside_a_quoted_string() {
-        let markers = vec!["CLOSE".to_string()];
+        let markers = ["CLOSE"];
         // A marker-looking sequence entirely inside a string is data, not
         // structure -- must be skipped in favor of the real one afterward.
         assert_eq!(
-            find_first_outside_strings(r#"{"a":"has CLOSE inside"}CLOSE"#, &markers),
+            find_first_outside_strings(r#"{"a":"has CLOSE inside"}CLOSE"#, markers,),
             Some((24, 5)),
         );
     }
 
     #[test]
     fn find_first_outside_strings_handles_an_escaped_quote_next_to_the_marker() {
-        let markers = vec!["CLOSE".to_string()];
+        let markers = ["CLOSE"];
         // `\"` immediately before the embedded marker must not be misread as
         // the string's real closing quote (which would wrongly un-toggle
         // `in_string` one byte early and expose the embedded marker).
         assert_eq!(
-            find_first_outside_strings(r#"{"a":"ends with \" then CLOSE inside"}CLOSE"#, &markers),
+            find_first_outside_strings(r#"{"a":"ends with \" then CLOSE inside"}CLOSE"#, markers,),
             Some((38, 5)),
         );
     }
 
     #[test]
     fn find_first_outside_strings_returns_the_earliest_of_multiple_markers() {
-        let markers = vec!["BB".to_string(), "A".to_string()];
+        let markers = ["BB", "A"];
         // Earliest BYTE POSITION wins regardless of which marker string it
         // belongs to or the order markers are listed in.
         assert_eq!(
-            find_first_outside_strings("xxAxxBBxx", &markers),
+            find_first_outside_strings("xxAxxBBxx", markers),
             Some((2, 1))
         );
     }
 
     #[test]
     fn find_first_outside_strings_on_empty_or_no_match_is_none() {
-        let markers = vec!["CLOSE".to_string()];
-        assert_eq!(find_first_outside_strings("", &markers), None);
-        assert_eq!(find_first_outside_strings("no marker here", &markers), None);
+        let markers = ["CLOSE"];
+        assert_eq!(find_first_outside_strings("", markers), None);
+        assert_eq!(find_first_outside_strings("no marker here", markers), None);
         assert_eq!(
-            find_first_outside_strings(r#""CLOSE only inside a string""#, &markers),
+            find_first_outside_strings(r#""CLOSE only inside a string""#, markers,),
             None
         );
     }

--- a/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
+++ b/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use super::super::ToolDefinition;
 use super::super::config::KimiK2ParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
-use crate::tool_calling::scan::json_value_end;
+use crate::tool_calling::scan::{find_first_outside_strings, json_value_end};
 
 static ID_REGEX: OnceLock<Regex> = OnceLock::new();
 
@@ -123,9 +123,10 @@ fn find_section_start(
 ///   never be mistaken for a boundary, because `json_value_end` parses the
 ///   whole value rather than pattern-matching mid-string.
 /// - A MALFORMED (non-JSON) argument -- not itself illegal Kimi output,
-///   just a raw-string-fallback case -- falls back to a literal search for
-///   THIS call's own `call_end` token, bounded to just this call's span; no
-///   quote state escapes to influence any other call.
+///   just a raw-string-fallback case -- uses the shared quote-aware marker
+///   scan for THIS call's own boundaries. If its quotes never close, the
+///   conservative raw fence comparison keeps a real section end from being
+///   swallowed into the argument.
 ///
 /// Neither path lets one call's content affect how a DIFFERENT call is
 /// scanned, so a malformed call's damage is bounded to itself and a
@@ -183,8 +184,8 @@ fn find_section_end(
         cursor = match valid_json_end {
             Some(json_end) => arg_pos + json_end,
             None => {
-                // Malformed argument (json_value_end failed): the literal
-                // `call_end` fallback below must not blindly trust a match
+                // Malformed argument (json_value_end failed): the boundary
+                // fallback below must not blindly trust a `call_end` match
                 // that has a REAL section-end marker sitting before it --
                 // that means this call never got its own closer and the
                 // section actually ends at that marker. Without this
@@ -198,24 +199,66 @@ fn find_section_end(
                 // recovered a call streaming correctly dropped, a real
                 // streaming/batch divergence in the opposite direction).
                 let after_arg = &region[arg_pos..];
-                let intervening_section_end = config
-                    .section_end_variants
-                    .iter()
-                    .filter_map(|m| after_arg.find(m.as_str()).map(|p| (p, m.len())))
-                    .min_by_key(|&(p, _)| p);
-                match after_arg.find(config.call_end.as_str()) {
-                    Some(p) => match intervening_section_end {
-                        Some((sp, slen)) if sp < p => return Some((arg_pos + sp, slen)),
-                        _ => arg_pos + p + config.call_end.len(),
-                    },
-                    // No literal call_end at all -- if a section-end
-                    // exists ahead, the section ends there (this malformed
-                    // call is truncated inside a still-open section);
-                    // otherwise genuinely nothing further to skip.
-                    None => match intervening_section_end {
-                        Some((sp, slen)) => return Some((arg_pos + sp, slen)),
-                        None => return None,
-                    },
+                // Quote state from malformed arguments is meaningful only
+                // inside this call. Bound every structural and raw fallback
+                // search at the next literal opener, then restart the loop
+                // there so an unmatched quote cannot hide the next call and
+                // later resynchronize on that call's quotes.
+                let next_call_start = after_arg.find(config.call_start.as_str());
+                let current_call_region = &after_arg[..next_call_start.unwrap_or(after_arg.len())];
+                let structural_call_end =
+                    find_first_outside_strings(current_call_region, [config.call_end.as_str()]);
+                let structural_section_end = find_first_outside_strings(
+                    current_call_region,
+                    config.section_end_variants.iter().map(String::as_str),
+                );
+                if let Some((call_pos, call_len)) = structural_call_end {
+                    if let Some((section_pos, section_len)) = structural_section_end
+                        && section_pos < call_pos
+                    {
+                        return Some((arg_pos + section_pos, section_len));
+                    }
+                    arg_pos + call_pos + call_len
+                } else {
+                    // No quote-aware call end means this malformed call has
+                    // no structurally provable boundary. Do not trust a later
+                    // quote-aware section match either: an unmatched quote in
+                    // this call can coincidentally resynchronize on a quote in
+                    // the next call, recreating cross-call state leakage.
+                    // Preserve the conservative historical fallback for this
+                    // shape by comparing the first raw section end and call
+                    // end, so the current call is bounded before scanning the
+                    // next one independently.
+                    let raw_section_end = config
+                        .section_end_variants
+                        .iter()
+                        .filter_map(|marker| {
+                            current_call_region
+                                .find(marker.as_str())
+                                .map(|position| (position, marker.len()))
+                        })
+                        .min_by_key(|&(position, _)| position);
+                    match current_call_region.find(config.call_end.as_str()) {
+                        Some(call_pos) => match raw_section_end {
+                            Some((section_pos, section_len)) if section_pos < call_pos => {
+                                return Some((arg_pos + section_pos, section_len));
+                            }
+                            _ => arg_pos + call_pos + config.call_end.len(),
+                        },
+                        // No literal call_end at all -- if a section-end
+                        // exists ahead, the section ends there (this malformed
+                        // call is truncated inside a still-open section);
+                        // otherwise genuinely nothing further to skip.
+                        None => match raw_section_end {
+                            Some((section_pos, section_len)) => {
+                                return Some((arg_pos + section_pos, section_len));
+                            }
+                            None => match next_call_start {
+                                Some(next) => arg_pos + next,
+                                None => return None,
+                            },
+                        },
+                    }
                 }
             }
         };
@@ -425,48 +468,42 @@ fn parse_section_block(
             .map(|m| m.as_str().trim())
             .unwrap_or("{}");
 
-        // The capture above is lazy (`.*?`) and stops at the FIRST literal
-        // `call_end` in the block -- including a copy embedded inside a
-        // quoted string argument (`I7`). Prefer the structurally balanced
-        // JSON boundary, anchored at the SAME start position the lazy
-        // capture used, whenever the body is clean JSON immediately followed
-        // by the real closer; fall back to the lazy capture for genuinely
-        // malformed/non-JSON argument bodies, which still need the
-        // permissive raw-string path (`serde_json::from_str` below falls
-        // back to the raw text on a parse error either way).
-        //
-        // `json_value_end` only proves bracket/quote NESTING is balanced,
-        // not that the bytes are valid JSON. Without validating here, a
-        // bracket-balanced-but-invalid body containing an embedded
-        // `call_end`-looking substring as literal (non-string) data --
-        // e.g. `{not<|tool_call_end|>json}` -- can still pass this override
-        // whenever a literal `call_end` genuinely follows it, silently
-        // REPLACING the lazy capture's own (differently wrong, but at least
-        // independently-derived) boundary with a longer span that swallows
-        // the embedded fake closer as content instead of stopping there.
-        // Neither span is valid JSON either way, but which raw string ships
-        // to the caller should not depend on an unvalidated coincidence of
-        // where `json_value_end` happens to balance. Validating here means
-        // the override only ever fires for genuinely valid JSON, matching
-        // the identical hoist already applied to `kimi_invoke_end` and
-        // `find_section_end`'s own `json_value_end` consumers.
+        // The capture above is lazy (`.*?`) and stops at the first literal
+        // `call_end`, including a copy inside a closed quoted span. That
+        // corrupts both valid JSON strings and Kimi's permissive malformed
+        // raw-string fallback before the latter reaches its typing branch.
+        // Reuse the same quote-aware marker owner as streaming and section
+        // discovery, bounded against a later invoke opener. An unmatched
+        // quote intentionally falls back to the lazy capture: no structural
+        // closer can be proved in that shape, and the historical conservative
+        // recovery remains the safer contract.
         let arguments_raw = cap
             .name("arguments")
             .and_then(|m| {
                 let args_start = m.start();
-                let json_end = args_start + json_value_end(&block[args_start..])?;
-                let candidate = block[args_start..json_end].trim();
-                // Match the SAME `\s*` tolerance the regex above (and the
-                // streaming boundary finder, `kimi_invoke_end`) already give
-                // the closer -- an exact `starts_with` here silently falls
-                // back to the lazy capture (the original I7 bug) whenever
-                // the model puts ordinary whitespace between the JSON and
-                // `call_end`, corrupting an argument that WAS byte-exact.
-                (block[json_end..]
-                    .trim_start()
-                    .starts_with(config.call_end.as_str())
-                    && serde_json::from_str::<serde_json::Value>(candidate).is_ok())
-                .then_some(candidate)
+                let argument_region = &block[args_start..];
+                if let Some(json_len) = json_value_end(argument_region).filter(|&json_len| {
+                    serde_json::from_str::<serde_json::Value>(&argument_region[..json_len]).is_ok()
+                }) {
+                    let after_json = &argument_region[json_len..];
+                    let call_end = after_json.find(config.call_end.as_str())?;
+                    let next_call_start = after_json.find(config.call_start.as_str());
+                    next_call_start
+                        .is_none_or(|next| call_end < next)
+                        .then(|| argument_region[..json_len].trim())
+                } else {
+                    // Once JSON is malformed, quote state cannot safely span
+                    // a later invoke: two adjacent calls with unmatched
+                    // quotes can cancel each other's state and make the first
+                    // call borrow the second call's closer. The raw opener is
+                    // therefore the conservative per-call damage boundary.
+                    let next_call_start = argument_region.find(config.call_start.as_str());
+                    let (call_end, _) =
+                        find_first_outside_strings(argument_region, [config.call_end.as_str()])?;
+                    next_call_start
+                        .is_none_or(|next| call_end < next)
+                        .then(|| argument_region[..call_end].trim())
+                }
             })
             .unwrap_or(lazy_arguments);
 
@@ -682,6 +719,25 @@ mod tests {
             "the override must still extend past the embedded fake closer when it's \
              genuinely inside a well-formed JSON string"
         );
+    }
+
+    /// This stays a unit-level regression because the unified fixture corpus
+    /// normalizes malformed raw arguments; it cannot assert the byte-exact
+    /// v1 fallback values that prove each regex capture kept its own call.
+    #[test]
+    fn adjacent_malformed_calls_keep_their_own_raw_argument_boundaries() {
+        let config = KimiK2ParserConfig::default();
+        let msg = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>x\"1<|tool_call_end|><|tool_call_begin|>functions.run:1<|tool_call_argument_begin|>y\"2<|tool_call_end|><|tool_calls_section_end|>";
+        let (calls, _content) = try_tool_call_parse_kimi_k2(msg, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            2,
+            "one malformed call must not absorb the next"
+        );
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[0].function.arguments, "x\"1");
+        assert_eq!(calls[1].function.name, "run");
+        assert_eq!(calls[1].function.arguments, "y\"2");
     }
 
     /// Finding 1 regression: the tool-call regex must be built from the config

--- a/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
+++ b/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use super::super::ToolDefinition;
 use super::super::config::KimiK2ParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
+use crate::tool_calling::scan::json_value_end;
 
 static ID_REGEX: OnceLock<Regex> = OnceLock::new();
 
@@ -307,10 +308,37 @@ fn parse_section_block(
             .name("function_id")
             .map(|m| m.as_str().trim())
             .unwrap_or("");
-        let arguments_raw = cap
+        let lazy_arguments = cap
             .name("arguments")
             .map(|m| m.as_str().trim())
             .unwrap_or("{}");
+
+        // The capture above is lazy (`.*?`) and stops at the FIRST literal
+        // `call_end` in the block -- including a copy embedded inside a
+        // quoted string argument (`I7`). Prefer the structurally balanced
+        // JSON boundary, anchored at the SAME start position the lazy
+        // capture used, whenever the body is clean JSON immediately followed
+        // by the real closer; fall back to the lazy capture for genuinely
+        // malformed/non-JSON argument bodies, which still need the
+        // permissive raw-string path (`serde_json::from_str` below falls
+        // back to the raw text on a parse error either way).
+        let arguments_raw = cap
+            .name("arguments")
+            .and_then(|m| {
+                let args_start = m.start();
+                let json_end = args_start + json_value_end(&block[args_start..])?;
+                // Match the SAME `\s*` tolerance the regex above (and the
+                // streaming boundary finder, `kimi_invoke_end`) already give
+                // the closer -- an exact `starts_with` here silently falls
+                // back to the lazy capture (the original I7 bug) whenever
+                // the model puts ordinary whitespace between the JSON and
+                // `call_end`, corrupting an argument that WAS byte-exact.
+                block[json_end..]
+                    .trim_start()
+                    .starts_with(config.call_end.as_str())
+                    .then(|| block[args_start..json_end].trim())
+            })
+            .unwrap_or(lazy_arguments);
 
         // Parse function ID
         let function_name = if let Some(id_cap) = id_regex.captures(function_id) {

--- a/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
+++ b/parsers/v2/src/tool_calling/v1core/xml/kimi_k2_parser.rs
@@ -75,6 +75,11 @@ pub fn try_tool_call_parse_kimi_k2(
 }
 
 /// Find the first occurrence of any section start variant in `text[cursor..]`.
+/// Deliberately a plain (non-string-aware) search, unlike `find_section_end`
+/// below: `cursor` only ever lands on gap/narration text between sections
+/// (never inside an open JSON tool-call argument), and narration is where a
+/// stray, ordinary quotation mark is expected -- string-tracking there would
+/// risk mis-toggling on the user's own prose instead of protecting anything.
 /// Returns `(relative_position, matched_token_length)` or `None`.
 fn find_section_start(
     text: &str,
@@ -92,22 +97,129 @@ fn find_section_start(
     best
 }
 
-/// Find the first occurrence of any section end variant in `text[from..]`.
+/// Find the first occurrence of any section end variant in `text[from..]`,
+/// skipping over each embedded call's own JSON argument body rather than
+/// tracking quotes as one continuous scan across the whole region.
+///
+/// `text[from..]` spans potentially multiple calls plus narration, not one
+/// call's own body, and a naive single quote-tracking pass over that whole
+/// span cannot safely tell "a `call_end`-shaped byte sequence embedded as
+/// DATA inside one call's own well-formed string argument" apart from "an
+/// earlier call's malformed, unbalanced-quote argument having desynced
+/// `in_string` for everything after it" -- both look identical as local
+/// per-character state (an earlier version of this function tried resolving
+/// that ambiguity with a "reset at every `call_end` occurrence" heuristic
+/// and a later "prefer honest tracking, fall back to reset" refinement;
+/// both were reproduced as unsound: `in_string` carries desync GLOBALLY
+/// across the whole multi-call span with either approach, so a stray quote
+/// in one call could silently resync at exactly the wrong position inside a
+/// LATER, unrelated call's own legitimate string).
+///
+/// So this walks call-by-call instead, using [`json_value_end`] -- real
+/// bracket/quote-aware JSON structure, not a heuristic -- to skip each
+/// call's argument body:
+/// - A WELL-FORMED argument's structural end is trusted completely; a
+///   `call_end`-shaped byte sequence embedded in one of ITS OWN strings can
+///   never be mistaken for a boundary, because `json_value_end` parses the
+///   whole value rather than pattern-matching mid-string.
+/// - A MALFORMED (non-JSON) argument -- not itself illegal Kimi output,
+///   just a raw-string-fallback case -- falls back to a literal search for
+///   THIS call's own `call_end` token, bounded to just this call's span; no
+///   quote state escapes to influence any other call.
+///
+/// Neither path lets one call's content affect how a DIFFERENT call is
+/// scanned, so a malformed call's damage is bounded to itself and a
+/// well-formed call's embedded marker-looking data is never mistaken for a
+/// real boundary, regardless of what came before it in the same section.
 /// Returns `(relative_position, matched_token_length)` or `None`.
 fn find_section_end(
     text: &str,
     from: usize,
     config: &KimiK2ParserConfig,
 ) -> Option<(usize, usize)> {
-    let mut best: Option<(usize, usize)> = None;
-    for variant in &config.section_end_variants {
-        if let Some(pos) = text[from..].find(variant.as_str())
-            && best.is_none_or(|(bp, _)| pos < bp)
-        {
-            best = Some((pos, variant.len()));
+    let region = &text[from..];
+    let mut cursor = 0usize;
+    loop {
+        let next_section_end = config
+            .section_end_variants
+            .iter()
+            .filter_map(|m| {
+                region[cursor..]
+                    .find(m.as_str())
+                    .map(|p| (cursor + p, m.len()))
+            })
+            .min_by_key(|&(p, _)| p);
+        // Plain, non-string-aware search for the next call's argument
+        // start: outside an already-open call, `argument_begin` is a real
+        // structural marker, the same trust level `find_section_start`
+        // above already places in the surrounding section markers.
+        let next_arg_begin_start = region[cursor..]
+            .find(config.argument_begin.as_str())
+            .map(|p| cursor + p);
+
+        let section_end_is_first = match (next_section_end, next_arg_begin_start) {
+            (Some((end_pos, _)), Some(arg_pos)) => end_pos < arg_pos,
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+        if section_end_is_first {
+            return next_section_end;
         }
+        let arg_pos = next_arg_begin_start? + config.argument_begin.len();
+        // `json_value_end` only proves bracket/quote nesting is balanced,
+        // not that the bytes are valid JSON (`{<|tool_calls_section_end|>}`
+        // balances even though its "content" is a section-end marker, not
+        // JSON). Trusting a bracket-balanced-but-invalid body as this
+        // call's real argument boundary means its embedded section-end
+        // marker is never scanned for at all -- the call-by-call walk just
+        // skips straight past it as if it were legitimate JSON content.
+        // Validating here routes an invalid body through the SAME
+        // malformed/raw-string fallback below (with its own intervening-
+        // section-end guard) instead of trusting `json_value_end` alone;
+        // mirrors the identical hoist in streaming's `kimi_invoke_end`.
+        let valid_json_end = json_value_end(&region[arg_pos..]).filter(|&json_end| {
+            serde_json::from_str::<serde_json::Value>(&region[arg_pos..arg_pos + json_end]).is_ok()
+        });
+        cursor = match valid_json_end {
+            Some(json_end) => arg_pos + json_end,
+            None => {
+                // Malformed argument (json_value_end failed): the literal
+                // `call_end` fallback below must not blindly trust a match
+                // that has a REAL section-end marker sitting before it --
+                // that means this call never got its own closer and the
+                // section actually ends at that marker. Without this
+                // check, the malformed call's raw text (which still
+                // contains the section-end bytes, since nothing skipped
+                // past them) swallows the real boundary and the call
+                // recovers with a corrupted argument -- streaming's
+                // `kimi_invoke_end` has the identical guard on its own
+                // sibling malformed-argument fallback for exactly this
+                // reason (blind-audit-caught: without this, batch mode
+                // recovered a call streaming correctly dropped, a real
+                // streaming/batch divergence in the opposite direction).
+                let after_arg = &region[arg_pos..];
+                let intervening_section_end = config
+                    .section_end_variants
+                    .iter()
+                    .filter_map(|m| after_arg.find(m.as_str()).map(|p| (p, m.len())))
+                    .min_by_key(|&(p, _)| p);
+                match after_arg.find(config.call_end.as_str()) {
+                    Some(p) => match intervening_section_end {
+                        Some((sp, slen)) if sp < p => return Some((arg_pos + sp, slen)),
+                        _ => arg_pos + p + config.call_end.len(),
+                    },
+                    // No literal call_end at all -- if a section-end
+                    // exists ahead, the section ends there (this malformed
+                    // call is truncated inside a still-open section);
+                    // otherwise genuinely nothing further to skip.
+                    None => match intervening_section_end {
+                        Some((sp, slen)) => return Some((arg_pos + sp, slen)),
+                        None => return None,
+                    },
+                }
+            }
+        };
     }
-    best
 }
 
 /// Extract tool calls and normal text from message.
@@ -322,21 +434,39 @@ fn parse_section_block(
         // malformed/non-JSON argument bodies, which still need the
         // permissive raw-string path (`serde_json::from_str` below falls
         // back to the raw text on a parse error either way).
+        //
+        // `json_value_end` only proves bracket/quote NESTING is balanced,
+        // not that the bytes are valid JSON. Without validating here, a
+        // bracket-balanced-but-invalid body containing an embedded
+        // `call_end`-looking substring as literal (non-string) data --
+        // e.g. `{not<|tool_call_end|>json}` -- can still pass this override
+        // whenever a literal `call_end` genuinely follows it, silently
+        // REPLACING the lazy capture's own (differently wrong, but at least
+        // independently-derived) boundary with a longer span that swallows
+        // the embedded fake closer as content instead of stopping there.
+        // Neither span is valid JSON either way, but which raw string ships
+        // to the caller should not depend on an unvalidated coincidence of
+        // where `json_value_end` happens to balance. Validating here means
+        // the override only ever fires for genuinely valid JSON, matching
+        // the identical hoist already applied to `kimi_invoke_end` and
+        // `find_section_end`'s own `json_value_end` consumers.
         let arguments_raw = cap
             .name("arguments")
             .and_then(|m| {
                 let args_start = m.start();
                 let json_end = args_start + json_value_end(&block[args_start..])?;
+                let candidate = block[args_start..json_end].trim();
                 // Match the SAME `\s*` tolerance the regex above (and the
                 // streaming boundary finder, `kimi_invoke_end`) already give
                 // the closer -- an exact `starts_with` here silently falls
                 // back to the lazy capture (the original I7 bug) whenever
                 // the model puts ordinary whitespace between the JSON and
                 // `call_end`, corrupting an argument that WAS byte-exact.
-                block[json_end..]
+                (block[json_end..]
                     .trim_start()
                     .starts_with(config.call_end.as_str())
-                    .then(|| block[args_start..json_end].trim())
+                    && serde_json::from_str::<serde_json::Value>(candidate).is_ok())
+                .then_some(candidate)
             })
             .unwrap_or(lazy_arguments);
 
@@ -400,6 +530,159 @@ fn parse_section_block(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Reviewer-caught regression: a MALFORMED (non-JSON) argument containing
+    /// one unescaped `"` used to desync `in_string` for the rest of the scan,
+    /// so the real `section_end` after it was missed entirely and
+    /// `extract_tool_calls`'s "no section_end found" fallback swallowed
+    /// genuinely trailing normal text into the tool section. Confirmed with a
+    /// scratch repro before fixing: `find_section_end` returned `None` even
+    /// though a real closer existed further in the text. Fixed by walking
+    /// call-by-call and falling back to a literal `call_end` search bounded
+    /// to just this one call's own span (see the function's doc comment).
+    #[test]
+    fn find_section_end_survives_an_unbalanced_quote_in_a_malformed_argument() {
+        let config = KimiK2ParserConfig::default();
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>bad\"arg<|tool_call_end|><|tool_calls_section_end|>After.";
+        let real_pos = text.find("<|tool_calls_section_end|>").unwrap();
+        let (pos, len) = find_section_end(text, 0, &config)
+            .expect("must find the real closer despite the unbalanced quote");
+        assert_eq!(pos, real_pos);
+        assert_eq!(&text[pos..pos + len], "<|tool_calls_section_end|>");
+    }
+
+    /// Sibling case: TWO malformed calls each with their own unbalanced quote
+    /// -- proves the literal `call_end` fallback is applied independently to
+    /// EVERY call's own span, not just the first.
+    #[test]
+    fn find_section_end_survives_two_malformed_arguments_each_with_an_unbalanced_quote() {
+        let config = KimiK2ParserConfig::default();
+        let text = "<|tool_call_begin|>functions.a:0<|tool_call_argument_begin|>x\"1<|tool_call_end|><|tool_call_begin|>functions.b:1<|tool_call_argument_begin|>y\"2<|tool_call_end|><|tool_calls_section_end|>After.";
+        let real_pos = text.find("<|tool_calls_section_end|>").unwrap();
+        let (pos, len) = find_section_end(text, 0, &config)
+            .expect("must find the real closer past both malformed calls");
+        assert_eq!(pos, real_pos);
+        assert_eq!(&text[pos..pos + len], "<|tool_calls_section_end|>");
+    }
+
+    /// Direct unit test on the shared boundary owner itself: `find_section_end`
+    /// must skip a section-end-looking byte sequence embedded inside a JSON
+    /// string argument and find the REAL trailing marker instead. Before this
+    /// fix, `extract_tool_calls` truncated the section at the embedded copy,
+    /// so the block handed to `parse_section_block` never contained the real
+    /// `call_end` and the whole call silently vanished (`tool_index` for any
+    /// later call in the same section then desynced, since nothing advanced
+    /// past the dropped one).
+    #[test]
+    fn find_section_end_skips_a_marker_embedded_in_a_json_string() {
+        let config = KimiK2ParserConfig::default();
+        let text = "<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\":\"echo <|tool_calls_section_end|>\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let (pos, len) = find_section_end(text, 0, &config).expect("must find the real closer");
+        assert_eq!(
+            &text[pos..pos + len],
+            "<|tool_calls_section_end|>",
+            "must resolve to the REAL trailing marker, not the embedded copy"
+        );
+        assert!(
+            text[..pos].ends_with("<|tool_call_end|>"),
+            "the resolved position must be the marker AFTER the invoke's own call_end, \
+             not the earlier embedded lookalike inside the JSON string"
+        );
+    }
+
+    /// Blind-audit-caught regression IN the prior fix: an EARLIER malformed
+    /// call's unbalanced quote must not affect whether a LATER, well-formed
+    /// call's embedded section-end lookalike is (correctly) treated as
+    /// string data. A single continuous quote-tracking pass across the whole
+    /// multi-call region -- whether or not it force-resets at every
+    /// `call_end` -- carries desync state across call boundaries; this test
+    /// combines both single-call regressions above into one input to prove
+    /// the call-by-call structural walk keeps them fully independent.
+    #[test]
+    fn find_section_end_is_unaffected_by_an_earlier_malformed_calls_desync() {
+        let config = KimiK2ParserConfig::default();
+        let text = "<|tool_call_begin|>functions.a:0<|tool_call_argument_begin|>bad\"arg<|tool_call_end|>\
+                     <|tool_call_begin|>functions.b:1<|tool_call_argument_begin|>{\"cmd\":\"echo <|tool_calls_section_end|>\"}<|tool_call_end|>\
+                     After.<|tool_calls_section_end|>";
+        let real_pos = text.rfind("<|tool_calls_section_end|>").unwrap();
+        let (pos, len) = find_section_end(text, 0, &config)
+            .expect("must find the real trailing closer past both calls");
+        assert_eq!(
+            pos, real_pos,
+            "must resolve to the REAL trailing marker after \"After.\", not the earlier \
+             embedded copy inside call b's own string, and not None"
+        );
+        assert_eq!(&text[pos..pos + len], "<|tool_calls_section_end|>");
+    }
+
+    /// Blind-audit-caught regression: batch mode used to disagree with
+    /// streaming's `kimi_invoke_end` on the identical malformed-argument
+    /// shape (a real section-end marker occurring before a malformed call's
+    /// only available `call_end`) -- `find_section_end` couldn't find ANY
+    /// section end at all (its own scan is bounded to look for a section
+    /// end only in the gap AFTER a call's own span resolves, and this
+    /// malformed call's span never resolves), so `parse_section_block`
+    /// treated the rest of the buffer as one long section and recovered
+    /// the call with the section-end marker swallowed into its raw-string
+    /// argument -- a real streaming/batch divergence in the opposite
+    /// direction from the one this session's fixes were meant to close.
+    /// End-to-end via the real public entry point, not just the boundary
+    /// function directly, to prove the whole pipeline agrees.
+    #[test]
+    fn batch_mode_drops_a_malformed_call_when_a_section_end_intervenes_before_its_call_end() {
+        let config = KimiK2ParserConfig::default();
+        let msg = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\": \"unterminated<|tool_calls_section_end|><|tool_call_end|>";
+        let (calls, _content) = try_tool_call_parse_kimi_k2(msg, &config, None).unwrap();
+        assert!(
+            calls.is_empty(),
+            "batch mode must drop this call, matching streaming's kimi_invoke_end -- \
+             got {calls:?}"
+        );
+    }
+
+    /// Reviewer-caught regression: `parse_section_block`'s I7 override used
+    /// to trust `json_value_end`'s bracket-balance alone before REPLACING
+    /// the lazy regex capture's own boundary -- a bracket-balanced but
+    /// JSON-GRAMMAR-INVALID body containing an embedded `call_end`-looking
+    /// substring as literal (non-string) content, immediately followed by
+    /// the real literal `call_end`, still passed the override and shipped
+    /// `arguments` containing the embedded fake closer as swallowed text
+    /// instead of falling back to the lazy capture's own (shorter, but
+    /// independently-derived) boundary. Reproduced directly before fixing:
+    /// unpatched code shipped `arguments: "{not<|tool_call_end|>json}"`.
+    #[test]
+    fn i7_override_requires_actually_valid_json_not_just_balanced_brackets() {
+        let config = KimiK2ParserConfig::default();
+        let msg = "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{not<|tool_call_end|>json}<|tool_call_end|><|tool_calls_section_end|>";
+        let (calls, _content) = try_tool_call_parse_kimi_k2(msg, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "the call must still ship, just with the lazy boundary"
+        );
+        assert_eq!(
+            calls[0].function.arguments, "{not",
+            "must fall back to the lazy capture's own boundary, not the invalid \
+             bracket-balanced span that swallows the embedded fake closer"
+        );
+    }
+
+    /// Sibling positive control: the SAME override still correctly extends
+    /// past an embedded fake closer that's legitimate DATA inside a
+    /// well-formed JSON string (the original I7 case this override exists
+    /// for) -- this fix must not regress that contract.
+    #[test]
+    fn i7_override_still_extends_past_a_fake_closer_inside_a_well_formed_string() {
+        let config = KimiK2ParserConfig::default();
+        let msg = "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"note\":\"<|tool_call_end|>\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let (calls, _content) = try_tool_call_parse_kimi_k2(msg, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments, "{\"note\":\"<|tool_call_end|>\"}",
+            "the override must still extend past the embedded fake closer when it's \
+             genuinely inside a well-formed JSON string"
+        );
+    }
 
     /// Finding 1 regression: the tool-call regex must be built from the config
     /// passed on each call, never frozen by a global cache. Two configs with

--- a/parsers/v2/src/unified/kimi_k2.rs
+++ b/parsers/v2/src/unified/kimi_k2.rs
@@ -39,8 +39,8 @@ pub(crate) fn kimi_k2_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
 mod tests {
     use super::*;
     use crate::unified::{
-        InvalidGuidedPayloadPolicy, UnifiedEvent, UnifiedParserExt, UnifiedParserInit,
-        UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
+        InvalidGuidedPayloadPolicy, UnifiedEvent, UnifiedParserEvent, UnifiedParserExt,
+        UnifiedParserInit, UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
     };
 
     fn tools() -> Vec<Tool> {
@@ -159,6 +159,111 @@ mod tests {
                 arguments: serde_json::json!({}),
             }]
         );
+    }
+
+    fn assert_malformed_quoted_marker_emits_before_finish_at_every_split(marker: &str) {
+        let header = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>";
+        let arguments = format!(r#"{{"location" "München {marker} literal"}}"#);
+        let input = format!("{header}{arguments}<|tool_call_end|><|tool_calls_section_end|>");
+        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+            let mut parser = kimi_k2_unified(&tools());
+            let mut emitted = parser.push(&input[..split]).unwrap();
+            emitted.extend(parser.push(&input[split..]).unwrap());
+            let calls: Vec<_> = emitted
+                .iter()
+                .filter_map(|event| match event {
+                    UnifiedParserEvent::ToolCall(call) => Some(call),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                calls.len(),
+                1,
+                "marker {marker:?}, split at byte {split} must emit once the closer is available"
+            );
+            assert_eq!(calls[0].arguments, arguments);
+            assert!(
+                parser.finish().unwrap().events.is_empty(),
+                "marker {marker:?}, split at byte {split} must not defer the call until finish"
+            );
+        }
+    }
+
+    fn assert_malformed_quoted_marker_emits_on_the_closing_chunk(marker: &str) {
+        let arguments = format!(r#"{{"location" "München {marker} literal"}}"#);
+        let mut parser = kimi_k2_unified(&tools());
+        assert!(
+            parser
+                .push("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>")
+                .unwrap()
+                .is_empty()
+        );
+        let emitted = parser
+            .push(&format!(
+                "{arguments}<|tool_call_end|><|tool_calls_section_end|>"
+            ))
+            .unwrap();
+        assert_eq!(
+            emitted,
+            vec![UnifiedParserEvent::ToolCall(
+                crate::tool_calling::traits::ToolCallDelta {
+                    tool_index: 0,
+                    name: Some("get_weather".to_string()),
+                    arguments,
+                }
+            )]
+        );
+        assert!(parser.finish().unwrap().events.is_empty());
+    }
+
+    #[test]
+    fn malformed_quoted_call_end_emits_on_the_closing_chunk() {
+        assert_malformed_quoted_marker_emits_on_the_closing_chunk("<|tool_call_end|>");
+    }
+
+    #[test]
+    fn malformed_quoted_section_end_emits_on_the_closing_chunk() {
+        assert_malformed_quoted_marker_emits_on_the_closing_chunk("<|tool_calls_section_end|>");
+    }
+
+    #[test]
+    fn malformed_quoted_call_end_emits_before_finish_at_every_valid_utf8_split() {
+        assert_malformed_quoted_marker_emits_before_finish_at_every_split("<|tool_call_end|>");
+    }
+
+    #[test]
+    fn malformed_quoted_section_end_emits_before_finish_at_every_valid_utf8_split() {
+        assert_malformed_quoted_marker_emits_before_finish_at_every_split(
+            "<|tool_calls_section_end|>",
+        );
+    }
+
+    /// This stays a unit-level property test because the fixture corpus uses
+    /// fixed delivery schedules and normalized JSON output; it cannot sweep
+    /// every UTF-8 split or preserve malformed raw argument bytes.
+    #[test]
+    fn adjacent_malformed_calls_stay_separate_at_every_valid_utf8_split() {
+        let tools = vec![tools()[0].clone(), run_tool()[0].clone()];
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>x\"1<|tool_call_end|><|tool_call_begin|>functions.run:1<|tool_call_argument_begin|>y\"2<|tool_call_end|><|tool_calls_section_end|>";
+        let first = UnifiedParserEvent::ToolCall(crate::tool_calling::traits::ToolCallDelta {
+            tool_index: 0,
+            name: Some("get_weather".to_string()),
+            arguments: "x\"1".to_string(),
+        });
+        let second = UnifiedParserEvent::ToolCall(crate::tool_calling::traits::ToolCallDelta {
+            tool_index: 1,
+            name: Some("run".to_string()),
+            arguments: "y\"2".to_string(),
+        });
+
+        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+            let mut parser = kimi_k2_unified(&tools);
+            let mut emitted = parser.push(&input[..split]).unwrap();
+            emitted.extend(parser.push(&input[split..]).unwrap());
+            assert_eq!(emitted, vec![first.clone()], "split at byte {split}");
+            let finished = parser.finish().unwrap().events;
+            assert_eq!(finished, vec![second.clone()], "split at byte {split}");
+        }
     }
 
     /// Every valid UTF-8 split point of `input`, pushed as separate chunks
@@ -327,16 +432,15 @@ mod tests {
     /// thought as stray markup to strip; it never types or emits a call --
     /// that happens entirely through the independent, array-indexed
     /// `GuidedJsonCursor`/`emit_completed_json` path.
-    /// Concretely: a properly CLOSED first native marker is fully stripped
-    /// from reasoning, an INCOMPLETE second one survives verbatim as
-    /// reasoning text (no phantom call), and the real guided payload after
-    /// both still types exactly once, correctly.
+    /// Concretely: both a properly closed first native marker and an
+    /// incomplete second one are stripped from reasoning, while the real
+    /// guided payload after both still types exactly once.
     #[test]
-    fn two_native_markers_in_guided_reasoning_second_incomplete_one_is_not_recovered() {
+    fn two_native_markers_in_guided_reasoning_are_stripped_before_the_guided_payload() {
         let input = "<think>First: <|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\":\"ok\"}<|tool_call_end|> Second: <|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{\"cmd\":\"partial</think>[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]";
         let want = vec![
             UnifiedEvent::Reasoning {
-                text: "First:  Second: <|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{\"cmd\":\"partial".into(),
+                text: "First:  Second: ".into(),
             },
             UnifiedEvent::ToolCall {
                 name: "get_weather".into(),
@@ -348,6 +452,22 @@ mod tests {
             .enumerate()
         {
             assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// The fixture corpus does not cover native envelopes inside guided
+    /// output, so this unit property sweeps every split and checks the public
+    /// event stream directly: an unrecoverable partial call is dropped at
+    /// EOF rather than emitted as visible recovery text.
+    #[test]
+    fn incomplete_native_envelope_in_guided_mode_does_not_leak_at_finish() {
+        let input =
+            "<|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{\"cmd\":\"partial";
+        for (i, got) in assemble_guided_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert!(got.is_empty(), "split at byte {i}, got {got:?}");
         }
     }
 

--- a/parsers/v2/src/unified/kimi_k2.rs
+++ b/parsers/v2/src/unified/kimi_k2.rs
@@ -555,6 +555,35 @@ mod tests {
         }
     }
 
+    /// Reviewer-caught regression: the Kimi batch grammar permits `\s*`
+    /// between `NAME:IDX` and `argument_begin`, but the two partial-marker
+    /// holdback checks in `kimi_invoke_end` used the raw remainder verbatim
+    /// -- a chunk split landing right after that permitted whitespace
+    /// (`remainder == " "`) matched neither marker's prefix, so the
+    /// function wrongly committed to a header-only boundary one push
+    /// early, before `argument_begin` streamed in. `K2Emitter` cannot parse
+    /// that header-only span, and the real call was silently lost. This
+    /// sibling of the test above adds exactly one space before
+    /// `argument_begin` -- absent from that test, which is why it never
+    /// caught this.
+    #[test]
+    fn whitespace_before_argument_marker_is_split_invariant() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0 <|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "get_weather".into(),
+            arguments: serde_json::json!({"city": "Paris"}),
+        }];
+        for (i, got) in assemble_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(
+                got, want,
+                "valid whitespace-delimited call changed at split byte {i}: {got:?}"
+            );
+        }
+    }
+
     /// A first invoke that never closes (`call_end` missing) before a
     /// second invoke opens must not reach across the new opener and swallow
     /// the second call's bytes as if they belonged to the first -- that

--- a/parsers/v2/src/unified/kimi_k2.rs
+++ b/parsers/v2/src/unified/kimi_k2.rs
@@ -313,6 +313,44 @@ mod tests {
             .collect()
     }
 
+    /// Proves `tool_index: 0` is safe at `GuidedState::control_marker_at`'s
+    /// two `scan.end` call sites (`unified/mod.rs`) even for the disputed
+    /// "second invoke" shape, not just a lone one. Two structural facts make
+    /// this safe together:
+    /// (1) `kimi_invoke_opens` (`tool_calling/kimi_k2.rs`) always returns
+    /// `true`, so `control_marker_at`'s scan loop returns on the FIRST
+    /// `invoke_start` occurrence in whatever `haystack` it searches -- the
+    /// `cursor = at + ...` advance to look for a second occurrence is
+    /// structurally unreachable for Kimi, so this hook can never itself walk
+    /// past a first marker to inspect a second one.
+    /// (2) The result only classifies a native-looking marker inside a
+    /// thought as stray markup to strip; it never types or emits a call --
+    /// that happens entirely through the independent, array-indexed
+    /// `GuidedJsonCursor`/`emit_completed_json` path.
+    /// Concretely: a properly CLOSED first native marker is fully stripped
+    /// from reasoning, an INCOMPLETE second one survives verbatim as
+    /// reasoning text (no phantom call), and the real guided payload after
+    /// both still types exactly once, correctly.
+    #[test]
+    fn two_native_markers_in_guided_reasoning_second_incomplete_one_is_not_recovered() {
+        let input = "<think>First: <|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\":\"ok\"}<|tool_call_end|> Second: <|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{\"cmd\":\"partial</think>[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]";
+        let want = vec![
+            UnifiedEvent::Reasoning {
+                text: "First:  Second: <|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{\"cmd\":\"partial".into(),
+            },
+            UnifiedEvent::ToolCall {
+                name: "get_weather".into(),
+                arguments: serde_json::json!({"city": "Paris"}),
+            },
+        ];
+        for (i, got) in assemble_guided_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
     /// `UNIFIED.guided_json_gt_in_argument_bare_opener.kimi_k2`: guided
     /// decoding constrains the payload to JSON, but the model still narrates
     /// a bare `<|tool_call_begin|>functions.` header with no `NAME:IDX`, no

--- a/parsers/v2/src/unified/kimi_k2.rs
+++ b/parsers/v2/src/unified/kimi_k2.rs
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kimi K2 on the UnifiedParser.
+//!
+//! The whole family is the shared scanner plus a `ReasoningSpec`. Kimi's tool
+//! grammar is a plain wrapped block (`<|tool_calls_section_begin|>` … ) and its
+//! reasoning channel is `<think>`/`</think>` — the same markers qwen3 uses — so
+//! this port needs NOTHING that the scanner does not already have. That is the
+//! interesting result: gemma4's `invoke_scan` and `start_label` are gemma4's,
+//! not a general cost of porting a family.
+
+use crate::tool_calling::kimi_k2::kimi_k2_scanner;
+use crate::tool_calling::scan::ReasoningSpec;
+use crate::tool_calling::traits::Tool;
+use crate::unified::{ScannerUnified, UnifiedParser};
+
+const REASONING_START: &str = "<think>";
+const REASONING_END: &str = "</think>";
+
+/// Build the Kimi K2 unified parser for one stream.
+pub(crate) fn kimi_k2_unified(tools: &[Tool]) -> Box<dyn UnifiedParser> {
+    Box::new(ScannerUnified::new(kimi_k2_scanner(tools).with_reasoning(
+        ReasoningSpec {
+            start: REASONING_START,
+            end: REASONING_END,
+            // Kimi emits its own `<think>`; the template does not pre-fill one,
+            // so the stream starts in visible content (policy P5).
+            forced_start: false,
+            // `<think>` is not a tokenizer special token for this family; the
+            // grammar's own markers carry that requirement via the block spec.
+            preserve_special_tokens: false,
+            ..Default::default()
+        },
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unified::{
+        InvalidGuidedPayloadPolicy, UnifiedEvent, UnifiedParserExt, UnifiedParserInit,
+        UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
+    };
+
+    fn tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type":"object","properties":{"city":{"type":"string"}}}),
+            strict: None,
+        }]
+    }
+
+    fn run_tool() -> Vec<Tool> {
+        vec![Tool {
+            name: "run".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type":"object","properties":{"cmd":{"type":"string"}}}),
+            strict: None,
+        }]
+    }
+
+    /// A `<|tool_call_end|>` found before any `<|tool_call_argument_begin|>`
+    /// used to be trusted immediately, with no `flush` gate -- but streaming
+    /// only ever appends bytes, so a legitimate `argument_begin` that just
+    /// hasn't arrived yet can still turn up later and change the correct
+    /// reading entirely. Same final input, split only at whether the real
+    /// `argument_begin` had streamed in yet: one push dropped the call
+    /// silently, two pushes leaked the raw JSON as visible text. Every split
+    /// point must agree with the whole-input result.
+    #[test]
+    fn call_end_before_argument_begin_does_not_depend_on_the_chunk_boundary() {
+        let input = "<|tool_call_begin|>functions.get_weather:0<|tool_call_end|><|tool_call_argument_begin|>{\"city\": \"NYC\"}<|tool_call_end|>";
+        let want = assemble_at_every_split(&tools(), input)
+            .into_iter()
+            .next()
+            .expect("at least one split");
+        for (i, got) in assemble_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}, want {want:?}");
+        }
+    }
+
+    /// A bare invoke that closes with its own `call_end` before EVER having
+    /// an `argument_begin`, immediately followed by a real, well-formed
+    /// second invoke. Model output is probabilistic and can violate its own
+    /// grammar this way even though the downstream batch regex and every
+    /// golden fixture require `argument_begin` unconditionally -- the
+    /// streaming boundary finder still has to survive it rather than let the
+    /// second invoke's `argument_begin` get matched to the first invoke's
+    /// span. That merged both invokes into one string handed to the typing
+    /// layer, which only ever returns its first parsed call, so the
+    /// malformed first invoke silently absorbed the second invoke's bytes
+    /// and the second call vanished with it. The malformed first invoke has
+    /// no valid recovery (no argument section ever existed for it) and is
+    /// correctly dropped; the second, valid call must still ship on its own.
+    #[test]
+    fn bare_close_before_argument_begin_does_not_swallow_the_next_invoke() {
+        let tools = vec![tools()[0].clone(), run_tool()[0].clone()];
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "get_weather".into(),
+            arguments: serde_json::json!({"city": "Paris"}),
+        }];
+        for (i, got) in assemble_at_every_split(&tools, input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// Same malformed shape, but at true EOF with no `<|tool_calls_section_end|>`
+    /// ever arriving -- the second (valid) call must still recover via the
+    /// same best-effort EOF path `UNIFIED.5.b` already covers, not get lost
+    /// because the first invoke's bytes were merged into its span.
+    #[test]
+    fn bare_close_before_argument_begin_still_recovers_the_second_call_at_finish() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_end|><|tool_call_begin|>functions.run:1<|tool_call_argument_begin|>{\"cmd\": \"ls\"}";
+        let mut p = kimi_k2_unified(&run_tool());
+        let mut ev = p.push(input).expect("push");
+        ev.extend(p.finish().expect("finish").events);
+        let got = assemble(&ev);
+        assert_eq!(
+            got,
+            vec![UnifiedEvent::ToolCall {
+                name: "run".into(),
+                arguments: serde_json::json!({"cmd": "ls"}),
+            }],
+            "got {got:?}"
+        );
+    }
+
+    /// The batch-mode typing layer (`parse_section_block`) has its own
+    /// raw-string fallback for an argument body that never parses as JSON --
+    /// `serde_json::from_str` fails and it ships the raw text verbatim
+    /// rather than rejecting the call. The streaming boundary finder used to
+    /// short-circuit on the SAME shape (`json_value_end` returning `None`)
+    /// and drop the whole invoke before it ever reached that fallback --
+    /// this pins that the call still ships (best-effort P3, not a silent
+    /// drop) once the family's own literal `call_end` is present.
+    #[test]
+    fn malformed_non_json_arguments_still_ship_the_call_instead_of_vanishing() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>not-json-at-all<|tool_call_end|><|tool_calls_section_end|>";
+        let mut p = kimi_k2_unified(&tools());
+        let mut ev = p.push(input).expect("push");
+        ev.extend(p.finish().expect("finish").events);
+        assert_eq!(
+            assemble(&ev),
+            vec![UnifiedEvent::ToolCall {
+                name: "get_weather".into(),
+                // P3 best-effort (assemble's own documented fallback): a raw
+                // argument string that doesn't parse as JSON lands as an
+                // empty object rather than being discarded -- the call
+                // itself is what must survive here, not this specific value.
+                arguments: serde_json::json!({}),
+            }]
+        );
+    }
+
+    /// Every valid UTF-8 split point of `input`, pushed as separate chunks
+    /// then finished, assembled into one ordered event list. Sweeps chunk
+    /// boundaries around every control marker rather than trusting one
+    /// hand-picked split (gate: "derive cases from the property").
+    fn assemble_at_every_split(tools: &[Tool], input: &str) -> Vec<Vec<UnifiedEvent>> {
+        (0..=input.len())
+            .filter(|&i| input.is_char_boundary(i))
+            .map(|i| {
+                let mut p = kimi_k2_unified(tools);
+                let mut ev = p.push(&input[..i]).expect("push prefix");
+                ev.extend(p.push(&input[i..]).expect("push suffix"));
+                ev.extend(p.finish().expect("finish").events);
+                assemble(&ev)
+            })
+            .collect()
+    }
+
+    /// `UNIFIED.5.b` (`tool_no_close`): the JSON argument body is complete but
+    /// `<|tool_call_end|>` never streams before EOF. Best-effort recovery
+    /// (policy P2 sibling) must still emit the call at `finish`, identically
+    /// for a single push and for every chunk-split point -- not just recover
+    /// at EOF and then silently regress mid-stream for some split.
+    #[test]
+    fn tool_no_close_recovers_the_call_at_finish_across_every_split() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "get_weather".into(),
+            arguments: serde_json::json!({"city":"Paris"}),
+        }];
+        for (i, got) in assemble_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// Negative control for the same property: a body that is genuinely
+    /// truncated mid-JSON (never balances) must still drop the call, not be
+    /// swept up by the new EOF-recovery path. Mirrors
+    /// `tool_calling::kimi_k2::tests::suppresses_truncated_call_at_eof` at the
+    /// unified layer.
+    #[test]
+    fn genuinely_truncated_json_still_drops_at_finish() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"NY";
+        let mut p = kimi_k2_unified(&tools());
+        let mut ev = p.push(input).expect("push");
+        ev.extend(p.finish().expect("finish").events);
+        let got = assemble(&ev);
+        assert_eq!(got, vec![], "truncated body must still drop, got {got:?}");
+    }
+
+    /// `UNIFIED.7.b` (`arg_marker_in_string`): a `<|tool_call_end|>`-looking
+    /// byte sequence sits INSIDE the quoted JSON string argument. Invariant
+    /// I7 -- it is data, preserved byte-exact, never mistaken for the real
+    /// closer -- identically for a single push and every chunk-split point,
+    /// including splits that land INSIDE the embedded marker itself.
+    #[test]
+    fn arg_marker_in_string_survives_byte_exact_across_every_split() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\": \"git log <|tool_call_end|> --oneline\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "run".into(),
+            arguments: serde_json::json!({"cmd": "git log <|tool_call_end|> --oneline"}),
+        }];
+        for (i, got) in assemble_at_every_split(&run_tool(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// `UNIFIED.7.b` (`arg_marker_in_string`) with ordinary whitespace between
+    /// the JSON body and the real `<|tool_call_end|>`. The byte-exact override
+    /// in `parse_section_block` (v1core) used to require the closer to
+    /// immediately abut the JSON (`starts_with`, no whitespace tolerance),
+    /// while the regex it patches over -- and the streaming boundary finder,
+    /// `kimi_invoke_end` -- both already tolerate `\s*` there. Any whitespace
+    /// silently fell back to the lazy regex capture, which stops at the
+    /// EMBEDDED fake closer inside the string and ships either a truncated,
+    /// unparseable argument or (once `assemble`'s P3 fallback catches the
+    /// unparseable string) an empty object -- losing the whole call.
+    #[test]
+    fn arg_marker_in_string_survives_whitespace_before_the_real_closer_across_every_split() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{\"cmd\": \"git log <|tool_call_end|> --oneline\"} <|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "run".into(),
+            arguments: serde_json::json!({"cmd": "git log <|tool_call_end|> --oneline"}),
+        }];
+        for (i, got) in assemble_at_every_split(&run_tool(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// The corpus case `UNIFIED.11.b`: a thought, a call, a second thought, an
+    /// answer. This is the ordering the split path cannot represent — it hoists
+    /// both thoughts to the front and fuses them.
+    #[test]
+    fn thought_call_thought_answer_keeps_its_order() {
+        let input = "<think>Look it up.</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|><think>Now answer.</think>It's 18C.";
+        let mut p = kimi_k2_unified(&tools());
+        let mut ev = p.push(input).expect("push");
+        ev.extend(p.finish().expect("finish").events);
+        let got = assemble(&ev);
+        assert_eq!(
+            got,
+            vec![
+                UnifiedEvent::Reasoning {
+                    text: "Look it up.".into()
+                },
+                UnifiedEvent::ToolCall {
+                    name: "get_weather".into(),
+                    arguments: serde_json::json!({"city":"Paris"})
+                },
+                UnifiedEvent::Reasoning {
+                    text: "Now answer.".into()
+                },
+                UnifiedEvent::Text {
+                    text: "It's 18C.".into()
+                },
+            ],
+            "got {got:?}"
+        );
+    }
+
+    /// Every valid UTF-8 split point of `input`, pushed as separate chunks
+    /// then finished under GuidedJson mode with `RecoverAsText`. Mirrors
+    /// `assemble_at_every_split` but for the guided path, which needs
+    /// `initialize_request` before any bytes arrive.
+    fn assemble_guided_at_every_split(tools: &[Tool], input: &str) -> Vec<Vec<UnifiedEvent>> {
+        (0..=input.len())
+            .filter(|&i| input.is_char_boundary(i))
+            .map(|i| {
+                let mut p = kimi_k2_unified(tools);
+                p.initialize_request(UnifiedParserInit {
+                    starting_state: UnifiedParserStartingState::None,
+                    tool_output_mode: UnifiedToolOutputMode::GuidedJson { named_tool: None },
+                    invalid_guided_payload: InvalidGuidedPayloadPolicy::RecoverAsText,
+                    ..UnifiedParserInit::default()
+                })
+                .expect("initialize");
+                let mut ev = p.push(&input[..i]).expect("push prefix");
+                ev.extend(p.push(&input[i..]).expect("push suffix"));
+                ev.extend(p.finish().expect("finish").events);
+                assemble(&ev)
+            })
+            .collect()
+    }
+
+    /// `UNIFIED.guided_json_gt_in_argument_bare_opener.kimi_k2`: guided
+    /// decoding constrains the payload to JSON, but the model still narrates
+    /// a bare `<|tool_call_begin|>functions.` header with no `NAME:IDX`, no
+    /// `argument_begin`, and no `call_end` -- nothing `kimi_invoke_end` used
+    /// to treat as a resolvable boundary, so the header AND the JSON payload
+    /// after it leaked as one blob of visible text instead of the header
+    /// being stripped and the JSON being parsed as the call.
+    #[test]
+    fn bare_opener_before_guided_json_strips_the_header_and_recovers_the_call() {
+        let input = "<|tool_call_begin|>functions.[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"a > b\"}}]";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "get_weather".into(),
+            arguments: serde_json::json!({"city": "a > b"}),
+        }];
+        for (i, got) in assemble_guided_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// `UNIFIED.guided_json_schema_error_not_a_call_bare_opener.kimi_k2`:
+    /// same bare-header shape, but the guided payload isn't a call at all
+    /// (no `name`) -- policy P2, surface it as text rather than dropping it.
+    #[test]
+    fn bare_opener_before_non_call_guided_json_surfaces_the_payload_as_text() {
+        let input = "<|tool_call_begin|>functions.{\"unexpected\": \"shape\"}";
+        let want = vec![UnifiedEvent::Text {
+            text: "{\"unexpected\": \"shape\"}".into(),
+        }];
+        for (i, got) in assemble_guided_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// `UNIFIED.guided_json_narrated_prefix_inside_reasoning.kimi_k2`: a
+    /// narrated header with a bare NAME and no `:IDX` at all
+    /// (`functions.get_weather`, no colon) is prose the model wrote while
+    /// still thinking, not a real invoke id -- it must survive as reasoning
+    /// text, not be swallowed as control markup the way a real
+    /// `functions.NAME:IDX` id would be.
+    #[test]
+    fn bare_name_with_no_index_inside_reasoning_survives_as_reasoning_text() {
+        let input = "<think>I'll call <|tool_call_begin|>functions.get_weather</think>[{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Paris\"}}]";
+        let want = vec![
+            UnifiedEvent::Reasoning {
+                text: "I'll call get_weather".into(),
+            },
+            UnifiedEvent::ToolCall {
+                name: "get_weather".into(),
+                arguments: serde_json::json!({"city": "Paris"}),
+            },
+        ];
+        for (i, got) in assemble_guided_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// Negative control for the same fix: a real `functions.NAME:IDX` id
+    /// (colon present) inside a native invoke must still be recognized and
+    /// consumed as control markup, not left dangling as text -- the tri-state
+    /// id scan must not treat every bare name as "no id" indiscriminately.
+    #[test]
+    fn a_real_native_id_is_still_recognized_across_every_split() {
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![UnifiedEvent::ToolCall {
+            name: "get_weather".into(),
+            arguments: serde_json::json!({"city": "Paris"}),
+        }];
+        for (i, got) in assemble_at_every_split(&tools(), input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+
+    /// A first invoke that never closes (`call_end` missing) before a
+    /// second invoke opens must not reach across the new opener and swallow
+    /// the second call's bytes as if they belonged to the first -- that
+    /// silently corrupted the first call's arguments AND dropped the second
+    /// call entirely. The first is recovered best-effort (its JSON is
+    /// complete); the second parses as its own independent invoke.
+    #[test]
+    fn unclosed_invoke_does_not_swallow_the_next_invoke_across_every_split() {
+        let tools = vec![tools()[0].clone(), run_tool()[0].clone()];
+        let input = "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Paris\"}<|tool_call_begin|>functions.run:1<|tool_call_argument_begin|>{\"cmd\": \"ls\"}<|tool_call_end|><|tool_calls_section_end|>";
+        let want = vec![
+            UnifiedEvent::ToolCall {
+                name: "get_weather".into(),
+                arguments: serde_json::json!({"city": "Paris"}),
+            },
+            UnifiedEvent::ToolCall {
+                name: "run".into(),
+                arguments: serde_json::json!({"cmd": "ls"}),
+            },
+        ];
+        for (i, got) in assemble_at_every_split(&tools, input)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(got, want, "split at byte {i}, got {got:?}");
+        }
+    }
+}

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -1480,14 +1480,39 @@ impl GuidedState {
                 // types or emits a call -- that goes entirely through the
                 // independent, array-indexed `GuidedJsonCursor`/
                 // `emit_completed_json` path, untouched by this value. Proven
-                // end-to-end, including the disputed "properly-closed first
-                // marker, incomplete second marker" shape, by
-                // `two_native_markers_in_guided_reasoning_second_incomplete_one_is_not_recovered`
-                // in `unified/kimi_k2.rs`.
-                if let Some(len) = (scan.end)(suffix, flush, 0) {
+                // end-to-end, including a properly closed first marker and
+                // an incomplete second marker, by the Kimi guided-reasoning
+                // every-split tests in `unified/kimi_k2.rs`.
+                let competing_boundary = limit.filter(|boundary| {
+                    *boundary > at
+                        && competing
+                            .iter()
+                            .any(|marker| haystack[*boundary..].starts_with(marker))
+                });
+                let local_flush = flush || competing_boundary.is_some();
+                if let Some(len) = (scan.end)(suffix, local_flush, 0)
+                    && competing_boundary.is_none_or(|boundary| at + len <= boundary)
+                {
                     return regular
                         .filter(|(regular_at, _)| *regular_at < at)
                         .or(Some((at, len)));
+                }
+                // A competing reasoning marker proves the native envelope
+                // ended locally even while the overall stream remains open.
+                // Strip only through that boundary so the reasoning closer
+                // and guided JSON after it are scanned independently.
+                if let Some(boundary) = competing_boundary {
+                    return regular
+                        .filter(|(regular_at, _)| *regular_at < at)
+                        .or(Some((at, boundary - at)));
+                }
+                // At true EOF an unresolved native envelope is an
+                // unrecoverable partial call (P2), not visible recovery text.
+                // No future bytes can establish a narrower safe boundary.
+                if flush {
+                    return regular
+                        .filter(|(regular_at, _)| *regular_at < at)
+                        .or(Some((at, suffix.len())));
                 }
                 return regular.filter(|(regular_at, _)| *regular_at < at);
             }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -1151,7 +1151,12 @@ fn guided_holdback_len(
                 .match_indices(start)
                 .filter_map(|(at, _)| {
                     let suffix = &input[at..];
-                    ((scan.opens)(input, at) && (scan.end)(suffix, false).is_none())
+                    // `flush: false` here always makes `tool_index` inert (Kimi's
+                    // EOF-only recovery gate can only fire when `flush` is true) --
+                    // 0 is not a claim about which call this is, just the value
+                    // that keeps this holdback-length probe's result identical to
+                    // before `tool_index` existed.
+                    ((scan.opens)(input, at) && (scan.end)(suffix, false, 0).is_none())
                         .then_some(input.len() - at)
                 })
                 .max()
@@ -1464,7 +1469,22 @@ impl GuidedState {
             let at = cursor + relative;
             let suffix = &haystack[at..];
             if (scan.opens)(haystack, at) {
-                if let Some(len) = (scan.end)(suffix, flush) {
+                // `tool_index: 0` is provably safe here, not merely convenient:
+                // this loop can NEVER walk past a first `invoke_start` match to
+                // examine a second one for a family whose `opens` hook always
+                // returns `true` (Kimi's `kimi_invoke_opens` does) -- this `if`
+                // branch returns unconditionally on the first match, so the
+                // `cursor = at + ...` advance below is unreachable for Kimi. And
+                // the result only classifies a native-looking marker leaking into
+                // otherwise-guided output as stray markup to strip; it never
+                // types or emits a call -- that goes entirely through the
+                // independent, array-indexed `GuidedJsonCursor`/
+                // `emit_completed_json` path, untouched by this value. Proven
+                // end-to-end, including the disputed "properly-closed first
+                // marker, incomplete second marker" shape, by
+                // `two_native_markers_in_guided_reasoning_second_incomplete_one_is_not_recovered`
+                // in `unified/kimi_k2.rs`.
+                if let Some(len) = (scan.end)(suffix, flush, 0) {
                     return regular
                         .filter(|(regular_at, _)| *regular_at < at)
                         .or(Some((at, len)));

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -49,6 +49,7 @@
 //! divergence is stated at the item.
 
 mod guided_cursor;
+pub mod kimi_k2;
 pub mod muse_glimmer;
 pub mod qwen3;
 
@@ -854,6 +855,14 @@ impl<E: InvokeEmitter + Send> UnifiedParser for ScannerUnified<E> {
         self.started = false;
         self.finished = false;
         recovered
+    }
+
+    /// The model-emitted id for a call, delegated to the scanner's emitter.
+    /// See [`InvokeEmitter::tool_call_id`] — the trait default (`None`) is
+    /// correct for every family whose grammar does not name the call; Kimi
+    /// is the one family that overrides it.
+    fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+        self.scanner.tool_call_id(tool_index)
     }
 }
 
@@ -2443,6 +2452,7 @@ macro_rules! unified_registry {
 unified_registry! {
     "qwen3" | "qwen3_coder" => qwen3::qwen3_unified,
     "muse_glimmer" => muse_glimmer::muse_glimmer_unified,
+    "kimi_k2"               => kimi_k2::kimi_k2_unified,
 }
 
 /// Stderr instrumentation for the unified path under `DYNAMO_PARSERS_DEBUG`.

--- a/parsers/v2/tests/preserve_special_tokens_parity.rs
+++ b/parsers/v2/tests/preserve_special_tokens_parity.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Capability parity in a process that cannot observe vendor-registry mutation.
+//!
+//! `vendor_registry.rs` intentionally mutates process-global parser factories.
+//! Keeping read-only built-in assertions in that same test binary let them
+//! observe a temporary qwen3 override when Rust ran the tests in parallel.
+
+use dynamo_parsers_v2::tool_calling::create_tool_parser_for_family;
+use dynamo_parsers_v2::unified::create_unified_parser_for_family;
+
+fn tool_only_value() -> bool {
+    create_tool_parser_for_family("qwen3_coder", &[])
+        .expect("qwen3_coder tool parser")
+        .preserve_special_tokens()
+}
+
+#[test]
+fn canonical_family_matches_the_tool_only_adapter() {
+    let unified = create_unified_parser_for_family("qwen3", &[]).expect("qwen3 unified");
+    assert_eq!(
+        unified.preserve_special_tokens(),
+        tool_only_value(),
+        "unified and tool-only must not report different decoding requirements"
+    );
+}
+
+#[test]
+fn alias_matches_the_tool_only_adapter() {
+    let unified =
+        create_unified_parser_for_family("qwen3_coder", &[]).expect("qwen3_coder unified");
+    assert_eq!(
+        unified.preserve_special_tokens(),
+        tool_only_value(),
+        "the alias must agree with the canonical family and the tool-only adapter"
+    );
+}

--- a/parsers/v2/tests/vendor_registry.rs
+++ b/parsers/v2/tests/vendor_registry.rs
@@ -192,39 +192,3 @@ fn unknown_family_error_explains_how_to_register() {
     assert!(err.contains("register_unified_parser"), "{err}");
     assert!(err.contains("no_such_family"), "{err}");
 }
-
-/// The two surfaces over one Qwen scanner must report the SAME decoding requirement.
-/// They disagreed before: tool-only said `true`, unified inherited the trait default
-/// `false`, so a decoder honouring the flag could hand the two adapters different bytes
-/// for identical markup.
-mod preserve_special_tokens_parity {
-    use dynamo_parsers_v2::tool_calling::create_tool_parser_for_family;
-    use dynamo_parsers_v2::unified::create_unified_parser_for_family;
-
-    fn tool_only_value() -> bool {
-        create_tool_parser_for_family("qwen3_coder", &[])
-            .expect("qwen3_coder tool parser")
-            .preserve_special_tokens()
-    }
-
-    #[test]
-    fn canonical_family_matches_the_tool_only_adapter() {
-        let unified = create_unified_parser_for_family("qwen3", &[]).expect("qwen3 unified");
-        assert_eq!(
-            unified.preserve_special_tokens(),
-            tool_only_value(),
-            "unified and tool-only must not report different decoding requirements"
-        );
-    }
-
-    #[test]
-    fn alias_matches_the_tool_only_adapter() {
-        let unified =
-            create_unified_parser_for_family("qwen3_coder", &[]).expect("qwen3_coder unified");
-        assert_eq!(
-            unified.preserve_special_tokens(),
-            tool_only_value(),
-            "the alias must agree with the canonical family and the tool-only adapter"
-        );
-    }
-}


### PR DESCRIPTION
#### Overview:

This PR ports Kimi K2 only to the v2 parser, preserving reasoning, text, and tool-call order. It also refreshes live-version Dynamo captures and makes fixture extraction safe across concurrent worktrees.

#### Details:

- Shares one Kimi K2 grammar between the tool-only path and v2 parser.
- Covers native and guided tool calls across every valid UTF-8 split, malformed boundaries, and EOF recovery.
- Keys fixture generations by shard identity and selects the live-version capture.

#### Verification:

GitHub Actions pass at `e71ace59`.

#### Where should the reviewer start?

`parsers/v2/src/unified/kimi_k2.rs`, then `conformance/utils/src/extract_fixtures.py`

Closes [DIS-2700](https://linear.app/nvidia/issue/DIS-2700)

/coderabbit profile chill