### PR TITLE
feat(protocols): add Responses API input-token counting

### DIFF
--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -616,7 +616,7 @@ where
 /// to the backend. An unparseable tool was going to be worth 0 either way; this
 /// only decides whether the rest of the body still gets counted. That is the
 /// same trade `estimate_tool_len` documents when it wildcards where
-/// `estimate_item_len` is exhaustive — `Tool` is upstream's type, and we carry
+/// `measure_item` is exhaustive — `Tool` is upstream's type, and we carry
 /// no obligation to mirror its variants.
 fn deserialize_lenient_tools<'de, D>(deserializer: D) -> Result<Option<Vec<Tool>>, D::Error>
 where
@@ -682,11 +682,7 @@ impl CountInputTokensRequest {
         match &self.input {
             InputParam::Text(text) if text.is_empty() => {}
             InputParam::Text(text) => total_len += role_len(Role::User) + text.len(),
-            InputParam::Items(items) => {
-                for item in items {
-                    total_len += estimate_input_item_len(item);
-                }
-            }
+            InputParam::Items(items) => total_len += estimate_input_items_len(items),
         }
 
         if let Some(tools) = &self.tools {
@@ -723,15 +719,78 @@ fn input_role_len(role: InputRole) -> usize {
     }
 }
 
-fn estimate_input_item_len(item: &InputItem) -> usize {
+/// The `tool` role marker on a tool-result message.
+///
+/// `role_len` covers only the roles upstream's `Role` enum models; chat
+/// completions' `tool` role has no variant there, so it gets its own constant
+/// on the same basis the others use — the length of the role word.
+const TOOL_ROLE_LEN: usize = 4;
+
+/// What an input item does to the converter's pending assistant message.
+enum GroupEffect {
+    /// Opens or extends the pending assistant message, emitting no message of
+    /// its own.
+    Assistant,
+    /// Flushes any pending assistant message and emits its own.
+    Flush,
+    /// Neither emits nor flushes — the converter skips it outright.
+    Skip,
+}
+
+/// Sum the input items, mirroring `convert_input_items_to_messages` — including
+/// its coalescing.
+///
+/// Assistant-side items do not each become a message. An echoed assistant
+/// message, a function call, and a reasoning summary all push into one
+/// `PendingAssistant`, which is flushed only by the next non-assistant item or
+/// by the end of the list. So the assistant role marker is charged once per
+/// flushed group, not once per item: two parallel function calls are one
+/// assistant turn and cost one marker between them.
+///
+/// A per-item sum cannot express that, which is why this walks the list rather
+/// than mapping over it.
+fn estimate_input_items_len(items: &[InputItem]) -> usize {
+    let mut total = 0;
+    let mut assistant_open = false;
+
+    for item in items {
+        let (effect, len) = measure_input_item(item);
+        total += len;
+        match effect {
+            GroupEffect::Assistant => {
+                if !assistant_open {
+                    assistant_open = true;
+                    total += role_len(Role::Assistant);
+                }
+            }
+            GroupEffect::Flush => assistant_open = false,
+            GroupEffect::Skip => {}
+        }
+    }
+
+    total
+}
+
+/// Measure one item and report what it does to the pending assistant group.
+///
+/// Assistant-side arms return content only: their role marker is the caller's
+/// to add, once per group.
+fn measure_input_item(item: &InputItem) -> (GroupEffect, usize) {
     match item {
         // A pointer to an item held server-side. The content it names is not in
-        // this request, so there is nothing here to measure.
-        InputItem::ItemReference(_) => 0,
+        // this request, so there is nothing here to measure — and the converter
+        // skips it without flushing, so it cannot split an assistant group.
+        InputItem::ItemReference(_) => (GroupEffect::Skip, 0),
         InputItem::EasyMessage(message) => {
-            role_len(message.role) + estimate_easy_content_len(&message.content)
+            let content = estimate_easy_content_len(&message.content);
+            match message.role {
+                // A prior assistant turn echoed back; coalesces like the strict
+                // `MessageItem::Output` path.
+                Role::Assistant => (GroupEffect::Assistant, content),
+                role => (GroupEffect::Flush, role_len(role) + content),
+            }
         }
-        InputItem::Item(item) => estimate_item_len(item),
+        InputItem::Item(item) => measure_item(item),
     }
 }
 
@@ -752,38 +811,54 @@ fn estimate_input_content_len(part: &InputContent) -> usize {
     }
 }
 
-fn estimate_item_len(item: &Item) -> usize {
+fn measure_item(item: &Item) -> (GroupEffect, usize) {
     match item {
-        Item::Message(MessageItem::Input(message)) => {
+        Item::Message(MessageItem::Input(message)) => (
+            GroupEffect::Flush,
             input_role_len(message.role)
                 + message
                     .content
                     .iter()
                     .map(estimate_input_content_len)
-                    .sum::<usize>()
-        }
-        Item::Message(MessageItem::Output(message)) => {
-            role_len(Role::Assistant)
-                + message
-                    .content
-                    .iter()
-                    .map(|part| match part {
-                        InputOutputMessageContent::OutputText(text) => text.text.len(),
-                        InputOutputMessageContent::Refusal(refusal) => refusal.refusal.len(),
-                    })
-                    .sum::<usize>()
-        }
-        Item::FunctionCall(call) => call.name.len() + call.arguments.len(),
-        Item::FunctionCallOutput(output) => match &output.output {
-            FunctionCallOutput::Text(text) => text.len(),
-            FunctionCallOutput::Content(parts) => parts
+                    .sum::<usize>(),
+        ),
+        // Assistant-side: pushed into the pending message, so no role marker
+        // here. See `estimate_input_items_len`.
+        Item::Message(MessageItem::Output(message)) => (
+            GroupEffect::Assistant,
+            message
+                .content
                 .iter()
                 .map(|part| match part {
-                    UpstreamInputContent::InputText(text) => text.text.len(),
-                    UpstreamInputContent::InputImage(_) | UpstreamInputContent::InputFile(_) => 0,
+                    InputOutputMessageContent::OutputText(text) => text.text.len(),
+                    InputOutputMessageContent::Refusal(refusal) => refusal.refusal.len(),
                 })
-                .sum(),
-        },
+                .sum::<usize>(),
+        ),
+        // Rendered as a tool call on the pending assistant message. `call_id`
+        // is excluded deliberately: it is correlation plumbing, not prompt
+        // text, in the templates Dynamo renders.
+        Item::FunctionCall(call) => (
+            GroupEffect::Assistant,
+            call.name.len() + call.arguments.len(),
+        ),
+        // Its own `tool`-role message, one per output, so it both flushes the
+        // assistant group and carries a role marker of its own.
+        Item::FunctionCallOutput(output) => (
+            GroupEffect::Flush,
+            TOOL_ROLE_LEN
+                + match &output.output {
+                    FunctionCallOutput::Text(text) => text.len(),
+                    FunctionCallOutput::Content(parts) => parts
+                        .iter()
+                        .map(|part| match part {
+                            UpstreamInputContent::InputText(text) => text.text.len(),
+                            UpstreamInputContent::InputImage(_)
+                            | UpstreamInputContent::InputFile(_) => 0,
+                        })
+                        .sum(),
+                },
+        ),
         // Only `summary` is measured, because only `summary` is rendered:
         // the converter joins the summary parts and drops the rest of the
         // item. `content` is excluded for that reason alone — if Dynamo
@@ -791,13 +866,16 @@ fn estimate_item_len(item: &Item) -> usize {
         // `encrypted_content` is excluded on its own merits: it is an opaque
         // blob the model never sees as prompt text, and it is routinely far
         // larger than the reasoning it stands for.
-        Item::Reasoning(reasoning) => reasoning
-            .summary
-            .iter()
-            .map(|part| match part {
-                SummaryPart::SummaryText(text) => text.text.len(),
-            })
-            .sum(),
+        Item::Reasoning(reasoning) => (
+            GroupEffect::Assistant,
+            reasoning
+                .summary
+                .iter()
+                .map(|part| match part {
+                    SummaryPart::SummaryText(text) => text.text.len(),
+                })
+                .sum(),
+        ),
         // Everything below contributes nothing, because nothing below reaches
         // the prompt: Dynamo's `convert_input_items_to_messages` flushes and
         // skips every one of these ("we do not have a faithful Chat
@@ -834,7 +912,7 @@ fn estimate_item_len(item: &Item) -> usize {
         | Item::McpApprovalResponse(_)
         | Item::McpCall(_)
         | Item::CustomToolCallOutput(_)
-        | Item::CustomToolCall(_) => 0,
+        | Item::CustomToolCall(_) => (GroupEffect::Flush, 0),
     }
 }
 
@@ -843,7 +921,7 @@ fn estimate_item_len(item: &Item) -> usize {
 /// (web search, file search, computer use) are dropped there and so cost
 /// nothing here.
 ///
-/// Wildcarded where `estimate_item_len` is exhaustive, and deliberately so:
+/// Wildcarded where `measure_item` is exhaustive, and deliberately so:
 /// `Tool` is upstream's type, not one of our shadows, so we carry no
 /// obligation to mirror its variants. Pinning it exhaustively would only
 /// break the build every time async-openai adds a hosted tool we would
@@ -1533,20 +1611,18 @@ mod tests {
 
     #[test]
     fn count_tokens_short_input_never_rounds_to_zero() {
-        // A function call carries no role marker, so it is the smallest
-        // non-empty body there is: name (1) + arguments (0) == 1, and
-        // 1 / 3 == 0 — but content was present, so report 1.
+        // Every item that reaches the prompt now carries a role marker of at
+        // least 4, so no `input` can land under the rounding threshold. Tools
+        // are the one remaining path: they are appended to the request rather
+        // than rendered as a message, so they carry no marker. A one-character
+        // function name is 1, and 1 / 3 == 0 — but content was present, so
+        // report 1.
         assert_eq!(
-            count(serde_json::json!({"input": [{
-                "type": "function_call",
-                "call_id": "c",
-                "name": "a",
-                "arguments": ""
-            }]})),
+            count(serde_json::json!({"tools": [{"type": "function", "name": "a"}]})),
             1
         );
-        // A bare string input clears the guard on its role marker alone:
-        // user (4) + "Hi" (2) == 6; 6 / 3 == 2.
+        // For comparison, the shortest possible input clears the guard on its
+        // role marker alone: user (4) + "Hi" (2) == 6; 6 / 3 == 2.
         assert_eq!(count(serde_json::json!({"input": "Hi"})), 2);
     }
 
@@ -1607,7 +1683,9 @@ mod tests {
 
     #[test]
     fn count_tokens_function_call_counts_name_and_arguments() {
-        // "get_weather" (11) + r#"{"city":"SF"}"# (13) == 24; 24 / 3 == 8.
+        // A function call is rendered as a tool call on an assistant message:
+        // assistant role (9) + "get_weather" (11) + r#"{"city":"SF"}"# (13)
+        // == 33; 33 / 3 == 11.
         assert_eq!(
             count(serde_json::json!({"input": [{
                 "type": "function_call",
@@ -1615,20 +1693,93 @@ mod tests {
                 "name": "get_weather",
                 "arguments": r#"{"city":"SF"}"#,
             }]})),
-            8
+            11
         );
     }
 
     #[test]
+    fn count_tokens_charges_one_assistant_marker_per_coalesced_turn() {
+        // `convert_input_items_to_messages` accumulates assistant-side items
+        // into one `PendingAssistant`, so two parallel tool calls are a single
+        // assistant message. Charging a marker per item would invent a turn
+        // that never reaches the prompt.
+        let one = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""}
+        ]});
+        let two = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""},
+            {"type": "function_call", "call_id": "c2", "name": "bb", "arguments": ""}
+        ]});
+        // assistant (9) + "aa" (2) == 11 → 3; adding "bb" (2) == 13 → 4.
+        // The marker is paid once, not twice.
+        assert_eq!(count(one), 3);
+        assert_eq!(count(two), 4);
+
+        // Assistant text, reasoning, and a tool call in one turn: still one
+        // marker across all three.
+        let mixed = serde_json::json!({"input": [
+            {"role": "assistant", "content": "aa"},
+            {"type": "reasoning", "summary": [{"type": "summary_text", "text": "bb"}]},
+            {"type": "function_call", "call_id": "c1", "name": "cc", "arguments": ""}
+        ]});
+        assert_eq!(count(mixed), 5); // 9 + 2 + 2 + 2 == 15 → 5
+    }
+
+    #[test]
+    fn count_tokens_reopens_the_assistant_turn_after_a_flush() {
+        // A tool result ends the assistant turn, so the assistant items after
+        // it are a second turn and pay a second marker.
+        let two_turns = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""},
+            {"type": "function_call_output", "call_id": "c1", "output": ""},
+            {"type": "function_call", "call_id": "c2", "name": "bb", "arguments": ""}
+        ]});
+        // assistant (9) + "aa" (2) + tool (4) + assistant (9) + "bb" (2)
+        // == 26; 26 / 3 == 8.
+        assert_eq!(count(two_turns), 8);
+    }
+
+    #[test]
+    fn count_tokens_item_reference_does_not_split_an_assistant_turn() {
+        // The converter skips item references without flushing, so one sitting
+        // between two tool calls must not make them look like two turns.
+        let split = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""},
+            {"type": "item_reference", "id": "item_abc"},
+            {"type": "function_call", "call_id": "c2", "name": "bb", "arguments": ""}
+        ]});
+        let unsplit = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""},
+            {"type": "function_call", "call_id": "c2", "name": "bb", "arguments": ""}
+        ]});
+        assert_eq!(count(split), count(unsplit));
+    }
+
+    #[test]
+    fn count_tokens_unsupported_item_splits_an_assistant_turn() {
+        // The converter flushes before skipping an unsupported variant
+        // precisely so a later function call cannot coalesce across it. The
+        // estimate has to agree, or it undercounts the second turn's marker.
+        let across = serde_json::json!({"input": [
+            {"type": "function_call", "call_id": "c1", "name": "aa", "arguments": ""},
+            {"type": "web_search_call", "id": "ws_1", "status": "completed"},
+            {"type": "function_call", "call_id": "c2", "name": "bb", "arguments": ""}
+        ]});
+        // Two turns: 9 + 2 + 9 + 2 == 22; 22 / 3 == 7.
+        assert_eq!(count(across), 7);
+    }
+
+    #[test]
     fn count_tokens_function_call_output_counts_text() {
-        // "sunny" (5) == 5; 5 / 3 == 1.
+        // Rendered as its own tool-role message: tool role (4) + "sunny" (5)
+        // == 9; 9 / 3 == 3.
         assert_eq!(
             count(serde_json::json!({"input": [{
                 "type": "function_call_output",
                 "call_id": "call_1",
                 "output": "sunny",
             }]})),
-            1
+            3
         );
     }
 
