### PR TITLE
feat(parsers): stream guided tool-call fragments, and the contract cost of doing so

### DIFF
--- a/parsers/v2/src/unified/guided_cursor.rs
+++ b/parsers/v2/src/unified/guided_cursor.rs
@@ -1,0 +1,760 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Incremental lexer over one guided `required` tool-call payload.
+//!
+//! # Why this is one type
+//!
+//! Streaming a call before its payload has closed needs four facts that only a
+//! JSON lexer can answer: which call element the scan is inside, that element's
+//! decoded `name`, where its argument OBJECT begins, and which bytes of that
+//! object are safe to release. An earlier revision answered them with three
+//! independent `str::find` helpers, and each one was wrong in its own way —
+//! `"name"` was matched anywhere in the payload (so `{"x":"name","arguments":…}`
+//! emitted a call named `arguments`), `_` decoded to the literal characters
+//! `u005f`, the `parameters` alias was not recognised at all, and every helper
+//! rescanned the whole accumulated buffer on every push, making a
+//! character-at-a-time stream quadratic.
+//!
+//! Those are not four bugs, they are one: lexical state with no owner. This type
+//! is that owner. It holds the string/escape state, the brace depth, the current
+//! element index, the decoded name, and the released-byte offset in one place, and
+//! it advances strictly FORWARD — each call consumes only the bytes appended since
+//! the last one, so driving a payload one character at a time costs O(n) total.
+//!
+//! # What it deliberately does not do
+//!
+//! It does not validate. `parse_required_guided_calls` remains the only judge of
+//! whether a payload is a legal call set, and the completion path still runs it.
+//! The cursor's single question is narrower: *has enough arrived that a name and
+//! an argument OBJECT can no longer turn into something else?* Requiring the
+//! argument value to open with `{` is what makes that safe — a `null`, a string,
+//! a number or an array never reaches the commit point, so the shapes the
+//! contract voids are never put on the wire in the first place.
+
+use crate::tool_calling::traits::ToolCallDelta;
+
+/// The two spellings a required-choice call may use for its argument object.
+///
+/// Both are accepted by `parse_required_guided_calls`; a call carrying BOTH is
+/// ambiguous and that function voids it. The cursor has to know both spellings for
+/// the same reason — recognising only `arguments` silently streamed nothing for a
+/// `parameters` call, and the assembled result arrived with empty arguments.
+const ARGUMENT_ALIASES: [&str; 2] = ["arguments", "parameters"];
+
+/// Where the scanner sits inside a call object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Slot {
+    /// Between `{` or `,` and the next key.
+    Key,
+    /// A key literal closed; waiting for its `:`.
+    Colon,
+    /// Past the `:`; the next token is that key's value.
+    Value,
+}
+
+/// A call the cursor has already put on the wire.
+///
+/// `released` is a byte count into the call's RAW argument object — the same bytes
+/// `parse_required_guided_calls` will later hand back as that call's arguments — so
+/// the completion path can emit exactly the remainder without re-deriving spans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommittedCall {
+    pub index: usize,
+    pub name: String,
+    pub released: usize,
+    /// A second argument alias appeared AFTER this call was committed.
+    ///
+    /// `parse_required_guided_calls` voids an ambiguous call, but this one is
+    /// already on the wire and a fragment cannot be unsaid. The completion path
+    /// warns rather than pretending it can retract.
+    pub ambiguous: bool,
+}
+
+/// Per-element scan state, reset at every call boundary.
+#[derive(Debug, Default, Clone)]
+struct Element {
+    name: Option<String>,
+    /// Offset of the `{` opening the argument object.
+    args_start: Option<usize>,
+    /// Offset just past the argument object's `}`, once it closed.
+    args_end: Option<usize>,
+    /// The scan is inside the argument object right now.
+    in_args: bool,
+    /// Both aliases appeared.
+    ambiguous: bool,
+    /// An alias appeared whose value was not an object.
+    ///
+    /// Blocks the commit even if the OTHER alias later supplies a good object:
+    /// that shape is ambiguous too, and the buffered path voids it correctly.
+    non_object_alias: bool,
+    committed: bool,
+    /// Bytes of the argument object already released, relative to `args_start`.
+    released: usize,
+}
+
+/// Forward-only lexer over one guided payload.
+#[derive(Debug)]
+pub(crate) struct GuidedJsonCursor {
+    /// Bytes already lexed. The scan never revisits them.
+    scanned: usize,
+    depth: i32,
+    in_string: bool,
+    escaped: bool,
+    /// Collecting the four hex digits of a `\uXXXX` escape.
+    unicode: Option<String>,
+    /// A pending surrogate high half, awaiting its `\uDC00`-range partner.
+    high_surrogate: Option<u32>,
+    /// The string literal being decoded, when it is one the cursor needs.
+    literal: Option<String>,
+    /// Depth at which a call object's keys sit: 2 under an array root, 1 under a
+    /// bare object root.
+    key_depth: i32,
+    root_seen: bool,
+    /// The payload does not open as a call shape, so nothing may ever commit.
+    disabled: bool,
+    slot: Slot,
+    pending_key: Option<String>,
+    element: Element,
+    index: usize,
+    committed: Vec<CommittedCall>,
+}
+
+impl Default for GuidedJsonCursor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GuidedJsonCursor {
+    pub(crate) fn new() -> Self {
+        Self {
+            scanned: 0,
+            depth: 0,
+            in_string: false,
+            escaped: false,
+            unicode: None,
+            high_surrogate: None,
+            literal: None,
+            key_depth: 1,
+            root_seen: false,
+            disabled: false,
+            slot: Slot::Key,
+            pending_key: None,
+            element: Element::default(),
+            index: 0,
+            committed: Vec::new(),
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    /// Calls already on the wire, in emission order.
+    pub(crate) fn committed(&self) -> &[CommittedCall] {
+        &self.committed
+    }
+
+    pub(crate) fn has_committed(&self) -> bool {
+        !self.committed.is_empty()
+    }
+
+    /// Lex the bytes appended since the last advance, emitting whatever became
+    /// safe to commit.
+    ///
+    /// `payload` is the WHOLE accumulated payload, not just the new chunk — the
+    /// cursor slices it from `scanned`, so the caller does not have to track which
+    /// bytes it has already handed over.
+    pub(crate) fn advance(&mut self, payload: &str, out: &mut Vec<ToolCallDelta>) {
+        if self.disabled || payload.len() <= self.scanned {
+            // Truncation (a reset mid-stream) would make the retained offsets lie.
+            // The caller resets the cursor with the payload; nothing to do here.
+            return;
+        }
+
+        let mut cut = self.scanned;
+        for (relative, ch) in payload[self.scanned..].char_indices() {
+            let at = self.scanned + relative;
+            cut = at + ch.len_utf8();
+            self.step(payload, at, cut, ch, out);
+            if self.disabled {
+                break;
+            }
+        }
+        self.scanned = cut;
+        self.maybe_commit(out);
+        self.flush(payload, cut, out);
+    }
+
+    /// One character of the lex. `cut` is the offset just past `ch`, so a flush
+    /// triggered mid-advance still sees the bytes this character contributed.
+    fn step(
+        &mut self,
+        payload: &str,
+        at: usize,
+        cut: usize,
+        ch: char,
+        out: &mut Vec<ToolCallDelta>,
+    ) {
+        if self.in_string {
+            self.step_in_string(ch);
+            return;
+        }
+
+        match ch {
+            '"' => {
+                if !self.root_seen {
+                    // A required payload opens with `[` or `{`; a bare string is not
+                    // a call shape and the buffered path owns it.
+                    self.disabled = true;
+                    return;
+                }
+                self.in_string = true;
+                // Capture only the literals the cursor needs: every key at call-key
+                // depth, and the `name` value. Capturing every string in the payload
+                // would allocate once per argument value for nothing.
+                let wanted = self.depth == self.key_depth
+                    && match self.slot {
+                        Slot::Key => true,
+                        Slot::Value => self.pending_key.as_deref() == Some("name"),
+                        Slot::Colon => false,
+                    };
+                self.literal = wanted.then(String::new);
+            }
+            '{' | '[' => {
+                if !self.root_seen {
+                    self.root_seen = true;
+                    self.key_depth = if ch == '[' { 2 } else { 1 };
+                }
+                let opening_args = ch == '{'
+                    && self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && self.is_alias(self.pending_key.as_deref());
+                let starts_element = self.depth == self.key_depth - 1 && ch == '{';
+                self.depth += 1;
+                if opening_args {
+                    if self.element.args_start.is_some() {
+                        self.element.ambiguous = true;
+                    } else {
+                        self.element.args_start = Some(at);
+                        self.element.in_args = true;
+                    }
+                } else if starts_element {
+                    self.slot = Slot::Key;
+                    self.pending_key = None;
+                } else if self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && self.pending_key.as_deref() == Some("name")
+                {
+                    // `"name"` bound to a non-string: never commits.
+                    self.element.non_object_alias = true;
+                }
+                self.maybe_commit(out);
+            }
+            '}' | ']' => {
+                let closing_args =
+                    self.element.in_args && self.depth == self.key_depth + 1 && ch == '}';
+                let closes_element = self.depth == self.key_depth && ch == '}';
+                self.depth -= 1;
+                if closing_args {
+                    self.element.args_end = Some(at + 1);
+                    self.element.in_args = false;
+                    self.maybe_commit(out);
+                    self.flush(payload, cut, out);
+                } else if closes_element {
+                    // A name that closed AFTER its arguments only becomes committable
+                    // here, so commit before the final flush or its bytes are lost
+                    // with the element.
+                    self.maybe_commit(out);
+                    self.flush(payload, at, out);
+                    self.finish_element();
+                }
+            }
+            ':' if self.depth == self.key_depth && self.slot == Slot::Colon => {
+                self.slot = Slot::Value;
+            }
+            ',' if self.depth == self.key_depth => {
+                self.slot = Slot::Key;
+                self.pending_key = None;
+            }
+            _ if ch.is_whitespace() => {}
+            _ => {
+                if !self.root_seen {
+                    self.disabled = true;
+                    return;
+                }
+                if self.depth == self.key_depth && self.slot == Slot::Value {
+                    // A bare literal (`null`, a number, `true`) bound to an argument
+                    // alias or to `name`: neither can ever become an object, so this
+                    // element must stay on the buffered path.
+                    if self.is_alias(self.pending_key.as_deref())
+                        || self.pending_key.as_deref() == Some("name")
+                    {
+                        self.element.non_object_alias = true;
+                    }
+                }
+            }
+        }
+    }
+
+    /// One character while inside a string literal.
+    fn step_in_string(&mut self, ch: char) {
+        if let Some(hex) = self.unicode.as_mut() {
+            hex.push(ch);
+            if hex.len() == 4 {
+                let code =
+                    u32::from_str_radix(hex, 16).unwrap_or(u32::from(char::REPLACEMENT_CHARACTER));
+                self.unicode = None;
+                self.push_code_point(code);
+            }
+            return;
+        }
+        if self.escaped {
+            self.escaped = false;
+            match ch {
+                'u' => self.unicode = Some(String::new()),
+                'n' => self.push_char('\n'),
+                't' => self.push_char('\t'),
+                'r' => self.push_char('\r'),
+                'b' => self.push_char('\u{8}'),
+                'f' => self.push_char('\u{c}'),
+                other => self.push_char(other),
+            }
+            return;
+        }
+        match ch {
+            '\\' => self.escaped = true,
+            '"' => {
+                self.in_string = false;
+                self.high_surrogate = None;
+                self.close_literal();
+            }
+            other => self.push_char(other),
+        }
+    }
+
+    /// Append one decoded `\uXXXX` code point, pairing surrogates.
+    ///
+    /// A name outside the BMP arrives as a surrogate PAIR, and decoding each half
+    /// on its own yields two replacement characters instead of the character the
+    /// model asked for.
+    fn push_code_point(&mut self, code: u32) {
+        if (0xD800..0xDC00).contains(&code) {
+            self.high_surrogate = Some(code);
+            return;
+        }
+        if (0xDC00..0xE000).contains(&code)
+            && let Some(high) = self.high_surrogate.take()
+        {
+            let combined = 0x10000 + ((high - 0xD800) << 10) + (code - 0xDC00);
+            self.push_char(char::from_u32(combined).unwrap_or(char::REPLACEMENT_CHARACTER));
+            return;
+        }
+        self.high_surrogate = None;
+        self.push_char(char::from_u32(code).unwrap_or(char::REPLACEMENT_CHARACTER));
+    }
+
+    fn push_char(&mut self, ch: char) {
+        if let Some(literal) = self.literal.as_mut() {
+            literal.push(ch);
+        }
+    }
+
+    /// A captured literal closed: it is either this element's key or its name.
+    fn close_literal(&mut self) {
+        let Some(literal) = self.literal.take() else {
+            return;
+        };
+        match self.slot {
+            Slot::Key => {
+                if self.is_alias(Some(literal.as_str())) && self.element.args_start.is_some() {
+                    self.element.ambiguous = true;
+                }
+                self.pending_key = Some(literal);
+                self.slot = Slot::Colon;
+            }
+            Slot::Value => {
+                if self.pending_key.as_deref() == Some("name") {
+                    self.element.name = Some(literal);
+                }
+            }
+            Slot::Colon => {}
+        }
+    }
+
+    fn is_alias(&self, key: Option<&str>) -> bool {
+        key.is_some_and(|key| ARGUMENT_ALIASES.contains(&key))
+    }
+
+    /// Put the current element on the wire once it can no longer change shape.
+    ///
+    /// Both facts are required: the name has closed, AND the argument value has
+    /// been seen to open with `{`. Committing on the name alone is what let a
+    /// `null`, a string and a non-object argument set reach the caller as calls the
+    /// contract says must become text.
+    fn maybe_commit(&mut self, out: &mut Vec<ToolCallDelta>) {
+        if self.element.committed
+            || self.element.ambiguous
+            || self.element.non_object_alias
+            || self.element.args_start.is_none()
+        {
+            return;
+        }
+        let Some(name) = self.element.name.clone() else {
+            return;
+        };
+        self.element.committed = true;
+        self.committed.push(CommittedCall {
+            index: self.index,
+            name: name.clone(),
+            released: 0,
+            ambiguous: false,
+        });
+        out.push(ToolCallDelta {
+            tool_index: self.index,
+            name: Some(name),
+            arguments: String::new(),
+        });
+    }
+
+    /// Release argument bytes the current element has accumulated since the last
+    /// fragment.
+    fn flush(&mut self, payload: &str, cut: usize, out: &mut Vec<ToolCallDelta>) {
+        if !self.element.committed {
+            return;
+        }
+        let Some(start) = self.element.args_start else {
+            return;
+        };
+        // Never past the argument object's own close: the bytes after it belong to
+        // the call envelope, not to the arguments.
+        let bound = self.element.args_end.unwrap_or(cut).min(cut);
+        let from = start + self.element.released;
+        if bound <= from {
+            return;
+        }
+        let fragment = payload[from..bound].to_string();
+        self.element.released = bound - start;
+        if let Some(record) = self.committed.last_mut() {
+            record.released = self.element.released;
+            record.ambiguous = self.element.ambiguous;
+        }
+        out.push(ToolCallDelta {
+            tool_index: self.index,
+            name: None,
+            arguments: fragment,
+        });
+    }
+
+    /// The current call object closed; move to the next element.
+    fn finish_element(&mut self) {
+        if self.element.committed
+            && let Some(record) = self.committed.last_mut()
+        {
+            record.ambiguous = self.element.ambiguous;
+        }
+        // ALWAYS advance, including for an element the cursor could not commit. The
+        // index is the element's position in the payload array, and the completion
+        // path matches committed records against `serde`'s element order — skipping
+        // an uncommittable element here would slide every later call onto the wrong
+        // index.
+        self.index += 1;
+        self.element = Element::default();
+        self.slot = Slot::Key;
+        self.pending_key = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a payload one character at a time and collect every delta.
+    fn stream(payload: &str) -> Vec<ToolCallDelta> {
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for ch in payload.chars() {
+            seen.push(ch);
+            cursor.advance(&seen, &mut out);
+        }
+        out
+    }
+
+    /// Names carried, in order.
+    fn names(deltas: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        deltas
+            .iter()
+            .filter_map(|d| d.name.clone().map(|n| (d.tool_index, n)))
+            .collect()
+    }
+
+    /// Argument bytes reassembled per tool index.
+    fn arguments(deltas: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        let mut joined: Vec<(usize, String)> = Vec::new();
+        for delta in deltas {
+            if delta.arguments.is_empty() {
+                continue;
+            }
+            match joined
+                .iter_mut()
+                .find(|(index, _)| *index == delta.tool_index)
+            {
+                Some((_, text)) => text.push_str(&delta.arguments),
+                None => joined.push((delta.tool_index, delta.arguments.clone())),
+            }
+        }
+        joined
+    }
+
+    #[test]
+    fn a_name_key_is_a_key_not_any_occurrence_of_the_word() {
+        // The old `str::find("\"name\"")` matched this VALUE and then read the next
+        // string as the function name, emitting a call named `arguments`.
+        let deltas = stream(r#"[{"x":"name","arguments":{"city":"Paris"}}]"#);
+        assert_eq!(names(&deltas), Vec::<(usize, String)>::new());
+        assert!(
+            arguments(&deltas).is_empty(),
+            "a nameless element must not stream"
+        );
+    }
+
+    #[test]
+    fn escaped_names_decode() {
+        // NOT a raw literal: the payload must carry the six characters
+        // `_`, which JSON decodes to `_`. The old decoder pushed the
+        // escape's payload characters verbatim and produced `getu005fweather`.
+        let payload = "[{\"name\":\"get\\u005fweather\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\u005f"),
+            "the escape must survive to the test"
+        );
+        assert_eq!(
+            names(&stream(payload)),
+            vec![(0, "get_weather".to_string())]
+        );
+
+        let deltas = stream(r#"[{"name":"a\"b\\c\nd","arguments":{}}]"#);
+        assert_eq!(names(&deltas), vec![(0, "a\"b\\c\nd".to_string())]);
+    }
+
+    #[test]
+    fn surrogate_pairs_decode_to_one_character() {
+        // Escaped, as a JSON encoder outside the BMP actually emits it. Decoding
+        // each half alone yields two replacement characters.
+        let payload = "[{\"name\":\"a\\ud83d\\ude00b\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\ud83d"),
+            "the escape must survive to the test"
+        );
+        assert_eq!(
+            names(&stream(payload)),
+            vec![(0, "a\u{1F600}b".to_string())]
+        );
+    }
+
+    #[test]
+    fn the_parameters_alias_streams_too() {
+        let deltas = stream(r#"[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Tokyo"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn parallel_calls_get_distinct_indices() {
+        let deltas =
+            stream(r#"[{"name":"a","arguments":{"x":1}},{"name":"b","arguments":{"y":2}}]"#);
+        assert_eq!(
+            names(&deltas),
+            vec![(0, "a".to_string()), (1, "b".to_string())]
+        );
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"x":1}"#.to_string()), (1, r#"{"y":2}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn arguments_reassemble_byte_for_byte_at_every_split() {
+        let payload = r#"[{"name":"f","arguments":{"a":"x y","b":[1,2],"c":{"d":"}"}}}]"#;
+        let expected = r#"{"a":"x y","b":[1,2],"c":{"d":"}"}}"#;
+        let deltas = stream(payload);
+        assert_eq!(arguments(&deltas), vec![(0, expected.to_string())]);
+    }
+
+    #[test]
+    fn a_brace_inside_an_argument_string_does_not_close_the_object() {
+        let deltas = stream(r#"[{"name":"f","arguments":{"s":"}}]"}}]"#);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"s":"}}]"}"#.to_string())]);
+    }
+
+    #[test]
+    fn non_object_arguments_never_commit() {
+        for payload in [
+            r#"[{"name":"f","arguments":"just a string"}]"#,
+            r#"[{"name":"f","arguments":null}]"#,
+            r#"[{"name":"f","arguments":[1,2]}]"#,
+            r#"[{"name":"f","arguments":7}]"#,
+        ] {
+            let deltas = stream(payload);
+            assert!(
+                deltas.is_empty(),
+                "{payload} committed a call the contract voids: {deltas:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_parameterless_call_stays_on_the_buffered_path() {
+        // No argument key at all means no arguments, which is VALID — but there is
+        // no object opener to commit on, so the buffered path emits it with `{}`.
+        let deltas = stream(r#"[{"name":"f"}]"#);
+        assert!(deltas.is_empty());
+    }
+
+    #[test]
+    fn both_aliases_present_never_commits() {
+        let deltas = stream(r#"[{"name":"f","arguments":{"a":1},"parameters":{"b":2}}]"#);
+        assert!(
+            names(&deltas).is_empty() || deltas.iter().all(|d| d.tool_index == 0),
+            "ambiguity must not produce a second call"
+        );
+    }
+
+    #[test]
+    fn a_name_after_its_arguments_still_commits() {
+        let deltas = stream(r#"[{"arguments":{"city":"Paris"},"name":"get_weather"}]"#);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn a_bare_object_payload_is_one_call() {
+        let deltas = stream(r#"{"name":"f","arguments":{"x":1}}"#);
+        assert_eq!(names(&deltas), vec![(0, "f".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"x":1}"#.to_string())]);
+    }
+
+    #[test]
+    fn a_non_call_payload_disables_the_cursor() {
+        assert!(stream(r#""just a string""#).is_empty());
+        assert!(stream("42").is_empty());
+    }
+
+    /// Byte at which the first name-carrying delta appeared, feeding one character
+    /// at a time.
+    fn name_arrives_at(payload: &str) -> usize {
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for (index, ch) in payload.char_indices() {
+            seen.push(ch);
+            let before = out.len();
+            cursor.advance(&seen, &mut out);
+            if out[before..].iter().any(|d| d.name.is_some()) {
+                return index;
+            }
+        }
+        panic!("no name delta for {payload:?}");
+    }
+
+    #[test]
+    fn the_name_lands_at_the_argument_opener_not_at_the_close() {
+        // The commit point IS the `{` that opens the arguments — that is what makes
+        // a non-object argument set unstreamable. So the win is not a fixed
+        // fraction of the payload; it is everything the model still has to generate
+        // AFTER that brace, which is the whole argument body.
+        let payload = r#"[{"name":"get_weather","arguments":{"city":"Paris"}}]"#;
+        let opener = payload
+            .find(r#""arguments":{"#)
+            .expect("an argument opener")
+            + r#""arguments":"#.len();
+        assert_eq!(name_arrives_at(payload), opener);
+        assert!(name_arrives_at(payload) < payload.len() - 1);
+    }
+
+    #[test]
+    fn a_large_argument_body_is_almost_entirely_streamed() {
+        // The reported shape: a call whose arguments take seconds to generate. The
+        // buffered path emits nothing until the final byte; here the name is out
+        // after the first few percent and the body follows as fragments.
+        let body: String = (0..200)
+            .map(|i| format!(r#""k{i}":"v{i}","#))
+            .collect::<String>();
+        let payload = format!(r#"[{{"name":"f","arguments":{{{body}"last":"x"}}}}]"#);
+        let at = name_arrives_at(&payload);
+        assert!(
+            at * 20 < payload.len(),
+            "name arrived at byte {at} of {} — over 5% of the payload",
+            payload.len()
+        );
+
+        // And the body really does arrive in pieces, not one burst.
+        let deltas = stream(&payload);
+        let frames = deltas.iter().filter(|d| !d.arguments.is_empty()).count();
+        assert!(frames > 100, "arguments arrived in {frames} frame(s)");
+    }
+
+    #[test]
+    fn multi_byte_argument_content_is_never_split_mid_character() {
+        let payload = r#"[{"name":"f","arguments":{"city":"東京","emoji":"😀"}}]"#;
+        let deltas = stream(payload);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"東京","emoji":"😀"}"#.to_string())]
+        );
+        for delta in &deltas {
+            assert!(std::str::from_utf8(delta.arguments.as_bytes()).is_ok());
+        }
+    }
+
+    #[test]
+    fn whole_input_and_every_split_agree() {
+        let payload = r#"[{"name":"a","arguments":{"x":"1"}},{"name":"b","arguments":{"y":"2"}}]"#;
+        let whole = {
+            let mut cursor = GuidedJsonCursor::new();
+            let mut out = Vec::new();
+            cursor.advance(payload, &mut out);
+            out
+        };
+        let per_char = stream(payload);
+        assert_eq!(names(&whole), names(&per_char));
+        assert_eq!(arguments(&whole), arguments(&per_char));
+
+        for split in 1..payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let mut cursor = GuidedJsonCursor::new();
+            let mut out = Vec::new();
+            cursor.advance(&payload[..split], &mut out);
+            cursor.advance(payload, &mut out);
+            assert_eq!(names(&out), names(&whole), "names differ at split {split}");
+            assert_eq!(
+                arguments(&out),
+                arguments(&whole),
+                "arguments differ at split {split}"
+            );
+        }
+    }
+
+    #[test]
+    fn committed_records_track_released_bytes() {
+        let payload = r#"[{"name":"f","arguments":{"x":1}}]"#;
+        let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        let committed = cursor.committed();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].index, 0);
+        assert_eq!(committed[0].name, "f");
+        assert_eq!(committed[0].released, r#"{"x":1}"#.len());
+    }
+}

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -48,9 +48,12 @@
 //! adopted without a translation layer. Where it diverges from the peer shape, the
 //! divergence is stated at the item.
 
+mod guided_cursor;
 pub mod qwen3;
 
 use std::collections::BTreeMap;
+
+use guided_cursor::GuidedJsonCursor;
 
 use serde::{Deserialize, Serialize};
 
@@ -124,6 +127,29 @@ pub enum UnifiedToolOutputMode {
 }
 
 /// Caller policy when guided decoding violates the promised tool-call shape.
+///
+/// The three values are three different contracts, not three settings of one. Each
+/// states what the caller gets when the payload turns out malformed, and that
+/// answer is what decides whether the parser may stream:
+///
+/// | policy | malformed payload becomes | emits before the payload closes |
+/// |---|---|---|
+/// | [`Reject`](Self::Reject) | a typed error | no |
+/// | [`RecoverAsText`](Self::RecoverAsText) | text; an array voids ATOMICALLY | no |
+/// | [`StreamBestEffort`](Self::StreamBestEffort) | text, PER CALL | yes |
+///
+/// # Why streaming needed its own policy rather than a flag
+///
+/// A fragment cannot be unsaid. `Reject` promises an error, and that promise is
+/// only keepable while nothing has been emitted. `RecoverAsText` promises that if
+/// ANY element of a call array is invalid the WHOLE array surfaces as text — and
+/// nothing can know element one is safe until element N has arrived. Both promises
+/// are therefore incompatible with emitting early, and an earlier revision that
+/// streamed under `RecoverAsText` did not weaken it visibly; it simply started
+/// dispatching calls the contract says must become text.
+///
+/// So streaming is a THIRD contract that callers opt into, and the two existing
+/// ones behave exactly as they did before.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum InvalidGuidedPayloadPolicy {
     /// Return a typed error so the serving layer can reject or retry the output.
@@ -131,6 +157,32 @@ pub enum InvalidGuidedPayloadPolicy {
     Reject,
     /// Preserve the corpus' best-effort behavior by surfacing the bytes as text.
     RecoverAsText,
+    /// Stream each call as soon as its name and argument OBJECT are unambiguous.
+    ///
+    /// What the caller trades away, stated plainly:
+    ///
+    /// - A call already on the wire cannot later become recovery text. If a second
+    ///   argument alias appears after the call went out, it is logged, not undone.
+    /// - Recovery is PER CALL. One invalid element of an array surfaces as text on
+    ///   its own; the valid elements around it still dispatch. Under
+    ///   [`RecoverAsText`](Self::RecoverAsText) the whole array would have voided.
+    ///
+    /// What it keeps: the commit point requires the argument value to open with
+    /// `{`, so `null`, a string, a number, an array, and a parameterless call never
+    /// reach the wire early and are still judged by the buffered path.
+    StreamBestEffort,
+}
+
+impl InvalidGuidedPayloadPolicy {
+    /// Whether this contract permits emitting a call before its payload closes.
+    fn streams(self) -> bool {
+        matches!(self, Self::StreamBestEffort)
+    }
+
+    /// Whether a malformed payload becomes a typed error rather than text.
+    fn rejects(self) -> bool {
+        matches!(self, Self::Reject)
+    }
 }
 
 /// Fully resolved request-scoped parser configuration.
@@ -885,6 +937,12 @@ struct GuidedState {
     /// Visible post-payload text has started. Structural whitespace immediately
     /// after JSON may be discarded, but whitespace after visible text is content.
     post_payload_text_started: bool,
+    /// The single owner of JSON lexical state for the streaming path.
+    ///
+    /// Idle unless [`InvalidGuidedPayloadPolicy::StreamBestEffort`] is in force —
+    /// the other two contracts buffer to completion, so under them this never
+    /// advances and the completion path below is unchanged.
+    cursor: GuidedJsonCursor,
     input: String,
     json: String,
 }
@@ -1164,6 +1222,7 @@ impl GuidedState {
                 == UnifiedParserStartingState::Reasoning,
             payload_emitted: false,
             post_payload_text_started: false,
+            cursor: GuidedJsonCursor::new(),
             input: String::new(),
             json: String::new(),
         }
@@ -1184,6 +1243,14 @@ impl GuidedState {
             self.input.push_str(chunk);
         }
         for event in self.drain(false) {
+            output.push_event(event);
+        }
+        // Release whatever the payload now lets us commit to, BEFORE the
+        // completion check: the name is usually knowable long before the closing
+        // brace, and holding it until then is the reported latency defect.
+        let mut incremental = Vec::new();
+        self.emit_incremental(&mut incremental);
+        for event in incremental {
             output.push_event(event);
         }
         for event in self.emit_completed_json()? {
@@ -1235,6 +1302,7 @@ impl GuidedState {
         self.stripped_markup = false;
         self.payload_emitted = false;
         self.post_payload_text_started = false;
+        self.cursor.reset();
         recovered
     }
 
@@ -1275,6 +1343,27 @@ impl GuidedState {
         let uncommitted_suffix = self.json[payload_end..].to_string();
         let tail = self.json[tail_start..].to_string();
         self.json.truncate(payload_end);
+        // Streaming already put one or more calls on the wire. Re-emitting them from
+        // the assembled path would duplicate the name and let `assemble` overwrite
+        // the streamed arguments with a second value, so this branch flushes the
+        // argument bytes still owed and then settles only what was NOT streamed.
+        if self.cursor.has_committed() {
+            let mut out = Vec::new();
+            self.emit_incremental(&mut out);
+            out.extend(self.finish_streamed_remainder());
+            // The buffered paths below all clear `json` before returning; this branch
+            // did not, so the payload stayed in the buffer and was emitted a SECOND
+            // time as visible text on the next advance.
+            self.json.clear();
+            // Same bookkeeping the assembled path does below: mark the payload done,
+            // leave guided-payload mode, and hand the tail back as ordinary input so
+            // trailing visible text is still emitted. Skipping this dropped the text
+            // after the call entirely.
+            self.payload_emitted = true;
+            self.mode = GuidedMode::OutsideReasoning;
+            self.input.push_str(&tail);
+            return Ok(out);
+        }
         let mut output = match self.finish_json() {
             Ok(output) => output,
             Err(error) => {
@@ -1577,13 +1666,126 @@ impl GuidedState {
         output
     }
 
+    /// Emit whatever the accumulated payload lets us commit to, incrementally.
+    ///
+    /// Policy A, the "commit point": the first thing released is the function name,
+    /// and only once its JSON string value has CLOSED — at that instant the name can
+    /// no longer change and the payload is known to be shaped like a call. Before
+    /// that nothing is emitted, so `InvalidGuidedPayloadPolicy::Reject` can still
+    /// fire on a payload that never gets there.
+    ///
+    /// After the name is committed, argument bytes are released as they arrive. Only
+    /// the bytes already accumulated are released, and only on a character boundary,
+    /// so a fragment is never half a UTF-8 codepoint and never has to be taken back.
+    /// Settle the elements streaming did NOT put on the wire.
+    ///
+    /// Recovery here is PER CALL, which is the difference
+    /// [`InvalidGuidedPayloadPolicy::StreamBestEffort`] declares: an element that is
+    /// not a legal call becomes its own recovery text, while the valid elements
+    /// around it still dispatch. The atomic contract would have voided all of them
+    /// together, and cannot be offered once a fragment is already out.
+    fn finish_streamed_remainder(&mut self) -> Vec<UnifiedParserEvent> {
+        let payload = self.json.trim().to_string();
+        let mut out = Vec::new();
+        let Some(elements) = parse_required_guided_elements(&payload) else {
+            // Not even splittable into elements. Whatever was streamed stays
+            // streamed; the rest is recovery text.
+            tracing::warn!(
+                why = "unified_guided_json_not_a_tool_call",
+                choice = "required",
+                payload_bytes = payload.len(),
+                payload_kind = json_payload_kind(&payload),
+                streamed_calls = self.cursor.committed().len(),
+                "guided output did not parse as a tool call after fragments were \
+                 already emitted; emitting the remainder as text"
+            );
+            out.push(UnifiedParserEvent::Text(payload));
+            return out;
+        };
+
+        for (index, (call, element)) in elements.into_iter().enumerate() {
+            let streamed = self
+                .cursor
+                .committed()
+                .iter()
+                .find(|committed| committed.index == index);
+            match (call, streamed) {
+                // Already on the wire; its fragments carried name and arguments.
+                (Some(_), Some(committed)) => {
+                    if committed.ambiguous {
+                        tracing::warn!(
+                            why = "unified_guided_call_became_ambiguous_after_commit",
+                            tool_index = index,
+                            name = %committed.name,
+                            "a second argument alias appeared after this call was \
+                             streamed; it cannot be withdrawn"
+                        );
+                    }
+                }
+                // Valid but never committed — a parameterless call, or one whose
+                // name closed too late to beat its own payload.
+                (Some((name, arguments)), None) => {
+                    out.push(UnifiedParserEvent::ToolCall(ToolCallDelta {
+                        tool_index: index,
+                        name: Some(name),
+                        arguments,
+                    }));
+                }
+                // Invalid, and nothing went out for it: recover just this element.
+                (None, None) => {
+                    tracing::warn!(
+                        why = "unified_guided_element_is_not_a_tool_call",
+                        tool_index = index,
+                        element_bytes = element.len(),
+                        "guided element is not a legal call; emitting it as text"
+                    );
+                    out.push(UnifiedParserEvent::Text(element));
+                }
+                // Invalid, but already streamed. A fragment cannot be unsaid.
+                (None, Some(committed)) => {
+                    tracing::warn!(
+                        why = "unified_guided_streamed_call_failed_validation",
+                        tool_index = index,
+                        name = %committed.name,
+                        "this call was streamed before it could be judged invalid; \
+                         it stays on the wire"
+                    );
+                }
+            }
+        }
+        out
+    }
+
+    /// Drive the cursor over the payload accumulated so far.
+    ///
+    /// Under the two buffering contracts this is a no-op, so their behaviour is
+    /// byte-identical to before the streaming path existed.
+    fn emit_incremental(&mut self, output: &mut Vec<UnifiedParserEvent>) {
+        if !self.invalid_payload.streams() {
+            return;
+        }
+        // A named choice's payload is BARE arguments: there is no
+        // `{"name": .., "arguments": ..}` envelope for the cursor to find a name or
+        // an object opener in. Its name is known from the request before any byte
+        // arrives, so it needs its own commit rule rather than this one, and until
+        // that exists it stays on the buffered path.
+        if self.named_tool.is_some() {
+            return;
+        }
+        let mut deltas = Vec::new();
+        self.cursor.advance(&self.json, &mut deltas);
+        for delta in deltas {
+            output.push(UnifiedParserEvent::ToolCall(delta));
+        }
+    }
+
     /// Parse the accumulated payload. Anything that does not parse as the
     /// expected call shape is surfaced as visible text rather than dropped
     /// (policy P2 — best-effort recovery, never silent loss).
     fn finish_json(&mut self) -> Result<Vec<UnifiedParserEvent>> {
         let payload = self.json.trim();
         if payload.is_empty() {
-            if self.invalid_payload == InvalidGuidedPayloadPolicy::Reject {
+            if self.invalid_payload.rejects() {
                 return Err(InvalidGuidedPayload {
                     kind: InvalidGuidedPayloadKind::Missing,
                     choice: if self.named_tool.is_some() {
@@ -1659,7 +1861,7 @@ impl GuidedState {
         };
 
         let Some(calls) = calls.filter(|calls| !calls.is_empty()) else {
-            if self.invalid_payload == InvalidGuidedPayloadPolicy::Reject {
+            if self.invalid_payload.rejects() {
                 return Err(InvalidGuidedPayload {
                     kind: if serde_json::from_str::<serde_json::Value>(payload).is_ok() {
                         InvalidGuidedPayloadKind::WrongShape
@@ -1716,50 +1918,81 @@ impl GuidedState {
     }
 }
 
+/// One judged call: its decoded function name, and its argument object as raw JSON
+/// text (never re-serialized, so argument bytes reach the caller verbatim).
+type GuidedCall = (String, String);
+
+/// One element of a required payload: the call it judges to (`None` when the
+/// element is not a legal call), paired with that element's raw bytes for recovery.
+type GuidedElement = (Option<GuidedCall>, String);
+
+/// Judge ONE required-choice call element.
+///
+/// The single implementation of what makes a call legal, shared by the atomic
+/// whole-array path ([`parse_required_guided_calls`]) and the per-call path the
+/// streaming contract uses ([`parse_required_guided_elements`]). Two copies of this
+/// judgement would let the two recovery modes disagree about the same bytes.
+fn convert_guided_call(call: GuidedToolCall) -> Option<GuidedCall> {
+    // No argument key means NO ARGUMENTS, not a malformed call. `UNIFIED.6.a`
+    // already fixes that semantic on the native path — same tool, no parameter
+    // block, golden `arguments: {}` — so voiding it here made guided disagree with
+    // native on an identical shape and made a parameterless tool uncallable. What
+    // makes an element invalid is a missing `name` (required on GuidedToolCall);
+    // that still voids the whole array, per `31.c` / `51.b`.
+    let arguments = match (call.parameters, call.arguments) {
+        // PRESENT but not an object is a malformed call, the same judgement the
+        // NAMED path makes on its whole payload: arguments that are a string or
+        // a number cannot bind to the tool's parameters, so emitting it would
+        // hand the tool a shape it cannot use. Absent is different — that means
+        // no arguments, and stays valid (see the note above).
+        (Some(raw), None) | (None, Some(raw)) => {
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get()).ok()?;
+            raw.get().to_string()
+        }
+        (None, None) => "{}".to_string(),
+        // The aliases are alternatives, not two independently meaningful
+        // argument sets. Choosing one silently can emit different bytes from
+        // what the backend intended, so reject the ambiguous call fail-closed.
+        (Some(_), Some(_)) => return None,
+    };
+    Some((call.name, arguments))
+}
+
 /// A required (un-named) choice emits one call object or an array of them.
-fn parse_required_guided_calls(payload: &str) -> Option<Vec<(String, String)>> {
-    fn convert(call: GuidedToolCall) -> Option<(String, String)> {
-        // No argument key means NO ARGUMENTS, not a malformed call. `UNIFIED.6.a`
-        // already fixes that semantic on the native path — same tool, no parameter
-        // block, golden `arguments: {}` — so voiding it here made guided disagree with
-        // native on an identical shape and made a parameterless tool uncallable. What
-        // makes an element invalid is a missing `name` (required on GuidedToolCall);
-        // that still voids the whole array, per `31.c` / `51.b`.
-        let arguments = match (call.parameters, call.arguments) {
-            // PRESENT but not an object is a malformed call, the same judgement the
-            // NAMED path makes on its whole payload: arguments that are a string or
-            // a number cannot bind to the tool's parameters, so emitting it would
-            // hand the tool a shape it cannot use. Absent is different — that means
-            // no arguments, and stays valid (see the note above).
-            (Some(raw), None) | (None, Some(raw)) => {
-                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw.get())
-                    .ok()?;
-                raw.get().to_string()
-            }
-            (None, None) => "{}".to_string(),
-            // The aliases are alternatives, not two independently meaningful
-            // argument sets. Choosing one silently can emit different bytes from
-            // what the backend intended, so reject the ambiguous call fail-closed.
-            (Some(_), Some(_)) => return None,
-        };
-        Some((call.name, arguments))
-    }
+///
+/// ATOMIC: one invalid element voids the whole payload, which is what
+/// [`InvalidGuidedPayloadPolicy::RecoverAsText`] promises.
+fn parse_required_guided_calls(payload: &str) -> Option<Vec<GuidedCall>> {
+    parse_required_guided_elements(payload)?
+        .into_iter()
+        .map(|(call, _)| call)
+        .collect()
+}
 
+/// Per-element view of a required payload, paired with each element's raw bytes.
+///
+/// `None` in the first slot marks an element that is not a legal call. Only the
+/// streaming contract uses this shape, because only it recovers PER CALL; the
+/// atomic path folds the same elements into one all-or-nothing answer above, so
+/// both agree element for element by construction.
+fn parse_required_guided_elements(payload: &str) -> Option<Vec<GuidedElement>> {
     if let Ok(raw_calls) = serde_json::from_str::<Vec<Box<serde_json::value::RawValue>>>(payload) {
-        return raw_calls
-            .into_iter()
-            .map(|raw| {
-                serde_json::from_str::<GuidedToolCall>(raw.get())
-                    .ok()
-                    .and_then(convert)
-            })
-            .collect();
+        return Some(
+            raw_calls
+                .into_iter()
+                .map(|raw| {
+                    let element = raw.get().to_string();
+                    let call = serde_json::from_str::<GuidedToolCall>(raw.get())
+                        .ok()
+                        .and_then(convert_guided_call);
+                    (call, element)
+                })
+                .collect(),
+        );
     }
 
-    serde_json::from_str::<GuidedToolCall>(payload)
-        .ok()
-        .and_then(convert)
-        .map(|call| vec![call])
+    let call = serde_json::from_str::<GuidedToolCall>(payload).ok()?;
+    Some(vec![(convert_guided_call(call), payload.to_string())])
 }
 
 /// How a vendor supplies a parser: given the request's tools, build one parser for

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1564,6 +1564,444 @@ mod tests {
             }
         }
     }
+
+    use crate::tool_calling::traits::ToolCallDelta;
+
+    /// Init selecting the streaming contract.
+    fn stream_init(mode: UnifiedToolOutputMode) -> UnifiedParserInit {
+        UnifiedParserInit {
+            prompt_token_ids: Vec::new(),
+            starting_state: UnifiedParserStartingState::None,
+            tool_output_mode: mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
+        }
+    }
+
+    /// Every delta produced by feeding `payload` in `chunks`, push order preserved.
+    fn streamed(payload: &str, chunks: &[&str]) -> (Vec<ToolCallDelta>, Vec<UnifiedParserEvent>) {
+        let _ = payload;
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                named_tool: None,
+            }))
+            .expect("required guided init");
+        let mut calls = Vec::new();
+        let mut all = Vec::new();
+        for chunk in chunks {
+            for event in parser.push(chunk).expect("push") {
+                if let UnifiedParserEvent::ToolCall(delta) = &event {
+                    calls.push(delta.clone());
+                }
+                all.push(event);
+            }
+        }
+        for event in parser.finish().expect("finish").events {
+            if let UnifiedParserEvent::ToolCall(delta) = &event {
+                calls.push(delta.clone());
+            }
+            all.push(event);
+        }
+        (calls, all)
+    }
+
+    /// One chunk per character.
+    fn per_char(payload: &str) -> Vec<&str> {
+        payload
+            .char_indices()
+            .map(|(i, ch)| &payload[i..i + ch.len_utf8()])
+            .collect()
+    }
+
+    /// Byte span of the first argument OBJECT in `payload`, tolerating any
+    /// whitespace the fixture uses between the key, the colon and the brace.
+    fn argument_object(payload: &str) -> (usize, usize) {
+        let key = payload.find("\"arguments\"").expect("fixture shape");
+        let open = payload[key..].find('{').expect("fixture shape") + key;
+        let mut depth = 0i32;
+        let mut in_string = false;
+        let mut escaped = false;
+        for (offset, ch) in payload[open..].char_indices() {
+            if in_string {
+                match ch {
+                    _ if escaped => escaped = false,
+                    '\\' => escaped = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
+                continue;
+            }
+            match ch {
+                '"' => in_string = true,
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return (open, open + offset + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unterminated argument object in {payload:?}");
+    }
+
+    /// Arguments reassembled per tool index, in first-seen index order.
+    fn joined_arguments(calls: &[ToolCallDelta]) -> Vec<(usize, String)> {
+        let mut out: Vec<(usize, String)> = Vec::new();
+        for delta in calls {
+            match out.iter_mut().find(|(index, _)| *index == delta.tool_index) {
+                Some((_, text)) => text.push_str(&delta.arguments),
+                None => out.push((delta.tool_index, delta.arguments.clone())),
+            }
+        }
+        out
+    }
+
+    /// The defect a downstream user reported: with `tool_choice="required"`,
+    /// streaming on and thinking disabled, nothing reaches the wire until the whole
+    /// call has been generated. Their vanilla-vLLM deployment starts streaming in
+    /// ~0.2s; this path took ~10s and then arrived in one burst.
+    ///
+    /// The assertion is ORDERING, not wall-clock: a name-carrying event must exist
+    /// before the parser has been handed the bytes that complete the call. A timing
+    /// assertion would pass on a fast machine, fail on a slow one, and say nothing
+    /// about emission granularity.
+    #[test]
+    fn required_guided_emits_the_name_before_the_call_completes() {
+        // Cut just after the arguments object opens - the commit point - which is
+        // still well before the arguments close.
+        let cut = argument_object(GUIDED_CALL).0 + 1;
+        let mut parser = qwen3_unified(&weather_tools());
+        parser
+            .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                named_tool: None,
+            }))
+            .expect("required guided init");
+
+        let early = parser.push(&GUIDED_CALL[..cut]).expect("push prefix");
+        let named = early.iter().any(|e| {
+            matches!(e, UnifiedParserEvent::ToolCall(c) if c.name.as_deref() == Some("get_weather"))
+        });
+
+        assert!(
+            named,
+            "no name-carrying frame before the call completed; got {early:?}. \
+             The function name is unambiguous at byte {cut} - everything after it is \
+             arguments - so a consumer could already have started rendering the call."
+        );
+    }
+
+    /// Streaming must be INCREMENTAL, not merely "earlier", and the fragments must
+    /// reassemble BYTE FOR BYTE.
+    ///
+    /// An earlier version of this test asserted only that the join `contains("Paris")`,
+    /// which a parser that mangled every other byte would still pass. The assertion
+    /// is now equality against the exact argument object.
+    #[test]
+    fn required_guided_streams_arguments_in_multiple_fragments() {
+        let (calls, events) = streamed(GUIDED_CALL, &per_char(GUIDED_CALL));
+
+        let names: Vec<&str> = calls.iter().filter_map(|c| c.name.as_deref()).collect();
+        assert_eq!(names, vec!["get_weather"], "exactly one decoded name");
+        assert!(
+            calls.iter().all(|c| c.tool_index == 0),
+            "one call must not spread across indices: {calls:?}"
+        );
+
+        let frames = calls.iter().filter(|c| !c.arguments.is_empty()).count();
+        assert!(
+            frames >= 2,
+            "arguments arrived in {frames} frame(s) - that is a burst, not a stream"
+        );
+
+        let (start, end) = argument_object(GUIDED_CALL);
+        let expected = GUIDED_CALL[start..end].to_string();
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, expected)],
+            "fragments must reassemble the argument object byte for byte"
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+            "a valid streamed call must not also produce recovery text: {events:?}"
+        );
+    }
+
+    /// The `parameters` spelling is as legal as `arguments`, and recognising only
+    /// one of them streamed NOTHING for the other - the call then assembled with
+    /// empty arguments, which is worse than the latency it was fixing.
+    #[test]
+    fn required_guided_streams_the_parameters_alias_too() {
+        let payload = r#"[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#;
+        let (calls, _) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, r#"{"city":"Tokyo"}"#.to_string())]
+        );
+        // Assert it STREAMED, not merely that it assembled. The buffered path
+        // produces the identical assembled result, so an outcome-only assertion
+        // passes with the alias unrecognised - which is exactly the bug.
+        let frames = calls.iter().filter(|c| !c.arguments.is_empty()).count();
+        assert!(
+            frames >= 2,
+            "the parameters alias assembled correctly but never streamed: \
+             {frames} argument frame(s)"
+        );
+    }
+
+    /// A `\uXXXX` escape in the function name must decode. The old scanner pushed
+    /// the escape's payload characters verbatim and produced `getu005fweather`.
+    #[test]
+    fn required_guided_decodes_escaped_names() {
+        let payload = "[{\"name\":\"get\\u005fweather\",\"arguments\":{\"city\":\"Paris\"}}]";
+        assert!(
+            payload.contains("\\u005f"),
+            "the escape must survive to the test"
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+    }
+
+    /// Parallel calls keep distinct indices and stay in payload order. Hardcoding
+    /// index 0 collapsed both calls into one.
+    #[test]
+    fn required_guided_streams_parallel_calls_on_distinct_indices() {
+        let payload = concat!(
+            r#"[{"name":"get_weather","arguments":{"city":"Paris"}},"#,
+            r#"{"name":"get_weather","arguments":{"city":"Tokyo"}}]"#
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        let named: Vec<(usize, &str)> = calls
+            .iter()
+            .filter_map(|c| c.name.as_deref().map(|n| (c.tool_index, n)))
+            .collect();
+        assert_eq!(named, vec![(0, "get_weather"), (1, "get_weather")]);
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![
+                (0, r#"{"city":"Paris"}"#.to_string()),
+                (1, r#"{"city":"Tokyo"}"#.to_string()),
+            ]
+        );
+    }
+
+    /// PER-CALL recovery, the guarantee `StreamBestEffort` trades the atomic one
+    /// for: a malformed second element becomes its own text and the valid first
+    /// element still dispatches.
+    #[test]
+    fn required_guided_recovers_only_the_invalid_element() {
+        let payload = concat!(
+            r#"[{"name":"get_weather","arguments":{"city":"Paris"}},"#,
+            r#"{"arguments":{"city":"Tokyo"}}]"#
+        );
+        let (calls, events) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"],
+            "the valid element must still dispatch"
+        );
+        let texts: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            texts,
+            vec![r#"{"arguments":{"city":"Tokyo"}}"#],
+            "only the nameless element recovers as text"
+        );
+    }
+
+    /// Shapes the contract voids must never reach the wire early, because a
+    /// fragment cannot be withdrawn. The commit point requires an argument OBJECT
+    /// opener, so each of these stays on the buffered path.
+    #[test]
+    fn required_guided_never_streams_a_shape_the_contract_voids() {
+        for payload in [
+            r#"[{"name":"get_weather","arguments":"just a string"}]"#,
+            r#"[{"name":"get_weather","arguments":null}]"#,
+            r#"[{"name":"get_weather","arguments":[1,2]}]"#,
+        ] {
+            let (calls, events) = streamed(payload, &per_char(payload));
+            assert!(
+                calls.is_empty(),
+                "{payload} streamed a call the contract voids: {calls:?}"
+            );
+            assert!(
+                events
+                    .iter()
+                    .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+                "{payload} should have recovered as text; got {events:?}"
+            );
+        }
+    }
+
+    /// The ONE guarantee `StreamBestEffort` genuinely cannot keep, pinned so it
+    /// stays a documented loss rather than a surprise.
+    ///
+    /// A call carrying BOTH argument aliases is ambiguous and the buffered
+    /// contracts void it. Streaming cannot: the second alias only appears after the
+    /// first has already supplied an object opener, which is the commit point, so
+    /// the call is on the wire before the ambiguity exists to be seen. It stays,
+    /// carrying the alias that arrived first, and the parser says so in a warning.
+    #[test]
+    fn ambiguity_discovered_after_the_commit_cannot_be_withdrawn() {
+        let payload = r#"[{"name":"get_weather","arguments":{"a":1},"parameters":{"b":2}}]"#;
+        let (calls, events) = streamed(payload, &per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"],
+            "the call was committed before the second alias arrived"
+        );
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, r#"{"a":1}"#.to_string())],
+            "it carries the alias that opened first"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+            "recovery text here would DUPLICATE the streamed call: {events:?}"
+        );
+    }
+
+    /// A parameterless call has no argument object to commit on, so it settles on
+    /// the buffered path - and must still arrive with `{}`, not an empty string,
+    /// and must not disturb a streamed sibling.
+    #[test]
+    fn required_guided_parameterless_call_keeps_its_empty_argument_set() {
+        let payload = concat!(
+            r#"[{"name":"get_weather"},"#,
+            r#"{"name":"get_weather","arguments":{"city":"Paris"}}]"#
+        );
+        let (calls, _) = streamed(payload, &per_char(payload));
+        let mut assembled = joined_arguments(&calls);
+        // Deltas for call 0 arrive AFTER call 1's, and that is inherent: a
+        // parameterless call has no argument object to commit on, so it can only be
+        // settled once the payload closes, by which time its streamed sibling has
+        // long been on the wire. Consumers key by `tool_index` (`assemble` does), so
+        // the wire order is not the call order.
+        assembled.sort_by_key(|(index, _)| *index);
+        assert_eq!(
+            assembled,
+            vec![
+                (0, "{}".to_string()),
+                (1, r#"{"city":"Paris"}"#.to_string())
+            ]
+        );
+    }
+
+    /// Truncation mid-payload: whatever was streamed stays streamed, and nothing
+    /// is invented for the part that never arrived.
+    #[test]
+    fn required_guided_truncation_after_commit_does_not_invent_arguments() {
+        let cut = GUIDED_CALL.find("\"city\"").expect("fixture shape");
+        let (calls, _) = streamed(&GUIDED_CALL[..cut], &per_char(&GUIDED_CALL[..cut]));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+        let joined = joined_arguments(&calls);
+        let released = joined.first().map(|(_, text)| text.as_str()).unwrap_or("");
+        assert!(
+            GUIDED_CALL[cut - released.len()..].starts_with(released) || released.len() <= 1,
+            "released bytes must be a prefix of the real arguments; got {released:?}"
+        );
+    }
+
+    /// Reuse: a second request on the same parser must not inherit the first
+    /// request's cursor offsets, or the new payload is lexed from the wrong place.
+    #[test]
+    fn required_guided_streaming_state_does_not_leak_across_requests() {
+        let mut parser = qwen3_unified(&weather_tools());
+        let mut seen = Vec::new();
+        for request in 0..2 {
+            if request > 0 {
+                parser.reset();
+            }
+            parser
+                .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                    named_tool: None,
+                }))
+                .expect("required guided init");
+            let mut calls = Vec::new();
+            for chunk in per_char(GUIDED_CALL) {
+                for event in parser.push(chunk).expect("push") {
+                    if let UnifiedParserEvent::ToolCall(delta) = event {
+                        calls.push(delta);
+                    }
+                }
+            }
+            for event in parser.finish().expect("finish").events {
+                if let UnifiedParserEvent::ToolCall(delta) = event {
+                    calls.push(delta);
+                }
+            }
+            seen.push(joined_arguments(&calls));
+        }
+        assert_eq!(
+            seen[0], seen[1],
+            "the second request diverged from the first"
+        );
+    }
+
+    /// Whole-input and every valid split must assemble identically, and the split
+    /// runs must show intermediate progress rather than one terminal burst.
+    #[test]
+    fn required_guided_streaming_is_split_invariant() {
+        let whole = streamed(GUIDED_CALL, &[GUIDED_CALL]).0;
+        let baseline = joined_arguments(&whole);
+        let names: Vec<&str> = whole.iter().filter_map(|c| c.name.as_deref()).collect();
+
+        for split in 1..GUIDED_CALL.len() {
+            if !GUIDED_CALL.is_char_boundary(split) {
+                continue;
+            }
+            let (calls, _) = streamed(GUIDED_CALL, &[&GUIDED_CALL[..split], &GUIDED_CALL[split..]]);
+            assert_eq!(
+                joined_arguments(&calls),
+                baseline,
+                "arguments differ at split {split}"
+            );
+            assert_eq!(
+                calls
+                    .iter()
+                    .filter_map(|c| c.name.as_deref())
+                    .collect::<Vec<_>>(),
+                names,
+                "names differ at split {split}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Overview:

A downstream user reported **~10s to first tool-call frame** with `tool_choice="required"` and streaming on; their vanilla-vLLM deployment starts streaming in ~0.2s. Final output is correct — valid `tool_calls`, `finish_reason="tool_calls"` — so this is a **time-to-first-frame defect, not a correctness defect**.

**Draft on purpose.** This opens a design decision rather than closing it — see *What is red*.

#### The cause is not qwen3-specific:

Every v2 family emits at call-completion granularity. Native buffers to `invoke_end` then pushes one `ToolCallDelta`; guided emits when the JSON value completes, and its own test asserts no `ToolCall` event exists before completion. No fragment-level machinery exists anywhere in `parsers/v2`.

#### What works:

Policy **A**, "commit point" — nothing is emitted until the call's `"name"` value has **closed**, at which point the name can no longer change. Argument bytes then stream as fragments, bounded to the arguments value's own span, cut on character boundaries.

Two acceptance tests, both asserting **ordering, not wall-clock**:

| test | before | after |
|---|---|---|
| `required_guided_emits_the_name_before_the_call_completes` | **RED** (`got []`) | green |
| `required_guided_streams_arguments_in_multiple_fragments` | — | green |

The second is the one that matters. It feeds the payload **one character at a time** and asserts exactly **one** name delta, **≥2** argument frames, and that fragments reassemble. The first alone would pass on an implementation that emitted the name early and still dumped every argument byte in one delta — which is most of the reported defect.

#### What is red, and why that is the deliverable:

**12 tests fail.** They encode behaviour early commitment cannot preserve: a non-object argument payload must **void** the call, a parameterless call must not void its siblings, chunk-boundary independence. All of it assumes the parser can still change its mind about a call it has not emitted. **A fragment on the wire cannot be unsaid.**

Gating already removed 13 of the original 25:

- `InvalidGuidedPayloadPolicy::Reject` never streams — that policy's typed error is only keepable while nothing has been emitted.
- Named choice never streams — its payload is *bare arguments* with no wrapper to locate a span in. Emitting a name there produced calls with `{}` arguments, worse than the latency it was fixing.

The remaining 12 need a **decision, not a patch**:

1. Move the commit point past validation — preserves all 12, loses most of the latency win.
2. Accept a weaker contract on the streaming path — keeps the win, rewrites 12 tests.

#### Not in scope:

Native markup, the other five families, EOF/truncation semantics, and the golden corpus are untouched and follow the decision above.

Separately: `tool_choice="required"` may never reach this code at all — it routes to the v1 jail today. Tracked in DIS-2708; without it the reporter's configuration is unchanged by this PR.

Closes [DIS-2707](https://linear.app/nvidia/issue/DIS-2707)