### PR TITLE
feat(parsers): stream guided tool calls in v1 and v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,8 @@ dependencies = [
  "anyhow",
  "dynamo-parsers",
  "dynamo-parsers-v2",
+ "dynamo-protocols",
+ "futures",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -12,6 +12,8 @@ publish = false
 anyhow = { workspace = true }
 dynamo-parsers = { workspace = true }
 dynamo-parsers-v2 = { path = "../parsers/v2", version = "0.3.1" }
+dynamo-protocols = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = "0.9"

--- a/conformance/tests/guided_streaming_contract.rs
+++ b/conformance/tests/guided_streaming_contract.rs
@@ -184,7 +184,9 @@ async fn v1_and_v2_share_the_guided_streaming_contract() {
 /// message: the array shape delivered `},{"name":` as text and the single-call shape
 /// delivered a bare `}`. The cursor releases argument bytes only up to the argument
 /// object's own closing brace, so everything after it is envelope. Once streaming has
-/// committed, that tail is never assistant text.
+/// committed, that tail is never assistant text. v2 had the identical bug at a
+/// different, pre-existing site (frontend-crates#195) - both generations are driven
+/// here, the way the sibling contract test above does.
 #[tokio::test]
 async fn a_truncated_guided_payload_never_leaks_its_envelope_as_text() {
     let cases = [
@@ -203,18 +205,26 @@ async fn a_truncated_guided_payload_never_leaks_its_envelope_as_text() {
     ];
 
     for case in cases {
-        let (carrying, names, arguments, content) = v1(&case).await;
-        assert_eq!(names, vec!["search".to_string()], "{:?}", case.payload);
-        assert_eq!(arguments, case.arguments, "{:?}", case.payload);
-        assert!(
-            content.is_empty(),
-            "truncated payload {:?} leaked envelope bytes as text: {content:?}",
-            case.payload
-        );
-        assert!(
-            carrying > 2,
-            "truncated payload {:?} buffered instead of streaming",
-            case.payload
-        );
+        let v1 = v1(&case).await;
+        let v2 = v2(&case);
+        for (name, output) in [("v1", &v1), ("v2", &v2)] {
+            assert_eq!(
+                output.1,
+                vec!["search".to_string()],
+                "{name} {:?}",
+                case.payload
+            );
+            assert_eq!(output.2, case.arguments, "{name} {:?}", case.payload);
+            assert!(
+                output.3.is_empty(),
+                "{name} truncated payload {:?} leaked envelope bytes as text: {output:?}",
+                case.payload
+            );
+            assert!(
+                output.0 > 2,
+                "{name} truncated payload {:?} buffered instead of streaming",
+                case.payload
+            );
+        }
     }
 }

--- a/conformance/tests/guided_streaming_contract.rs
+++ b/conformance/tests/guided_streaming_contract.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream};
+use dynamo_parsers_v2::{
+    InvalidGuidedPayloadPolicy, Tool, UnifiedParserEvent, UnifiedParserExt, UnifiedParserInit,
+    UnifiedParserStartingState, UnifiedToolOutputMode, create_unified_parser_for_family,
+};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, Role,
+};
+use futures::StreamExt;
+use futures::stream;
+
+struct Case {
+    named: bool,
+    payload: &'static str,
+    arguments: &'static str,
+}
+
+fn v1_chunk(content: &str) -> Annotated<CreateChatCompletionStreamResponse> {
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            role: Some(Role::Assistant),
+            content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        logprobs: None,
+    };
+    Annotated {
+        data: Some(CreateChatCompletionStreamResponse {
+            id: "guided-conformance".to_string(),
+            choices: vec![choice],
+            created: 0,
+            model: "test".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        }),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+fn chunks(payload: &str) -> Vec<&str> {
+    payload
+        .char_indices()
+        .map(|(at, ch)| &payload[at..at + ch.len_utf8()])
+        .collect()
+}
+
+async fn v1(case: &Case) -> (usize, Vec<String>, String, String) {
+    let builder = JailedStream::builder().guided_streaming(true);
+    let jail = if case.named {
+        builder.tool_choice_named("search".to_string()).build()
+    } else {
+        builder.tool_choice_required().build()
+    };
+    let input = chunks(case.payload).into_iter().map(v1_chunk);
+    let output: Vec<_> = jail
+        .apply_with_finish_reason(stream::iter(input))
+        .collect()
+        .await;
+
+    let mut carrying = 0;
+    let mut names = Vec::new();
+    let mut arguments = String::new();
+    let mut content = String::new();
+    for response in output {
+        let Some(data) = response.data else {
+            continue;
+        };
+        for choice in data.choices {
+            if let Some(ChatCompletionMessageContent::Text(text)) = choice.delta.content {
+                content.push_str(&text);
+            }
+            if let Some(calls) = choice.delta.tool_calls {
+                carrying += 1;
+                for call in calls {
+                    if let Some(function) = call.function {
+                        if let Some(name) = function.name {
+                            names.push(name);
+                        }
+                        if let Some(fragment) = function.arguments {
+                            arguments.push_str(&fragment);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (carrying, names, arguments, content)
+}
+
+fn v2(case: &Case) -> (usize, Vec<String>, String, String) {
+    let tools = [Tool {
+        name: "search".to_string(),
+        description: None,
+        parameters: serde_json::json!({"type":"object"}),
+        strict: None,
+    }];
+    let mut parser = create_unified_parser_for_family("qwen3", &tools).unwrap();
+    parser
+        .initialize_request(UnifiedParserInit {
+            prompt_token_ids: Vec::new(),
+            starting_state: UnifiedParserStartingState::None,
+            tool_output_mode: UnifiedToolOutputMode::GuidedJson {
+                named_tool: case.named.then(|| "search".to_string()),
+            },
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
+        })
+        .unwrap();
+
+    let mut events = Vec::new();
+    for chunk in chunks(case.payload) {
+        events.extend(parser.push(chunk).unwrap());
+    }
+    events.extend(parser.finish().unwrap().events);
+
+    let mut carrying = 0;
+    let mut names = Vec::new();
+    let mut arguments = String::new();
+    let mut content = String::new();
+    for event in events {
+        match event {
+            UnifiedParserEvent::ToolCall(call) => {
+                carrying += 1;
+                if let Some(name) = call.name {
+                    names.push(name);
+                }
+                arguments.push_str(&call.arguments);
+            }
+            UnifiedParserEvent::Text(text) => content.push_str(&text),
+            UnifiedParserEvent::Reasoning(_) => {}
+        }
+    }
+    (carrying, names, arguments, content)
+}
+
+#[tokio::test]
+async fn v1_and_v2_share_the_guided_streaming_contract() {
+    let cases = [
+        Case {
+            named: false,
+            payload: r#"[{"name":"search","parameters":{"query":"Rust","limit":10}}]"#,
+            arguments: r#"{"query":"Rust","limit":10}"#,
+        },
+        Case {
+            named: true,
+            payload: "  {\"query\":\"Rust\",\"limit\":10}",
+            arguments: r#"{"query":"Rust","limit":10}"#,
+        },
+    ];
+
+    for case in cases {
+        let v1 = v1(&case).await;
+        let v2 = v2(&case);
+        for (name, output) in [("v1", &v1), ("v2", &v2)] {
+            assert_eq!(output.1, vec!["search".to_string()], "{name}");
+            assert_eq!(output.2, case.arguments, "{name}");
+            assert!(
+                output.3.is_empty(),
+                "{name} leaked JSON as text: {output:?}"
+            );
+            assert!(
+                output.0 > 2,
+                "{name} buffered instead of streaming: {output:?}"
+            );
+        }
+    }
+}
+
+/// A truncated guided payload used to leak its call envelope into the assistant
+/// message: the array shape delivered `},{"name":` as text and the single-call shape
+/// delivered a bare `}`. The cursor releases argument bytes only up to the argument
+/// object's own closing brace, so everything after it is envelope. Once streaming has
+/// committed, that tail is never assistant text.
+#[tokio::test]
+async fn a_truncated_guided_payload_never_leaks_its_envelope_as_text() {
+    let cases = [
+        // Cut mid-envelope, just after a complete first call.
+        Case {
+            named: false,
+            payload: r#"[{"name":"search","parameters":{"query":"Rust"}},{"name":"#,
+            arguments: r#"{"query":"Rust"}"#,
+        },
+        // Cut before the array's own `]`.
+        Case {
+            named: false,
+            payload: r#"[{"name":"search","parameters":{"query":"Rust"}}"#,
+            arguments: r#"{"query":"Rust"}"#,
+        },
+    ];
+
+    for case in cases {
+        let (carrying, names, arguments, content) = v1(&case).await;
+        assert_eq!(names, vec!["search".to_string()], "{:?}", case.payload);
+        assert_eq!(arguments, case.arguments, "{:?}", case.payload);
+        assert!(
+            content.is_empty(),
+            "truncated payload {:?} leaked envelope bytes as text: {content:?}",
+            case.payload
+        );
+        assert!(
+            carrying > 2,
+            "truncated payload {:?} buffered instead of streaming",
+            case.payload
+        );
+    }
+}

--- a/parsers/v1/src/tool_calling/jail/guided_stream.rs
+++ b/parsers/v1/src/tool_calling/jail/guided_stream.rs
@@ -1,0 +1,962 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Incremental lexer over a guided (`tool_choice`) tool-call payload.
+//!
+//! # Why a lexer and not a few `str::find` calls
+//!
+//! Streaming a guided call before its payload has closed needs four facts that
+//! only a JSON lexer can answer: which array element the scan is inside, that
+//! element's decoded `name`, where its argument OBJECT begins, and which bytes of
+//! that object are safe to put on the wire. Substring search answers none of them
+//! correctly — `"name"` occurs as a VALUE in `{"x":"name","parameters":{}}`,
+//! `_` is six characters that must decode to one, the `parameters` spelling
+//! is as legal as `arguments`, and rescanning the whole accumulated buffer on
+//! every chunk makes a token-at-a-time stream quadratic.
+//!
+//! [`GuidedStreamCursor`] owns that state in one place and advances strictly
+//! FORWARD: every call consumes only the bytes appended since the last one, the
+//! same "scan only what is new" discipline as `JsonCompletionProgress` in this
+//! module's parent.
+//!
+//! # What it deliberately does not do
+//!
+//! It does not validate. The jail's buffered parse remains the only judge of
+//! whether a payload is a legal call set. The cursor answers one narrower
+//! question: *has enough arrived that a name and an argument OBJECT can no longer
+//! turn into something else?* Requiring the argument value to open with `{` is
+//! what makes an early emission safe — `null`, a string, a number and an array
+//! never reach the commit point, so a shape the buffered path would void is never
+//! put on the wire.
+//!
+//! # The one thing it cannot promise
+//!
+//! An emitted byte cannot be retracted. An element that names BOTH `arguments`
+//! and `parameters` is ambiguous, and the cursor refuses to commit it whenever
+//! the second spelling appears before the commit point (which is every ordering
+//! except one: the alias that opens the object arriving first AND the name having
+//! already closed). In that one ordering the call is already on the wire; the
+//! cursor then blocks the element — no further argument bytes, no second call —
+//! rather than pretending it can unsay them.
+
+use std::collections::BTreeMap;
+
+use super::ToolChoiceFormat;
+
+/// The two spellings a guided call may use for its argument object. A call
+/// carrying both is ambiguous — see the module header.
+const ARGUMENT_ALIASES: [&str; 2] = ["arguments", "parameters"];
+
+/// One fragment the cursor is willing to stand behind.
+///
+/// `name` is carried exactly once per call, on the delta that commits it; every
+/// later delta for that call carries argument bytes and `name: None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuidedDelta {
+    pub tool_index: usize,
+    pub name: Option<String>,
+    pub arguments: String,
+}
+
+/// One call whose opening delta has already reached the client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StreamedCall {
+    /// Argument bytes released so far, in their original wire representation.
+    pub arguments: String,
+}
+
+/// What the payload is shaped like, derived from the jail's [`ToolChoiceFormat`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mode {
+    /// `tool_choice=required`: `[{"name":…,"arguments":{…}}, …]`.
+    Array,
+    /// `tool_choice=<named>`: the payload IS the bare argument object; the name
+    /// is known up front and never appears in the bytes.
+    Single { tool_name: String },
+}
+
+/// Where the scan sits inside a call object (array mode only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Slot {
+    /// Between `{` or `,` and the next key.
+    Key,
+    /// A key literal closed; waiting for its `:`.
+    Colon,
+    /// Past the `:`; the next token is that key's value.
+    Value,
+}
+
+/// Per-element scan state. Reset at every call boundary.
+#[derive(Debug, Default, Clone)]
+struct Element {
+    name: Option<String>,
+    /// Offset of the `{` that opened the argument object.
+    args_start: Option<usize>,
+    /// Offset just past the argument object's closing `}`, once it arrived.
+    args_end: Option<usize>,
+    /// The scan is inside the argument object right now.
+    in_args: bool,
+    /// An argument alias key has been seen for this element.
+    alias_seen: bool,
+    /// This element may never commit, and may never release another byte:
+    /// either an alias bound a non-object value, or both spellings appeared.
+    blocked: bool,
+    committed: bool,
+    /// Argument bytes already released, relative to `args_start`.
+    released: usize,
+}
+
+/// Forward-only lexer over one guided payload.
+#[derive(Debug, Clone)]
+pub(crate) struct GuidedStreamCursor {
+    mode: Mode,
+    /// Bytes already lexed. The scan never revisits them.
+    scanned: usize,
+    depth: i32,
+    in_string: bool,
+    escape: bool,
+    /// Opening quote of a literal the cursor needs (a call key, or the `name`
+    /// value). Decoding happens once, when the closing quote arrives, so JSON
+    /// escape semantics stay owned by `serde_json`.
+    literal_start: Option<usize>,
+    /// Depth at which call keys sit: 2 under an array root, 1 under an object
+    /// root. Array mode only.
+    key_depth: i32,
+    root_seen: bool,
+    /// The payload does not open as a call shape; nothing may ever commit.
+    disabled: bool,
+    slot: Slot,
+    pending_key: Option<String>,
+    element: Element,
+    index: usize,
+    /// Calls already put on the wire, keyed in the cursor's source-index space.
+    streamed: BTreeMap<usize, StreamedCall>,
+}
+
+impl GuidedStreamCursor {
+    pub(crate) fn new(format: &ToolChoiceFormat) -> Self {
+        let mode = match format {
+            ToolChoiceFormat::ArrayOfTools => Mode::Array,
+            ToolChoiceFormat::SingleObject { tool_name } => Mode::Single {
+                tool_name: tool_name.clone(),
+            },
+        };
+        Self::with_mode(mode)
+    }
+
+    fn with_mode(mode: Mode) -> Self {
+        Self {
+            mode,
+            scanned: 0,
+            depth: 0,
+            in_string: false,
+            escape: false,
+            literal_start: None,
+            key_depth: 1,
+            root_seen: false,
+            disabled: false,
+            slot: Slot::Key,
+            pending_key: None,
+            element: Element::default(),
+            index: 0,
+            streamed: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        let mode = self.mode.clone();
+        *self = Self::with_mode(mode);
+    }
+
+    pub(crate) fn streamed(&self) -> &BTreeMap<usize, StreamedCall> {
+        &self.streamed
+    }
+
+    /// Lex the bytes appended since the last advance and emit whatever became
+    /// safe to send.
+    ///
+    /// `payload` is the WHOLE accumulated payload, not just the new chunk: the
+    /// cursor slices it from its own `scanned` offset, so the caller never has to
+    /// track which bytes it already handed over. The buffer must only ever grow —
+    /// shrinking it would make every retained offset lie, so a shorter payload is
+    /// treated as "nothing new" and the caller is expected to [`Self::reset`].
+    pub(crate) fn advance(&mut self, payload: &str, out: &mut Vec<GuidedDelta>) {
+        if self.disabled || payload.len() <= self.scanned {
+            return;
+        }
+
+        let mut cut = self.scanned;
+        for (relative, ch) in payload[self.scanned..].char_indices() {
+            let at = self.scanned + relative;
+            cut = at + ch.len_utf8();
+            match self.mode {
+                Mode::Array => self.step_array(payload, at, cut, ch, out),
+                Mode::Single { .. } => self.step_single(at, ch),
+            }
+            if self.disabled {
+                break;
+            }
+        }
+        self.scanned = cut;
+        self.maybe_commit(out);
+        self.flush(payload, cut, out);
+    }
+
+    // ----- single-object mode -------------------------------------------------
+
+    /// One character of a bare argument object. Everything before the first `{`
+    /// is skipped: guided decoding can prefix whitespace, and only the object
+    /// itself is the arguments.
+    fn step_single(&mut self, at: usize, ch: char) {
+        if !self.root_seen {
+            if ch == '{' {
+                self.root_seen = true;
+                self.depth = 1;
+                self.element.args_start = Some(at);
+            } else if !ch.is_whitespace() {
+                // Only WHITESPACE may precede a bare argument object. Anything else
+                // means this payload is not one - the backend ignored the grammar and
+                // emitted its native markup. Scanning on for a later `{` would stream
+                // a brace from inside that markup as the arguments (MiniMax M2 emits
+                // `<parameter name="location">San Francisco {CA}</parameter>` under a
+                // named tool_choice). Disable instead and leave it to the jail's
+                // native fallback, which is why that fallback still exists.
+                self.disabled = true;
+            }
+            return;
+        }
+        if self.element.args_end.is_some() {
+            // The object closed; trailing bytes are not arguments.
+            return;
+        }
+        if self.in_string {
+            self.step_in_string_raw(ch);
+            return;
+        }
+        match ch {
+            '"' => self.in_string = true,
+            '{' | '[' => self.depth += 1,
+            '}' | ']' => {
+                self.depth -= 1;
+                if self.depth == 0 {
+                    self.element.args_end = Some(at + ch.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // ----- array mode ---------------------------------------------------------
+
+    /// One character of the array lex. `cut` is the offset just past `ch`, so a
+    /// flush triggered mid-advance still sees the bytes this character added.
+    fn step_array(
+        &mut self,
+        payload: &str,
+        at: usize,
+        cut: usize,
+        ch: char,
+        out: &mut Vec<GuidedDelta>,
+    ) {
+        if self.in_string {
+            self.step_in_string(payload, at, ch);
+            return;
+        }
+
+        match ch {
+            '"' => {
+                if !self.root_seen {
+                    // A guided `required` payload opens with `[` or `{`; a bare
+                    // string is not a call shape.
+                    self.disabled = true;
+                    return;
+                }
+                self.in_string = true;
+                // Capture only the literals that matter: keys at call-key depth,
+                // and the `name` value. Capturing every string would allocate
+                // once per argument value for nothing.
+                let wanted = self.depth == self.key_depth
+                    && match self.slot {
+                        Slot::Key => true,
+                        Slot::Value => self.pending_key.as_deref() == Some("name"),
+                        Slot::Colon => false,
+                    };
+                self.literal_start = wanted.then_some(at);
+            }
+            '{' | '[' => {
+                if !self.root_seen {
+                    self.root_seen = true;
+                    self.key_depth = if ch == '[' { 2 } else { 1 };
+                }
+                let opens_args = ch == '{'
+                    && self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && is_alias(self.pending_key.as_deref());
+                let opens_element = ch == '{' && self.depth == self.key_depth - 1;
+                let name_is_not_a_string = self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && self.pending_key.as_deref() == Some("name");
+                self.depth += 1;
+                if opens_args {
+                    if self.element.args_start.is_some() {
+                        self.element.blocked = true;
+                    } else {
+                        self.element.args_start = Some(at);
+                        self.element.in_args = true;
+                    }
+                } else if opens_element {
+                    self.slot = Slot::Key;
+                    self.pending_key = None;
+                } else if name_is_not_a_string {
+                    self.element.blocked = true;
+                }
+                self.maybe_commit(out);
+            }
+            '}' | ']' => {
+                let closes_args =
+                    ch == '}' && self.element.in_args && self.depth == self.key_depth + 1;
+                let closes_element = ch == '}' && self.depth == self.key_depth;
+                self.depth -= 1;
+                if closes_args {
+                    self.element.args_end = Some(at + 1);
+                    self.element.in_args = false;
+                    self.maybe_commit(out);
+                    self.flush(payload, cut, out);
+                } else if closes_element {
+                    // A `name` that closed AFTER its argument object only becomes
+                    // committable here, so commit before the final flush or the
+                    // element's bytes leave with it.
+                    self.maybe_commit(out);
+                    self.flush(payload, cut, out);
+                    self.finish_element();
+                }
+            }
+            ':' if self.depth == self.key_depth && self.slot == Slot::Colon => {
+                self.slot = Slot::Value;
+            }
+            ',' if self.depth == self.key_depth => {
+                self.slot = Slot::Key;
+                self.pending_key = None;
+            }
+            _ if ch.is_whitespace() => {}
+            _ => {
+                if !self.root_seen {
+                    self.disabled = true;
+                    return;
+                }
+                if self.depth == self.key_depth
+                    && self.slot == Slot::Value
+                    && (is_alias(self.pending_key.as_deref())
+                        || self.pending_key.as_deref() == Some("name"))
+                {
+                    // A bare literal (`null`, a number, `true`) bound to an
+                    // argument alias or to `name`: neither can become an object,
+                    // so this element stays off the wire.
+                    self.element.blocked = true;
+                }
+            }
+        }
+    }
+
+    /// One character inside a string literal the cursor may want to decode.
+    fn step_in_string(&mut self, payload: &str, at: usize, ch: char) {
+        if self.escape {
+            self.escape = false;
+            return;
+        }
+        match ch {
+            '\\' => self.escape = true,
+            '"' => {
+                self.in_string = false;
+                self.close_literal(payload, at);
+            }
+            _ => {}
+        }
+    }
+
+    /// One character inside a string literal whose content is irrelevant.
+    fn step_in_string_raw(&mut self, ch: char) {
+        if self.escape {
+            self.escape = false;
+            return;
+        }
+        match ch {
+            '\\' => self.escape = true,
+            '"' => self.in_string = false,
+            _ => {}
+        }
+    }
+
+    /// A captured literal closed: it is this element's key, or its name.
+    fn close_literal(&mut self, payload: &str, end: usize) {
+        let Some(start) = self.literal_start.take() else {
+            return;
+        };
+        // `serde_json` owns escape semantics, including `\uXXXX` and surrogate
+        // pairs. Hand-rolling that decode is how `_` became `u005f`.
+        let Ok(literal) = serde_json::from_str::<String>(&payload[start..=end]) else {
+            return;
+        };
+        match self.slot {
+            Slot::Key => {
+                if is_alias(Some(literal.as_str())) {
+                    if self.element.alias_seen {
+                        // Both spellings in one element: ambiguous.
+                        self.element.blocked = true;
+                    }
+                    self.element.alias_seen = true;
+                }
+                self.pending_key = Some(literal);
+                self.slot = Slot::Colon;
+            }
+            Slot::Value => {
+                if self.pending_key.as_deref() == Some("name") {
+                    self.element.name = Some(literal);
+                }
+            }
+            Slot::Colon => {}
+        }
+    }
+
+    // ----- emission -----------------------------------------------------------
+
+    /// Put the current call on the wire once its shape can no longer change.
+    ///
+    /// Both facts are required: the name is known, AND the argument value has
+    /// been seen to open with `{`. Committing on the name alone is what would let
+    /// `"arguments": null` reach the client as a call.
+    fn maybe_commit(&mut self, out: &mut Vec<GuidedDelta>) {
+        if self.element.committed || self.element.blocked || self.element.args_start.is_none() {
+            return;
+        }
+        let name = match &self.mode {
+            Mode::Single { tool_name } => tool_name.clone(),
+            Mode::Array => match &self.element.name {
+                Some(name) => name.clone(),
+                None => return,
+            },
+        };
+        self.element.committed = true;
+        self.streamed.insert(
+            self.index,
+            StreamedCall {
+                arguments: String::new(),
+            },
+        );
+        out.push(GuidedDelta {
+            tool_index: self.index,
+            name: Some(name),
+            arguments: String::new(),
+        });
+    }
+
+    /// Release argument bytes accumulated since the last fragment, RAW and
+    /// byte-exact — the client reassembles the source object, so re-encoding
+    /// here would change bytes the buffered path would have emitted verbatim.
+    fn flush(&mut self, payload: &str, cut: usize, out: &mut Vec<GuidedDelta>) {
+        if !self.element.committed || self.element.blocked {
+            return;
+        }
+        let Some(start) = self.element.args_start else {
+            return;
+        };
+        // Never past the argument object's own `}`: the bytes after it belong to
+        // the call envelope, not to the arguments.
+        let bound = self.element.args_end.unwrap_or(cut).min(cut);
+        let from = start + self.element.released;
+        if bound <= from {
+            return;
+        }
+        let fragment = payload[from..bound].to_string();
+        self.element.released = bound - start;
+        // `maybe_commit` is the only writer and inserts at this same index, so a miss
+        // is impossible today. Assert it in tests rather than panicking a live stream:
+        // a future commit site that breaks the invariant should cost one fragment, not
+        // the request.
+        let Some(record) = self.streamed.get_mut(&self.index) else {
+            debug_assert!(
+                false,
+                "a committed element must have a streamed-call record at index {}",
+                self.index
+            );
+            tracing::error!(
+                tool_index = self.index,
+                "guided streaming committed an element with no streamed-call record; \
+                 dropping the fragment"
+            );
+            return;
+        };
+        record.arguments.push_str(&fragment);
+        out.push(GuidedDelta {
+            tool_index: self.index,
+            name: None,
+            arguments: fragment,
+        });
+    }
+
+    /// The current call object closed; move to the next element.
+    fn finish_element(&mut self) {
+        // ALWAYS advance, including for an element that never committed: the
+        // index is the element's position in the array, and skipping one here
+        // would slide every later call onto the wrong index.
+        self.index += 1;
+        self.element = Element::default();
+        self.slot = Slot::Key;
+        self.pending_key = None;
+    }
+}
+
+fn is_alias(key: Option<&str>) -> bool {
+    key.is_some_and(|key| ARGUMENT_ALIASES.contains(&key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn array_cursor() -> GuidedStreamCursor {
+        GuidedStreamCursor::new(&ToolChoiceFormat::ArrayOfTools)
+    }
+
+    fn named_cursor(tool_name: &str) -> GuidedStreamCursor {
+        GuidedStreamCursor::new(&ToolChoiceFormat::SingleObject {
+            tool_name: tool_name.to_string(),
+        })
+    }
+
+    /// Drive a payload one character at a time.
+    fn stream(mut cursor: GuidedStreamCursor, payload: &str) -> Vec<GuidedDelta> {
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for ch in payload.chars() {
+            seen.push(ch);
+            cursor.advance(&seen, &mut out);
+        }
+        out
+    }
+
+    /// Feed the whole payload in one call.
+    fn whole(mut cursor: GuidedStreamCursor, payload: &str) -> Vec<GuidedDelta> {
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        out
+    }
+
+    /// Names carried, in emission order.
+    fn names(deltas: &[GuidedDelta]) -> Vec<(usize, String)> {
+        deltas
+            .iter()
+            .filter_map(|d| d.name.clone().map(|n| (d.tool_index, n)))
+            .collect()
+    }
+
+    /// Argument bytes reassembled per tool index, in first-seen order.
+    fn arguments(deltas: &[GuidedDelta]) -> Vec<(usize, String)> {
+        let mut joined: Vec<(usize, String)> = Vec::new();
+        for delta in deltas {
+            if delta.arguments.is_empty() {
+                continue;
+            }
+            match joined
+                .iter_mut()
+                .find(|(index, _)| *index == delta.tool_index)
+            {
+                Some((_, text)) => text.push_str(&delta.arguments),
+                None => joined.push((delta.tool_index, delta.arguments.clone())),
+            }
+        }
+        joined
+    }
+
+    // ----- required (array) mode ---------------------------------------------
+
+    #[test]
+    fn required_splits_the_name_from_its_arguments() {
+        let payload = r#"[{"name":"get_weather","arguments":{"city":"Paris","unit":"c"}}]"#;
+        let expected = r#"{"city":"Paris","unit":"c"}"#;
+        let deltas = stream(array_cursor(), payload);
+
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        // The name-carrying delta is the commit, and it carries no bytes.
+        let first = deltas.first().expect("a commit delta");
+        assert_eq!(first.name.as_deref(), Some("get_weather"));
+        assert!(first.arguments.is_empty());
+        assert_eq!(arguments(&deltas), vec![(0, expected.to_string())]);
+        // Byte-for-byte against the source slice, not against a re-encode.
+        let start = payload.find(expected).expect("the argument object");
+        assert_eq!(
+            arguments(&deltas)[0].1,
+            payload[start..start + expected.len()]
+        );
+    }
+
+    #[test]
+    fn required_accepts_the_parameters_spelling() {
+        let deltas = stream(
+            array_cursor(),
+            r#"[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#,
+        );
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Tokyo"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn two_calls_in_one_array_get_distinct_indices() {
+        let payload = r#"[{"name":"a","arguments":{"x":1}},{"name":"b","parameters":{"y":[1,2]}}]"#;
+        let deltas = stream(array_cursor(), payload);
+        assert_eq!(
+            names(&deltas),
+            vec![(0, "a".to_string()), (1, "b".to_string())]
+        );
+        assert_eq!(
+            arguments(&deltas),
+            vec![
+                (0, r#"{"x":1}"#.to_string()),
+                (1, r#"{"y":[1,2]}"#.to_string())
+            ]
+        );
+        // The whole-payload path must agree with the character-at-a-time path.
+        let at_once = whole(array_cursor(), payload);
+        assert_eq!(names(&at_once), names(&deltas));
+        assert_eq!(arguments(&at_once), arguments(&deltas));
+    }
+
+    #[test]
+    fn a_non_object_argument_value_is_never_committed() {
+        for payload in [
+            r#"[{"name":"f","arguments":"just a string"}]"#,
+            r#"[{"name":"f","arguments":null}]"#,
+            r#"[{"name":"f","arguments":7}]"#,
+            r#"[{"name":"f","arguments":[1,2]}]"#,
+            r#"[{"name":"f","parameters":null}]"#,
+            // No argument key at all: valid, but there is no object to open on.
+            r#"[{"name":"f"}]"#,
+        ] {
+            assert!(
+                stream(array_cursor(), payload).is_empty(),
+                "{payload} put a call on the wire that has no argument object"
+            );
+            assert!(whole(array_cursor(), payload).is_empty(), "{payload}");
+        }
+    }
+
+    #[test]
+    fn both_argument_aliases_in_one_element_do_not_commit() {
+        // Ambiguity visible before the commit point: nothing is ever emitted.
+        for payload in [
+            r#"[{"parameters":{"b":2},"arguments":{"a":1},"name":"f"}]"#,
+            r#"[{"name":"f","parameters":null,"arguments":{"a":1}}]"#,
+            r#"[{"name":"f","arguments":[1,2],"parameters":{"b":2}}]"#,
+        ] {
+            assert!(
+                stream(array_cursor(), payload).is_empty(),
+                "{payload} committed an ambiguous element"
+            );
+            assert!(whole(array_cursor(), payload).is_empty(), "{payload}");
+        }
+
+        // The orderings where the FIRST alias completes a name-plus-object pair
+        // before the second key exists: that call is already on the wire and a
+        // fragment cannot be unsaid. The cursor must then release NOTHING
+        // further — no byte of the second object, and never a second call.
+        for (payload, first_object) in [
+            (
+                r#"[{"name":"f","arguments":{"a":1},"parameters":{"b":2}}]"#,
+                r#"{"a":1}"#,
+            ),
+            (
+                r#"[{"parameters":{"b":2},"name":"f","arguments":{"a":1}}]"#,
+                r#"{"b":2}"#,
+            ),
+        ] {
+            let deltas = stream(array_cursor(), payload);
+            assert_eq!(names(&deltas), vec![(0, "f".to_string())], "{payload}");
+            assert_eq!(
+                arguments(&deltas),
+                vec![(0, first_object.to_string())],
+                "{payload} released bytes from the ambiguous second object"
+            );
+        }
+    }
+
+    #[test]
+    fn the_word_name_as_a_value_is_not_the_call_name() {
+        // Substring search matched this VALUE and then read the next string as
+        // the function name, emitting a call named `arguments`.
+        for payload in [
+            r#"[{"x":"name","parameters":{}}]"#,
+            r#"[{"x":"name","arguments":{"city":"Paris"}}]"#,
+            r#"[{"arguments":{"name":"not the call name"}}]"#,
+        ] {
+            let deltas = stream(array_cursor(), payload);
+            assert!(
+                deltas.is_empty(),
+                "{payload} invented a name: {deltas:?} — a nameless element must not stream"
+            );
+        }
+    }
+
+    #[test]
+    fn escapes_in_the_name_decode() {
+        // NOT a raw string literal: the payload carries the six characters
+        // `_`, which JSON decodes to `_`. A hand-rolled decoder produced
+        // `getu005fweather`.
+        let payload = "[{\"name\":\"get\\u005fweather\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\u005f"),
+            "the escape must reach the lexer"
+        );
+        assert_eq!(
+            names(&stream(array_cursor(), payload)),
+            vec![(0, "get_weather".to_string())]
+        );
+
+        // Escaped quotes and backslashes inside the name.
+        let payload = r#"[{"name":"a\"b\\c\nd","arguments":{}}]"#;
+        assert_eq!(
+            names(&stream(array_cursor(), payload)),
+            vec![(0, "a\"b\\c\nd".to_string())]
+        );
+
+        // A surrogate pair, as an encoder outside the BMP actually emits it.
+        let payload = "[{\"name\":\"a\\ud83d\\ude00b\",\"arguments\":{}}]";
+        assert!(
+            payload.contains("\\ud83d"),
+            "the escape must reach the lexer"
+        );
+        assert_eq!(
+            names(&stream(array_cursor(), payload)),
+            vec![(0, "a\u{1F600}b".to_string())]
+        );
+    }
+
+    #[test]
+    fn a_brace_inside_an_argument_string_does_not_close_the_object() {
+        let payload = r#"[{"name":"f","arguments":{"s":"}}]","t":"\""}}]"#;
+        let deltas = stream(array_cursor(), payload);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"s":"}}]","t":"\""}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn a_name_that_closes_after_its_arguments_still_commits() {
+        let payload = r#"[{"arguments":{"city":"Paris"},"name":"get_weather"}]"#;
+        let deltas = stream(array_cursor(), payload);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn a_payload_that_is_not_a_call_shape_emits_nothing() {
+        assert!(stream(array_cursor(), r#""just a string""#).is_empty());
+        assert!(stream(array_cursor(), "42").is_empty());
+    }
+
+    #[test]
+    fn reset_returns_the_cursor_to_a_fresh_stream() {
+        let mut cursor = array_cursor();
+        let mut out = Vec::new();
+        cursor.advance(r#"[{"name":"a","arguments":{"x":1}}]"#, &mut out);
+        assert_eq!(names(&out), vec![(0, "a".to_string())]);
+
+        cursor.reset();
+        let mut second = Vec::new();
+        cursor.advance(r#"[{"name":"b","arguments":{"y":2}}]"#, &mut second);
+        assert_eq!(names(&second), vec![(0, "b".to_string())]);
+        assert_eq!(arguments(&second), vec![(0, r#"{"y":2}"#.to_string())]);
+    }
+
+    // ----- named (single-object) mode ----------------------------------------
+
+    #[test]
+    fn named_carries_the_name_on_the_first_delta_only() {
+        let payload = r#"{"city":"Paris","unit":"c"}"#;
+        let deltas = stream(named_cursor("get_weather"), payload);
+
+        let first = deltas.first().expect("a commit delta");
+        assert_eq!(first.name.as_deref(), Some("get_weather"));
+        assert!(first.arguments.is_empty());
+        assert!(
+            deltas[1..].iter().all(|d| d.name.is_none()),
+            "the name rode more than the first delta: {deltas:?}"
+        );
+        assert_eq!(arguments(&deltas), vec![(0, payload.to_string())]);
+    }
+
+    #[test]
+    fn named_skips_whitespace_before_the_object() {
+        let payload = "  \n\t{\"city\":\"Paris\"}";
+        let deltas = stream(named_cursor("get_weather"), payload);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())]
+        );
+    }
+
+    #[test]
+    fn named_never_releases_past_the_closing_brace() {
+        // Trailing bytes after the object are not arguments.
+        let payload = "{\"a\":1}\n\ntrailing";
+        let deltas = stream(named_cursor("f"), payload);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"a":1}"#.to_string())]);
+    }
+
+    #[test]
+    fn named_handles_braces_inside_strings() {
+        let payload = r#"{"s":"}{ \" }","n":{"deep":[1,{"x":"}"}]}}"#;
+        let deltas = stream(named_cursor("f"), payload);
+        assert_eq!(arguments(&deltas), vec![(0, payload.to_string())]);
+    }
+
+    // ----- split-boundary sweeps (both modes) --------------------------------
+
+    /// Feed `payload` as `[..split]` then the whole thing, for EVERY valid UTF-8
+    /// split, and assert the reassembly and the fragment boundaries.
+    fn assert_every_split(build: impl Fn() -> GuidedStreamCursor, payload: &str, expected: &str) {
+        for split in 0..=payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let mut cursor = build();
+            let mut out = Vec::new();
+            cursor.advance(&payload[..split], &mut out);
+            cursor.advance(payload, &mut out);
+
+            let joined = arguments(&out);
+            assert_eq!(
+                joined,
+                vec![(0, expected.to_string())],
+                "reassembly differs at split {split}"
+            );
+
+            // No fragment may start or end mid-character.
+            let mut offset = 0usize;
+            for delta in out.iter().filter(|d| !d.arguments.is_empty()) {
+                assert!(
+                    expected.is_char_boundary(offset),
+                    "fragment starts mid-character at {offset} (split {split})"
+                );
+                offset += delta.arguments.len();
+                assert!(
+                    expected.is_char_boundary(offset),
+                    "fragment ends mid-character at {offset} (split {split})"
+                );
+            }
+            assert_eq!(offset, expected.len());
+        }
+    }
+
+    #[test]
+    fn required_survives_every_char_boundary_split() {
+        let payload = r#"[{"name":"f","arguments":{"city":"東京","emoji":"😀","q":"a\"b"}}]"#;
+        let expected = r#"{"city":"東京","emoji":"😀","q":"a\"b"}"#;
+        assert!(
+            payload.chars().any(|c| c.len_utf8() > 1),
+            "the sweep needs a multi-byte character"
+        );
+        assert_every_split(array_cursor, payload, expected);
+    }
+
+    #[test]
+    fn named_survives_every_char_boundary_split() {
+        let payload = r#"{"city":"東京","emoji":"😀","q":"a\"b"}"#;
+        assert!(payload.chars().any(|c| c.len_utf8() > 1));
+        assert_every_split(|| named_cursor("get_weather"), payload, payload);
+    }
+
+    // ----- long payloads (both modes) ----------------------------------------
+
+    /// A >2000-byte argument object with nesting, escaped quotes and a literal
+    /// `}` inside a string.
+    fn long_arguments() -> String {
+        let mut body = String::from(r#"{"note":"a \" quote and a } brace","items":["#);
+        for i in 0..120 {
+            if i > 0 {
+                body.push(',');
+            }
+            body.push_str(&format!(
+                r#"{{"k{i}":"v{i} }} \" x","nested":{{"deep":[{i},"文字"]}}}}"#
+            ));
+        }
+        body.push_str(r#"],"last":"x"}"#);
+        assert!(body.len() > 2000, "body was only {} bytes", body.len());
+        body
+    }
+
+    /// Feed a payload in `chunk`-character steps.
+    fn stream_chunks(
+        mut cursor: GuidedStreamCursor,
+        payload: &str,
+        chunk: usize,
+    ) -> Vec<GuidedDelta> {
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for (n, ch) in payload.chars().enumerate() {
+            seen.push(ch);
+            if (n + 1) % chunk == 0 {
+                cursor.advance(&seen, &mut out);
+            }
+        }
+        cursor.advance(payload, &mut out);
+        out
+    }
+
+    #[test]
+    fn required_streams_a_long_payload_in_many_fragments() {
+        let expected = long_arguments();
+        let payload = format!(r#"[{{"name":"f","arguments":{expected}}}]"#);
+        let deltas = stream_chunks(array_cursor(), &payload, 7);
+
+        assert_eq!(names(&deltas), vec![(0, "f".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, expected.clone())]);
+        let fragments = deltas.iter().filter(|d| !d.arguments.is_empty()).count();
+        assert!(
+            fragments > 100,
+            "arguments arrived in {fragments} fragment(s), not a stream"
+        );
+        // And the whole-payload path produces the same bytes in one go.
+        assert_eq!(
+            arguments(&whole(array_cursor(), &payload)),
+            vec![(0, expected)]
+        );
+    }
+
+    #[test]
+    fn named_native_markup_with_an_inner_brace_never_commits() {
+        // A brace inside native markup is not the start of an argument object.
+        let payload = "<minimax:tool_call><invoke name=\"get_weather\">\
+<parameter name=\"location\">San Francisco {CA}</parameter></invoke></minimax:tool_call>";
+        let mut cursor = GuidedStreamCursor::new(&ToolChoiceFormat::SingleObject {
+            tool_name: "get_weather".to_string(),
+        });
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        assert!(
+            out.is_empty(),
+            "native markup must not be streamed as arguments, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn named_streams_a_long_payload_in_many_fragments() {
+        let payload = long_arguments();
+        let deltas = stream_chunks(named_cursor("f"), &payload, 7);
+
+        assert_eq!(names(&deltas), vec![(0, "f".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, payload.clone())]);
+        let fragments = deltas.iter().filter(|d| !d.arguments.is_empty()).count();
+        assert!(
+            fragments > 100,
+            "arguments arrived in {fragments} fragment(s), not a stream"
+        );
+    }
+}

--- a/parsers/v1/src/tool_calling/jail/mod.rs
+++ b/parsers/v1/src/tool_calling/jail/mod.rs
@@ -18,6 +18,8 @@
 // at that point the jail-and-batch mechanism and this whole v1 crate are removed.
 
 pub mod annotated;
+mod guided_stream;
+use guided_stream::{GuidedDelta, GuidedStreamCursor};
 mod prefix_matcher;
 
 use async_stream::stream;
@@ -35,11 +37,13 @@ use dynamo_protocols::types::{
     FunctionCallStream, FunctionType, Role,
 };
 use futures::{Stream, StreamExt};
+use serde_json::value::RawValue;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::tool_calling::config::{JsonParserConfig, ParserConfig};
 use crate::tool_calling::gemma4::split_partial_call_prefix_gemma4;
+use crate::tool_calling::json::base_json_parser::parse_indexed_calls;
 use crate::tool_calling::json::{JsonParserType, try_tool_call_parse_basic_json};
 use crate::tool_calling::parsers::get_tool_parser_map;
 use crate::tool_calling::{
@@ -212,6 +216,10 @@ struct ChoiceJailState {
     /// Incremental lexical progress used to decide when parser validation is
     /// worthwhile. Parser acceptance is never cached here.
     completion_progress: JailCompletionProgress,
+    /// Guided-payload cursor, present only in `Immediate` mode. Under a guided
+    /// grammar the payload's shape is already known, so calls can be released as
+    /// they arrive instead of at the closing brace.
+    guided_cursor: Option<GuidedStreamCursor>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -445,7 +453,7 @@ fn stream_choice_chunk_from_template(
 
 impl ChoiceJailState {
     /// Create a new jail state for a choice
-    fn new(index: u32, starts_jailed: bool) -> Self {
+    fn new(index: u32, starts_jailed: bool, guided: Option<&ToolChoiceFormat>) -> Self {
         Self {
             index,
             is_jailed: starts_jailed,
@@ -456,6 +464,7 @@ impl ChoiceJailState {
             emitted_tool_calls_count: 0,
             pending_reasoning_content: None,
             completion_progress: JailCompletionProgress::default(),
+            guided_cursor: guided.map(GuidedStreamCursor::new),
         }
     }
 
@@ -525,6 +534,11 @@ impl ChoiceJailState {
         self.is_jailed = false;
         self.accumulated_logprobs = None;
         self.completion_progress.reset();
+        // The cursor's byte offsets describe THIS payload. Carrying them into a
+        // second jailed value would suppress its arguments as already streamed.
+        if let Some(cursor) = self.guided_cursor.as_mut() {
+            cursor.reset();
+        }
         std::mem::take(&mut self.accumulated_content)
     }
 
@@ -658,6 +672,147 @@ impl ChoiceJailState {
         }
     }
 
+    /// Release any guided calls the cursor can now commit to.
+    ///
+    /// No-op outside `Immediate` mode: a marker-based stream has no grammar
+    /// guaranteeing the payload's shape, so nothing can be committed early.
+    ///
+    /// The cursor records every byte it releases, so the completion path can emit
+    /// only the remainder. A fragment cannot be unsaid, so the cursor is the single
+    /// owner of what the client has already seen.
+    fn emit_guided_progress(
+        &mut self,
+        choice: &ChatChoiceStream,
+        emissions: &mut Vec<ChoiceEmission>,
+    ) {
+        let Some(cursor) = self.guided_cursor.as_mut() else {
+            return;
+        };
+        let mut deltas: Vec<GuidedDelta> = Vec::new();
+        cursor.advance(&self.accumulated_content, &mut deltas);
+        if deltas.is_empty() {
+            return;
+        }
+
+        let mut chunks: Vec<ChatCompletionMessageToolCallChunk> = Vec::new();
+        for delta in deltas {
+            let first = delta.name.is_some();
+            chunks.push(ChatCompletionMessageToolCallChunk {
+                index: (self.emitted_tool_calls_count + delta.tool_index) as u32,
+                id: first.then(|| format!("call-{}", uuid::Uuid::new_v4())),
+                r#type: first.then_some(FunctionType::Function),
+                function: Some(FunctionCallStream {
+                    name: delta.name,
+                    arguments: Some(delta.arguments),
+                }),
+            });
+        }
+
+        emissions.push(ChoiceEmission::ToolCall(create_choice_stream(
+            choice.index,
+            None,
+            "",
+            Some(chunks),
+            None,
+            None,
+        )));
+    }
+
+    /// Reconcile a rebuilt choice against what the cursor already streamed.
+    ///
+    /// Both completion paths - normal completion and EOF finalization - rebuild every
+    /// call in full, so both must subtract the streamed bytes and both must advance the
+    /// tool-index offset by the same rule. Keeping that in one place is why this is a
+    /// method: when the two paths each carried their own copy, they disagreed.
+    ///
+    /// The offset advances by the highest LOCAL index reached, not by how many calls
+    /// exist. The cursor advances its element index even for elements it refuses to
+    /// commit - one with no name, or with a non-object argument value - so the indices
+    /// on the wire can be sparse, and counting would leave the offset short enough for
+    /// the next payload to reuse an index this one already used.
+    fn reconcile_streamed_calls(&mut self, choice: &mut ChatChoiceStream) {
+        let rebuilt = choice.delta.tool_calls.as_ref().map_or(0, |calls| {
+            calls
+                .iter()
+                .map(|chunk| {
+                    (chunk.index as usize).saturating_sub(self.emitted_tool_calls_count) + 1
+                })
+                .max()
+                .unwrap_or(0)
+        });
+        let streamed = self
+            .guided_cursor
+            .as_ref()
+            .and_then(|cursor| cursor.streamed().keys().next_back())
+            .map_or(0, |index| index + 1);
+        self.subtract_streamed_calls(choice);
+        self.emitted_tool_calls_count += rebuilt.max(streamed);
+    }
+
+    /// Strip from a completed choice everything the cursor already put on the wire.
+    ///
+    /// The completion path rebuilds every call in full. For a call that was streamed,
+    /// the client already has its id, name and the streamed argument prefix, so
+    /// re-sending them would duplicate the arguments. Emit only the tail.
+    fn subtract_streamed_calls(&self, unjailed: &mut ChatChoiceStream) {
+        let Some(cursor) = self.guided_cursor.as_ref() else {
+            return;
+        };
+        if cursor.streamed().is_empty() {
+            return;
+        }
+
+        let had_rebuilt_calls = unjailed.delta.tool_calls.is_some();
+        if let Some(tool_calls) = unjailed.delta.tool_calls.as_mut() {
+            tool_calls.retain_mut(|chunk| {
+                let Some(local) = (chunk.index as usize).checked_sub(self.emitted_tool_calls_count)
+                else {
+                    return true;
+                };
+                let Some(streamed) = cursor.streamed().get(&local) else {
+                    return true;
+                };
+                let full = chunk
+                    .function
+                    .as_ref()
+                    .and_then(|f| f.arguments.as_deref())
+                    .unwrap_or("");
+                let Some(remainder) = full.strip_prefix(&streamed.arguments) else {
+                    tracing::warn!(
+                        streamed_len = streamed.arguments.len(),
+                        rebuilt_len = full.len(),
+                        tool_index = local,
+                        "guided streaming cursor disagrees with the rebuilt call; \
+                         suppressing the rebuild because emitted bytes cannot be retracted"
+                    );
+                    return false;
+                };
+                if remainder.is_empty() {
+                    return false;
+                }
+                chunk.id = None;
+                chunk.r#type = None;
+                chunk.function = Some(FunctionCallStream {
+                    name: None,
+                    arguments: Some(remainder.to_string()),
+                });
+                true
+            });
+            if tool_calls.is_empty() {
+                unjailed.delta.tool_calls = None;
+            }
+        }
+
+        if !had_rebuilt_calls {
+            // The cursor streamed, so the buffer is guided JSON by construction. What
+            // is left after the last released byte is call envelope - `},{"name":` on a
+            // truncated array, a bare `}` on a truncated single call - and the rebuild
+            // already failed to make calls of it. Emitting it as content leaks JSON
+            // punctuation into the assistant message, so emit nothing.
+            unjailed.delta.content = None;
+        }
+    }
+
     async fn emit_completed_jail(
         &mut self,
         completed: CompletedJail,
@@ -682,9 +837,12 @@ impl ChoiceJailState {
             )
             .await;
         unjailed_choice.logprobs = jail_logprobs;
+        // Count what this payload REBUILT, not what survives subtraction. A fully
+        // streamed call leaves no chunk behind, so counting survivors would leave the
+        // offset at zero and the next payload would reuse this payload's tool indices.
+        self.reconcile_streamed_calls(&mut unjailed_choice);
 
-        if let Some(ref tool_calls) = unjailed_choice.delta.tool_calls {
-            self.emitted_tool_calls_count += tool_calls.len();
+        if unjailed_choice.delta.tool_calls.is_some() {
             emissions.push(ChoiceEmission::ToolCall(unjailed_choice));
         } else {
             emissions.push(ChoiceEmission::Content(unjailed_choice));
@@ -835,6 +993,11 @@ impl ChoiceJailState {
             // Already jailed - accumulate content AND logprobs, then check for unjail
             self.accumulate(content, choice.logprobs.as_ref());
 
+            // Under a guided grammar the payload's shape is already fixed, so release
+            // whatever the cursor can commit to BEFORE the completion check. Holding a
+            // call until the closing brace is the latency defect this exists to fix.
+            self.emit_guided_progress(choice, &mut emissions);
+
             let completion = jail_stream
                 .check_jail_completion(&self.accumulated_content, &mut self.completion_progress)
                 .await;
@@ -843,7 +1006,7 @@ impl ChoiceJailState {
                 self.emit_completed_jail(completed, choice, jail_stream, &mut emissions)
                     .await;
             }
-            // If not unjailing, don't emit anything (still accumulating)
+            // If not unjailing, only the guided deltas above (if any) are emitted.
         }
         emissions
     }
@@ -874,6 +1037,10 @@ impl ChoiceJailState {
                 .await;
             // Attach the full accumulated logprobs to the final choice
             final_choice.logprobs = self.take_accumulated_logprobs();
+            // Same rule as normal completion: a truncated payload still rebuilds every
+            // call in full here, so anything the cursor already streamed must be
+            // subtracted or its arguments are delivered twice.
+            self.reconcile_streamed_calls(&mut final_choice);
 
             // Preserve any pending reasoning content collected while jailed.
             if let Some(pending_reasoning) = self.pending_reasoning_content.take() {
@@ -882,10 +1049,6 @@ impl ChoiceJailState {
                 } else {
                     final_choice.delta.reasoning_content = Some(pending_reasoning);
                 }
-            }
-
-            if let Some(ref tool_calls) = final_choice.delta.tool_calls {
-                self.emitted_tool_calls_count += tool_calls.len();
             }
 
             // End jailing
@@ -928,7 +1091,12 @@ impl ChoiceJailStateCollection {
     }
 
     /// Get or create state for a choice index
-    fn get_or_create_state(&mut self, index: u32, starts_jailed: bool) -> &mut ChoiceJailState {
+    fn get_or_create_state(
+        &mut self,
+        index: u32,
+        starts_jailed: bool,
+        guided: Option<&ToolChoiceFormat>,
+    ) -> &mut ChoiceJailState {
         // Find the position where this index should be
         match self.states.binary_search_by_key(&index, |s| s.index) {
             Ok(pos) => {
@@ -937,7 +1105,7 @@ impl ChoiceJailStateCollection {
             }
             Err(insert_pos) => {
                 // Need to create new state
-                let new_state = ChoiceJailState::new(index, starts_jailed);
+                let new_state = ChoiceJailState::new(index, starts_jailed, guided);
                 self.states.insert(insert_pos, new_state);
                 &mut self.states[insert_pos]
             }
@@ -970,6 +1138,12 @@ pub struct JailedStream {
     emission_mode: EmissionMode,
     marker_matcher: MarkerMatcher,
     jail_mode: JailMode,
+    /// Release guided calls as they arrive instead of at the closing brace.
+    ///
+    /// Off by default: turning it on changes the emission SHAPE for every consumer
+    /// of this jail (one terminal delta becomes many), so the serving layer opts in
+    /// per request rather than inheriting it. Mirrors `StreamBestEffort` in v2.
+    guided_streaming: bool,
 }
 
 impl JailedStream {
@@ -981,6 +1155,20 @@ impl JailedStream {
     /// Whether the jail starts already-jailed (tool_choice=required/named path).
     fn is_immediate(&self) -> bool {
         matches!(self.jail_mode, JailMode::Immediate { .. })
+    }
+
+    /// The guided payload shape, when generation was constrained to JSON.
+    ///
+    /// `Some` means the grammar already fixed the payload's shape, so a cursor can
+    /// release calls as they arrive instead of waiting for the closing brace.
+    fn guided_format(&self) -> Option<&ToolChoiceFormat> {
+        if !self.guided_streaming {
+            return None;
+        }
+        match &self.jail_mode {
+            JailMode::Immediate { format } => Some(format),
+            JailMode::MarkerBased => None,
+        }
     }
 
     /// Apply jail stream transformation with finish_reason fix
@@ -1057,7 +1245,11 @@ impl JailedStream {
 
                             if let Some(text) = text_content {
                                 let choice_state = choice_states
-                                    .get_or_create_state(choice.index, self.is_immediate());
+                                    .get_or_create_state(
+                                        choice.index,
+                                        self.is_immediate(),
+                                        self.guided_format(),
+                                    );
 
                                 if let Some(reasoning_content) = &choice.delta.reasoning_content {
                                     let pending = choice_state
@@ -1114,7 +1306,11 @@ impl JailedStream {
                             // of the stream — `get_or_create_state` ignores the argument on
                             // subsequent calls.
                             let choice_state = choice_states
-                                .get_or_create_state(choice.index, self.is_immediate());
+                                .get_or_create_state(
+                                    choice.index,
+                                    self.is_immediate(),
+                                    self.guided_format(),
+                                );
                             // Also track stream finish reason from content-less final chunks
                             // (e.g. finish_reason=Stop arriving in a chunk with content=None) so
                             // the Immediate-mode finalize path can emit the correct finish_reason.
@@ -1782,26 +1978,40 @@ impl JailedStream {
                 //     XML). In that case try_tool_call_parse_aggregate with
                 //     the configured tool_call_parser recovers the call.
                 let mut tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> = Vec::new();
+                let mut preserve_source_indices = false;
 
-                // 1. Primary: bare-JSON extraction — handles
+                // 1. Required-choice extraction preserves each array element's
+                //    SOURCE index so it stays in the cursor's sparse index space.
+                if self.guided_streaming
+                    && matches!(format, ToolChoiceFormat::ArrayOfTools)
+                    && let Ok(chunks) = self.parse_tool_choice_json(accumulated_content, format)
+                    && !chunks.is_empty()
+                {
+                    tool_call_chunks = chunks;
+                    preserve_source_indices = true;
+                }
+
+                // 2. Primary: bare-JSON extraction — handles
                 //    `[{name,parameters}, ...]`, `{name,parameters}`,
                 //    `{name,arguments}`, and arrays of either.
                 let basic_json_cfg = JsonParserConfig {
                     bare_json_mode: true,
                     ..Default::default()
                 };
-                // Per-path indices are placeholders — final indices are assigned
-                // below after the named filter so dropped entries don't leave
-                // gaps and multi-emission streams don't collide.
-                if let Ok((parsed, _)) = try_tool_call_parse_basic_json(
-                    accumulated_content,
-                    &basic_json_cfg,
-                    self.tool_definitions.as_deref(),
-                ) && !parsed.is_empty()
+                // This fallback has no malformed-entry gaps, so enumeration is its
+                // local index space. The required streaming path above retains source
+                // positions; both receive the cumulative payload offset below.
+                if tool_call_chunks.is_empty()
+                    && let Ok((parsed, _)) = try_tool_call_parse_basic_json(
+                        accumulated_content,
+                        &basic_json_cfg,
+                        self.tool_definitions.as_deref(),
+                    )
+                    && !parsed.is_empty()
                 {
-                    tool_call_chunks.extend(parsed.into_iter().map(|tc| {
+                    tool_call_chunks.extend(parsed.into_iter().enumerate().map(|(idx, tc)| {
                         ChatCompletionMessageToolCallChunk {
-                            index: 0,
+                            index: idx as u32,
                             id: Some(tc.id),
                             r#type: Some(FunctionType::Function),
                             function: Some(FunctionCallStream {
@@ -1812,7 +2022,7 @@ impl JailedStream {
                     }));
                 }
 
-                // 2. Named-only fallback: output is just the parameters object
+                // 3. Named-only fallback: output is just the parameters object
                 //    (tool_name is supplied by SingleObject format).
                 if tool_call_chunks.is_empty()
                     && let Ok(chunks) = self.parse_tool_choice_json(accumulated_content, format)
@@ -1820,7 +2030,7 @@ impl JailedStream {
                     tool_call_chunks = chunks;
                 }
 
-                // 3. Marker-based fallback for backends that did not enforce
+                // 4. Marker-based fallback for backends that did not enforce
                 //    guided decoding and emitted the model's native format.
                 if tool_call_chunks.is_empty()
                     && self.tool_call_parser.is_some()
@@ -1831,9 +2041,9 @@ impl JailedStream {
                     )
                     .await
                 {
-                    tool_call_chunks.extend(tool_calls.into_iter().map(|tc| {
+                    tool_call_chunks.extend(tool_calls.into_iter().enumerate().map(|(idx, tc)| {
                         ChatCompletionMessageToolCallChunk {
-                            index: 0,
+                            index: idx as u32,
                             id: Some(tc.id),
                             r#type: Some(FunctionType::Function),
                             function: Some(FunctionCallStream {
@@ -1864,11 +2074,18 @@ impl JailedStream {
                     }
                 }
 
-                // Assign final indices: renumber survivors 0..n (no gaps from
-                // the filter) then add the cumulative offset for consistency
-                // with the MarkerBased branch across multi-emission streams.
-                for (new_idx, chunk) in tool_call_chunks.iter_mut().enumerate() {
-                    chunk.index = (tool_call_offset + new_idx) as u32;
+                if preserve_source_indices {
+                    // The guided required cursor uses source array positions, including
+                    // gaps for malformed elements, so completion must keep that space.
+                    for chunk in &mut tool_call_chunks {
+                        chunk.index += tool_call_offset as u32;
+                    }
+                } else {
+                    // Fallback parsers have no streamed source indices to reconcile.
+                    // Compact after named filtering to keep the public index contract.
+                    for (index, chunk) in tool_call_chunks.iter_mut().enumerate() {
+                        chunk.index = (tool_call_offset + index) as u32;
+                    }
                 }
 
                 if !tool_call_chunks.is_empty() {
@@ -1934,27 +2151,32 @@ impl JailedStream {
         match format {
             ToolChoiceFormat::SingleObject { tool_name } => {
                 // For named tool choice: JSON is the parameters object
-                if parsed.is_object() {
+                if parsed.is_object()
+                    && let Ok(raw) = serde_json::from_str::<Box<RawValue>>(json_content)
+                {
                     Ok(vec![Self::create_tool_call_chunk(
                         0,
                         tool_name.clone(),
-                        json_content.to_string(),
+                        raw.get().to_string(),
                     )])
                 } else {
                     Ok(vec![])
                 }
             }
             ToolChoiceFormat::ArrayOfTools => {
-                // For required tool choice: JSON is array of {name, parameters}
-                if let Some(array) = parsed.as_array() {
-                    let chunks: Vec<ChatCompletionMessageToolCallChunk> = array
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(idx, entry)| {
-                            let name = entry.get("name")?.as_str()?.to_string();
-                            let parameters = entry.get("parameters")?;
-                            let args = serde_json::to_string(parameters).ok()?;
-                            Some(Self::create_tool_call_chunk(idx as u32, name, args))
+                // Keep source array positions and raw argument bytes. The cursor
+                // uses those same positions, including gaps for malformed entries.
+                if parsed.is_array()
+                    && let Some(calls) = parse_indexed_calls(json_content, false)?
+                {
+                    let chunks = calls
+                        .into_iter()
+                        .map(|(idx, call)| {
+                            Self::create_tool_call_chunk(
+                                idx as u32,
+                                call.function.name,
+                                call.function.arguments,
+                            )
                         })
                         .collect();
                     Ok(chunks)
@@ -2115,6 +2337,7 @@ pub struct JailedStreamBuilder {
     tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
     emission_mode: EmissionMode,
     jail_mode: JailMode,
+    guided_streaming: bool,
 }
 
 impl JailedStreamBuilder {
@@ -2124,6 +2347,7 @@ impl JailedStreamBuilder {
             jail_start_sequences: Vec::new(),
             jail_end_sequences: Vec::new(),
             has_custom_end_sequences: false,
+            guided_streaming: false,
             tool_call_parser: None,
             named_tool_name: None,
             tool_definitions: None,
@@ -2212,7 +2436,18 @@ impl JailedStreamBuilder {
         self
     }
 
-    /// Enable immediate jail mode for tool_choice=required
+    /// Release guided tool calls incrementally instead of buffering to the closing brace.
+    ///
+    /// Only meaningful with `tool_choice_required` / `tool_choice_named`, where guided
+    /// decoding already fixed the payload's shape. Off by default because it changes
+    /// the emission shape: a single terminal tool-call delta becomes a name delta
+    /// followed by argument fragments.
+    pub fn guided_streaming(mut self, enabled: bool) -> Self {
+        self.guided_streaming = enabled;
+        self
+    }
+
+    /// Enable immediate jail mode for tool_choice=required.
     pub fn tool_choice_required(mut self) -> Self {
         self.jail_mode = JailMode::Immediate {
             format: ToolChoiceFormat::ArrayOfTools,
@@ -2347,6 +2582,7 @@ impl JailedStreamBuilder {
             emission_mode: self.emission_mode,
             marker_matcher,
             jail_mode: self.jail_mode,
+            guided_streaming: self.guided_streaming,
         }
     }
 }
@@ -2374,9 +2610,56 @@ pub fn apply_tool_calling_jail<S>(
 where
     S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
 {
+    apply_tool_calling_jail_configured(
+        tool_call_parser,
+        tool_choice,
+        tool_definitions,
+        uses_tool_call_structural_tag,
+        false,
+        stream,
+    )
+}
+
+/// Like [`apply_tool_calling_jail`], but able to release guided tool calls as they
+/// arrive instead of buffering to the payload's closing brace.
+///
+/// Separate entry point so the existing signature keeps working for published
+/// consumers: incremental release changes the emission SHAPE (one terminal tool-call
+/// delta becomes a name delta followed by argument fragments), so a caller opts in.
+pub fn apply_tool_calling_jail_with_guided_streaming<S>(
+    tool_call_parser: Option<String>,
+    tool_choice: Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
+    tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
+    uses_tool_call_structural_tag: bool,
+    stream: S,
+) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    apply_tool_calling_jail_configured(
+        tool_call_parser,
+        tool_choice,
+        tool_definitions,
+        uses_tool_call_structural_tag,
+        true,
+        stream,
+    )
+}
+
+fn apply_tool_calling_jail_configured<S>(
+    tool_call_parser: Option<String>,
+    tool_choice: Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
+    tool_definitions: Option<Vec<crate::tool_calling::ToolDefinition>>,
+    uses_tool_call_structural_tag: bool,
+    guided_streaming: bool,
+    stream: S,
+) -> impl Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<CreateChatCompletionStreamResponse>> + Send + 'static,
+{
     use dynamo_protocols::types::ChatCompletionToolChoiceOption;
 
-    let mut builder = JailedStream::builder();
+    let mut builder = JailedStream::builder().guided_streaming(guided_streaming);
 
     let uses_native_forced_format = tool_call_parser
         .as_deref()

--- a/parsers/v1/src/tool_calling/json/base_json_parser.rs
+++ b/parsers/v1/src/tool_calling/json/base_json_parser.rs
@@ -290,6 +290,16 @@ fn parse_calls(
     payload: &str,
     allow_name_only: bool,
 ) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
+    Ok(parse_indexed_calls(payload, allow_name_only)?
+        .map(|calls| calls.into_iter().map(|(_, call)| call).collect::<Vec<_>>()))
+}
+
+/// Parse the same bare-JSON shapes as [`parse_calls`], retaining each call's
+/// source array position so incremental and buffered consumers share one index space.
+pub(crate) fn parse_indexed_calls(
+    payload: &str,
+    allow_name_only: bool,
+) -> anyhow::Result<Option<Vec<(usize, ToolCallResponse)>>> {
     fn make_tool_call(name: String, args: &RawValue) -> ToolCallResponse {
         ToolCallResponse {
             id: format!("call-{}", Uuid::new_v4()),
@@ -329,11 +339,11 @@ fn parse_calls(
 
     if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(payload) {
         let mut calls = Vec::new();
-        for item in array {
+        for (index, item) in array.into_iter().enumerate() {
             if let Ok(raw) = serde_json::from_str::<CalledFunctionRaw>(item.get())
                 && let Some(call) = convert_raw(raw, true, allow_name_only)?
             {
-                calls.push(call);
+                calls.push((index, call));
             }
             // Skip malformed entries silently.
         }
@@ -342,7 +352,7 @@ fn parse_calls(
     if let Ok(single) = serde_json::from_str::<CalledFunctionRaw>(payload)
         && let Some(call) = convert_raw(single, false, allow_name_only)?
     {
-        return Ok(Some(vec![call]));
+        return Ok(Some(vec![(0, call)]));
     }
     Ok(None)
 }
@@ -707,6 +717,26 @@ pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig)
     });
 
     has_partial_token || trimmed.contains('{') || trimmed.contains('[')
+}
+
+#[cfg(test)]
+mod indexed_call_tests {
+    use super::*;
+
+    #[test]
+    fn indexed_and_dense_views_share_one_parse() {
+        let payload = r#"[{"parameters":{"missing":"name"}},{"name":"b","parameters":{"x":1}}]"#;
+        let indexed = parse_indexed_calls(payload, false).unwrap().unwrap();
+        let dense = parse_calls(payload, false).unwrap().unwrap();
+
+        assert_eq!(indexed.len(), 1);
+        assert_eq!(indexed[0].0, 1);
+        assert_eq!(indexed[0].1.function.name, "b");
+        assert_eq!(indexed[0].1.function.arguments, r#"{"x":1}"#);
+        assert_eq!(dense.len(), 1);
+        assert_eq!(dense[0].function.name, indexed[0].1.function.name);
+        assert_eq!(dense[0].function.arguments, indexed[0].1.function.arguments);
+    }
 }
 
 #[cfg(test)]

--- a/parsers/v1/tests/jail.rs
+++ b/parsers/v1/tests/jail.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream, apply_tool_calling_jail};
+use dynamo_parsers::tool_calling::jail::{
+    Annotated, JailedStream, apply_tool_calling_jail, apply_tool_calling_jail_with_guided_streaming,
+};
 use dynamo_protocols::types::{
     ChatChoiceStream, ChatCompletionStreamResponseDelta, ChatCompletionToolChoiceOption,
     CompletionUsage, CreateChatCompletionStreamResponse, FinishReason, Role,
@@ -4564,6 +4566,61 @@ fahrenheit
             tool_call_count, 0,
             "named_tool_filter must drop tool calls whose name doesn't match the requested tool"
         );
+    }
+
+    #[tokio::test]
+    async fn test_tool_choice_named_filter_compacts_surviving_call_indices() {
+        let bare_json = r#"[{"name":"search","parameters":{"q":"foo"}},{"name":"get_weather","parameters":{"location":"Tokyo"}}]"#;
+
+        for guided_streaming in [false, true] {
+            let input_chunks = vec![
+                test_utils::create_mock_response_chunk(bare_json.to_string(), 0),
+                test_utils::create_final_response_chunk(0),
+            ];
+            let tool_choice = Some(ChatCompletionToolChoiceOption::Named(
+                "get_weather".to_string().into(),
+            ));
+            let results: Vec<_> = if guided_streaming {
+                apply_tool_calling_jail_with_guided_streaming(
+                    None,
+                    tool_choice,
+                    None,
+                    false,
+                    stream::iter(input_chunks),
+                )
+                .collect()
+                .await
+            } else {
+                apply_tool_calling_jail(None, tool_choice, None, false, stream::iter(input_chunks))
+                    .collect()
+                    .await
+            };
+
+            let tool_calls: Vec<_> = results
+                .iter()
+                .flat_map(|result| {
+                    result
+                        .data
+                        .as_ref()
+                        .into_iter()
+                        .flat_map(|data| data.choices.iter())
+                        .flat_map(|choice| choice.delta.tool_calls.iter().flatten())
+                })
+                .collect();
+
+            assert_eq!(tool_calls.len(), 1, "guided_streaming={guided_streaming}");
+            assert_eq!(
+                tool_calls[0].index, 0,
+                "the named filter left a gap when guided_streaming={guided_streaming}"
+            );
+            assert_eq!(
+                tool_calls[0]
+                    .function
+                    .as_ref()
+                    .and_then(|function| function.name.as_deref()),
+                Some("get_weather")
+            );
+        }
     }
 
     #[tokio::test]

--- a/parsers/v1/tests/jail_guided_stream.rs
+++ b/parsers/v1/tests/jail_guided_stream.rs
@@ -1,0 +1,544 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Guided tool-call payloads must reach the client AS THEY ARRIVE.
+//!
+//! Under `tool_choice=required` or a named tool, generation is constrained to a
+//! known JSON shape, so the jail does not have to buffer until the closing brace.
+//! These tests assert the delivery TIMELINE, not just the final value: a buffering
+//! path produces one terminal delta, a streaming path spreads them across chunks.
+
+use dynamo_parsers::tool_calling::jail::{Annotated, JailedStream};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, Role,
+};
+use futures::StreamExt;
+use futures::stream;
+
+fn chunk(content: &str) -> Annotated<CreateChatCompletionStreamResponse> {
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            role: Some(Role::Assistant),
+            content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        logprobs: None,
+    };
+    Annotated {
+        data: Some(CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices: vec![choice],
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        }),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+/// Split on char boundaries so a chunk never cuts a multi-byte character.
+fn split_every(payload: &str, n: usize) -> Vec<Annotated<CreateChatCompletionStreamResponse>> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at < payload.len() {
+        let mut end = (at + n).min(payload.len());
+        while !payload.is_char_boundary(end) {
+            end += 1;
+        }
+        out.push(chunk(&payload[at..end]));
+        at = end;
+    }
+    out
+}
+
+/// Tool-call delivery plus visible assistant content.
+async fn drive(
+    jail: JailedStream,
+    chunks: Vec<Annotated<CreateChatCompletionStreamResponse>>,
+) -> (usize, Vec<String>, String, String) {
+    let results: Vec<_> = jail
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await;
+    let mut carrying = 0usize;
+    let mut names = Vec::new();
+    let mut args = String::new();
+    let mut content = String::new();
+    for r in &results {
+        let Some(data) = r.data.as_ref() else {
+            continue;
+        };
+        let mut saw = false;
+        for choice in &data.choices {
+            if let Some(ChatCompletionMessageContent::Text(text)) = choice.delta.content.as_ref() {
+                content.push_str(text);
+            }
+            let Some(calls) = choice.delta.tool_calls.as_ref() else {
+                continue;
+            };
+            saw = true;
+            for call in calls {
+                if let Some(f) = call.function.as_ref() {
+                    if let Some(n) = f.name.as_ref() {
+                        names.push(n.clone());
+                    }
+                    if let Some(a) = f.arguments.as_ref() {
+                        args.push_str(a);
+                    }
+                }
+            }
+        }
+        if saw {
+            carrying += 1;
+        }
+    }
+    (carrying, names, args, content)
+}
+
+#[tokio::test]
+async fn required_streams_across_chunks_instead_of_one_burst() {
+    let payload = r#"[{"name":"search","parameters":{"query":"Rust","limit":10,"note":"a longer value so there are many fragments to release"}}]"#;
+    let (carrying, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_required()
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 7),
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["search".to_string()],
+        "name must ride exactly one delta"
+    );
+    assert_eq!(
+        args,
+        r#"{"query":"Rust","limit":10,"note":"a longer value so there are many fragments to release"}"#,
+        "arguments must reassemble byte for byte, exactly once"
+    );
+    assert!(
+        carrying > 3,
+        "arguments must arrive across many responses, got {carrying}"
+    );
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn named_streams_across_chunks_instead_of_one_burst() {
+    let payload = r#"{"query":"Rust","limit":10,"note":"a longer value so there are many fragments to release"}"#;
+    let (carrying, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_named("search".to_string())
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 7),
+    )
+    .await;
+
+    assert_eq!(names, vec!["search".to_string()]);
+    assert_eq!(
+        args, payload,
+        "arguments must reassemble byte for byte, exactly once"
+    );
+    assert!(
+        carrying > 3,
+        "arguments must arrive across many responses, got {carrying}"
+    );
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+/// The hazard: the completion path rebuilds every call in full, so a streamed call
+/// must be subtracted or the client receives its arguments twice.
+#[tokio::test]
+async fn streamed_arguments_are_never_emitted_twice() {
+    let payload = r#"[{"name":"search","parameters":{"query":"Rust"}}]"#;
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_required()
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 5),
+    )
+    .await;
+    assert_eq!(
+        names.len(),
+        1,
+        "the name must not be repeated, got {names:?}"
+    );
+    assert_eq!(
+        args, r#"{"query":"Rust"}"#,
+        "duplicated arguments: {args:?}"
+    );
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+/// EOF after a call was already committed.
+///
+/// `finalize` rebuilds calls independently of the normal completion path, so it runs
+/// the same subtraction. NOTE: this test currently passes with that subtraction
+/// removed - for Immediate mode the recovery parse yields no call for a truncated
+/// payload, so there is nothing to duplicate. The subtraction is kept so both exits
+/// share one reconciliation rule rather than relying on that. This test pins the
+/// INVARIANT (arguments appear once at EOF); it is not proof the subtraction bites.
+#[tokio::test]
+async fn truncated_after_commit_does_not_duplicate_streamed_arguments() {
+    // Committed (name closed, argument object opened) but never closed.
+    let payload = r#"[{"name":"search","parameters":{"query":"Rust"}}"#;
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_required()
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 6),
+    )
+    .await;
+
+    assert!(
+        names.len() <= 1,
+        "the name must not be repeated at EOF, got {names:?}"
+    );
+    assert!(
+        !args.contains(r#"{"query":"Rust{"query":"Rust"#),
+        "truncated payload duplicated its arguments: {args:?}"
+    );
+    assert_eq!(
+        args.matches(r#""query""#).count(),
+        1,
+        "argument bytes must appear exactly once, got {args:?}"
+    );
+    assert!(
+        !content.contains("query") && !content.contains("Rust"),
+        "streamed argument bytes also appeared as content: {content:?}"
+    );
+}
+
+/// Two guided payloads in one stream. The cursor's byte offsets and released-byte
+/// counts describe one payload; carrying them across would suppress the second call's
+/// arguments as "already streamed".
+#[tokio::test]
+async fn a_second_guided_payload_is_not_poisoned_by_the_first() {
+    let first = r#"[{"name":"search","parameters":{"query":"Rust"}}]"#;
+    let second = r#"[{"name":"search","parameters":{"query":"Zig"}}]"#;
+    let mut chunks = split_every(first, 6);
+    chunks.extend(split_every(second, 6));
+
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_required()
+            .guided_streaming(true)
+            .build(),
+        chunks,
+    )
+    .await;
+
+    assert!(
+        args.contains(r#""Rust""#),
+        "first payload's arguments missing: {args:?}"
+    );
+    assert!(
+        args.contains(r#""Zig""#),
+        "second payload's arguments were suppressed by the first payload's ledger: {args:?}"
+    );
+    assert_eq!(
+        names.len(),
+        2,
+        "expected one name per payload, got {names:?}"
+    );
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn named_leading_whitespace_does_not_shift_the_rebuilt_tail() {
+    let payload = "  \n\t{\"query\":\"Rust\",\"limit\":10}";
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_named("search".to_string())
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 5),
+    )
+    .await;
+
+    assert_eq!(names, vec!["search".to_string()]);
+    assert_eq!(args, r#"{"query":"Rust","limit":10}"#);
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn truncated_named_arguments_do_not_reappear_as_content() {
+    let payload = "  {\"query\":\"Par";
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_named("search".to_string())
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 4),
+    )
+    .await;
+
+    assert_eq!(names, vec!["search".to_string()]);
+    assert_eq!(args, r#"{"query":"Par"#);
+    assert!(
+        content.is_empty(),
+        "streamed argument bytes also appeared as content: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn disagreement_never_reemits_a_streamed_call() {
+    let payload = r#"[{"name":"search","parameters":{"q":1},"arguments":{"different":true}}]"#;
+    let (_, names, args, content) = drive(
+        JailedStream::builder()
+            .tool_choice_required()
+            .guided_streaming(true)
+            .build(),
+        split_every(payload, 6),
+    )
+    .await;
+
+    assert_eq!(names, vec!["search".to_string()]);
+    assert_eq!(args, r#"{"q":1}"#, "the rebuilt call was emitted again");
+    assert!(
+        content.is_empty(),
+        "guided JSON leaked as text: {content:?}"
+    );
+}
+
+#[tokio::test]
+async fn reconciliation_is_invariant_at_every_split() {
+    let cases = [
+        (
+            false,
+            r#"[{"parameters":{"q":1}},{"name":"b","parameters":{"x":1}}]"#,
+            "b",
+            r#"{"x":1}"#,
+        ),
+        (
+            false,
+            r#"[{"name":"search","parameters":{"q":1},"arguments":{"different":true}}]"#,
+            "search",
+            r#"{"q":1}"#,
+        ),
+        (
+            true,
+            "  \n\t{\"query\":\"Rust\",\"limit\":10}",
+            "search",
+            r#"{"query":"Rust","limit":10}"#,
+        ),
+        (true, "  {\"query\":\"Par", "search", r#"{"query":"Par"#),
+    ];
+
+    for (named, payload, expected_name, expected_arguments) in cases {
+        for split in 0..=payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let chunks = if split == 0 || split == payload.len() {
+                vec![chunk(payload)]
+            } else {
+                vec![chunk(&payload[..split]), chunk(&payload[split..])]
+            };
+            let builder = JailedStream::builder().guided_streaming(true);
+            let jail = if named {
+                builder.tool_choice_named("search".to_string()).build()
+            } else {
+                builder.tool_choice_required().build()
+            };
+            let (_, names, arguments, content) = drive(jail, chunks).await;
+            assert_eq!(
+                names,
+                vec![expected_name.to_string()],
+                "name differed at split {split} of {payload:?}"
+            );
+            assert_eq!(
+                arguments, expected_arguments,
+                "arguments differed at split {split} of {payload:?}"
+            );
+            assert!(
+                !content.contains("query")
+                    && !content.contains("Rust")
+                    && !content.contains("different"),
+                "streamed bytes leaked as text at split {split} of {payload:?}: {content:?}"
+            );
+        }
+    }
+}
+
+/// Two guided payloads must not reuse tool-call indices.
+///
+/// `emit_completed_jail` advances `emitted_tool_calls_count` from the chunks that
+/// SURVIVE subtraction. A fully streamed call leaves none, so without counting the
+/// rebuilt calls the offset never moves and the second payload restarts at index 0 —
+/// the client sees two different calls sharing one index.
+#[tokio::test]
+async fn a_second_guided_payload_gets_a_distinct_tool_index() {
+    let first = r#"[{"name":"search","parameters":{"query":"Rust"}}]"#;
+    let second = r#"[{"name":"search","parameters":{"query":"Zig"}}]"#;
+    let mut chunks = split_every(first, 6);
+    chunks.extend(split_every(second, 6));
+
+    let results: Vec<_> = JailedStream::builder()
+        .tool_choice_required()
+        .guided_streaming(true)
+        .build()
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await;
+
+    // Map each emitted argument fragment to the tool index it arrived on.
+    let mut by_index: std::collections::BTreeMap<u32, String> = Default::default();
+    for r in &results {
+        let Some(data) = r.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.choices {
+            let Some(calls) = choice.delta.tool_calls.as_ref() else {
+                continue;
+            };
+            for call in calls {
+                if let Some(f) = call.function.as_ref()
+                    && let Some(a) = f.arguments.as_ref()
+                {
+                    by_index.entry(call.index).or_default().push_str(a);
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        by_index.len(),
+        2,
+        "two payloads must occupy two tool indices, got {by_index:?}"
+    );
+    assert!(
+        by_index.values().any(|v| v.contains("Rust")),
+        "first payload missing: {by_index:?}"
+    );
+    assert!(
+        by_index.values().any(|v| v.contains("Zig")),
+        "second payload missing: {by_index:?}"
+    );
+}
+
+/// Sparse indices: the cursor advances its element index even for elements it
+/// refuses to commit, so a payload whose FIRST element is uncommittable streams its
+/// second element at index 1 while only ONE call is on the wire. Advancing the offset
+/// by the COUNT would move it to 1 and the next payload would reuse index 1.
+#[tokio::test]
+async fn a_skipped_element_still_advances_the_index_offset() {
+    // Element 0 has no `name`, so the cursor never commits it - but it still advances
+    // its element index, so `b` streams at tool index 1 while only ONE call is on the
+    // wire and completion rebuilds only one. Advancing the offset by the COUNT leaves
+    // it at 1 and the next payload reuses index 1.
+    let first = r#"[{"parameters":{"q":1}},{"name":"b","parameters":{"x":1}}]"#;
+    let second = r#"[{"name":"c","parameters":{"y":2}}]"#;
+    let mut chunks = split_every(first, 7);
+    chunks.extend(split_every(second, 7));
+
+    let results: Vec<_> = JailedStream::builder()
+        .tool_choice_required()
+        .guided_streaming(true)
+        .build()
+        .apply_with_finish_reason(stream::iter(chunks))
+        .collect()
+        .await;
+
+    let mut by_index: std::collections::BTreeMap<u32, String> = Default::default();
+    for r in &results {
+        let Some(data) = r.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.choices {
+            let Some(calls) = choice.delta.tool_calls.as_ref() else {
+                continue;
+            };
+            for call in calls {
+                if let Some(f) = call.function.as_ref()
+                    && let Some(a) = f.arguments.as_ref()
+                {
+                    by_index.entry(call.index).or_default().push_str(a);
+                }
+            }
+        }
+    }
+
+    let merged: Vec<_> = by_index
+        .iter()
+        .filter(|(_, v)| v.contains("\"x\"") && v.contains("\"y\""))
+        .collect();
+    assert!(
+        merged.is_empty(),
+        "a skipped element left the offset short and two payloads shared an index: {by_index:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_sparse_streamed_call_is_not_rebuilt_on_a_dense_index() {
+    let payload = r#"[{"parameters":{"q":1}},{"name":"b","parameters":{"x":1}}]"#;
+    let results: Vec<_> = JailedStream::builder()
+        .tool_choice_required()
+        .guided_streaming(true)
+        .build()
+        .apply_with_finish_reason(stream::iter(split_every(payload, 7)))
+        .collect()
+        .await;
+
+    let mut by_index: std::collections::BTreeMap<u32, String> = Default::default();
+    let mut names = Vec::new();
+    for result in &results {
+        let Some(data) = result.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.choices {
+            let Some(calls) = choice.delta.tool_calls.as_ref() else {
+                continue;
+            };
+            for call in calls {
+                if let Some(function) = call.function.as_ref() {
+                    if let Some(name) = function.name.as_ref() {
+                        names.push((call.index, name.clone()));
+                    }
+                    if let Some(arguments) = function.arguments.as_ref() {
+                        by_index.entry(call.index).or_default().push_str(arguments);
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(names, vec![(1, "b".to_string())]);
+    assert_eq!(
+        by_index,
+        std::collections::BTreeMap::from([(1, r#"{"x":1}"#.to_string())]),
+        "the completion parser rebuilt the streamed call on another index"
+    );
+}

--- a/parsers/v2/src/lib.rs
+++ b/parsers/v2/src/lib.rs
@@ -27,10 +27,11 @@ pub use tool_calling::{CalledFunctionStream, ToolCallResponseChunk, ToolCallType
 // One state machine per stream owning reasoning + content + tool calls, emitting
 // ONE ordered event stream (see `unified`).
 pub use unified::{
-    InvalidGuidedPayload, InvalidGuidedPayloadKind, InvalidGuidedPayloadPolicy,
-    REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser, UnifiedParserEvent, UnifiedParserExt,
-    UnifiedParserFactory, UnifiedParserInit, UnifiedParserOutput, UnifiedParserStartingState,
-    UnifiedToolOutputMode, assemble, builtin_unified_families, canonical_unified_family,
-    create_unified_parser_for_family, register_unified_parser, tool_arguments_raw,
-    unregister_unified_parser, vendor_unified_families,
+    CommittedCall, GuidedJsonCursor, InvalidGuidedPayload, InvalidGuidedPayloadKind,
+    InvalidGuidedPayloadPolicy, REGISTERED_UNIFIED_FAMILIES, UnifiedEvent, UnifiedParser,
+    UnifiedParserEvent, UnifiedParserExt, UnifiedParserFactory, UnifiedParserInit,
+    UnifiedParserOutput, UnifiedParserStartingState, UnifiedToolOutputMode, assemble,
+    builtin_unified_families, canonical_unified_family, create_unified_parser_for_family,
+    register_unified_parser, tool_arguments_raw, unregister_unified_parser,
+    vendor_unified_families,
 };

--- a/parsers/v2/src/unified/guided_cursor.rs
+++ b/parsers/v2/src/unified/guided_cursor.rs
@@ -31,6 +31,27 @@
 //! argument value to open with `{` is what makes that safe — a `null`, a string,
 //! a number or an array never reaches the commit point, so the shapes the
 //! contract voids are never put on the wire in the first place.
+//!
+//! # The two payload shapes
+//!
+//! `tool_choice` decides what the backend is constrained to emit, so it decides
+//! what the cursor is lexing:
+//!
+//! - **required** ([`GuidedJsonCursor::new`]) — an array (or a bare object) of
+//!   `{"name": …, "arguments": …}` envelopes. The name has to be *found*, and the
+//!   commit point is the `{` that opens that envelope's argument object.
+//! - **named** ([`GuidedJsonCursor::named`]) — the chosen tool's BARE argument
+//!   object, with no envelope at all. The name is not in the payload: the request
+//!   fixed it before the first byte arrived. So the commit point is the payload's
+//!   own opening `{`, and the whole payload from that brace to its matching `}`
+//!   is the argument set.
+//!
+//! Both modes keep the same rule about what may go on the wire — the first
+//! non-whitespace byte of the argument set must be `{`. A named payload that opens
+//! as a string, a number, `null` or an array is not an argument set, cannot be
+//! bound to the tool, and stays on the buffered path that already surfaces it as
+//! text. Committing it early would be the same unwithdrawable mistake the required
+//! mode refuses to make.
 
 use crate::tool_calling::traits::ToolCallDelta;
 
@@ -41,6 +62,22 @@ use crate::tool_calling::traits::ToolCallDelta;
 /// the same reason — recognising only `arguments` silently streamed nothing for a
 /// `parameters` call, and the assembled result arrived with empty arguments.
 const ARGUMENT_ALIASES: [&str; 2] = ["arguments", "parameters"];
+
+/// Which payload shape the cursor is lexing.
+///
+/// A mode rather than an `Option<String>` threaded through every method: the two
+/// shapes disagree about where the name comes from and where the argument object
+/// starts, and those two facts are the whole difference. Keeping them in one field
+/// means `reset` restores the mode too — a cursor that forgot it was named would
+/// silently lex the next request's arguments as a required envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mode {
+    /// `tool_choice=required`: envelopes carrying their own `name`.
+    Required,
+    /// `tool_choice={"type":"function","function":{"name":…}}`: bare arguments for
+    /// the tool the request already named.
+    Named { name: String },
+}
 
 /// Where the scanner sits inside a call object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,7 +96,7 @@ enum Slot {
 /// `parse_required_guided_calls` will later hand back as that call's arguments — so
 /// the completion path can emit exactly the remainder without re-deriving spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CommittedCall {
+pub struct CommittedCall {
     pub index: usize,
     pub name: String,
     pub released: usize,
@@ -95,7 +132,9 @@ struct Element {
 
 /// Forward-only lexer over one guided payload.
 #[derive(Debug)]
-pub(crate) struct GuidedJsonCursor {
+pub struct GuidedJsonCursor {
+    /// Which payload shape is being lexed; fixed at construction by `tool_choice`.
+    mode: Mode,
     /// Bytes already lexed. The scan never revisits them.
     scanned: usize,
     depth: i32,
@@ -129,8 +168,34 @@ impl Default for GuidedJsonCursor {
 }
 
 impl GuidedJsonCursor {
-    pub(crate) fn new() -> Self {
+    /// A cursor for a `required` payload: envelopes that carry their own names.
+    pub fn new() -> Self {
+        Self::in_mode(Mode::Required)
+    }
+
+    /// A cursor for a NAMED choice: the payload is `tool_name`'s bare argument
+    /// object, and the name rides the first delta because the request already
+    /// fixed it.
+    pub fn named(tool_name: impl Into<String>) -> Self {
+        Self::in_mode(Mode::Named {
+            name: tool_name.into(),
+        })
+    }
+
+    fn in_mode(mode: Mode) -> Self {
+        // The named mode's name is known NOW, before any byte arrives, so it is
+        // seeded here rather than discovered by the lexer. Everything downstream —
+        // `maybe_commit`, `CommittedCall`, `flush` — then works on both shapes
+        // unchanged, which is why there is one commit rule and not two.
+        let element = Element {
+            name: match &mode {
+                Mode::Required => None,
+                Mode::Named { name } => Some(name.clone()),
+            },
+            ..Element::default()
+        };
         Self {
+            mode,
             scanned: 0,
             depth: 0,
             in_string: false,
@@ -141,29 +206,33 @@ impl GuidedJsonCursor {
             disabled: false,
             slot: Slot::Key,
             pending_key: None,
-            element: Element::default(),
+            element,
             index: 0,
             committed: Vec::new(),
             released_end: 0,
         }
     }
 
-    pub(crate) fn reset(&mut self) {
-        *self = Self::new();
+    /// Back to the start of a payload — in the SAME mode. `tool_choice` belongs to
+    /// the request, not to the payload, so a reset between chunks (or between
+    /// requests, where the caller re-initialises) must not turn a named cursor into
+    /// a required one.
+    pub fn reset(&mut self) {
+        *self = Self::in_mode(self.mode.clone());
     }
 
     /// Calls already on the wire, in emission order.
-    pub(crate) fn committed(&self) -> &[CommittedCall] {
+    pub fn committed(&self) -> &[CommittedCall] {
         &self.committed
     }
 
-    pub(crate) fn has_committed(&self) -> bool {
+    pub fn has_committed(&self) -> bool {
         !self.committed.is_empty()
     }
 
     /// Absolute end of the bytes already released as call fragments, in the
     /// coordinates of the payload passed to [`Self::advance`].
-    pub(crate) fn released_end(&self) -> usize {
+    pub fn released_end(&self) -> usize {
         self.released_end
     }
 
@@ -173,7 +242,7 @@ impl GuidedJsonCursor {
     /// `payload` is the WHOLE accumulated payload, not just the new chunk — the
     /// cursor slices it from `scanned`, so the caller does not have to track which
     /// bytes it has already handed over.
-    pub(crate) fn advance(&mut self, payload: &str, out: &mut Vec<ToolCallDelta>) {
+    pub fn advance(&mut self, payload: &str, out: &mut Vec<ToolCallDelta>) {
         if self.disabled || payload.len() <= self.scanned {
             // Truncation (a reset mid-stream) would make the retained offsets lie.
             // The caller resets the cursor with the payload; nothing to do here.
@@ -204,6 +273,10 @@ impl GuidedJsonCursor {
         ch: char,
         out: &mut Vec<ToolCallDelta>,
     ) {
+        if let Mode::Named { .. } = self.mode {
+            self.step_named(payload, at, cut, ch, out);
+            return;
+        }
         if self.in_string {
             self.step_in_string(payload, at, ch);
             return;
@@ -302,6 +375,75 @@ impl GuidedJsonCursor {
                     }
                 }
             }
+        }
+    }
+
+    /// One character of the lex for a NAMED choice.
+    ///
+    /// There is no envelope to walk: the payload IS the argument object, so this
+    /// only has to find its opening `{`, track brace depth through strings, and
+    /// stop at the matching `}`. It shares `Element`, `maybe_commit` and `flush`
+    /// with the required mode so the commit rule and the released-byte accounting
+    /// have exactly one implementation.
+    fn step_named(
+        &mut self,
+        payload: &str,
+        at: usize,
+        cut: usize,
+        ch: char,
+        out: &mut Vec<ToolCallDelta>,
+    ) {
+        if self.in_string {
+            // `literal_start` is never set in this mode, so `close_literal` is a
+            // no-op: the only reason to track strings here is that a brace or a
+            // quote inside one must not move the depth.
+            self.step_in_string(payload, at, ch);
+            return;
+        }
+
+        if self.element.args_start.is_none() {
+            // Before the object opener. Whitespace is structural; anything that is
+            // not `{` means the payload is not an argument set at all, and the
+            // buffered path owns it.
+            if ch.is_whitespace() {
+                return;
+            }
+            if ch != '{' {
+                self.disabled = true;
+                return;
+            }
+            self.element.args_start = Some(at);
+            self.element.in_args = true;
+            self.depth = 1;
+            self.root_seen = true;
+            // The name is already known, so the commit lands on this brace — the
+            // earliest instant the payload is provably an argument set.
+            self.maybe_commit(out);
+            return;
+        }
+
+        if self.element.args_end.is_some() {
+            // Past the object's `}`. Trailing bytes belong to the buffer's tail
+            // handling, never to the arguments.
+            return;
+        }
+
+        match ch {
+            '"' => self.in_string = true,
+            '{' | '[' => self.depth += 1,
+            '}' | ']' => {
+                // Depth back to zero ends the argument set. A MISMATCHED closer
+                // ends it here too: the payload is malformed, the buffered path
+                // will say so, and the alternative is releasing every byte after
+                // it as arguments because the real close never arrives.
+                self.depth -= 1;
+                if self.depth == 0 {
+                    self.element.args_end = Some(at + ch.len_utf8());
+                    self.element.in_args = false;
+                    self.flush(payload, cut, out);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -437,6 +579,18 @@ mod tests {
     /// Drive a payload one character at a time and collect every delta.
     fn stream(payload: &str) -> Vec<ToolCallDelta> {
         let mut cursor = GuidedJsonCursor::new();
+        let mut out = Vec::new();
+        let mut seen = String::new();
+        for ch in payload.chars() {
+            seen.push(ch);
+            cursor.advance(&seen, &mut out);
+        }
+        out
+    }
+
+    /// Drive a NAMED payload one character at a time and collect every delta.
+    fn stream_named(tool: &str, payload: &str) -> Vec<ToolCallDelta> {
+        let mut cursor = GuidedJsonCursor::named(tool);
         let mut out = Vec::new();
         let mut seen = String::new();
         for ch in payload.chars() {
@@ -720,5 +874,168 @@ mod tests {
         assert_eq!(committed[0].index, 0);
         assert_eq!(committed[0].name, "f");
         assert_eq!(committed[0].released, r#"{"x":1}"#.len());
+    }
+
+    // ---- named choice: the payload is the tool's BARE argument object ----
+
+    #[test]
+    fn a_named_payload_streams_its_bare_arguments() {
+        let payload = r#"{"city":"Paris","unit":"c"}"#;
+        let deltas = stream_named("get_weather", payload);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, payload.to_string())]);
+        let frames = deltas.iter().filter(|d| !d.arguments.is_empty()).count();
+        assert!(frames > 1, "arguments arrived in {frames} frame(s)");
+    }
+
+    #[test]
+    fn a_named_name_rides_only_the_first_delta() {
+        let deltas = stream_named("get_weather", r#"{"city":"Paris"}"#);
+        let carrying: Vec<usize> = deltas
+            .iter()
+            .enumerate()
+            .filter(|(_, d)| d.name.is_some())
+            .map(|(at, _)| at)
+            .collect();
+        assert_eq!(carrying, vec![0], "the name must ride exactly one delta");
+        assert!(
+            deltas[0].arguments.is_empty(),
+            "the commit frame carries the name, not bytes: {:?}",
+            deltas[0]
+        );
+    }
+
+    #[test]
+    fn a_named_payload_that_is_not_an_object_never_commits() {
+        for payload in [
+            r#""just a string""#,
+            "42",
+            "null",
+            "[1,2]",
+            "true",
+            r#"  "leading whitespace then a string""#,
+        ] {
+            let deltas = stream_named("get_weather", payload);
+            assert!(
+                deltas.is_empty(),
+                "{payload} committed a shape that is not an argument set: {deltas:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_named_payload_skips_whitespace_before_its_opener() {
+        let deltas = stream_named("get_weather", "  \n\t{\"city\":\"Paris\"}");
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())],
+            "leading whitespace is structural, not an argument byte"
+        );
+    }
+
+    #[test]
+    fn a_named_brace_inside_a_string_does_not_close_the_object() {
+        let deltas = stream_named("f", r#"{"s":"}{[]"}"#);
+        assert_eq!(arguments(&deltas), vec![(0, r#"{"s":"}{[]"}"#.to_string())]);
+    }
+
+    #[test]
+    fn a_named_payload_never_releases_past_its_closing_brace() {
+        // Bytes after the object belong to the buffer's tail handling. Releasing
+        // them would put non-argument bytes into the tool's argument set.
+        let payload = r#"{"city":"Paris"} trailing"#;
+        let deltas = stream_named("get_weather", payload);
+        assert_eq!(
+            arguments(&deltas),
+            vec![(0, r#"{"city":"Paris"}"#.to_string())]
+        );
+        let mut cursor = GuidedJsonCursor::named("get_weather");
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        assert_eq!(cursor.released_end(), r#"{"city":"Paris"}"#.len());
+    }
+
+    #[test]
+    fn named_committed_records_track_released_bytes() {
+        let payload = r#"{"x":1}"#;
+        let mut cursor = GuidedJsonCursor::named("f");
+        let mut out = Vec::new();
+        cursor.advance(payload, &mut out);
+        let committed = cursor.committed();
+        assert_eq!(committed.len(), 1, "a named choice is exactly one call");
+        assert_eq!(committed[0].index, 0);
+        assert_eq!(committed[0].name, "f");
+        assert_eq!(committed[0].released, payload.len());
+        assert!(!committed[0].ambiguous);
+    }
+
+    #[test]
+    fn a_named_reset_stays_named() {
+        // `tool_choice` belongs to the request. A reset that forgot the mode would
+        // lex the next payload as a required envelope and stream nothing.
+        let mut cursor = GuidedJsonCursor::named("f");
+        let mut out = Vec::new();
+        cursor.advance(r#"{"x":1}"#, &mut out);
+        cursor.reset();
+        out.clear();
+        cursor.advance(r#"{"y":2}"#, &mut out);
+        assert_eq!(names(&out), vec![(0, "f".to_string())]);
+        assert_eq!(arguments(&out), vec![(0, r#"{"y":2}"#.to_string())]);
+    }
+
+    #[test]
+    fn named_whole_input_and_every_split_agree() {
+        // Multi-byte content on purpose: `advance` takes `&str`, so a split can only
+        // land on a char boundary, and the released fragments must never cut one.
+        let payload = r#"{"city":"東京","emoji":"😀","note":"a\"b"}"#;
+        let whole = {
+            let mut cursor = GuidedJsonCursor::named("get_weather");
+            let mut out = Vec::new();
+            cursor.advance(payload, &mut out);
+            out
+        };
+        assert_eq!(arguments(&whole), vec![(0, payload.to_string())]);
+
+        let per_char = stream_named("get_weather", payload);
+        assert_eq!(names(&per_char), names(&whole));
+        assert_eq!(arguments(&per_char), arguments(&whole));
+
+        for split in 1..payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let mut cursor = GuidedJsonCursor::named("get_weather");
+            let mut out = Vec::new();
+            cursor.advance(&payload[..split], &mut out);
+            cursor.advance(payload, &mut out);
+            assert_eq!(names(&out), names(&whole), "names differ at split {split}");
+            assert_eq!(
+                arguments(&out),
+                arguments(&whole),
+                "arguments differ at split {split}"
+            );
+            for delta in &out {
+                assert!(
+                    std::str::from_utf8(delta.arguments.as_bytes()).is_ok(),
+                    "split {split} released a fragment that is not valid UTF-8"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_truncated_named_payload_releases_only_what_arrived() {
+        let payload = r#"{"city":"Par"#;
+        let deltas = stream_named("get_weather", payload);
+        assert_eq!(names(&deltas), vec![(0, "get_weather".to_string())]);
+        assert_eq!(arguments(&deltas), vec![(0, payload.to_string())]);
+    }
+
+    #[test]
+    fn the_required_mode_still_needs_a_name_from_the_payload() {
+        // The named seed must not leak into the required mode: a nameless required
+        // element still may not commit.
+        assert!(stream(r#"[{"arguments":{"a":1}}]"#).is_empty());
     }
 }

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -54,7 +54,7 @@ pub mod qwen3;
 
 use std::collections::BTreeMap;
 
-use guided_cursor::GuidedJsonCursor;
+pub use guided_cursor::{CommittedCall, GuidedJsonCursor};
 
 use serde::{Deserialize, Serialize};
 
@@ -938,7 +938,9 @@ struct GuidedState {
     post_payload_text_started: bool,
     /// The single owner of JSON lexical state for the streaming path.
     ///
-    /// Idle unless [`InvalidGuidedPayloadPolicy::StreamBestEffort`] is in force —
+    /// Built in the shape `tool_choice` selected: envelopes for a required choice,
+    /// bare arguments for a named one. Idle unless
+    /// [`InvalidGuidedPayloadPolicy::StreamBestEffort`] is in force —
     /// the other two contracts buffer to completion, so under them this never
     /// advances and the completion path below is unchanged.
     cursor: GuidedJsonCursor,
@@ -1234,6 +1236,13 @@ impl GuidedState {
         starting_state: UnifiedParserStartingState,
         invalid_payload: InvalidGuidedPayloadPolicy,
     ) -> Self {
+        // `tool_choice` fixes the payload shape for the whole request, so the
+        // cursor is built in that shape once here rather than being told again on
+        // every advance.
+        let cursor = match &named_tool {
+            Some(name) => GuidedJsonCursor::named(name.clone()),
+            None => GuidedJsonCursor::new(),
+        };
         Self {
             stripped_markup: false,
             reasoning,
@@ -1246,7 +1255,7 @@ impl GuidedState {
                 == UnifiedParserStartingState::Reasoning,
             payload_emitted: false,
             post_payload_text_started: false,
-            cursor: GuidedJsonCursor::new(),
+            cursor,
             input: String::new(),
             json: String::new(),
         }
@@ -1769,10 +1778,19 @@ impl GuidedState {
     /// that nothing is emitted, so `InvalidGuidedPayloadPolicy::Reject` can still
     /// fire on a payload that never gets there.
     ///
+    /// A NAMED choice has no name to wait for: `tool_choice` fixed it before the
+    /// first byte. Its commit point is the payload's own opening `{`, which is the
+    /// same guarantee stated in the same terms — the argument set must be provably
+    /// an OBJECT before any of it goes out.
+    ///
     /// After the name is committed, argument bytes are released as they arrive. Only
     /// the bytes already accumulated are released, and only on a character boundary,
     /// so a fragment is never half a UTF-8 codepoint and never has to be taken back.
     /// Settle the elements streaming did NOT put on the wire.
+    ///
+    /// For a NAMED choice there are none — that payload is one call and the cursor
+    /// released all of it — so this delegates to [`Self::settle_streamed_named`].
+    /// Everything below is the required-choice, per-element reconciliation.
     ///
     /// Recovery here is PER CALL, which is the difference
     /// [`InvalidGuidedPayloadPolicy::StreamBestEffort`] declares: an element that is
@@ -1787,6 +1805,12 @@ impl GuidedState {
         let released_end = self.cursor.released_end().min(self.json.len());
         let remainder = self.json[released_end..].trim().to_string();
         let mut out = Vec::new();
+
+        // A named choice is ONE call and it is already fully on the wire.
+        if self.named_tool.is_some() {
+            return self.settle_streamed_named();
+        }
+
         let Some(elements) = parse_required_guided_elements(&payload) else {
             // Not even splittable into elements. Whatever was streamed stays
             // streamed; the rest is recovery text.
@@ -1856,6 +1880,45 @@ impl GuidedState {
         out
     }
 
+    /// Settle a NAMED choice whose call the cursor already streamed.
+    ///
+    /// The cursor put the name on the first delta and released every byte of the
+    /// argument object, up to and including its closing brace. So there is nothing
+    /// left to settle: running the assembled path as well would deliver the whole
+    /// argument object a SECOND time, and `assemble` would concatenate the two into
+    /// `{…}{…}`. That is the one failure this path exists to prevent, which is why
+    /// BOTH completion routes — [`Self::finish_streamed_remainder`] and
+    /// [`Self::finish_json`] — go through this single rule rather than each
+    /// deciding for itself.
+    ///
+    /// What it still owes the caller: the envelope warning the buffered path emits
+    /// (the bytes are already out, so it can only report the suspicion), and any
+    /// bytes that fell OUTSIDE the argument object, which were never released and
+    /// are not arguments.
+    fn settle_streamed_named(&self) -> Vec<UnifiedParserEvent> {
+        let Some(named_tool) = self.named_tool.as_deref() else {
+            return Vec::new();
+        };
+        if let Ok(obj) =
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(self.json.trim())
+        {
+            warn_if_named_payload_looks_like_an_envelope(named_tool, &obj);
+        }
+        // The cursor lexes `self.json`, so its offset slices that buffer directly.
+        let released_end = self.cursor.released_end().min(self.json.len());
+        let remainder = self.json[released_end..].trim().to_string();
+        if remainder.is_empty() {
+            return Vec::new();
+        }
+        tracing::warn!(
+            why = "unified_guided_named_payload_has_trailing_bytes",
+            named_tool = %named_tool,
+            remainder_bytes = remainder.len(),
+            "bytes followed the named-choice argument object; emitting them as text"
+        );
+        vec![UnifiedParserEvent::Text(remainder)]
+    }
+
     /// Drive the cursor over the payload accumulated so far.
     ///
     /// Under the two buffering contracts this is a no-op, so their behaviour is
@@ -1864,14 +1927,10 @@ impl GuidedState {
         if self.invalid_payload != InvalidGuidedPayloadPolicy::StreamBestEffort {
             return;
         }
-        // A named choice's payload is BARE arguments: there is no
-        // `{"name": .., "arguments": ..}` envelope for the cursor to find a name or
-        // an object opener in. Its name is known from the request before any byte
-        // arrives, so it needs its own commit rule rather than this one, and until
-        // that exists it stays on the buffered path.
-        if self.named_tool.is_some() {
-            return;
-        }
+        // Both choices stream. A named choice's payload is BARE arguments with no
+        // `{"name": .., "arguments": ..}` envelope, so the cursor was built in its
+        // own mode (`GuidedJsonCursor::named`) with the name the request already
+        // fixed; the driving is identical from here.
         let mut deltas = Vec::new();
         self.cursor.advance(&self.json, &mut deltas);
         for delta in deltas {
@@ -1922,6 +1981,19 @@ impl GuidedState {
             return Ok(Vec::new());
         }
 
+        // Output conservation for a NAMED choice that already streamed. Today
+        // `emit_completed_json` intercepts every complete payload before this
+        // function sees it, so a committed named cursor reaches here only on a
+        // TRUNCATED payload — but "unreachable" is not a guarantee, and the cost of
+        // being wrong is the client executing the tool with its arguments doubled.
+        // The rule is structural instead: once a fragment is out, completion may
+        // only settle what was never released.
+        if self.named_tool.is_some() && self.cursor.has_committed() {
+            let out = self.settle_streamed_named();
+            self.json.clear();
+            return Ok(out);
+        }
+
         let raw_payload = self.json.clone();
         let calls = match &self.named_tool {
             // A named choice constrains output to that tool's ARGUMENTS alone,
@@ -1929,37 +2001,17 @@ impl GuidedState {
             // Arguments are an OBJECT. A bare string / number / null / array is
             // syntactically valid JSON but is not an argument set, and EMITTING it
             // would hand the tool a shape it cannot bind — surface it as text instead.
-            Some(name) => serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
-                payload,
-            )
-            .ok()
-            .map(|obj| {
-                // The payload IS this tool's argument object — forward it verbatim.
-                //
-                // An earlier revision unwrapped a `{"name", "arguments"}` shape here to
-                // tolerate a backend that emits the whole call envelope despite
-                // `tool_choice` already naming the tool. That heuristic is unsound: the
-                // shape is not exclusive to envelopes, and a tool like
-                // `register_handler({"name": …, "parameters": …})` produces it. It broke
-                // BOTH ways — a non-matching inner name voided a legitimate forced call
-                // entirely, and a matching one forwarded only the inner value as the
-                // argument set. Guided decoding is schema-constrained by the backend, so
-                // the payload is trusted; a wrapping backend is out of spec and gets a
-                // warning rather than a guess.
-                if obj.contains_key("name")
-                    && (obj.contains_key("arguments") || obj.contains_key("parameters"))
-                {
-                    tracing::warn!(
-                        why = "guided_named_payload_looks_like_an_envelope",
-                        named_tool = %name,
-                        "named-choice payload carries `name` plus `arguments`/`parameters`; forwarding it verbatim as the argument set"
-                    );
-                }
-                vec![GuidedCall {
-                    name: name.clone(),
-                    arguments: raw_payload.clone(),
-                }]
-            }),
+            Some(name) => {
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(payload)
+                    .ok()
+                    .map(|obj| {
+                        warn_if_named_payload_looks_like_an_envelope(name, &obj);
+                        vec![GuidedCall {
+                            name: name.clone(),
+                            arguments: raw_payload.clone(),
+                        }]
+                    })
+            }
             None => parse_required_guided_calls(payload),
         };
 
@@ -2044,6 +2096,36 @@ struct GuidedCall {
 struct GuidedElement {
     call: Option<GuidedCall>,
     raw: String,
+}
+
+/// Warn when a NAMED choice's payload carries a whole call envelope.
+///
+/// The payload IS this tool's argument object and is forwarded verbatim.
+///
+/// An earlier revision unwrapped a `{"name", "arguments"}` shape to tolerate a
+/// backend that emits the whole call envelope despite `tool_choice` already naming
+/// the tool. That heuristic is unsound: the shape is not exclusive to envelopes,
+/// and a tool like `register_handler({"name": …, "parameters": …})` produces it. It
+/// broke BOTH ways — a non-matching inner name voided a legitimate forced call
+/// entirely, and a matching one forwarded only the inner value as the argument set.
+/// Guided decoding is schema-constrained by the backend, so the payload is trusted;
+/// a wrapping backend is out of spec and gets a warning rather than a guess.
+///
+/// One implementation, because BOTH named paths reach it now: the buffered
+/// completion path and the streamed one, which has already put these very bytes on
+/// the wire and can only report the suspicion, not act on it.
+fn warn_if_named_payload_looks_like_an_envelope(
+    named_tool: &str,
+    obj: &serde_json::Map<String, serde_json::Value>,
+) {
+    if obj.contains_key("name") && (obj.contains_key("arguments") || obj.contains_key("parameters"))
+    {
+        tracing::warn!(
+            why = "guided_named_payload_looks_like_an_envelope",
+            named_tool = %named_tool,
+            "named-choice payload carries `name` plus `arguments`/`parameters`; forwarding it verbatim as the argument set"
+        );
+    }
 }
 
 /// Judge ONE required-choice call element.

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -1799,11 +1799,6 @@ impl GuidedState {
     /// together, and cannot be offered once a fragment is already out.
     fn finish_streamed_remainder(&mut self) -> Vec<UnifiedParserEvent> {
         let payload = self.json.trim().to_string();
-        // Bytes already dispatched as call fragments may NOT come back as text.
-        // The cursor is fed `self.json`, so slice in THAT coordinate system before
-        // trimming, or a leading-whitespace offset silently re-emits committed bytes.
-        let released_end = self.cursor.released_end().min(self.json.len());
-        let remainder = self.json[released_end..].trim().to_string();
         let mut out = Vec::new();
 
         // A named choice is ONE call and it is already fully on the wire.
@@ -1812,8 +1807,14 @@ impl GuidedState {
         }
 
         let Some(elements) = parse_required_guided_elements(&payload) else {
-            // Not even splittable into elements. Whatever was streamed stays
-            // streamed; the rest is recovery text.
+            // This function is called only after the cursor has already streamed a
+            // fragment (see the sole caller, `emit_completed_json`'s
+            // `self.cursor.has_committed()` guard), so the payload is guided JSON by
+            // construction from that point forward. A whole-payload parse failure
+            // here means the shape changed after commit, not that the model wrote
+            // prose - the leftover bytes are call envelope, not text. Emitting them
+            // (as `finish_json`'s twin fallback used to) leaked JSON punctuation into
+            // the assistant message on a truncated array; same fix here.
             tracing::warn!(
                 why = "unified_guided_json_not_a_tool_call",
                 choice = "required",
@@ -1821,9 +1822,8 @@ impl GuidedState {
                 payload_kind = json_payload_kind(&payload),
                 streamed_calls = self.cursor.committed().len(),
                 "guided output did not parse as a tool call after fragments were \
-                 already emitted; emitting the remainder as text"
+                 already emitted; suppressing the remainder instead of leaking it as text"
             );
-            out.push(UnifiedParserEvent::Text(remainder));
             return out;
         };
 
@@ -2031,38 +2031,61 @@ impl GuidedState {
                 }
                 .into());
             }
-            // Best-effort (P2): guided decoding promised a tool call and did not
-            // deliver one, so the payload goes out as visible text rather than being
-            // dropped. That recovery is NOT silent — to a caller the result is
-            // indistinguishable from a model that simply chose to answer in prose,
-            // so without this the backend's guided-decoding failure never surfaces.
-            tracing::warn!(
-                why = "unified_guided_json_not_a_tool_call",
-                choice = if self.named_tool.is_some() {
-                    "named"
-                } else {
-                    "required"
-                },
-                named_tool = self.named_tool.as_deref().unwrap_or("-"),
-                payload_bytes = payload.len(),
-                payload_kind = json_payload_kind(payload),
-                "guided output did not parse as a tool call; emitting it as text"
-            );
             // The SAME bytes the parse was given, not the raw buffer. Trailing
             // control markup was stripped above precisely because it is markup, and
             // handing it back here would put `</tool_call>` in the user's visible
             // answer — a marker leak (`I3`) on the one path that exists to recover
             // gracefully. `raw_payload` is already the tail-trimmed value, and it
             // stays byte-identical to the buffer when nothing was stripped (`I7`).
+            //
             // Output conservation: bytes already dispatched as call fragments must
             // NOT come back as visible text, or a client executes the tool and then
-            // renders its JSON as prose. `raw_payload` is `self.json`, the same
-            // coordinates the cursor lexes in, so the released prefix slices off
-            // directly. Emitting nothing is correct when the whole payload was
-            // already streamed.
+            // renders its JSON as prose. Once the cursor has committed anything, the
+            // buffer is guided JSON by construction, so a rebuild failure here means
+            // the tail is call envelope (e.g. `},{"name":` on a truncated array, a
+            // bare `}` on a truncated single call, or a duplicate key that makes an
+            // otherwise-complete payload fail to deserialize) - not model text.
+            let had_committed = self.cursor.has_committed();
+            if had_committed {
+                tracing::warn!(
+                    why = "unified_guided_json_not_a_tool_call",
+                    choice = if self.named_tool.is_some() {
+                        "named"
+                    } else {
+                        "required"
+                    },
+                    named_tool = self.named_tool.as_deref().unwrap_or("-"),
+                    payload_bytes = payload.len(),
+                    payload_kind = json_payload_kind(payload),
+                    "guided output did not parse as a tool call after fragments were \
+                     already emitted; suppressing the remainder instead of leaking it as text"
+                );
+            } else {
+                // Best-effort (P2): guided decoding promised a tool call and did not
+                // deliver one, so the payload goes out as visible text rather than
+                // being dropped. That recovery is NOT silent — to a caller the
+                // result is indistinguishable from a model that simply chose to
+                // answer in prose, so without this the backend's guided-decoding
+                // failure never surfaces.
+                tracing::warn!(
+                    why = "unified_guided_json_not_a_tool_call",
+                    choice = if self.named_tool.is_some() {
+                        "named"
+                    } else {
+                        "required"
+                    },
+                    named_tool = self.named_tool.as_deref().unwrap_or("-"),
+                    payload_bytes = payload.len(),
+                    payload_kind = json_payload_kind(payload),
+                    "guided output did not parse as a tool call; emitting it as text"
+                );
+            }
+            self.json.clear();
+            if had_committed {
+                return Ok(Vec::new());
+            }
             let released_end = self.cursor.released_end().min(raw_payload.len());
             let remainder = raw_payload[released_end..].to_string();
-            self.json.clear();
             if remainder.is_empty() {
                 return Ok(Vec::new());
             }

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1984,8 +1984,39 @@ mod tests {
             .collect();
 
         assert!(
-            !text.contains(&streamed_args),
-            "recovery text re-emitted bytes already dispatched as call 0.\n               streamed args: {streamed_args:?}\n  recovery text: {text:?}"
+            text.is_empty(),
+            "recovery text leaked call envelope instead of staying empty once call 0 streamed.\n               streamed args: {streamed_args:?}\n  recovery text: {text:?}"
+        );
+    }
+
+    /// A DIFFERENT unsplittable case from the truncation above: the payload is
+    /// COMPLETE JSON (it closes), but a repeated `"name"` key makes the whole
+    /// object fail to deserialize as one call, so `parse_required_guided_elements`
+    /// returns `None` even though nothing was cut short. `finish_streamed_remainder`
+    /// must still treat the tail as call envelope once the cursor already streamed
+    /// the first `"name"` occurrence - found by an independent audit of frontend-
+    /// crates#194, which reproduced `,"name":2}` leaking as text before the fix.
+    #[test]
+    fn required_guided_complete_duplicate_name_does_not_leak_as_text() {
+        let payload = r#"{"name":"get_weather","arguments":{"city":"Paris"},"name":2}"#;
+        let (calls, all) = streamed(payload, &per_char(payload));
+
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.name.as_deref() == Some("get_weather")),
+            "expected the first name/arguments pair to stream: {calls:?}"
+        );
+        let text: String = all
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            text.is_empty(),
+            "duplicate-name tail leaked as text instead of staying empty: {text:?}"
         );
     }
 
@@ -2020,8 +2051,8 @@ mod tests {
                 })
                 .collect();
             assert!(
-                !text.contains(&streamed_args),
-                "split {split}: recovery text re-emitted dispatched bytes\n                   streamed: {streamed_args:?}\n  text: {text:?}"
+                text.is_empty(),
+                "split {split}: recovery text leaked call envelope instead of staying empty\n                   streamed: {streamed_args:?}\n  text: {text:?}"
             );
         }
     }
@@ -2050,8 +2081,8 @@ mod tests {
             })
             .collect();
         assert!(
-            !text.contains(&streamed_args),
-            "single-call truncation re-emitted dispatched bytes\n               streamed: {streamed_args:?}\n  text: {text:?}"
+            text.is_empty(),
+            "single-call truncation leaked call envelope instead of staying empty\n               streamed: {streamed_args:?}\n  text: {text:?}"
         );
     }
 
@@ -2368,8 +2399,8 @@ mod tests {
             })
             .collect();
         assert!(
-            !text.contains(&streamed_args),
-            "recovery text re-emitted dispatched bytes: {text:?}"
+            text.is_empty(),
+            "recovery text leaked call envelope instead of staying empty: {text:?}"
         );
     }
 

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1578,15 +1578,40 @@ mod tests {
         }
     }
 
-    /// Every delta produced by feeding `payload` in `chunks`, push order preserved.
+    /// Every delta produced by feeding `payload` in `chunks` under `tool_choice`
+    /// `required`, push order preserved.
     fn streamed(payload: &str, chunks: &[&str]) -> (Vec<ToolCallDelta>, Vec<UnifiedParserEvent>) {
         let _ = payload;
+        streamed_in(
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            InvalidGuidedPayloadPolicy::StreamBestEffort,
+            chunks,
+        )
+    }
+
+    /// The same, for a NAMED choice: the payload is `get_weather`'s bare arguments.
+    fn streamed_named(chunks: &[&str]) -> (Vec<ToolCallDelta>, Vec<UnifiedParserEvent>) {
+        streamed_in(
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            InvalidGuidedPayloadPolicy::StreamBestEffort,
+            chunks,
+        )
+    }
+
+    /// One driver for every guided contract: the required and named modes must be
+    /// exercised through the SAME push/finish sequence, or a divergence in the
+    /// harness hides a divergence in the parser.
+    fn streamed_in(
+        mode: UnifiedToolOutputMode,
+        policy: InvalidGuidedPayloadPolicy,
+        chunks: &[&str],
+    ) -> (Vec<ToolCallDelta>, Vec<UnifiedParserEvent>) {
         let mut parser = qwen3_unified(&weather_tools());
-        parser
-            .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
-                named_tool: None,
-            }))
-            .expect("required guided init");
+        let mut init = stream_init(mode);
+        init.invalid_guided_payload = policy;
+        parser.initialize_request(init).expect("guided init");
         let mut calls = Vec::new();
         let mut all = Vec::new();
         for chunk in chunks {
@@ -2114,6 +2139,294 @@ mod tests {
                 "names differ at split {split}"
             );
         }
+    }
+
+    // ---- named choice: bare arguments for the tool the request already fixed ----
+
+    /// The v2 gap this closes: a named choice refused to stream at all, so a client
+    /// waited for the whole argument object even though the tool name was known
+    /// before the first byte. The name must land on the FIRST delta, and argument
+    /// bytes must follow as fragments.
+    #[test]
+    fn named_guided_streams_its_bare_arguments() {
+        let payload = r#"{"city": "Paris", "unit": "celsius"}"#;
+        let (calls, events) = streamed_named(&per_char(payload));
+
+        let names: Vec<&str> = calls.iter().filter_map(|c| c.name.as_deref()).collect();
+        assert_eq!(names, vec!["get_weather"], "exactly one name, once");
+        assert!(
+            calls[0].name.as_deref() == Some("get_weather"),
+            "the name must ride the FIRST delta, not a later one: {calls:?}"
+        );
+        assert!(
+            calls[1..].iter().all(|c| c.name.is_none()),
+            "every later delta must carry name: None: {calls:?}"
+        );
+        assert!(
+            calls.iter().all(|c| c.tool_index == 0),
+            "a named choice is one call: {calls:?}"
+        );
+
+        let frames = calls.iter().filter(|c| !c.arguments.is_empty()).count();
+        assert!(
+            frames >= 2,
+            "arguments arrived in {frames} frame(s) - that is a burst, not a stream"
+        );
+        assert_eq!(
+            joined_arguments(&calls),
+            vec![(0, payload.to_string())],
+            "fragments must reassemble the payload byte for byte"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, UnifiedParserEvent::Text(_))),
+            "a valid streamed call must not also produce recovery text: {events:?}"
+        );
+    }
+
+    /// The highest-risk failure mode: streaming puts the arguments on the wire and
+    /// then the completion path settles the SAME call again, so the client receives
+    /// the argument bytes twice and `assemble` concatenates them into `{…}{…}`.
+    ///
+    /// The assertion is on the TOTAL: every argument byte the client receives across
+    /// streaming plus completion must equal the payload exactly once.
+    #[test]
+    fn named_guided_never_emits_the_arguments_twice() {
+        let payload = r#"{"city": "Paris"}"#;
+        for chunks in [
+            per_char(payload),
+            vec![payload],
+            vec![&payload[..1], &payload[1..]],
+        ] {
+            let (calls, _) = streamed_named(&chunks);
+            assert_eq!(
+                joined_arguments(&calls),
+                vec![(0, payload.to_string())],
+                "argument bytes were not delivered exactly once: {calls:?}"
+            );
+            assert_eq!(
+                calls.iter().filter(|c| c.name.is_some()).count(),
+                1,
+                "the name was delivered more than once: {calls:?}"
+            );
+        }
+    }
+
+    /// Same invariant at EVERY chunk boundary: the split decides how much streamed
+    /// before the payload closed, so one split can pass while another duplicates.
+    #[test]
+    fn named_guided_conserves_output_at_every_split() {
+        let payload = r#"{"city": "Paris", "unit": "celsius"}"#;
+        for split in 0..=payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let (calls, events) = streamed_named(&[&payload[..split], &payload[split..]]);
+            assert_eq!(
+                joined_arguments(&calls),
+                vec![(0, payload.to_string())],
+                "split {split}: arguments were not delivered exactly once"
+            );
+            let text: String = events
+                .iter()
+                .filter_map(|e| match e {
+                    UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                text.is_empty(),
+                "split {split}: streamed bytes came back as text: {text:?}"
+            );
+        }
+    }
+
+    /// A split can only land on a char boundary because `push` takes `&str`, but the
+    /// released fragments must still never cut a codepoint, and they must reassemble
+    /// the multi-byte content byte for byte.
+    #[test]
+    fn named_guided_is_split_invariant_with_multi_byte_arguments() {
+        let payload = r#"{"city": "東京", "emoji": "😀"}"#;
+        let baseline = vec![(0, payload.to_string())];
+        for split in 0..=payload.len() {
+            if !payload.is_char_boundary(split) {
+                continue;
+            }
+            let (calls, _) = streamed_named(&[&payload[..split], &payload[split..]]);
+            assert_eq!(
+                joined_arguments(&calls),
+                baseline,
+                "arguments differ at split {split}"
+            );
+            assert_eq!(
+                calls
+                    .iter()
+                    .filter_map(|c| c.name.as_deref())
+                    .collect::<Vec<_>>(),
+                vec!["get_weather"],
+                "names differ at split {split}"
+            );
+        }
+        let (per_char_calls, _) = streamed_named(&per_char(payload));
+        assert_eq!(joined_arguments(&per_char_calls), baseline);
+    }
+
+    /// A named payload that does not open with `{` is not an argument set: it cannot
+    /// be bound to the tool, and the buffered path already surfaces it as text.
+    /// Streaming it would put a shape the contract voids on the wire, unwithdrawably.
+    #[test]
+    fn named_guided_never_streams_a_payload_that_is_not_an_argument_set() {
+        for payload in [r#""just a string""#, "42", "null", "[1,2]"] {
+            let (calls, events) = streamed_named(&per_char(payload));
+            assert!(
+                calls.is_empty(),
+                "{payload}: streamed a payload that is not an argument set: {calls:?}"
+            );
+            let text: String = events
+                .iter()
+                .filter_map(|e| match e {
+                    UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                text, payload,
+                "{payload}: buffered recovery text changed shape"
+            );
+        }
+    }
+
+    /// Streaming stays OPT-IN. Under the default `Reject` policy a named choice must
+    /// still buffer to completion and arrive as one terminal delta.
+    #[test]
+    fn named_guided_still_buffers_under_the_default_reject_policy() {
+        let payload = r#"{"city": "Paris"}"#;
+        assert_eq!(
+            InvalidGuidedPayloadPolicy::default(),
+            InvalidGuidedPayloadPolicy::Reject,
+            "this test is about the DEFAULT policy"
+        );
+        let (calls, _) = streamed_in(
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string()),
+            },
+            InvalidGuidedPayloadPolicy::default(),
+            &per_char(payload),
+        );
+        assert_eq!(
+            calls.len(),
+            1,
+            "the payload streamed under Reject: {calls:?}"
+        );
+        assert_eq!(calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(calls[0].arguments, payload);
+    }
+
+    /// Text after the payload is still text, and none of the streamed argument bytes
+    /// may be repeated into it.
+    #[test]
+    fn named_guided_keeps_post_payload_text_out_of_the_arguments() {
+        let payload = r#"{"city": "Paris"}"#;
+        let input = format!("{payload}done");
+        let (calls, events) = streamed_named(&per_char(&input));
+        assert_eq!(joined_arguments(&calls), vec![(0, payload.to_string())]);
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "done", "post-payload text was lost or duplicated");
+    }
+
+    /// Truncation after the commit: whatever streamed stays streamed, nothing is
+    /// invented for the bytes that never arrived, and the released prefix must not
+    /// come back as visible text.
+    #[test]
+    fn named_guided_truncation_conserves_output() {
+        let payload = r#"{"city": "Par"#;
+        let (calls, events) = streamed_named(&per_char(payload));
+        assert_eq!(
+            calls
+                .iter()
+                .filter_map(|c| c.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["get_weather"]
+        );
+        let streamed_args: String = calls.iter().map(|c| c.arguments.as_str()).collect();
+        assert_eq!(
+            streamed_args, payload,
+            "released bytes must be the arrivals"
+        );
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !text.contains(&streamed_args),
+            "recovery text re-emitted dispatched bytes: {text:?}"
+        );
+    }
+
+    /// Reuse: a second request must not inherit the first request's cursor offsets,
+    /// and a named cursor must still be named after the reset.
+    #[test]
+    fn named_guided_streaming_state_does_not_leak_across_requests() {
+        let payload = r#"{"city": "Paris"}"#;
+        let mut parser = qwen3_unified(&weather_tools());
+        let mut seen = Vec::new();
+        for request in 0..2 {
+            if request > 0 {
+                parser.reset();
+            }
+            parser
+                .initialize_request(stream_init(UnifiedToolOutputMode::GuidedJson {
+                    named_tool: Some("get_weather".to_string()),
+                }))
+                .expect("named guided init");
+            let mut calls = Vec::new();
+            for chunk in per_char(payload) {
+                for event in parser.push(chunk).expect("push") {
+                    if let UnifiedParserEvent::ToolCall(delta) = event {
+                        calls.push(delta);
+                    }
+                }
+            }
+            for event in parser.finish().expect("finish").events {
+                if let UnifiedParserEvent::ToolCall(delta) = event {
+                    calls.push(delta);
+                }
+            }
+            seen.push(joined_arguments(&calls));
+        }
+        assert_eq!(seen[0], vec![(0, payload.to_string())]);
+        assert_eq!(
+            seen[0], seen[1],
+            "the second request diverged from the first"
+        );
+    }
+
+    /// The named payload arriving after a thought, in one piece, must still stream
+    /// and must not swallow or duplicate the reasoning.
+    #[test]
+    fn named_guided_streams_after_reasoning() {
+        let payload = r#"{"city": "Paris"}"#;
+        let input = format!("<think>hmm</think>{payload}");
+        let (calls, events) = streamed_named(&per_char(&input));
+        assert_eq!(joined_arguments(&calls), vec![(0, payload.to_string())]);
+        let reasoning: String = events
+            .iter()
+            .filter_map(|e| match e {
+                UnifiedParserEvent::Reasoning(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reasoning, "hmm");
     }
 }
 


### PR DESCRIPTION
## Overview

Guided tool calls now stream as they arrive, in BOTH parser generations. Under `tool_choice=required` or a named tool we already pinned the output to a known JSON shape, but both crates sat on the whole call and emitted one delta at the end. The client didn't learn the function name until the entire call was already generated.

## Details

v1 and v2 take different paths, so the work wasn't the same.

**v1 (`dynamo-parsers`)** goes into the jail, and the jail basically says, "I am never going to emit anything till the very end." So v1 needed a completely new guided-decoding lexer inside the jail.

The lexer walks the list item by item. For each item it buffers just the header — the tool name and the `{` that opens the arguments — then streams the argument bytes as they arrive:

```
buffered:   [{"name":"get_weather","parameters":{
streamed:                                        "city"  :"Par  is"}
```

That header wait is unavoidable. Until the name closes, `"get_weather"` could still turn out to be some other key's value, and you can't take back a delta you already sent. In the live run one tool call came out as 169 deltas.

This is opt-in through `JailedStreamBuilder::guided_streaming`, because turning it on changes the emission shape for every consumer of the jail. The published `apply_tool_calling_jail` signature stays the same, and all existing Immediate-mode tests pass unmodified.


Before and after PR #194, inside the jail. Every box is the same except the two in green. Watch the arrows into CLIENT.

**BEFORE PR #194** — jail `Immediate` mode. One arrow out, at the very end:

```mermaid
flowchart TD
    A[chunk<br/>arrives] --> B[append<br/>to buffer]
    B --> C{payload<br/>closed?}
    C -- no, loop<br/>silently --> A
    C -- yes --> E[parse<br/>whole buffer]
    E --> F[emit<br/>tool call]
    F --> OUT([CLIENT])
```

**AFTER PR #194** — `guided_streaming` enabled. Still buffers, but no longer silent: the cursor sends on EVERY loop:

```mermaid
flowchart TD
    A[chunk<br/>arrives] --> B[append<br/>to buffer]
    B --> N1[guided cursor:<br/>emit name,<br/>then arg bytes]
    N1 --> C{payload<br/>closed?}
    N1 -.->|every chunk| OUT([CLIENT])
    C -- no --> A
    C -- yes --> E[parse<br/>whole buffer]
    E --> N2[subtract<br/>what was<br/>already streamed]
    N2 --> F[emit<br/>remainder]
    F --> OUT
    classDef added fill:#c8f7c5,stroke:#22863a,stroke-width:3px,color:#111
    class N1,N2 added
```

The jail still accumulates exactly like before, and it still has to: the completion check needs the whole buffer to see the payload close, the cursor re-reads it each pass, and if the cursor never commits (backend ignored the grammar) that buffer is what the native fallback parses. What changed is that accumulating is no longer SILENT.


**v2 (`dynamo-parsers-v2`)** already had the lexer. `required` streamed after #190, but a named choice got refused, and lifting that refusal is the whole v2 half of this PR.

The lexer looked for that header — a `name`, then the `{`. A named payload has NONE of it, because we already told the model which tool to call, so it just writes the arguments:

```
required:  [{"name":"get_weather","parameters":{"city":"Paris"}}]
named:     {"city":"Paris"}
```

So it never found a header, never started, and the call sat buffered till the end. Worse, arguments carrying their own `name` field could get that value mistaken for the tool name.

So, named mode skips the hunt: the name comes from the request, the first `{` is the argument opener, and bytes stream until it closes. Both modes share one rule after that. Both need the arguments to be provably an object before anything goes out, so a bare string, number, null or array streams nothing and surfaces as text. Streaming stays opt-in — the default `Reject` policy still buffers.

Completion subtracts whatever already went out, in both crates, so arguments never arrive twice.

A backend can ignore the grammar and emit its native markup anyway — MiniMax M2 does exactly that under a named `tool_choice`. So only whitespace may come before a bare argument object; anything else shuts the cursor off and hands the payload to the jail's native fallback.

Measured end to end against a served model, long payload, comparing against a baseline of 0 tool-call chunks and one terminal burst.

What the columns mean:

- **tool_choice** — `required` means the model spits out an array of `{name, parameters}`. A **named** tool means it just spits out that one tool's arguments, because we already told it which tool to call.
- **path** — **v1** is the jail, which is what you get by default with `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` unset. **v2** is the unified parser, which you get with the flag on. Guided streaming does not read that flag at all; v2 is in the table just to show both generations stream.
- **deltas** — how many streaming chunks actually carried a piece of the tool call. Before this change that number was 1: the name and the whole argument blob, dumped at the very end.
- **first delta** — when the first tool-call chunk reached the client, as a percentage of the stream. Lower is better. This is the moment the client finds out which function is being called.
- **delivery span** — so, this is the time between the first and last tool-call delta (guys, pay attention to this one). It is the column that tells streaming apart from buffering. A buffered response hands you everything at once, so its span is basically 0% no matter how many chunks you slice it into. A span near 100% means bytes were flowing the whole time the model was generating.

| tool_choice | path | deltas | first delta | delivery span |
|---|---|---|---|---|
| required | v1 | 169 | 9.2% in | 90.2% |
| named | v1 | 181 | 1.0% in | 98.7% |
| required | v2 | 229 | 19.9% in | 79.4% |
| named | v2 | 260 | 1.4% in | 98.4% |

## Where

- `parsers/v1/src/tool_calling/jail/guided_stream.rs` (new), `jail/mod.rs`, `tests/jail_guided_stream.rs` (new)
- `parsers/v2/src/unified/guided_cursor.rs`, `unified/mod.rs`, `unified/qwen3.rs`, `lib.rs`