@@ -1696,7 +1847,7 @@ mod tests {
 
     #[test]
     fn count_tokens_counts_exactly_the_variants_the_converter_renders() {
-        // Guards the coupling documented on `estimate_item_len`: the explicit
+        // Guards the coupling documented on `measure_item`: the explicit
         // arms are meant to be the same set Dynamo's converter handles. Each
         // variant is asserted on its own — a single assertion over an array of
         // all four would still pass with three of the arms deleted. If dynamo
@@ -1747,8 +1898,9 @@ mod tests {
             "encrypted_content": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         }]});
 
-        // "thinking" (8) == 8; 8 / 3 == 2.
-        assert_eq!(count(summary_only.clone()), 2);
+        // Reasoning rides on the pending assistant message:
+        // assistant role (9) + "thinking" (8) == 17; 17 / 3 == 5.
+        assert_eq!(count(summary_only.clone()), 5);
         assert_eq!(count(with_dropped_fields), count(summary_only));
     }
 

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -666,12 +666,22 @@ impl CountInputTokensRequest {
     pub fn estimate_tokens(&self) -> u32 {
         let mut total_len: usize = 0;
 
-        if let Some(instructions) = &self.instructions {
-            total_len += instructions.len();
+        // `instructions` and a top-level string `input` are not free-floating
+        // text: the converter turns them into a system and a user chat message
+        // respectively, exactly like the item messages below. Charge them the
+        // same role markers, or the identical prompt scores differently
+        // depending on which shape the caller used to express it.
+        //
+        // Both are skipped when empty, because an absent field is not a
+        // message. `InputParam::default()` is `Text("")`, so a body with no
+        // `input` at all lands here — and it must stay worth zero.
+        if let Some(instructions) = &self.instructions.as_ref().filter(|text| !text.is_empty()) {
+            total_len += role_len(Role::System) + instructions.len();
         }
 
         match &self.input {
-            InputParam::Text(text) => total_len += text.len(),
+            InputParam::Text(text) if text.is_empty() => {}
+            InputParam::Text(text) => total_len += role_len(Role::User) + text.len(),
             InputParam::Items(items) => {
                 for item in items {
                     total_len += estimate_input_item_len(item);
@@ -1503,10 +1513,10 @@ mod tests {
 
     #[test]
     fn count_tokens_plain_text_input() {
-        // "Hello, world!" is 13 chars; 13 / 3 == 4.
+        // user role (4) + "Hello, world!" (13) == 17; 17 / 3 == 5.
         assert_eq!(
             count(serde_json::json!({"model": "m", "input": "Hello, world!"})),
-            4
+            5
         );
     }
 
@@ -1523,16 +1533,53 @@ mod tests {
 
     #[test]
     fn count_tokens_short_input_never_rounds_to_zero() {
-        // 2 chars / 3 == 0, but content was present, so report 1.
-        assert_eq!(count(serde_json::json!({"input": "Hi"})), 1);
+        // A function call carries no role marker, so it is the smallest
+        // non-empty body there is: name (1) + arguments (0) == 1, and
+        // 1 / 3 == 0 — but content was present, so report 1.
+        assert_eq!(
+            count(serde_json::json!({"input": [{
+                "type": "function_call",
+                "call_id": "c",
+                "name": "a",
+                "arguments": ""
+            }]})),
+            1
+        );
+        // A bare string input clears the guard on its role marker alone:
+        // user (4) + "Hi" (2) == 6; 6 / 3 == 2.
+        assert_eq!(count(serde_json::json!({"input": "Hi"})), 2);
     }
 
     #[test]
     fn count_tokens_instructions_contribute() {
-        // "You are helpful." (16) + "Hi" (2) == 18; 18 / 3 == 6.
+        // system role (6) + "You are helpful." (16)
+        //   + user role (4) + "Hi" (2) == 28; 28 / 3 == 9.
         assert_eq!(
             count(serde_json::json!({"input": "Hi", "instructions": "You are helpful."})),
-            6
+            9
+        );
+    }
+
+    #[test]
+    fn count_tokens_scores_the_two_spellings_of_a_prompt_identically() {
+        // `TryFrom<NvCreateResponse>` turns a top-level string `input` into a
+        // user message and `instructions` into a system message, so these two
+        // bodies build the same chat request and must score the same. Counting
+        // the top-level forms as bare text undercounted them by the role
+        // markers the item forms were already charged.
+        assert_eq!(
+            count(serde_json::json!({"input": "Hello"})),
+            count(serde_json::json!({"input": [{"role": "user", "content": "Hello"}]})),
+        );
+        assert_eq!(
+            count(serde_json::json!({
+                "input": "Hello",
+                "instructions": "You are helpful."
+            })),
+            count(serde_json::json!({"input": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"}
+            ]})),
         );
     }
 
@@ -1763,7 +1810,7 @@ mod tests {
                 "previous_response_id": "resp_abc123",
                 "conversation": {"id": "conv_1"},
             })),
-            4
+            5
         );
     }
 
@@ -1804,7 +1851,7 @@ mod tests {
                 "input": null,
                 "instructions": "You are helpful."
             })),
-            5
+            7
         );
     }
 
@@ -1822,7 +1869,7 @@ mod tests {
         assert_eq!(request.tools.as_deref(), Some(&[][..]));
         // Same count as the identical body with no `tools` key at all: the
         // dropped tool was worth 0 either way.
-        assert_eq!(request.estimate_tokens(), 4);
+        assert_eq!(request.estimate_tokens(), 5);
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -569,16 +569,67 @@ pub const RESPONSE_INPUT_TOKENS_OBJECT: &str = "response.input_tokens";
 /// Dynamo does not serve (`conversation`, `previous_response_id`) are accepted
 /// and disregarded rather than rejected. This endpoint reports a pre-flight
 /// estimate; it never generates, so there is nothing for them to affect.
+///
+/// Deserialization is forgiving in two further places — an explicit
+/// `"input": null` and unrecognized tool shapes — for the same reason
+/// `AnthropicTool` keeps every field but `name` optional: a pre-flight
+/// estimate that rejects a body it could have scored is strictly worse than
+/// one that scores it approximately. See [`deserialize_lenient_tools`].
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct CountInputTokensRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    #[serde(default)]
+    /// `#[serde(default)]` alone covers an absent `input`, but not an explicit
+    /// `"input": null` — serde still hands that null to `InputParam`, whose
+    /// deserializer rejects it. Here both mean "nothing to count".
+    #[serde(default, deserialize_with = "deserialize_null_default_input")]
     pub input: InputParam,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_lenient_tools"
+    )]
     pub tools: Option<Vec<Tool>>,
+}
+
+fn deserialize_null_default_input<'de, D>(deserializer: D) -> Result<InputParam, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<InputParam>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+/// Drop tool entries that do not deserialize into a known [`Tool`], rather than
+/// failing the whole request.
+///
+/// `Tool` is upstream's `#[serde(tag = "type")]` enum, so it models only the
+/// tool types the pinned `async-openai` knows. A caller that forwards a tool in
+/// a shape upstream does not model — a Chat-Completions-style `{"type":
+/// "custom", "custom": {...}}`, or a tool type newer than the pin — would
+/// otherwise get a 400 for a field that contributes almost nothing to the
+/// estimate.
+///
+/// Dropping costs nothing: [`estimate_tool_len`] already scores every
+/// non-function tool as 0, because `convert_tools` forwards only function tools
+/// to the backend. An unparseable tool was going to be worth 0 either way; this
+/// only decides whether the rest of the body still gets counted. That is the
+/// same trade `estimate_tool_len` documents when it wildcards where
+/// `estimate_item_len` is exhaustive — `Tool` is upstream's type, and we carry
+/// no obligation to mirror its variants.
+fn deserialize_lenient_tools<'de, D>(deserializer: D) -> Result<Option<Vec<Tool>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(raw) = Option::<Vec<serde_json::Value>>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        raw.into_iter()
+            .filter_map(|tool| serde_json::from_value::<Tool>(tool).ok())
+            .collect(),
+    ))
 }
 
 /// Response body for `POST /v1/responses/input_tokens`.
@@ -1740,6 +1791,73 @@ mod tests {
         );
         assert!(matches!(request.input, InputParam::Items(ref items) if items.len() == 1));
         assert!(request.estimate_tokens() > 0);
+    }
+
+    #[test]
+    fn count_tokens_accepts_explicit_null_input() {
+        // `#[serde(default)]` covers an absent `input`; this covers the null
+        // an emitter produces when it always writes the key.
+        assert_eq!(count(serde_json::json!({"model": "m", "input": null})), 0);
+        assert_eq!(
+            count(serde_json::json!({
+                "model": "m",
+                "input": null,
+                "instructions": "You are helpful."
+            })),
+            5
+        );
+    }
+
+    #[test]
+    fn count_tokens_drops_unparseable_tools_instead_of_failing() {
+        // A Chat-Completions-shaped `custom` tool: `Tool` models the Responses
+        // shape (`{"type": "custom", "name": ...}`), not the nested chat one.
+        // It must not take the whole request down with it.
+        let request: CountInputTokensRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "input": "Hello, world!",
+            "tools": [{"type": "custom", "custom": {"name": "x"}}],
+        }))
+        .expect("an unparseable tool should be dropped, not rejected");
+        assert_eq!(request.tools.as_deref(), Some(&[][..]));
+        // Same count as the identical body with no `tools` key at all: the
+        // dropped tool was worth 0 either way.
+        assert_eq!(request.estimate_tokens(), 4);
+    }
+
+    #[test]
+    fn count_tokens_keeps_parseable_tools_alongside_dropped_ones() {
+        // Dropping is per-entry, not all-or-nothing: a good function tool in
+        // the same array still gets counted.
+        let request: CountInputTokensRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "input": "Hello, world!",
+            "tools": [
+                {"type": "custom", "custom": {"name": "x"}},
+                {"type": "function", "name": "get_weather", "description": "Get weather"},
+            ],
+        }))
+        .expect("a mixed tool array should deserialize");
+        assert_eq!(request.tools.as_ref().map(Vec::len), Some(1));
+        assert!(
+            request.estimate_tokens()
+                > count(serde_json::json!({"model": "m", "input": "Hello, world!"}))
+        );
+    }
+
+    #[test]
+    fn count_tokens_distinguishes_absent_tools_from_empty_tools() {
+        // `None` and `Some([])` both score 0, but the field must round-trip
+        // its presence: `skip_serializing_if` relies on the distinction.
+        let absent: CountInputTokensRequest =
+            serde_json::from_value(serde_json::json!({"input": "hi"})).unwrap();
+        assert_eq!(absent.tools, None);
+        let empty: CountInputTokensRequest =
+            serde_json::from_value(serde_json::json!({"input": "hi", "tools": []})).unwrap();
+        assert_eq!(empty.tools.as_deref(), Some(&[][..]));
+        let null: CountInputTokensRequest =
+            serde_json::from_value(serde_json::json!({"input": "hi", "tools": null})).unwrap();
+        assert_eq!(null.tools, None);
     }
 
     #[test]

--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -550,6 +550,279 @@ pub struct CreateResponse {
     pub truncation: Option<Truncation>,
 }
 
+// ---------------------------------------------------------------------------
+// CountInputTokens (`POST /v1/responses/input_tokens`)
+// ---------------------------------------------------------------------------
+
+/// The `object` discriminator on a [`CountInputTokensResponse`].
+pub const RESPONSE_INPUT_TOKENS_OBJECT: &str = "response.input_tokens";
+
+/// Request body for `POST /v1/responses/input_tokens`.
+///
+/// A subset of [`CreateResponse`] — only the fields that reach the rendered
+/// prompt. This mirrors `AnthropicCountTokensRequest`, which is the same
+/// subset-of-the-create-request shape for `POST /v1/messages/count_tokens`.
+///
+/// Two deliberate differences from `CreateResponse`: `input` defaults (the
+/// count endpoint accepts a body without one, whereas creating a response
+/// requires it), and unknown fields are ignored, so stateful parameters
+/// Dynamo does not serve (`conversation`, `previous_response_id`) are accepted
+/// and disregarded rather than rejected. This endpoint reports a pre-flight
+/// estimate; it never generates, so there is nothing for them to affect.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct CountInputTokensRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub input: InputParam,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+}
+
+/// Response body for `POST /v1/responses/input_tokens`.
+///
+/// `Deserialize` is derived where the Anthropic count response is
+/// serialize-only: this body is round-tripped by the frontend's integration
+/// tests, which assert on the parsed shape rather than on raw JSON.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct CountInputTokensResponse {
+    /// Always [`RESPONSE_INPUT_TOKENS_OBJECT`]. Required by the OpenAI spec.
+    pub object: String,
+    pub input_tokens: u32,
+}
+
+impl CountInputTokensResponse {
+    pub fn new(input_tokens: u32) -> Self {
+        Self {
+            object: RESPONSE_INPUT_TOKENS_OBJECT.to_string(),
+            input_tokens,
+        }
+    }
+}
+
+impl CountInputTokensRequest {
+    /// Estimate input token count using a `len/3` heuristic.
+    ///
+    /// Same contract as `AnthropicCountTokensRequest::estimate_tokens`: sum the
+    /// character lengths of everything that reaches the prompt, divide by three,
+    /// and never report zero for input that carried content.
+    ///
+    /// This is an estimate, not a tokenization. A frontend serving a
+    /// backend that tokenizes for itself has no tokenizer loaded, so this
+    /// endpoint has to be able to answer without one.
+    pub fn estimate_tokens(&self) -> u32 {
+        let mut total_len: usize = 0;
+
+        if let Some(instructions) = &self.instructions {
+            total_len += instructions.len();
+        }
+
+        match &self.input {
+            InputParam::Text(text) => total_len += text.len(),
+            InputParam::Items(items) => {
+                for item in items {
+                    total_len += estimate_input_item_len(item);
+                }
+            }
+        }
+
+        if let Some(tools) = &self.tools {
+            for tool in tools {
+                total_len += estimate_tool_len(tool);
+            }
+        }
+
+        let tokens = total_len / 3;
+        if tokens == 0 && total_len > 0 {
+            1
+        } else {
+            tokens as u32
+        }
+    }
+}
+
+/// Approximate character cost of a role marker, using the same constants
+/// `AnthropicCountTokensRequest::estimate_tokens` applies for the same purpose.
+fn role_len(role: Role) -> usize {
+    match role {
+        Role::User => 4,
+        Role::Assistant => 9,
+        Role::System => 6,
+        Role::Developer => 9,
+    }
+}
+
+fn input_role_len(role: InputRole) -> usize {
+    match role {
+        InputRole::User => 4,
+        InputRole::System => 6,
+        InputRole::Developer => 9,
+    }
+}
+
+fn estimate_input_item_len(item: &InputItem) -> usize {
+    match item {
+        // A pointer to an item held server-side. The content it names is not in
+        // this request, so there is nothing here to measure.
+        InputItem::ItemReference(_) => 0,
+        InputItem::EasyMessage(message) => {
+            role_len(message.role) + estimate_easy_content_len(&message.content)
+        }
+        InputItem::Item(item) => estimate_item_len(item),
+    }
+}
+
+fn estimate_easy_content_len(content: &EasyInputContent) -> usize {
+    match content {
+        EasyInputContent::Text(text) => text.len(),
+        EasyInputContent::ContentList(parts) => parts.iter().map(estimate_input_content_len).sum(),
+    }
+}
+
+/// Only text parts are measured. An image or file contributes tokens as a
+/// function of its decoded form, which a character count cannot model at all —
+/// the Anthropic estimator skips non-text blocks for the same reason.
+fn estimate_input_content_len(part: &InputContent) -> usize {
+    match part {
+        InputContent::InputText(text) => text.text.len(),
+        InputContent::InputImage(_) | InputContent::InputFile(_) => 0,
+    }
+}
+
+fn estimate_item_len(item: &Item) -> usize {
+    match item {
+        Item::Message(MessageItem::Input(message)) => {
+            input_role_len(message.role)
+                + message
+                    .content
+                    .iter()
+                    .map(estimate_input_content_len)
+                    .sum::<usize>()
+        }
+        Item::Message(MessageItem::Output(message)) => {
+            role_len(Role::Assistant)
+                + message
+                    .content
+                    .iter()
+                    .map(|part| match part {
+                        InputOutputMessageContent::OutputText(text) => text.text.len(),
+                        InputOutputMessageContent::Refusal(refusal) => refusal.refusal.len(),
+                    })
+                    .sum::<usize>()
+        }
+        Item::FunctionCall(call) => call.name.len() + call.arguments.len(),
+        Item::FunctionCallOutput(output) => match &output.output {
+            FunctionCallOutput::Text(text) => text.len(),
+            FunctionCallOutput::Content(parts) => parts
+                .iter()
+                .map(|part| match part {
+                    UpstreamInputContent::InputText(text) => text.text.len(),
+                    UpstreamInputContent::InputImage(_) | UpstreamInputContent::InputFile(_) => 0,
+                })
+                .sum(),
+        },
+        // Only `summary` is measured, because only `summary` is rendered:
+        // the converter joins the summary parts and drops the rest of the
+        // item. `content` is excluded for that reason alone — if Dynamo
+        // learns to render it, it needs to start counting here too.
+        // `encrypted_content` is excluded on its own merits: it is an opaque
+        // blob the model never sees as prompt text, and it is routinely far
+        // larger than the reasoning it stands for.
+        Item::Reasoning(reasoning) => reasoning
+            .summary
+            .iter()
+            .map(|part| match part {
+                SummaryPart::SummaryText(text) => text.text.len(),
+            })
+            .sum(),
+        // Everything below contributes nothing, because nothing below reaches
+        // the prompt: Dynamo's `convert_input_items_to_messages` flushes and
+        // skips every one of these ("we do not have a faithful Chat
+        // Completions mapping"). The arms above are exactly its handled set.
+        // Measuring the serialized form instead would bill callers for JSON
+        // scaffolding the model never sees: a bare `web_search_call` is 59
+        // characters, or 19 phantom tokens, and agentic clients echo many
+        // such items per turn.
+        //
+        // Listed out rather than wildcarded on purpose. `Item` is a shadow
+        // enum that "mirrors upstream variant-for-variant" and has to be
+        // extended by hand whenever upstream grows a variant (see CLAUDE.md,
+        // "Owned input chain"). A `_` arm would let that new variant default
+        // to zero silently; an exhaustive match turns it into a compile error
+        // that forces a render-or-not decision here, which is the same
+        // mechanism CLAUDE.md relies on to catch drift in `From` impls.
+        Item::FileSearchCall(_)
+        | Item::ComputerCall(_)
+        | Item::ComputerCallOutput(_)
+        | Item::WebSearchCall(_)
+        | Item::ToolSearchCall(_)
+        | Item::ToolSearchOutput(_)
+        | Item::Compaction(_)
+        | Item::ImageGenerationCall(_)
+        | Item::CodeInterpreterCall(_)
+        | Item::LocalShellCall(_)
+        | Item::LocalShellCallOutput(_)
+        | Item::ShellCall(_)
+        | Item::ShellCallOutput(_)
+        | Item::ApplyPatchCall(_)
+        | Item::ApplyPatchCallOutput(_)
+        | Item::McpListTools(_)
+        | Item::McpApprovalRequest(_)
+        | Item::McpApprovalResponse(_)
+        | Item::McpCall(_)
+        | Item::CustomToolCallOutput(_)
+        | Item::CustomToolCall(_) => 0,
+    }
+}
+
+/// Mirrors `convert_tools`: only function tools are forwarded to the backend,
+/// namespaced ones flattened to their bare function members. Hosted tools
+/// (web search, file search, computer use) are dropped there and so cost
+/// nothing here.
+///
+/// Wildcarded where `estimate_item_len` is exhaustive, and deliberately so:
+/// `Tool` is upstream's type, not one of our shadows, so we carry no
+/// obligation to mirror its variants. Pinning it exhaustively would only
+/// break the build every time async-openai adds a hosted tool we would
+/// score as zero anyway.
+fn estimate_tool_len(tool: &Tool) -> usize {
+    match tool {
+        Tool::Function(function) => function_tool_len(
+            &function.name,
+            function.description.as_ref(),
+            function.parameters.as_ref(),
+        ),
+        Tool::Namespace(namespace) => namespace
+            .tools
+            .iter()
+            .map(|tool| match tool {
+                // The namespace name is an origin marker used to detect
+                // collisions, not prompt text — `push_function` forwards the
+                // bare function name.
+                NamespaceToolParamTool::Function(function) => function_tool_len(
+                    &function.name,
+                    function.description.as_ref(),
+                    function.parameters.as_ref(),
+                ),
+                NamespaceToolParamTool::Custom(_) => 0,
+            })
+            .sum(),
+        _ => 0,
+    }
+}
+
+fn function_tool_len(
+    name: &str,
+    description: Option<&String>,
+    parameters: Option<&serde_json::Value>,
+) -> usize {
+    name.len()
+        + description.map_or(0, |description| description.len())
+        + parameters.map_or(0, |schema| schema.to_string().len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1167,5 +1440,313 @@ mod tests {
                 "turn {idx} did not route to EasyMessage: {item:?}",
             );
         }
+    }
+
+    // ---- count input tokens (POST /v1/responses/input_tokens) ----
+
+    fn count(body: serde_json::Value) -> u32 {
+        serde_json::from_value::<CountInputTokensRequest>(body)
+            .expect("count request should deserialize")
+            .estimate_tokens()
+    }
+
+    #[test]
+    fn count_tokens_plain_text_input() {
+        // "Hello, world!" is 13 chars; 13 / 3 == 4.
+        assert_eq!(
+            count(serde_json::json!({"model": "m", "input": "Hello, world!"})),
+            4
+        );
+    }
+
+    #[test]
+    fn count_tokens_input_is_optional() {
+        // The count endpoint accepts a body without `input`, unlike CreateResponse.
+        assert_eq!(count(serde_json::json!({"model": "m"})), 0);
+    }
+
+    #[test]
+    fn count_tokens_empty_input_is_zero() {
+        assert_eq!(count(serde_json::json!({"input": ""})), 0);
+    }
+
+    #[test]
+    fn count_tokens_short_input_never_rounds_to_zero() {
+        // 2 chars / 3 == 0, but content was present, so report 1.
+        assert_eq!(count(serde_json::json!({"input": "Hi"})), 1);
+    }
+
+    #[test]
+    fn count_tokens_instructions_contribute() {
+        // "You are helpful." (16) + "Hi" (2) == 18; 18 / 3 == 6.
+        assert_eq!(
+            count(serde_json::json!({"input": "Hi", "instructions": "You are helpful."})),
+            6
+        );
+    }
+
+    #[test]
+    fn count_tokens_easy_message_counts_role_and_content() {
+        // user role (4) + "Hello" (5) == 9; 9 / 3 == 3.
+        assert_eq!(
+            count(serde_json::json!({"input": [{"role": "user", "content": "Hello"}]})),
+            3
+        );
+    }
+
+    #[test]
+    fn count_tokens_structured_input_message() {
+        // user role (4) + "Hello" (5) == 9; 9 / 3 == 3.
+        assert_eq!(
+            count(serde_json::json!({"input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello"}],
+            }]})),
+            3
+        );
+    }
+
+    #[test]
+    fn count_tokens_function_call_counts_name_and_arguments() {
+        // "get_weather" (11) + r#"{"city":"SF"}"# (13) == 24; 24 / 3 == 8.
+        assert_eq!(
+            count(serde_json::json!({"input": [{
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "get_weather",
+                "arguments": r#"{"city":"SF"}"#,
+            }]})),
+            8
+        );
+    }
+
+    #[test]
+    fn count_tokens_function_call_output_counts_text() {
+        // "sunny" (5) == 5; 5 / 3 == 1.
+        assert_eq!(
+            count(serde_json::json!({"input": [{
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "sunny",
+            }]})),
+            1
+        );
+    }
+
+    #[test]
+    fn count_tokens_tools_contribute() {
+        // "get_weather" (11) + "Get weather" (11) + r#"{"type":"object"}"# (17)
+        // == 39; 39 / 3 == 13.
+        assert_eq!(
+            count(serde_json::json!({
+                "input": "",
+                "tools": [{
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object"},
+                }],
+            })),
+            13
+        );
+    }
+
+    #[test]
+    fn count_tokens_images_contribute_nothing() {
+        // Only the text part is measured; the image part cannot be estimated
+        // from character length.
+        let with_image = count(serde_json::json!({"input": [{
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this"},
+                {"type": "input_image", "image_url": "https://example.com/a-very-long-url.png"},
+            ],
+        }]}));
+        let without_image = count(serde_json::json!({"input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Describe this"}],
+        }]}));
+        assert_eq!(with_image, without_image);
+    }
+
+    #[test]
+    fn count_tokens_dropped_item_variants_cost_nothing() {
+        // Dynamo's `convert_input_items_to_messages` flushes and skips these,
+        // so they never reach the prompt. Counting their serialized form would
+        // bill callers for JSON scaffolding the model never sees.
+        for item in [
+            serde_json::json!({"type": "web_search_call", "id": "ws_1", "status": "completed"}),
+            serde_json::json!({
+                "type": "computer_call",
+                "call_id": "c_1",
+                "id": "cu_1",
+                "action": {"type": "screenshot"},
+                "pending_safety_checks": [],
+                "status": "completed",
+            }),
+        ] {
+            assert_eq!(
+                count(serde_json::json!({ "input": [item.clone()] })),
+                0,
+                "dropped item variant should not be counted: {item}"
+            );
+        }
+    }
+
+    #[test]
+    fn count_tokens_counts_exactly_the_variants_the_converter_renders() {
+        // Guards the coupling documented on `estimate_item_len`: the explicit
+        // arms are meant to be the same set Dynamo's converter handles. Each
+        // variant is asserted on its own — a single assertion over an array of
+        // all four would still pass with three of the arms deleted. If dynamo
+        // grows support for another variant, this test should gain a case.
+        for item in [
+            serde_json::json!({"role": "user", "content": "Hello"}),
+            serde_json::json!({
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello"}],
+            }),
+            serde_json::json!({
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Hi", "annotations": []}],
+            }),
+            serde_json::json!({
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "get_weather",
+                "arguments": "{}",
+            }),
+            serde_json::json!({"type": "function_call_output", "call_id": "c1", "output": "sunny"}),
+            serde_json::json!({
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "thinking"}],
+            }),
+        ] {
+            assert!(
+                count(serde_json::json!({ "input": [item.clone()] })) > 0,
+                "rendered variant should be counted: {item}"
+            );
+        }
+    }
+
+    #[test]
+    fn count_tokens_reasoning_counts_summary_only() {
+        // The converter joins `summary` and drops everything else on the item,
+        // so `content` and `encrypted_content` must not inflate the estimate.
+        let summary_only = serde_json::json!({"input": [{
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "thinking"}],
+        }]});
+        let with_dropped_fields = serde_json::json!({"input": [{
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "thinking"}],
+            "content": [{"type": "reasoning_text", "text": "a much longer private chain of thought"}],
+            "encrypted_content": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        }]});
+
+        // "thinking" (8) == 8; 8 / 3 == 2.
+        assert_eq!(count(summary_only.clone()), 2);
+        assert_eq!(count(with_dropped_fields), count(summary_only));
+    }
+
+    #[test]
+    fn count_tokens_hosted_tools_cost_nothing() {
+        // `convert_tools` forwards only function tools; hosted tools are
+        // dropped, so they must not inflate the estimate.
+        assert_eq!(
+            count(serde_json::json!({
+                "input": "",
+                "tools": [{"type": "web_search"}],
+            })),
+            0
+        );
+    }
+
+    #[test]
+    fn count_tokens_namespaced_tools_count_their_functions() {
+        // `convert_tools` flattens namespaces to their bare function members,
+        // so the members count and the namespace name does not.
+        // "get_weather" (11) + "Get weather" (11) + r#"{"type":"object"}"# (17)
+        // == 39; 39 / 3 == 13 — the same as the un-namespaced tool above.
+        assert_eq!(
+            count(serde_json::json!({
+                "input": "",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "weather_ns",
+                    "description": "Weather tools",
+                    "tools": [{
+                        "type": "function",
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {"type": "object"},
+                    }],
+                }],
+            })),
+            13
+        );
+    }
+
+    #[test]
+    fn count_tokens_item_reference_contributes_nothing() {
+        // The referenced content is held server-side and is not in this request.
+        assert_eq!(
+            count(serde_json::json!({"input": [{"type": "item_reference", "id": "msg_1"}]})),
+            0
+        );
+    }
+
+    #[test]
+    fn count_tokens_ignores_unsupported_stateful_fields() {
+        // `previous_response_id` / `conversation` are accepted and disregarded
+        // rather than rejected — this endpoint only estimates.
+        assert_eq!(
+            count(serde_json::json!({
+                "model": "m",
+                "input": "Hello, world!",
+                "previous_response_id": "resp_abc123",
+                "conversation": {"id": "conv_1"},
+            })),
+            4
+        );
+    }
+
+    #[test]
+    fn count_tokens_deserializes_the_litellm_request_shape() {
+        // The exact body LiteLLM's CountTokens handler sends:
+        // {model, input, instructions?, tools?} with chat tools already
+        // flattened into the Responses shape.
+        let request: CountInputTokensRequest = serde_json::from_value(serde_json::json!({
+            "model": "dynamo/deepseek-ai/deepseek-v4-pro-sglang",
+            "input": [{"role": "user", "content": "Hello"}],
+            "instructions": "You are helpful.",
+            "tools": [{
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object"},
+            }],
+        }))
+        .expect("LiteLLM request shape should deserialize");
+
+        assert_eq!(
+            request.model.as_deref(),
+            Some("dynamo/deepseek-ai/deepseek-v4-pro-sglang")
+        );
+        assert!(matches!(request.input, InputParam::Items(ref items) if items.len() == 1));
+        assert!(request.estimate_tokens() > 0);
+    }
+
+    #[test]
+    fn count_tokens_response_serializes_to_the_openai_shape() {
+        assert_eq!(
+            serde_json::to_value(CountInputTokensResponse::new(42)).unwrap(),
+            serde_json::json!({"object": "response.input_tokens", "input_tokens": 42})
+        );
     }
 }


### PR DESCRIPTION
Relates to https://github.com/ai-dynamo/dynamo/issues/13732

## What

Adds the protocol types and estimator for OpenAI's `POST /v1/responses/input_tokens`:

- `CountInputTokensRequest` / `CountInputTokensResponse`
- `estimate_tokens()` — a `len/3` heuristic

Types only. The route and handler follow in a companion `ai-dynamo/dynamo` PR.

## Why

- Dynamo doesn't serve this endpoint, so callers get a 404.
- LiteLLM calls it for any deployment configured with `custom_llm_provider: openai`, logging a `CountTokens handler` error on every pre-flight token count.
- It's noisy rather than breaking — LiteLLM falls back to its local tokenizer — but it's a steady error stream in production logs.

## Design notes

- Mirrors the Anthropic count endpoint: same subset-of-the-create-request shape, same role constants, same `len/3` and never-report-zero clamp.
- Counts only what reaches the prompt, tracking dynamo's converter field by field — so `Item::Reasoning` counts `summary` only, and namespaced tools count their flattened function members.
- The `Item` match is exhaustive on purpose: a `_` arm would let a new upstream variant score zero silently, where a compile error forces a render-or-not decision. `Tool` stays wildcarded — it's upstream's type, so we carry no mirroring obligation.
- `input` defaults, and unknown fields are ignored, so `previous_response_id` / `conversation` are accepted and disregarded rather than rejected.

## Testing

- 20 new unit tests, 107 passing overall; clippy and `fmt --check` clean.
- Covers the exact request body LiteLLM sends, the OpenAI response shape, and the per-field alignment with dynamo's converter.
