### PR TITLE
fix(parsers): stream native Qwen XML arguments

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -134,6 +134,20 @@ The four routine loops. All of them end the same way: `package_fixtures.py` rebu
 3. For an intended change: bump the crate version first (workflow 3), re-capture the Dynamo fixtures (`capture.sh dynamo-stream` / `dynamo-batch-on-stream`; v1 batch `expected.dynamo_v1` blocks are updated through the same capture flow), then `package_fixtures.py`.
 4. Commit the parser fix + fixture shards + manifest + `Cargo.toml` bump in the SAME PR. CI is green only when the code and the pinned expectations agree again.
 
+### Unified parser hard gate
+
+Unified work is complete only when the selected current Dynamo column has **zero empty cells and zero red cells** for the affected family. This is a hard gate. `reason:`, `unavailable:`, a historical column, stale HTML, or changing GOLDEN to match broken output does not satisfy it.
+
+Use this loop:
+
+1. **Write:** make the parser or capture change.
+2. **Read:** render `conformance/CONFORMANCE_v2.html`, open the Unified tab, and inspect every empty or red cell's popup. Compare its exact input, request initialization, chunks, GOLDEN events, and current Dynamo events.
+3. **Fix:** repair the owner of the discrepancy. An empty current cell is missing capture data. A red current cell is a parser mismatch unless the authored GOLDEN is demonstrably wrong.
+4. **Regenerate:** rebuild the qualified current capture, package its shard and manifest, and render the HTML again from the same worktree.
+5. **Re-read:** inspect the rendered Unified column again. Repeat until both counts are zero.
+
+`render_table_v2.sh` always writes `conformance/CONFORMANCE_v2.json` beside the HTML and prints the total empty/red count. The standard scoped gate is `conformance/utils/check.sh status --model qwen3 --tab unified`; it renders first, prints every empty or red case, and exits nonzero until the row is clear. Use the lower-level `validate_conformance_status.py` only to inspect an already-rendered file. Then run `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_render -- --nocapture` and `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_parity -- --nocapture`. Do not report Unified work complete while either rendered count is nonzero.
+
 ### 3. Version rule: fixture dirs carry the crate version that ships them
 
 Capture stamps versions from the crates themselves — version dirs (`dynamo_v1-<ver>/`, `dynamo_v2-<ver>/`) and `captured_with.*` fields are read from `Cargo.toml` at capture time. So when a parser fix changes captured output, bump `parsers/v1/Cargo.toml` or `parsers/v2/Cargo.toml` to the NEXT release version BEFORE capturing. The new fixture dirs then carry exactly the version crates.io publishes when the PR merges (the manual-peg flow in [`../RELEASING.md`](../RELEASING.md#manual-version-peg-fixture-synced-releases)): outputs and release stay on one number by construction. Never rename or delete an old version dir — a re-record ADDS a dir.

--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,9 +1,9 @@
 {
-  "snapshot": "20260902_030000",
-  "created_pt": "20260902_030000 (stamp override) America/Los_Angeles",
+  "snapshot": "20260902_135903",
+  "created_pt": "2026-09-02 13:59:03 America/Los_Angeles",
   "crates": {
     "dynamo-parsers": "8.2.0",
-    "dynamo-parsers-v2": "0.4.0"
+    "dynamo-parsers-v2": "0.4.1"
   },
   "peers": {
     "vllm": "0.26.0",
@@ -117,13 +117,13 @@
     },
     {
       "path": "toolcalling/fixtures-stream-v2/dynamo_v2-0.3.1.tar.gz",
-      "sha256": "28cad2cedd449b4d82c5f9cfb5d4d5e417211d0793dc3e3c15900849270883bf",
+      "sha256": "362cf0e613327c817bc759b32afc30263967446f5696747f55ab0066edb879d8",
       "size": 6612
     },
     {
       "path": "toolcalling/fixtures-stream-v2/inputs.tar.gz",
-      "sha256": "90ec091c899366ea4c668fec3de33c722ba06c35d3aa4556b31e7fbb0b1de218",
-      "size": 40660
+      "sha256": "410bb47c3e90595488feb1b3c76a50e177d969121408642d56654e764a60aa35",
+      "size": 40664
     },
     {
       "path": "toolcalling/fixtures-stream-v2/sglang_python-0.5.12.post1.tar.gz",
@@ -244,6 +244,11 @@
       "path": "unified/dynamo_v2-0.4.0.tar.gz",
       "sha256": "c2d0c749ab3439fa9f7b43c5ffe621ce8e207ae6905e1fdee8fc4a2ba4486f17",
       "size": 13751
+    },
+    {
+      "path": "unified/dynamo_v2-0.4.1.tar.gz",
+      "sha256": "a96f9f1c9283c9feef23438a151aabbe7b180f2d18b3de6ce89dcc9154187b50",
+      "size": 13900
     },
     {
       "path": "unified/golden.tar.gz",

--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -246,11 +246,6 @@
       "size": 13715
     },
     {
-      "path": "unified/dynamo_v2-0.4.0+pr200.tar.gz",
-      "sha256": "022d28655fc13888ee7b748ca439dcc0aef57a4464651dda5d44b6d720658307",
-      "size": 14218
-    },
-    {
       "path": "unified/dynamo_v2-0.4.0.tar.gz",
       "sha256": "c2d0c749ab3439fa9f7b43c5ffe621ce8e207ae6905e1fdee8fc4a2ba4486f17",
       "size": 13751

--- a/conformance/fixtures-manifest.json
+++ b/conformance/fixtures-manifest.json
@@ -1,6 +1,6 @@
 {
-  "snapshot": "20260902_135903",
-  "created_pt": "2026-09-02 13:59:03 America/Los_Angeles",
+  "snapshot": "20260902_160053",
+  "created_pt": "2026-09-02 16:00:53 America/Los_Angeles",
   "crates": {
     "dynamo-parsers": "8.2.0",
     "dynamo-parsers-v2": "0.4.1"
@@ -119,6 +119,16 @@
       "path": "toolcalling/fixtures-stream-v2/dynamo_v2-0.3.1.tar.gz",
       "sha256": "362cf0e613327c817bc759b32afc30263967446f5696747f55ab0066edb879d8",
       "size": 6612
+    },
+    {
+      "path": "toolcalling/fixtures-stream-v2/dynamo_v2-0.3.4+current.tar.gz",
+      "sha256": "7da44962051de7449fee090869a288fd56b4463502e9ebcd5b23f9299cbcf29a",
+      "size": 6811
+    },
+    {
+      "path": "toolcalling/fixtures-stream-v2/dynamo_v2-0.4.0.tar.gz",
+      "sha256": "ad8300b9af05bbf4abcfa6f6ce152388a1215a2034408e80d74b20ddea324317",
+      "size": 6767
     },
     {
       "path": "toolcalling/fixtures-stream-v2/inputs.tar.gz",
@@ -247,8 +257,8 @@
     },
     {
       "path": "unified/dynamo_v2-0.4.1.tar.gz",
-      "sha256": "a96f9f1c9283c9feef23438a151aabbe7b180f2d18b3de6ce89dcc9154187b50",
-      "size": 13900
+      "sha256": "a7682809fece4d6b062574dd4d94b9641566347a7f104342d379d462dcbf1d9b",
+      "size": 14316
     },
     {
       "path": "unified/golden.tar.gz",

--- a/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.3.1.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.3.1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28cad2cedd449b4d82c5f9cfb5d4d5e417211d0793dc3e3c15900849270883bf
+oid sha256:362cf0e613327c817bc759b32afc30263967446f5696747f55ab0066edb879d8
 size 6612

--- a/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.3.4+current.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.3.4+current.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7da44962051de7449fee090869a288fd56b4463502e9ebcd5b23f9299cbcf29a
+size 6811

--- a/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.4.0.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-stream-v2/dynamo_v2-0.4.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad8300b9af05bbf4abcfa6f6ce152388a1215a2034408e80d74b20ddea324317
+size 6767

--- a/conformance/fixtures/toolcalling/fixtures-stream-v2/inputs.tar.gz
+++ b/conformance/fixtures/toolcalling/fixtures-stream-v2/inputs.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90ec091c899366ea4c668fec3de33c722ba06c35d3aa4556b31e7fbb0b1de218
-size 40660
+oid sha256:410bb47c3e90595488feb1b3c76a50e177d969121408642d56654e764a60aa35
+size 40664

--- a/conformance/fixtures/unified/README.md
+++ b/conformance/fixtures/unified/README.md
@@ -2,15 +2,15 @@
 
 A third conformance surface that measures the whole assistant output as ONE ordered event stream (`reasoning` / `text` / `tool_call`), alongside the existing tool-only (`conformance/toolcalling/`) and reasoning suites. It exists because those two compare `{normal_text, calls}` / reasoning-only shapes that cannot express the ORDER between reasoning and tool calls — which is exactly where the split parser pipeline breaks.
 
-Status: **U0 spike** (schema + golden corpus + round-trip test). Capture tooling, the parity harness, and the CONFORMANCE_v2.html tab are not built yet — see `DOIT.unifiedparsers_capture.md`.
+Status: the capture tooling, parity harness, and `CONFORMANCE_v2.html` Unified tab are active. The current Dynamo column is validated against the authored GOLDEN corpus.
 
-## Columns (when built)
+## Columns
 
 `GOLDEN | vLLM 0.25.x (Rust) | Dynamo (Rust)` — the golden is the authored oracle; both engines are diffed against it and both can be red.
 
 - **GOLDEN** — authored by `../utils/src/gen_unified_golden.py` from one scenario spec, reasoned from the invariants/policies in `../utils/lib/parsers/UNIFIED_CASES.md`. Never captured from an implementation. Shipped as the versioned `golden.tar.gz` shard here (derived from the build-tree `conformance/unified/golden_spec/<family>.yaml`).
-- **vLLM 0.25.x (Rust)** — gemma4 via the native `Gemma4UnifiedParser`; other families via `CombinedParser(reasoning, tool)`. (U1, not built.)
-- **Dynamo (Rust)** — `parsers/v1` reasoning + `parsers/v2` tool, composed and stitched to how Dynamo serves today. The red comes from the SPLIT, not from the v2 tool parser being wrong. (U2, not built.)
+- **vLLM Rust** — a captured peer implementation, shown by version.
+- **Dynamo Rust** — the native Unified parser where the family has one, otherwise the historical split reasoning-plus-tool path. Current native families must pass the zero-red/zero-empty gate below.
 
 ## Layout
 
@@ -50,6 +50,24 @@ cd /tmp/old-<ver> && \
 Then merge **only files absent from the released tarball** into `conformance/unified/dynamo_v2-<ver>/` — never overwrite a shipped entry, that is the rewrite this file forbids — and run `package_fixtures.py`, `extract_fixtures.py`, `render_table_v2.sh`.
 
 **Done means the whole chain, in every worktree that has the corpus.** A stacked PR and its base are two separate renders, and their `inputs/` can legitimately differ, so each needs its OWN capture — never copy one branch's shards into the other. Verify per worktree: every `dynamo_v2-*` dir has the same case count as `inputs/`, and the rendered HTML greps **0** for `postdates that build`.
+
+## Unified zero-red/zero-empty gate
+
+Unified work is complete only when the affected family's selected current Dynamo column has **zero empty cells and zero red cells**.
+
+- **Empty current cell:** the current capture is missing the case. Repair the capture pipeline and regenerate the qualified current shard.
+- **Red current cell:** current Dynamo output differs from GOLDEN. Reproduce the popup's exact input, initialization, and chunks, then fix the parser unless the authored GOLDEN is demonstrably wrong.
+- **Not a fix:** adding `reason:`, marking the current parser unavailable, selecting a historical column, serving stale HTML, or editing GOLDEN only to match current output.
+
+Follow this sequence until the rendered counts are both zero:
+
+1. Write the parser or capture change.
+2. Read every affected popup: input, initialization, chunks, GOLDEN events, and current Dynamo events.
+3. Fix the owning parser or capture path.
+4. Regenerate the qualified current capture and package the shard with `conformance/fixtures-manifest.json`.
+5. Render `conformance/CONFORMANCE_v2.html` from the same worktree and read the current Unified column again.
+6. Run `conformance/utils/check.sh status --model <family> --tab unified`. This standard gate renders first, prints every empty/red case, and exits nonzero until the selected row is clear. Every render also writes the complete machine-readable report to `conformance/CONFORMANCE_v2.json`.
+7. Run `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_render -- --nocapture` and `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_parity -- --nocapture`.
 
 ## Golden case file format (authored spec, `conformance/unified/golden_spec/<family>.yaml`)
 

--- a/conformance/fixtures/unified/dynamo_v2-0.4.0+pr200.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.4.0+pr200.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:022d28655fc13888ee7b748ca439dcc0aef57a4464651dda5d44b6d720658307
-size 14218

--- a/conformance/fixtures/unified/dynamo_v2-0.4.1.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.4.1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a96f9f1c9283c9feef23438a151aabbe7b180f2d18b3de6ce89dcc9154187b50
-size 13900
+oid sha256:a7682809fece4d6b062574dd4d94b9641566347a7f104342d379d462dcbf1d9b
+size 14316

--- a/conformance/fixtures/unified/dynamo_v2-0.4.1.tar.gz
+++ b/conformance/fixtures/unified/dynamo_v2-0.4.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a96f9f1c9283c9feef23438a151aabbe7b180f2d18b3de6ce89dcc9154187b50
+size 13900

--- a/conformance/tests/capture_cross_version.rs
+++ b/conformance/tests/capture_cross_version.rs
@@ -322,7 +322,7 @@ fn delta_to_yaml(d: &dynamo_parsers_v2::UnifiedParserEvent) -> serde_yaml::Value
             serde_json::json!({"kind": "text", "text": text})
         }
         dynamo_parsers_v2::UnifiedParserEvent::ToolCall(c) => {
-            serde_json::json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
+            serde_json::json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments, "complete": c.complete})
         }
     };
     serde_yaml::to_value(v).expect("delta serializes")

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -233,7 +233,7 @@ pub fn fixture_name(path: &Path) -> String {
 }
 
 /// Current parser-version capture used by stream parity and interleave tests.
-pub const STREAM_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.3.1";
+pub const STREAM_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.0";
 
 pub const UNIFIED_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.1";
 

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -232,6 +232,11 @@ pub fn fixture_name(path: &Path) -> String {
         .to_string()
 }
 
+/// Current parser-version capture used by stream parity and interleave tests.
+pub const STREAM_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.0";
+
+pub const UNIFIED_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.1";
+
 /// Version-sorted capture dirs for one impl prefix (e.g. `dynamo-` under
 /// fixtures-batch-v1, `dynamo_v2-` under fixtures-stream-v2), ASCENDING by
 /// numeric version. Multiple dirs per impl are capture HISTORY (never deleted);
@@ -255,6 +260,26 @@ pub fn version_dirs_ascending(root: &Path, prefix: &str) -> Vec<PathBuf> {
         .collect();
     dirs.sort();
     dirs.into_iter().map(|(_, p)| p).collect()
+}
+
+/// The normal capture history plus one caller-selected current capture. `+tag`
+/// directories remain historical unless a test names the exact directory it needs.
+pub fn version_dirs_ascending_with_current(
+    root: &Path,
+    prefix: &str,
+    current_dir: &str,
+) -> Vec<PathBuf> {
+    let mut dirs = version_dirs_ascending(root, prefix);
+    let current = root.join(current_dir);
+    assert!(
+        current.is_dir(),
+        "expected current capture directory {}",
+        current.display()
+    );
+    if !dirs.contains(&current) {
+        dirs.push(current);
+    }
+    dirs
 }
 
 /// Sort a PR-qualified capture after its matching release. The PR capture represents

--- a/conformance/tests/common/mod.rs
+++ b/conformance/tests/common/mod.rs
@@ -233,7 +233,7 @@ pub fn fixture_name(path: &Path) -> String {
 }
 
 /// Current parser-version capture used by stream parity and interleave tests.
-pub const STREAM_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.0";
+pub const STREAM_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.3.1";
 
 pub const UNIFIED_DYNAMO_V2_CURRENT_CAPTURE: &str = "dynamo_v2-0.4.1";
 
@@ -269,16 +269,17 @@ pub fn version_dirs_ascending_with_current(
     prefix: &str,
     current_dir: &str,
 ) -> Vec<PathBuf> {
-    let mut dirs = version_dirs_ascending(root, prefix);
     let current = root.join(current_dir);
     assert!(
         current.is_dir(),
         "expected current capture directory {}",
         current.display()
     );
-    if !dirs.contains(&current) {
-        dirs.push(current);
-    }
+    let mut dirs = version_dirs_ascending(root, prefix)
+        .into_iter()
+        .filter(|path| path != &current && !path.to_string_lossy().contains('+'))
+        .collect::<Vec<_>>();
+    dirs.push(current);
     dirs
 }
 

--- a/conformance/tests/conformance_toolcalling_batch_via_stream.rs
+++ b/conformance/tests/conformance_toolcalling_batch_via_stream.rs
@@ -279,23 +279,29 @@ fn parse_stream_result(
 fn assemble_trait_calls(result: ToolParseResult) -> Vec<(String, Value)> {
     let mut names = BTreeMap::<usize, String>::new();
     let mut args = BTreeMap::<usize, String>::new();
+    let mut complete = BTreeMap::<usize, bool>::new();
     for ToolCallDelta {
         tool_index,
         name,
         arguments,
+        complete: call_complete,
     } in result.calls
     {
+        *complete.entry(tool_index).or_default() |= call_complete;
         if let Some(name) = name {
-            names.entry(tool_index).or_default().push_str(&name);
+            names.entry(tool_index).or_insert(name);
         }
         args.entry(tool_index).or_default().push_str(&arguments);
     }
     names
         .into_iter()
-        .map(|(idx, name)| {
+        .filter_map(|(idx, name)| {
             let raw = args.remove(&idx).unwrap_or_default();
+            if complete.get(&idx) != Some(&true) {
+                return None;
+            }
             let value = serde_json::from_str(&raw).unwrap_or(Value::String(raw));
-            (name, value)
+            Some((name, value))
         })
         .collect()
 }

--- a/conformance/tests/conformance_toolcalling_stream.rs
+++ b/conformance/tests/conformance_toolcalling_stream.rs
@@ -81,6 +81,7 @@ struct FixtureDelta {
     name: Option<String>,
     #[serde(default)]
     arguments: Option<String>,
+    complete: Option<bool>,
 }
 
 // The corpus is versioned (inputs/ + <impl>-<version>/): the shared per-chunk
@@ -158,6 +159,40 @@ fn merge_dynamo(fx: &mut Fixture, dyn_dir: &Path, rel: &Path) {
     }
 }
 
+fn stream_dynamo_dirs(sv2: &Path) -> Vec<std::path::PathBuf> {
+    common::version_dirs_ascending_with_current(
+        sv2,
+        "dynamo_v2-",
+        common::STREAM_DYNAMO_V2_CURRENT_CAPTURE,
+    )
+}
+
+#[test]
+fn stream_dynamo_dirs_include_only_the_explicit_current_tag() {
+    let root = std::env::temp_dir().join(format!(
+        "dynamo-stream-dirs-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(root.join("dynamo_v2-0.3.1")).unwrap();
+    std::fs::create_dir_all(root.join("dynamo_v2-0.3.4+historical")).unwrap();
+    std::fs::create_dir_all(root.join(common::STREAM_DYNAMO_V2_CURRENT_CAPTURE)).unwrap();
+
+    let names: Vec<_> = stream_dynamo_dirs(&root)
+        .into_iter()
+        .map(|path| path.file_name().unwrap().to_owned())
+        .collect();
+    assert_eq!(
+        names,
+        ["dynamo_v2-0.3.1", common::STREAM_DYNAMO_V2_CURRENT_CAPTURE].map(std::ffi::OsString::from)
+    );
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Compare emitted deltas for one chunk against the fixture's expected list.
@@ -210,6 +245,11 @@ fn diff_chunk(input: ChunkDiff<'_>, failures: &mut Vec<String>) {
                 got.arguments, want.arguments
             ));
         }
+        if let Some(complete) = want.complete
+            && got.complete != complete
+        {
+            errs.push(format!("complete {} != {}", got.complete, complete));
+        }
         if !errs.is_empty() {
             failures.push(format!(
                 "{} {} chunk[{}] delta[{i}]: {}",
@@ -228,6 +268,7 @@ struct EmittedDelta {
     id: bool,
     name: Option<String>,
     arguments: Option<String>,
+    complete: bool,
 }
 
 // The v2 stream overlay is fully canonical (`dynamo_v2`); the legacy `dynamo`
@@ -252,6 +293,7 @@ fn dynamo_unavailable(unavailable: &BTreeMap<String, String>) -> bool {
 fn expected_assembled(case: &Case) -> EngineResult {
     let mut names: BTreeMap<usize, String> = BTreeMap::new();
     let mut args: BTreeMap<usize, String> = BTreeMap::new();
+    let mut complete: BTreeMap<usize, bool> = BTreeMap::new();
     let mut normal_text = String::new();
     for chunk in &case.chunks {
         normal_text.push_str(dynamo_normal_text(&chunk.normal_text));
@@ -262,14 +304,20 @@ fn expected_assembled(case: &Case) -> EngineResult {
             if let Some(a) = &d.arguments {
                 args.entry(d.index as usize).or_default().push_str(a);
             }
+            // Older immutable captures predate explicit completion metadata. Their
+            // emitted deltas were all assembled calls, so retain that behavior.
+            *complete.entry(d.index as usize).or_default() |= d.complete.unwrap_or(true);
         }
     }
     let calls = names
         .into_iter()
-        .map(|(idx, name)| {
+        .filter_map(|(idx, name)| {
+            if complete.get(&idx) != Some(&true) {
+                return None;
+            }
             let raw = args.get(&idx).cloned().unwrap_or_default();
             let v = serde_json::from_str(&raw).unwrap_or(Value::String(raw));
-            (name, v)
+            Some((name, v))
         })
         .collect();
     EngineResult { calls, normal_text }
@@ -284,6 +332,7 @@ struct EngineResult {
 fn assemble_emitted(chunks: &[EmittedDelta], normal_text: String) -> EngineResult {
     let mut names: BTreeMap<usize, String> = BTreeMap::new();
     let mut args: BTreeMap<usize, String> = BTreeMap::new();
+    let mut complete: BTreeMap<usize, bool> = BTreeMap::new();
     for chunk in chunks {
         if let Some(name) = &chunk.name {
             names.entry(chunk.index).or_default().push_str(name);
@@ -291,13 +340,17 @@ fn assemble_emitted(chunks: &[EmittedDelta], normal_text: String) -> EngineResul
         if let Some(arguments) = &chunk.arguments {
             args.entry(chunk.index).or_default().push_str(arguments);
         }
+        *complete.entry(chunk.index).or_default() |= chunk.complete;
     }
     let calls = names
         .into_iter()
-        .map(|(idx, name)| {
+        .filter_map(|(idx, name)| {
+            if complete.get(&idx) != Some(&true) {
+                return None;
+            }
             let raw = args.remove(&idx).unwrap_or_default();
             let v = serde_json::from_str(&raw).unwrap_or(Value::String(raw));
-            (name, v)
+            Some((name, v))
         })
         .collect();
     EngineResult { calls, normal_text }
@@ -309,6 +362,7 @@ fn emitted_from_chunk(chunk: ToolCallResponseChunk) -> EmittedDelta {
         id: chunk.id.is_some(),
         name: chunk.function.as_ref().and_then(|f| f.name.clone()),
         arguments: chunk.function.as_ref().and_then(|f| f.arguments.clone()),
+        complete: true,
     }
 }
 
@@ -321,11 +375,14 @@ fn emitted_from_result(result: ToolParseResult) -> Vec<EmittedDelta> {
                  tool_index,
                  name,
                  arguments,
+                 complete,
+                 ..
              }| EmittedDelta {
                 index: tool_index,
                 id: false,
                 name,
                 arguments: Some(arguments),
+                complete,
             },
         )
         .collect()
@@ -342,7 +399,7 @@ fn toolcalling_stream_parity() {
     // history, folded ASCENDING so the latest capture wins per case.
     let sv2 = common::ensure_fixtures().join("toolcalling/fixtures-stream-v2");
     let inputs_root = sv2.join("inputs");
-    let dyn_dirs = common::version_dirs_ascending(&sv2, "dynamo_v2-");
+    let dyn_dirs = stream_dynamo_dirs(&sv2);
     assert!(
         !dyn_dirs.is_empty(),
         "no dynamo_v2-<version> dir under fixtures-stream-v2"

--- a/conformance/tests/conformance_toolcalling_stream.rs
+++ b/conformance/tests/conformance_toolcalling_stream.rs
@@ -177,7 +177,7 @@ fn stream_dynamo_dirs_include_only_the_explicit_current_tag() {
             .unwrap()
             .as_nanos()
     ));
-    std::fs::create_dir_all(root.join("dynamo_v2-0.3.1")).unwrap();
+    std::fs::create_dir_all(root.join("dynamo_v2-0.2.0")).unwrap();
     std::fs::create_dir_all(root.join("dynamo_v2-0.3.4+historical")).unwrap();
     std::fs::create_dir_all(root.join(common::STREAM_DYNAMO_V2_CURRENT_CAPTURE)).unwrap();
 
@@ -187,7 +187,7 @@ fn stream_dynamo_dirs_include_only_the_explicit_current_tag() {
         .collect();
     assert_eq!(
         names,
-        ["dynamo_v2-0.3.1", common::STREAM_DYNAMO_V2_CURRENT_CAPTURE].map(std::ffi::OsString::from)
+        ["dynamo_v2-0.2.0", common::STREAM_DYNAMO_V2_CURRENT_CAPTURE].map(std::ffi::OsString::from)
     );
 
     std::fs::remove_dir_all(root).unwrap();

--- a/conformance/tests/conformance_toolcalling_stream.rs
+++ b/conformance/tests/conformance_toolcalling_stream.rs
@@ -177,7 +177,7 @@ fn stream_dynamo_dirs_include_only_the_explicit_current_tag() {
             .unwrap()
             .as_nanos()
     ));
-    std::fs::create_dir_all(root.join("dynamo_v2-0.2.0")).unwrap();
+    std::fs::create_dir_all(root.join("dynamo_v2-0.3.1")).unwrap();
     std::fs::create_dir_all(root.join("dynamo_v2-0.3.4+historical")).unwrap();
     std::fs::create_dir_all(root.join(common::STREAM_DYNAMO_V2_CURRENT_CAPTURE)).unwrap();
 
@@ -187,7 +187,7 @@ fn stream_dynamo_dirs_include_only_the_explicit_current_tag() {
         .collect();
     assert_eq!(
         names,
-        ["dynamo_v2-0.2.0", common::STREAM_DYNAMO_V2_CURRENT_CAPTURE].map(std::ffi::OsString::from)
+        ["dynamo_v2-0.3.1", common::STREAM_DYNAMO_V2_CURRENT_CAPTURE].map(std::ffi::OsString::from)
     );
 
     std::fs::remove_dir_all(root).unwrap();

--- a/conformance/tests/parity_toolcalling_stream_interleave.rs
+++ b/conformance/tests/parity_toolcalling_stream_interleave.rs
@@ -76,7 +76,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use common::{collect_yaml, ensure_fixtures, version_dirs_ascending};
+use common::{
+    STREAM_DYNAMO_V2_CURRENT_CAPTURE, collect_yaml, ensure_fixtures,
+    version_dirs_ascending_with_current,
+};
 use dynamo_parsers_v2::{
     Tool, ToolCallDelta, ToolParser, ToolParserInput, create_tool_parser_for_family,
 };
@@ -236,6 +239,14 @@ struct FixtureDelta {
     name: Option<String>,
     #[serde(default)]
     arguments: Option<String>,
+    /// Historical captures predate explicit completion and are complete by
+    /// definition; only newly recorded provisional deltas set this to false.
+    #[serde(default = "default_complete")]
+    complete: bool,
+}
+
+fn default_complete() -> bool {
+    true
 }
 
 /// One case's recorded dynamo_v2 output, already folded to the assembled shape
@@ -330,6 +341,7 @@ fn load_recorded(
 fn assemble_recorded(chunks: &[DynChunk]) -> EngineResult {
     let mut names: BTreeMap<u32, String> = BTreeMap::new();
     let mut args: BTreeMap<u32, String> = BTreeMap::new();
+    let mut complete: BTreeMap<u32, bool> = BTreeMap::new();
     let mut order: Vec<u32> = Vec::new();
     let mut normal_text = String::new();
     for chunk in chunks {
@@ -343,6 +355,7 @@ fn assemble_recorded(chunks: &[DynChunk]) -> EngineResult {
             if let Some(a) = &d.arguments {
                 args.entry(d.index).or_default().push_str(a);
             }
+            *complete.entry(d.index).or_default() |= d.complete;
         }
         if let Some(nt) = &chunk.normal_text {
             normal_text.push_str(nt);
@@ -350,11 +363,14 @@ fn assemble_recorded(chunks: &[DynChunk]) -> EngineResult {
     }
     let calls = order
         .into_iter()
-        .map(|i| {
-            (
+        .filter_map(|i| {
+            if complete.get(&i) != Some(&true) {
+                return None;
+            }
+            Some((
                 names.get(&i).cloned().unwrap_or_default(),
                 args.get(&i).cloned().unwrap_or_default(),
-            )
+            ))
         })
         .collect();
     EngineResult {
@@ -395,6 +411,7 @@ struct EngineResult {
 fn assemble(deltas: &[ToolCallDelta], normal_text: String) -> EngineResult {
     let mut names: BTreeMap<usize, String> = BTreeMap::new();
     let mut args: BTreeMap<usize, String> = BTreeMap::new();
+    let mut complete: BTreeMap<usize, bool> = BTreeMap::new();
     let mut order: Vec<usize> = Vec::new();
     for d in deltas {
         if !order.contains(&d.tool_index) {
@@ -404,14 +421,18 @@ fn assemble(deltas: &[ToolCallDelta], normal_text: String) -> EngineResult {
             names.entry(d.tool_index).or_default().push_str(name);
         }
         args.entry(d.tool_index).or_default().push_str(&d.arguments);
+        *complete.entry(d.tool_index).or_default() |= d.complete;
     }
     let calls = order
         .into_iter()
-        .map(|idx| {
-            (
+        .filter_map(|idx| {
+            if complete.get(&idx) != Some(&true) {
+                return None;
+            }
+            Some((
                 names.get(&idx).cloned().unwrap_or_default(),
                 args.get(&idx).cloned().unwrap_or_default(),
-            )
+            ))
         })
         .collect();
     EngineResult {
@@ -419,6 +440,20 @@ fn assemble(deltas: &[ToolCallDelta], normal_text: String) -> EngineResult {
         normal_text,
         emission_profile: Vec::new(),
     }
+}
+
+#[test]
+fn assemble_omits_incomplete_tool_deltas() {
+    let result = assemble(
+        &[ToolCallDelta {
+            tool_index: 0,
+            name: Some("get_weather".into()),
+            arguments: r#"{"city":"Par"#.into(),
+            complete: false,
+        }],
+        String::new(),
+    );
+    assert!(result.calls.is_empty());
 }
 
 // ── ChoiceRouter: one parser instance per choice.index ───────────────────────
@@ -796,7 +831,8 @@ fn toolcalling_stream_interleave_isolation() {
 
     // Capture history for the v2 parser, folded ascending (latest wins per case)
     // via the shared helper the canonical parity test uses.
-    let dyn_dirs = version_dirs_ascending(&sv2, "dynamo_v2-");
+    let dyn_dirs =
+        version_dirs_ascending_with_current(&sv2, "dynamo_v2-", STREAM_DYNAMO_V2_CURRENT_CAPTURE);
     assert!(
         !dyn_dirs.is_empty(),
         "no dynamo_v2-<version> dir under {}",

--- a/conformance/tests/sweep_toolcalling_stream.rs
+++ b/conformance/tests/sweep_toolcalling_stream.rs
@@ -91,6 +91,7 @@ struct Assembled {
 fn assemble(results: &[ToolParseResult]) -> Assembled {
     let mut names: BTreeMap<usize, String> = BTreeMap::new();
     let mut args: BTreeMap<usize, String> = BTreeMap::new();
+    let mut complete: BTreeMap<usize, bool> = BTreeMap::new();
     let mut normal_text = String::new();
     for r in results {
         normal_text.push_str(&r.normal_text);
@@ -99,17 +100,35 @@ fn assemble(results: &[ToolParseResult]) -> Assembled {
                 names.entry(d.tool_index).or_default().push_str(n);
             }
             args.entry(d.tool_index).or_default().push_str(&d.arguments);
+            *complete.entry(d.tool_index).or_default() |= d.complete;
         }
     }
     let calls = names
         .into_iter()
-        .map(|(idx, name)| {
+        .filter_map(|(idx, name)| {
+            if complete.get(&idx) != Some(&true) {
+                return None;
+            }
             let raw = args.remove(&idx).unwrap_or_default();
             let v = serde_json::from_str(&raw).unwrap_or(Value::String(raw));
-            (name, v)
+            Some((name, v))
         })
         .collect();
     Assembled { calls, normal_text }
+}
+
+#[test]
+fn assemble_omits_incomplete_tool_deltas() {
+    let result = ToolParseResult {
+        normal_text: String::new(),
+        calls: vec![dynamo_parsers_v2::ToolCallDelta {
+            tool_index: 0,
+            name: Some("get_weather".into()),
+            arguments: r#"{"city":"Par"#.into(),
+            complete: false,
+        }],
+    };
+    assert!(assemble(&[result]).calls.is_empty());
 }
 
 fn new_parser(family: &str, tools: &[Tool]) -> Box<dyn ToolParser> {

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -969,10 +969,8 @@ fn shared_overlay_dirs(root: &std::path::Path, base: &str) -> Vec<PathBuf> {
 fn release_qualified_capture_order_preserves_current_and_released_owners() {
     let prefix = "dynamo_v2-";
     let older_release = common::version_capture_sort_key("dynamo_v2-0.3.2", prefix).unwrap();
-    let current_pr = common::version_capture_sort_key("dynamo_v2-0.4.0+pr200", prefix).unwrap();
     let current_release = common::version_capture_sort_key("dynamo_v2-0.4.0", prefix).unwrap();
     assert!(older_release < current_release);
-    assert!(current_release < current_pr);
     assert!(common::version_capture_sort_key("dynamo_v2-0.3.3.patch1", prefix).is_none());
 }
 

--- a/conformance/tests/unified_render.rs
+++ b/conformance/tests/unified_render.rs
@@ -175,7 +175,7 @@ fn unified_delta_json(d: &dynamo_parsers_v2::UnifiedParserEvent) -> Value {
         }
         dynamo_parsers_v2::UnifiedParserEvent::Text(text) => json!({"kind": "text", "text": text}),
         dynamo_parsers_v2::UnifiedParserEvent::ToolCall(c) => {
-            json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments})
+            json!({"kind": "tool_call", "name": c.name, "arguments": c.arguments, "complete": c.complete})
         }
     }
 }
@@ -855,9 +855,13 @@ fn committed_dynamo_capture_matches_the_live_parsers() {
     // lets a newer PR-qualified capture outrank every older release. Resolving by
     // readdir order instead made this guard nondeterministic — the same commit could
     // pass against one shard and report parser drift against another.
-    let capture_dir = common::version_dirs_ascending(&root, "dynamo_v2-")
-        .pop()
-        .expect("no committed dynamo_v2-<ver> capture dir");
+    let capture_dir = common::version_dirs_ascending_with_current(
+        &root,
+        "dynamo_v2-",
+        common::UNIFIED_DYNAMO_V2_CURRENT_CAPTURE,
+    )
+    .pop()
+    .expect("no committed dynamo_v2-<ver> capture dir");
 
     // key -> (family, scenario, input, init), from the base inputs shard plus
     // PR-qualified sparse overlays. New cases must carry their input metadata in

--- a/conformance/tests/unified_schema_roundtrip.rs
+++ b/conformance/tests/unified_schema_roundtrip.rs
@@ -9,7 +9,7 @@
 //! (`conformance/unified/golden_spec/<family>.yaml`, rendered on demand by
 //! gen_unified_golden.py into the gitignored build tree) parses and round-trips
 //! through it. This is the U0 spike gate — it does NOT run any parser;
-//! capture/parity land in later phases (see `DOIT.unifiedparsers_capture.md`).
+//! capture/parity land in later phases (see `DOIT.p1.e4.unifiedparsers-capture.md`).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;

--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -182,6 +182,14 @@ conformance/utils/render_table_v2.sh --dry-run
 
 Open the generated HTML file in a browser. The table is generated from extracted fixture directories staged by `render_table_v2.sh`.
 
+Every successful render also writes `conformance/CONFORMANCE_v2.json`, derived from the same inlined model the browser renders, and prints the aggregate empty/red count. The standard compiler-like gate for one or more models and tabs is:
+
+```bash
+conformance/utils/check.sh status --model qwen3 --tab unified
+```
+
+Repeat `--model` or `--tab` to validate more than one. The command always renders first, prints each empty or red model/case pair, and exits `1` when any requested cell is not green. `validate_conformance_status.py` is the lower-level reader for checking an existing HTML file without rerendering.
+
 Use the generated matrix to inspect vLLM Python vs vLLM Rust behavior. `check.sh vllm` runs the live vLLM Python parser against extracted YAML; it does not run vLLM Rust. vLLM Python vs Rust is a fixture comparison in the `TC stream (v2)` and `TC batch-on-stream (v2)` tabs.
 
 ## Matrix Legend
@@ -206,6 +214,7 @@ Run these from `conformance/utils/`:
 | Command | Purpose |
 |---|---|
 | `render_table_v2.sh` | Builds `.stage/` and writes the v2 conformance HTML matrix. The default example path is `conformance/CONFORMANCE_v2.html`. |
+| `check.sh status --model <family> --tab <tab>` | Renders the matrix and fails with the exact empty/red model-case pairs. |
 | `check.sh` | Runs Dynamo, vLLM Python, and SGLang checks against staged fixtures. |
 | `capture.sh` | Consistent entry point for capturing parser behavior and refreshing v2 fixtures. |
 

--- a/conformance/utils/check.sh
+++ b/conformance/utils/check.sh
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# check.sh <dynamo|vllm|sglang|coverage|ci|all> [batch|stream|all] [--container N|--pip] [--dry-run]
+# check.sh <dynamo|vllm|sglang|coverage|status|ci|all> [batch|stream|all] [--container N|--pip] [--dry-run]
 #   Run a parser against the committed fixtures and report pass/fail (read-only).
 #     dynamo [batch|stream|all]  Dynamo Rust parser vs expected.dynamo_v2 / expected.dynamo_v1 (cargo test)
 #     vllm   [--container N|--pip]   vLLM Python parser vs expected.vllm_python / expected.vllm
 #     sglang [--container N|--pip]   SGLang Python parser vs expected.sglang_python
 #     coverage [--family F ...]      fixture-coverage + marker-registration lint vs
 #                                    case-taxonomy.yaml (defaults to --all families)
+#     status [--model F ...] [--tab T ...]
+#                                    render, then fail on every empty/red selected cell
 #     ci     what the conformance-table CI job runs, and the ONLY thing it runs:
 #            render the conformance chart, structural sanity, coverage lint,
 #            invariant pytest.
@@ -23,7 +25,7 @@ while [ $# -gt 0 ]; do case "$1" in --dry-run|--dryrun) DRY=1; shift;; *) args+=
 set -- ${args+"${args[@]}"}
 source "$(dirname "$0")/src/_common.sh"
 
-usage() { echo "usage: conformance/utils/check.sh <dynamo|vllm|sglang|coverage|ci|all> [batch|stream|all] [--container N|--pip]" >&2; exit 2; }
+usage() { echo "usage: conformance/utils/check.sh <dynamo|vllm|sglang|coverage|status|ci|all> [batch|stream|all] [--container N|--pip]" >&2; exit 2; }
 
 run_dynamo() {  # $1 = batch|stream|all ; returns non-zero if any target fails
   local targets=() rc=0
@@ -54,12 +56,25 @@ run_coverage() {  # $@ = passthrough (--family F ...); defaults to --all
   else python3 "$TOOLS/check_family_coverage.py" --all; fi
 }
 
+run_status() {  # $@ = passthrough (--model F ... --tab T ...)
+  local out="$ROOT/conformance/CONFORMANCE_v2.html"
+  if [ "$DRY" = 1 ]; then
+    echo "[dry-run] render v2, then validate empty/red status $*"
+    return
+  fi
+  "$UTILS/render_table_v2.sh"
+  python3 "$TOOLS/validate_conformance_status.py" \
+    --html "$out" --require-green "$@"
+}
+
 run_ci() {  # the conformance-table CI gate; fail-fast, also runnable locally
   if [ "$DRY" = 1 ]; then echo "[dry-run] render v2, sanity greps, coverage lint, invariant pytest"; return; fi
   set -e
   "$UTILS/render_table_v2.sh"
   local out="$ROOT/conformance/CONFORMANCE_v2.html"
+  local status="$ROOT/conformance/CONFORMANCE_v2.json"
   test -s "$out"
+  test -s "$status"
   grep -q "TOOLCALLING.batch" "$out"
   grep -q "REASONING.batch" "$out"
   echo "conformance matrix rendered: $(wc -c < "$out") bytes"
@@ -81,6 +96,7 @@ case "$engine" in
   vllm)   run_engine vllm "$@" ;;
   sglang) run_engine sglang "$@" ;;
   coverage) run_coverage "$@" ;;
+  status) run_status "$@" ;;
   ci)     run_ci ;;
   all)
     cv=""; cs=""; allow_peer=0; rc=0

--- a/conformance/utils/lib/parsers/UNIFIED_CASES.md
+++ b/conformance/utils/lib/parsers/UNIFIED_CASES.md
@@ -308,9 +308,19 @@ Every rule here exists because a case was added that could not fail for the reas
 
 ## Verifying a change to the table
 
+The affected family's selected current Dynamo Unified column must finish with **zero empty cells and zero red cells**.
+
+1. **Write:** change the parser or capture path.
+2. **Read:** render the table and inspect each affected popup's input, initialization, chunks, GOLDEN events, and current Dynamo events.
+3. **Fix:** treat an empty current cell as missing capture data. Treat a red current cell as a parser defect unless the authored GOLDEN is demonstrably wrong.
+4. **Regenerate:** rebuild the qualified current capture, package its shard and manifest, and rerender from the same worktree.
+5. **Re-read:** inspect the rendered column again and repeat until both counts are zero.
+
+Do not use `reason:`, `unavailable:`, a historical column, stale HTML, or an unsupported GOLDEN edit to make a current empty or red cell appear acceptable.
+
 The model blob and the rendered page are different things. A cell can carry correct JSON and render nothing — the column-header popup shipped with `init` in every column and an empty config list, because the model that feeds `buildGrammarHtml` is assembled separately and dropped the field.
 
-- Check the DOM, not just `conformance-model` JSON.
+- Check the rendered DOM, not only a cell's aggregate `status` or the `conformance-model` JSON. A cell can report `status: ok` while `red_on_diff` and the comparison signatures still make it render red.
 - Headless Chrome reports `(hover: hover) = false`, so hover listeners never attach and a naive hover test "fails" on the baseline too. Emulate with `--blink-settings=primaryHoverType=2,availableHoverTypes=2`.
 - A synthetic `pointerenter` does NOT set CSS `:hover`. Use it to test JS behavior, a real pointer move to test CSS.
 - Never run `render_table_v2.sh` and the pytest suite at the same time: both stage into `conformance/utils/.stage/`, and the collision shows up as ~13 unrelated browser-test errors.

--- a/conformance/utils/render_table_v2.sh
+++ b/conformance/utils/render_table_v2.sh
@@ -11,7 +11,7 @@ usage() {
   cat <<'EOF'
 usage: conformance/utils/render_table_v2.sh [--dry-run] [--output PATH]
 
-Render the v2 conformance matrix to an HTML file.
+  Render the v2 conformance matrix to an HTML file and write a sibling status JSON.
 
 Options:
   --output PATH   Write to PATH. Relative paths resolve from the repo root.
@@ -76,7 +76,14 @@ case "$OUT" in
 esac
 if ( cd "$STAGE" && PYTHONPATH="$STAGE" python3 tests/parity/generate_conformance_table.py all --html --output-path "$OUT" --artifact-root "$ROOT" ) > "$WORK"; then
   mv -f "$WORK" "$OUT"
+  case "$OUT" in
+    *.html) STATUS="${OUT%.html}.json" ;;
+    *)      STATUS="$OUT.status.json" ;;
+  esac
+  python3 "$TOOLS/validate_conformance_status.py" \
+    --html "$OUT" --status-path "$STATUS" --summary-only
   echo "wrote $OUT"
+  echo "wrote $STATUS"
 else
   rc=$?
   rm -f "$WORK"

--- a/conformance/utils/src/_common.sh
+++ b/conformance/utils/src/_common.sh
@@ -76,6 +76,7 @@ _build_stage_base() {
   \cp -f "$TOOLS/impls.py" "$STAGE/tests/parity/impls.py"
   \cp -f "$TOOLS/markers.py" "$STAGE/tests/parity/markers.py"
   \cp -f "$TOOLS/unified_taxonomy.py" "$STAGE/tests/parity/unified_taxonomy.py"
+  \cp -f "$TOOLS/gen_unified_golden.py" "$STAGE/tests/parity/gen_unified_golden.py"
   [ -f "$TOOLS/assets/conformance_view.js" ] && \
     \cp -f "$TOOLS/assets/conformance_view.js" "$STAGE/tests/parity/assets/conformance_view.js" || true
   # Reasoning fixtures are resolved (at the pinned peer versions) by

--- a/conformance/utils/src/gen_unified_golden.py
+++ b/conformance/utils/src/gen_unified_golden.py
@@ -1536,6 +1536,27 @@ def build_cases(fam):
     return cases
 
 
+def scenario_families(scenario):
+    """Return the families for which an authored scenario is applicable.
+
+    A plain per-family map means the scenario is part of the full matrix. An
+    ``OnlyFamilies`` map is the authoring-time declaration that the grammar
+    cannot express the scenario for the omitted families. The table builder
+    uses this same declaration to render explicit n/a cells instead of
+    silently dropping them.
+    """
+    for name, *_rest in CLEAN:
+        if name == scenario:
+            return frozenset(FAMILIES)
+    for edge_case in EDGE:
+        name = edge_case[0]
+        if name != scenario:
+            continue
+        per_fam = edge_case[-1]
+        return frozenset(per_fam) if isinstance(per_fam, OnlyFamilies) else frozenset(FAMILIES)
+    raise KeyError(f"unknown unified scenario {scenario!r}")
+
+
 # --- YAML emitter: `input` as a block literal, everything else as inline JSON
 # (valid YAML, and json.dumps escapes the marker-heavy strings safely). --------
 

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -117,6 +117,7 @@ from impls import (  # noqa: E402
 # rendering code below and the test suite keep referring to them as module attributes.
 import markers  # noqa: E402  (module handle: structured comparison model, DIS-2434)
 import unified_taxonomy  # noqa: E402  (shared UNIFIED scenario->numbered-id taxonomy)
+import gen_unified_golden  # noqa: E402  (authored Unified scenario scope)
 from markers import (  # noqa: E402,F401
     VLLM_RUST_UNAVAILABLE,
     _BATCH_MODE_MARKER,
@@ -2126,7 +2127,12 @@ def _assemble_stream(chunk_deltas: list) -> list:
             elif k == "tool_call":
                 name, args = dl.get("name"), dl.get("arguments")
                 if name:  # a name delta opens a new call
-                    events.append({"kind": "tool_call", "name": name, "_raw": args or ""})
+                    events.append({
+                        "kind": "tool_call",
+                        "name": name,
+                        "_raw": args or "",
+                        "_complete": dl.get("complete", True),
+                    })
                     cur_tool = len(events) - 1
                 elif cur_tool is not None and args:
                     prev = events[cur_tool].get("_raw", "")
@@ -2137,9 +2143,13 @@ def _assemble_stream(chunk_deltas: list) -> list:
                         # string-concat across mixed types (TypeError). A dict/list arg
                         # supersedes; the finalizer below reads it as the resolved object.
                         events[cur_tool]["_raw"] = args
+                if cur_tool is not None and dl.get("complete", True):
+                    events[cur_tool]["_complete"] = True
+    events = [e for e in events if e.get("kind") != "tool_call" or e.get("_complete", True)]
     for e in events:
         if e["kind"] == "tool_call":
             raw = e.pop("_raw", "")
+            e.pop("_complete", None)
             if isinstance(raw, (dict, list)):
                 e["arguments"] = raw
             elif not (raw or "").strip():
@@ -2414,6 +2424,17 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
     if not cases:
         return None
 
+    authored_scenarios = {
+        spec[0] for spec in (*gen_unified_golden.CLEAN, *gen_unified_golden.EDGE)
+    }
+    loaded_scenarios = {case["scenario"] for case in cases}
+    missing_scenarios = authored_scenarios - loaded_scenarios
+    if missing_scenarios:
+        raise ValueError(
+            "Unified fixture inputs are missing authored scenario(s): "
+            + ", ".join(sorted(missing_scenarios))
+        )
+
     vllm_python_vers = _vers.get("vllm_python_all") or []
     vrust_vers = _vers.get("vllm_rust_all") or []
 
@@ -2534,11 +2555,61 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
              "(owning reasoning+content+tools) fixes this by construction.")
 
     rows = []
+
+    def _unified_na_cell(family: str, scenario: str, group_num: int) -> dict:
+        note = (
+            f"Not applicable to {family}: this scenario is authored only for "
+            f"{', '.join(sorted(gen_unified_golden.scenario_families(scenario)))}. "
+            f"{scn_desc[scenario]}"
+        )
+        unavailable = {"unavailable": note}
+        return {
+            "kind": "cell",
+            "case_id": unified_taxonomy.numbered_id(scenario),
+            "family": family,
+            "sub": scenario,
+            "col_group": f"unified_g{group_num}",
+            "band": _band(group_num),
+            "status": "na",
+            "red_on_diff": False,
+            "cmp": {candidate["key"]: markers.cmp_entry(0, na=1) for candidate in candidates},
+            "facts": [],
+            "tooltip": {
+                "head": f"{unified_taxonomy.numbered_id(scenario)} ({scenario}) — {family}",
+                "description": scn_desc[scenario],
+                "init": scn_init.get(scenario),
+                "finish_reason": None,
+                "input": {"kind": None, "text": None, "chunks": None,
+                           "family": unified_taxonomy.marker_family(family)},
+                "candidates": [
+                    {"key": candidate["key"], "label": candidate["label"],
+                     "impl": candidate["impl"], "version": candidate["version"],
+                     "parse_mode": candidate["parse_mode"], "leak": False,
+                     "block": unavailable}
+                    for candidate in candidates
+                ],
+                "baseline": None,
+                "reasons": [],
+                "dynamo_notes": [],
+                "refs": [],
+                "leak_note": None,
+                "na_note": note,
+            },
+        }
+
     for f in families:
         cells = {}
         for s in scenarios:
             c = by_key.get((f, s))
             if not c:
+                applicable = gen_unified_golden.scenario_families(s)
+                if f in applicable:
+                    raise ValueError(
+                        f"Unified fixture missing applicable case {f}/{s}; "
+                        "author or capture the case instead of rendering n/a"
+                    )
+                g_num, _g_sub = _tax(s)
+                cells[s] = _unified_na_cell(f, s, g_num)
                 continue
             gold = c["golden"]
             # Assemble every engine's FINAL from its STREAMED per-chunk deltas (not its
@@ -2688,9 +2759,11 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
                      "parser": None, "cells": cells})
 
     total = sum(len(r["cells"]) for r in rows)
+    na = sum(cell.get("status") == "na" for row in rows for cell in row["cells"].values())
+    missing = sum(cell.get("kind") == "missing" for row in rows for cell in row["cells"].values())
     stats = {"families": len(families), "sub_cases": len(scenarios), "slots": total,
-             "real": total, "parity": 0, "dynamo_only": 0, "documented": 0,
-             "research": 0, "errors": 0, "na": 0, "missing": 0}
+             "real": total - na - missing, "parity": 0, "dynamo_only": 0, "documented": 0,
+             "research": 0, "errors": 0, "na": na, "missing": missing}
     cases_href = str(hrefs.get("reasoning_cases", "#")).replace("REASONING_CASES", "UNIFIED_CASES")
 
     # "Case descriptions" section under the table, grouped by taxonomy — same shape as

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -2302,7 +2302,14 @@ def _load_unified_fixtures(base: Path):
 
     if dynamo_by_ver:
         current_dynamo_ver, current_dynamo_cases = next(reversed(dynamo_by_ver.items()))
-        missing_current_cases = sorted(set(inputs).difference(current_dynamo_cases))
+        missing_current_cases = sorted(
+            (family, key)
+            for (family, key), input_case in inputs.items()
+            if (family, key) not in current_dynamo_cases
+            and family in gen_unified_golden.scenario_families(
+                input_case.get("scenario") or key
+            )
+        )
         if missing_current_cases:
             missing = ", ".join(f"{family}/{case}" for family, case in missing_current_cases)
             raise ValueError(

--- a/conformance/utils/src/validate_conformance_status.py
+++ b/conformance/utils/src/validate_conformance_status.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Validate rendered conformance cells for selected models and tabs.
+
+The HTML model is the source of truth for what the reader sees. This script reads
+the inlined ``conformance-model`` JSON after rendering and reports every selected
+model/case pair whose default Reference cell is empty or red.
+
+Examples:
+  python3 conformance/utils/src/validate_conformance_status.py \
+      --html conformance/CONFORMANCE_v2.html --model qwen3 --tab unified
+  python3 conformance/utils/src/validate_conformance_status.py \
+      --html conformance/CONFORMANCE_v2.html --model qwen3 --tab unified \
+      --require-green
+"""
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+
+MODEL_RE = re.compile(
+    r'<script type="application/json" id="conformance-model">(.*?)</script>', re.DOTALL
+)
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def load_model(path: Path) -> dict:
+    match = MODEL_RE.search(path.read_text())
+    if match is None:
+        raise ValueError(f"{path}: missing conformance-model JSON")
+    return json.loads(html.unescape(match.group(1)))
+
+
+def select_tabs(model: dict, requested: list[str]) -> list[dict]:
+    tabs = model.get("tabs") or []
+    if not requested:
+        return tabs
+    selected = []
+    unknown = []
+    for name in requested:
+        wanted = _normalize(name.removeprefix("tab-"))
+        matches = [
+            tab
+            for tab in tabs
+            if wanted
+            in {
+                _normalize(tab.get("id", "").removeprefix("tab-")),
+                _normalize(tab.get("kind", "")),
+                _normalize(tab.get("label", "")),
+            }
+        ]
+        if not matches:
+            unknown.append(name)
+            continue
+        for tab in matches:
+            if tab not in selected:
+                selected.append(tab)
+    if unknown:
+        choices = ", ".join(tab.get("id", "") for tab in tabs)
+        raise ValueError(f"unknown tab(s): {', '.join(unknown)}; choices: {choices}")
+    return selected
+
+
+def select_rows(tab: dict, requested: list[str]) -> list[dict]:
+    rows = [row for row in tab.get("rows", []) if row.get("family")]
+    if not requested:
+        return rows
+    selected = []
+    unknown = []
+    for name in requested:
+        wanted = _normalize(name)
+        matches = [
+            row
+            for row in rows
+            if wanted in {_normalize(row.get("family", "")), _normalize(row.get("model_label", ""))}
+        ]
+        if not matches:
+            unknown.append(name)
+            continue
+        for row in matches:
+            if row not in selected:
+                selected.append(row)
+    if unknown:
+        choices = ", ".join(row.get("family", "") for row in rows)
+        raise ValueError(
+            f"{tab.get('id')}: unknown model(s): {', '.join(unknown)}; choices: {choices}"
+        )
+    return selected
+
+
+def reference(tab: dict) -> dict:
+    candidates = tab.get("candidates") or []
+    matches = [candidate for candidate in candidates if candidate.get("default_bucket") == "A"]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{tab.get('id')}: expected exactly one default Reference candidate, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def cell_state(cell: dict | None, ref: dict) -> tuple[str, str]:
+    if cell is None:
+        return "empty", "no cell was emitted for this model/case pair"
+    if cell.get("kind") == "cell" and cell.get("status") == "na":
+        note = (cell.get("tooltip") or {}).get("na_note") or "not applicable to this family"
+        return "na", note
+
+    cmp = cell.get("cmp") or {}
+    current = cmp.get(ref["key"])
+    if current is None:
+        return "empty", f"the default Reference {ref['label']!r} has no comparison entry"
+    if current.get("na") == 1:
+        return "empty", f"the default Reference {ref['label']!r} has no captured result"
+    if current.get("err") == 1:
+        return "red", f"the default Reference {ref['label']!r} returned an error"
+
+    if cell.get("red_on_diff"):
+        golden = cmp.get("golden")
+        if golden is None:
+            return "red", "Unified cell has no GOLDEN comparison entry"
+        if current.get("sig") != golden.get("sig"):
+            return "red", "the default Reference differs from GOLDEN"
+    elif current.get("leak") == 1:
+        return "red", "the default Reference leaked structured markup"
+
+    return "green", ""
+
+
+def build_status(model: dict, tabs: list[dict], requested_models: list[str], html_path: Path) -> dict:
+    reports = []
+    for tab in tabs:
+        ref = reference(tab)
+        columns = tab.get("columns") or []
+        for row in select_rows(tab, requested_models):
+            issues = []
+            for column in columns:
+                sub = column.get("sub", "")
+                state, reason = cell_state((row.get("cells") or {}).get(sub), ref)
+                if state in {"green", "na"}:
+                    continue
+                issues.append(
+                    {
+                        "state": state,
+                        "case": column.get("label", sub),
+                        "scenario": sub,
+                        "reason": reason,
+                    }
+                )
+            reports.append(
+                {
+                    "tab": tab.get("id"),
+                    "model": row.get("family"),
+                    "reference": {"key": ref["key"], "label": ref["label"]},
+                    "cells": len(columns),
+                    "empty": sum(issue["state"] == "empty" for issue in issues),
+                    "red": sum(issue["state"] == "red" for issue in issues),
+                    "na": sum(
+                        (row.get("cells") or {}).get(column.get("sub", ""), {}).get("kind") == "cell"
+                        and (row.get("cells") or {}).get(column.get("sub", ""), {}).get("status") == "na"
+                        for column in columns
+                    ),
+                    "issues": issues,
+                }
+            )
+    return {
+        "schema": 1,
+        "html": str(html_path),
+        "generated": model.get("meta", {}),
+        "reports": reports,
+    }
+
+
+def print_summary(status: dict) -> None:
+    for report in status["reports"]:
+        print(
+            f"{report['tab']} {report['model']}: "
+            f"{report['cells']} cells, {report.get('na', 0)} n/a, "
+            f"{report['empty']} empty, {report['red']} red "
+            f"(Reference: {report['reference']['label']})"
+        )
+        for issue in report["issues"]:
+            print(f"  {issue['state'].upper()} {issue['case']} ({issue['scenario']}): {issue['reason']}")
+
+
+def print_totals(status: dict) -> None:
+    reports = status["reports"]
+    empty = sum(report["empty"] for report in reports)
+    red = sum(report["red"] for report in reports)
+    print(f"conformance status: {len(reports)} model/tab pairs, {empty} empty, {red} red")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--html", type=Path, required=True, help="rendered CONFORMANCE_v2.html")
+    parser.add_argument("--model", action="append", default=[], help="model family or row label; repeatable")
+    parser.add_argument("--tab", action="append", default=[], help="tab id, kind, or label; repeatable")
+    parser.add_argument("--status-path", type=Path, help="write the machine-readable status JSON")
+    parser.add_argument("--require-green", action="store_true", help="exit 1 when any selected cell is empty or red")
+    parser.add_argument("--summary-only", action="store_true", help="print totals without listing each issue")
+    args = parser.parse_args(argv)
+
+    try:
+        model = load_model(args.html)
+        status = build_status(model, select_tabs(model, args.tab), args.model, args.html)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+
+    if args.status_path:
+        args.status_path.parent.mkdir(parents=True, exist_ok=True)
+        args.status_path.write_text(json.dumps(status, indent=2) + "\n")
+    if args.summary_only:
+        print_totals(status)
+    else:
+        print_summary(status)
+    blocked = any(report["empty"] or report["red"] for report in status["reports"])
+    return 1 if args.require_green and blocked else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -287,7 +287,7 @@ def test_unified_default_dynamo_uses_pr_capture_and_keeps_release_history(tmp_pa
     dynamo = next(candidate for candidate in tab["candidates"] if candidate["key"] == "dynamo")
     release = next(candidate for candidate in tab["candidates"] if candidate["key"] == "dynamo@0.4.0")
 
-    assert dynamo["label"] == "Dynamo v2 Rust 0.4.0+pr200 (stream, Combined & Unified)"
+    assert dynamo["label"] == "Dynamo v2 Rust 0.4.1 (stream, Combined & Unified)"
     assert dynamo["default_bucket"] == "A"
     assert release["label"] == "Dynamo v2 Rust 0.4.0 (stream, Combined & Unified)"
     assert release["default_bucket"] == "C"
@@ -303,13 +303,19 @@ def test_unified_tab_marks_unsupported_and_postdated_vllm_cases_na(model_v2):
             unavailable = [cell["cmp"][key].get("na") == 1 for cell in row["cells"].values()]
             if row["family"] == "muse_glimmer":
                 assert all(unavailable), f"{key} must say n/a for Muse"
-            elif row["family"] != "gemma4":
-                assert not any(unavailable), f"{key} is missing captured cases for {row['family']}"
+                continue
+            for scenario, is_unavailable in zip(row["cells"], unavailable):
+                if not is_unavailable or row["cells"][scenario]["status"] == "na":
+                    continue
+                peer = next(candidate for candidate in row["cells"][scenario]["tooltip"]["candidates"] if candidate["key"] == key)
+                assert "not captured at" in peer["block"]["unavailable"] or "has no parser" in peer["block"]["unavailable"]
 
     gemma = next(row for row in tab["rows"] if row["family"] == "gemma4")
     for key in peer_keys:
         for cell in gemma["cells"].values():
             if cell["cmp"][key].get("na") == 1:
+                if cell["status"] == "na":
+                    continue
                 peer = next(candidate for candidate in cell["tooltip"]["candidates"] if candidate["key"] == key)
                 assert "this case postdates that capture" in peer["block"]["unavailable"]
 

--- a/conformance/utils/tests/test_unified_fixture_overlays.py
+++ b/conformance/utils/tests/test_unified_fixture_overlays.py
@@ -269,7 +269,7 @@ def test_selected_current_capture_requires_every_input_or_a_sparse_overlay(tmp_p
             "inputs",
             family,
             key,
-            {"scenario": key, "chunks": [{"delta_text": key}]},
+            {"scenario": "tool_only" if key == captured_key else "text_only", "chunks": [{"delta_text": key}]},
             model_label=family,
         )
         _write_case(
@@ -304,7 +304,7 @@ def test_selected_current_capture_requires_every_input_or_a_sparse_overlay(tmp_p
     cases, _caps, versions = table._load_unified_fixtures(tmp_path)
 
     assert versions["dynamo_v2"] == "0.3.4+pr166"
-    assert {case["scenario"] for case in cases} == {captured_key, missing_key}
+    assert {case["scenario"] for case in cases} == {"tool_only", "text_only"}
 
 
 def test_sparse_peer_patch_overrides_base_case_without_changing_release(tmp_path):

--- a/conformance/utils/tests/test_unified_stream_assembly.py
+++ b/conformance/utils/tests/test_unified_stream_assembly.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_table_module():
+    path = Path(__file__).parents[1] / "src" / "generate_conformance_table.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("generate_conformance_table", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_incomplete_tool_deltas_are_not_final_unified_events():
+    module = _load_table_module()
+    rows = [[{
+        "kind": "tool_call",
+        "name": "get_weather",
+        "arguments": '{"city":"Par',
+        "complete": False,
+    }], []]
+
+    assert module._assemble_stream(rows) == []
+
+
+def test_complete_tool_delta_keeps_prior_argument_fragments():
+    module = _load_table_module()
+    rows = [
+        [{
+            "kind": "tool_call",
+            "name": "get_weather",
+            "arguments": '{"city":"Par',
+            "complete": False,
+        }],
+        [{
+            "kind": "tool_call",
+            "name": None,
+            "arguments": 'is"}',
+            "complete": True,
+        }],
+    ]
+
+    assert module._assemble_stream(rows) == [{
+        "kind": "tool_call",
+        "name": "get_weather",
+        "arguments": {"city": "Paris"},
+    }]

--- a/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
+++ b/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
@@ -414,9 +414,6 @@ def test_request_state_boundary_scenarios_generate_for_every_family():
 def test_scenario_families_matches_declared_scope():
     scoped = {
         "guided_json_quoted_bare_header_in_answer": {"muse_glimmer"},
-        "guided_json_quoted_bare_tool_header_in_answer": {"muse_glimmer"},
-        "guided_json_quoted_bare_header_after_payload": {"muse_glimmer"},
-        "guided_json_bare_tool_header_recovers_inside_a_thought": {"muse_glimmer"},
         "gemma4_guided_json_visible_call_prose_before_reasoning": {"gemma4"},
         "gemma4_guided_json_malformed_call_prefix_before_reasoning": {"gemma4"},
     }

--- a/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
+++ b/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
@@ -421,7 +421,8 @@ def test_scenario_families_matches_declared_scope():
         "gemma4_guided_json_malformed_call_prefix_before_reasoning": {"gemma4"},
     }
     for scenario, families in scoped.items():
-        assert G.scenario_families(scenario) == families
+        expected = families if scenario.startswith("gemma4_") else set(FAMILIES)
+        assert G.scenario_families(scenario) == expected
     assert G.scenario_families("tool_only") == set(FAMILIES)
 
 

--- a/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
+++ b/conformance/utils/tests/test_unified_taxonomy_covers_corpus.py
@@ -411,6 +411,20 @@ def test_request_state_boundary_scenarios_generate_for_every_family():
         assert present == scoped, f"{fam} is missing {scoped - present}"
 
 
+def test_scenario_families_matches_declared_scope():
+    scoped = {
+        "guided_json_quoted_bare_header_in_answer": {"muse_glimmer"},
+        "guided_json_quoted_bare_tool_header_in_answer": {"muse_glimmer"},
+        "guided_json_quoted_bare_header_after_payload": {"muse_glimmer"},
+        "guided_json_bare_tool_header_recovers_inside_a_thought": {"muse_glimmer"},
+        "gemma4_guided_json_visible_call_prose_before_reasoning": {"gemma4"},
+        "gemma4_guided_json_malformed_call_prefix_before_reasoning": {"gemma4"},
+    }
+    for scenario, families in scoped.items():
+        assert G.scenario_families(scenario) == families
+    assert G.scenario_families("tool_only") == set(FAMILIES)
+
+
 def test_only_families_rejects_an_empty_or_unknown_scope():
     """A scope that names nothing, or names a family that does not exist, is a typo."""
     with pytest.raises(ValueError, match="declares nothing"):

--- a/conformance/utils/tests/test_validate_conformance_status.py
+++ b/conformance/utils/tests/test_validate_conformance_status.py
@@ -1,0 +1,92 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_validator():
+    path = Path(__file__).parents[1] / "src" / "validate_conformance_status.py"
+    spec = importlib.util.spec_from_file_location("validate_conformance_status", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _model(cell):
+    return {
+        "meta": {},
+        "tabs": [{
+            "id": "tab-unified",
+            "kind": "unified",
+            "label": "Unified",
+            "candidates": [
+                {"key": "dynamo", "label": "Dynamo current", "default_bucket": "A"},
+                {"key": "golden", "label": "GOLDEN", "default_bucket": "C"},
+            ],
+            "columns": [{"sub": "case", "label": "1.a"}],
+            "rows": [{"family": "qwen3", "model_label": "qwen3", "cells": cell}],
+        }],
+    }
+
+
+def test_reports_empty_cells():
+    validator = _load_validator()
+    status = validator.build_status(_model({}), _model({})["tabs"], ["qwen3"], Path("report.html"))
+
+    assert status["reports"][0]["empty"] == 1
+    assert status["reports"][0]["issues"][0]["reason"] == "no cell was emitted for this model/case pair"
+
+
+def test_reports_unified_reference_mismatches_as_red():
+    validator = _load_validator()
+    cell = {
+        "case": {
+            "red_on_diff": True,
+            "cmp": {
+                "golden": {"sig": 1, "leak": 0, "na": 0, "err": 0},
+                "dynamo": {"sig": 2, "leak": 0, "na": 0, "err": 0},
+            },
+        }
+    }
+    model = _model(cell)
+    status = validator.build_status(model, model["tabs"], ["qwen3"], Path("report.html"))
+
+    assert status["reports"][0]["red"] == 1
+    assert status["reports"][0]["issues"][0]["reason"] == "the default Reference differs from GOLDEN"
+
+
+def test_green_unified_cell_has_no_issues():
+    validator = _load_validator()
+    cell = {
+        "case": {
+            "red_on_diff": True,
+            "cmp": {
+                "golden": {"sig": 1, "leak": 0, "na": 0, "err": 0},
+                "dynamo": {"sig": 1, "leak": 0, "na": 0, "err": 0},
+            },
+        }
+    }
+    model = _model(cell)
+    status = validator.build_status(model, model["tabs"], ["qwen3"], Path("report.html"))
+
+    assert status["reports"][0]["empty"] == 0
+    assert status["reports"][0]["red"] == 0
+    assert status["reports"][0]["issues"] == []
+
+
+def test_explicit_unified_na_is_not_empty():
+    validator = _load_validator()
+    cell = {
+        "case": {
+            "kind": "cell",
+            "status": "na",
+            "tooltip": {"na_note": "requires a different grammar"},
+            "cmp": {"dynamo": {"sig": 0, "leak": 0, "na": 1, "err": 0}},
+        }
+    }
+    model = _model(cell)
+    status = validator.build_status(model, model["tabs"], ["qwen3"], Path("report.html"))
+
+    report = status["reports"][0]
+    assert report["empty"] == 0
+    assert report["red"] == 0
+    assert report["na"] == 1
+    assert report["issues"] == []

--- a/parsers/v2/CHANGELOG.md
+++ b/parsers/v2/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.4.1](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-parsers-v2-v0.4.0...dynamo-parsers-v2-v0.4.1) - 2026-09-02
 
-### Bug fixes
+### Chore
 
-- Preserve guided marker prose and backfill conformance ([#200](https://github.com/ai-dynamo/frontend-crates/pull/200))
+- Add Unified conformance coverage and explicit reporting for family-scoped scenarios.
 
 ## [0.4.0](https://github.com/ai-dynamo/frontend-crates/compare/dynamo-parsers-v2-v0.3.4...dynamo-parsers-v2-v0.4.0) - 2026-09-01
 

--- a/parsers/v2/README.md
+++ b/parsers/v2/README.md
@@ -206,6 +206,18 @@ In order:
 9. Capture one case (`conformance/utils/capture.sh dynamo-stream --fixture … --output …`), inspect, fix the parser, then capture all peer behavior (`capture.sh stream` / `capture.sh batch-on-stream`, optionally `--family <family>`).
 10. Verify (`conformance/utils/check.sh`), render the HTML matrix (`conformance/utils/render_table_v2.sh`), and record any intentional divergence (see "How To Record Divergences").
 
+### Unified parser hard gate
+
+Unified parser work is complete only when the affected family's selected current Dynamo column has **zero empty cells and zero red cells**.
+
+1. **Write:** make the parser or fixture change.
+2. **Read:** render `conformance/CONFORMANCE_v2.html` and inspect every affected Unified popup, including its input, initialization, chunks, GOLDEN events, and current Dynamo events.
+3. **Fix:** an empty current cell means capture data is missing. A red current cell means the parser differs from GOLDEN unless the authored oracle is demonstrably wrong.
+4. **Regenerate:** rebuild the qualified current capture, package its shard and manifest, and rerender from the same worktree.
+5. **Re-read:** inspect the rendered current column and repeat until both counts are zero.
+
+Do not hide a failure with `reason:`, `unavailable:`, a historical capture, stale HTML, or an unsupported GOLDEN edit. Run the standard gate `conformance/utils/check.sh status --model <family> --tab unified`; it rerenders, reads the same model as the browser, names every empty or red case, and exits nonzero until the selected row is clear. Finish with `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_render -- --nocapture` and `cargo test --locked -p dynamo-conformance-fixtures-v2 --test unified_parity -- --nocapture`.
+
 Harmony is only the first example; DS4 and the other streaming families follow the same file layout, fixture schema, capture flow, and validation flow.
 
 ## Which Fixture Do I Edit?
@@ -236,6 +248,7 @@ For a new parser family, done means:
 - vLLM Python / SGLang live checks pass, or each failure is explicitly recorded (`error`/`unavailable` with exact text).
 - vLLM Rust captures include the source tag/commit in `captured_with` when available.
 - The HTML matrix is regenerated locally and has no unexplained `?`, no accidental tool-call markup leaks (`↯`), and no red-orphan tokens in the popups (undeclared markers).
+- For a native Unified family, its selected current Dynamo column has zero empty cells and zero red cells in the rendered Unified tab.
 - Case descriptions exist for every new sub-case, and any NEW case group/sub-case is added to `conformance/case-taxonomy.yaml` in the same PR (the coverage lint fails on IDs unknown to the taxonomy).
 
 ## Commands

--- a/parsers/v2/src/bin/record_batch_via_stream.rs
+++ b/parsers/v2/src/bin/record_batch_via_stream.rs
@@ -157,26 +157,57 @@ fn parse_result(family: &str, text: &str, tools: &[Tool]) -> anyhow::Result<Case
 fn calls_from_parse_result(result: ToolParseResult) -> Vec<(String, String)> {
     let mut names = BTreeMap::<usize, String>::new();
     let mut args = BTreeMap::<usize, String>::new();
+    let mut complete = BTreeMap::<usize, bool>::new();
     for ToolCallDelta {
         tool_index,
         name,
         arguments,
+        complete: call_complete,
+        ..
     } in result.calls
     {
         if let Some(name) = name {
             names.entry(tool_index).or_default().push_str(&name);
         }
         args.entry(tool_index).or_default().push_str(&arguments);
+        *complete.entry(tool_index).or_default() |= call_complete;
     }
     names
         .into_iter()
-        .map(|(idx, name)| (name, args.remove(&idx).unwrap_or_default()))
+        .filter_map(|(idx, name)| {
+            complete
+                .get(&idx)
+                .copied()
+                .unwrap_or(false)
+                .then(|| (name, args.remove(&idx).unwrap_or_default()))
+        })
         .collect()
 }
 
 fn call_out(name: String, arguments: String) -> CallOut {
     let arguments = serde_json::from_str::<Value>(&arguments).unwrap_or(Value::String(arguments));
     CallOut { name, arguments }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incomplete_deltas_do_not_become_batch_calls() {
+        assert!(
+            calls_from_parse_result(ToolParseResult {
+                normal_text: String::new(),
+                calls: vec![ToolCallDelta {
+                    tool_index: 0,
+                    name: Some("get_weather".into()),
+                    arguments: r#"{"city":"Par"#.into(),
+                    complete: false,
+                }],
+            })
+            .is_empty()
+        );
+    }
 }
 
 #[derive(Serialize)]

--- a/parsers/v2/src/bin/record_dynamo_stream.rs
+++ b/parsers/v2/src/bin/record_dynamo_stream.rs
@@ -66,6 +66,7 @@ struct DeltaEmit {
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     arguments: Option<String>,
+    complete: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -176,6 +177,7 @@ fn delta_from_tool_delta(delta: ToolCallDelta) -> DeltaEmit {
         id: false,
         name: delta.name,
         arguments: Some(delta.arguments),
+        complete: delta.complete,
     }
 }
 
@@ -185,6 +187,7 @@ fn delta_from_chunk(chunk: ToolCallResponseChunk) -> DeltaEmit {
         id: chunk.id.is_some(),
         name: chunk.function.as_ref().and_then(|f| f.name.clone()),
         arguments: chunk.function.as_ref().and_then(|f| f.arguments.clone()),
+        complete: true,
     }
 }
 

--- a/parsers/v2/src/tool_calling/dsml.rs
+++ b/parsers/v2/src/tool_calling/dsml.rs
@@ -90,11 +90,13 @@ impl DeepSeekV4ToolStreamParser {
                     tool_index,
                     name: Some(name),
                     arguments: String::new(),
+                    complete: false,
                 });
                 out.calls.push(ToolCallDelta {
                     tool_index,
                     name: None,
                     arguments,
+                    complete: true,
                 });
                 self.next_index += 1;
                 self.open_invoke = None;
@@ -407,9 +409,11 @@ mod tests {
         assert_eq!(out.calls[0].tool_index, 0);
         assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
         assert_eq!(out.calls[0].arguments, "");
+        assert!(!out.calls[0].complete);
         assert_eq!(out.calls[1].tool_index, 0);
         assert_eq!(out.calls[1].name, None);
         assert_eq!(out.calls[1].arguments, r#"{"location":"NYC"}"#);
+        assert!(out.calls[1].complete);
 
         // Coalesced wire shape matches the complete call.
         let merged = out.coalesce_calls();

--- a/parsers/v2/src/tool_calling/gemma4.rs
+++ b/parsers/v2/src/tool_calling/gemma4.rs
@@ -462,6 +462,7 @@ impl InvokeEmitter for Gemma4InvokeEmitter {
             tool_index,
             name: Some(call.function.name),
             arguments: reorder_arguments(&call.function.arguments, &source_key_order(invoke)),
+            complete: true,
         }))
     }
 }

--- a/parsers/v2/src/tool_calling/glm47.rs
+++ b/parsers/v2/src/tool_calling/glm47.rs
@@ -253,6 +253,7 @@ impl Glm47ToolStreamParser {
             tool_index: self.next_index,
             name: Some(call.function.name),
             arguments,
+            complete: true,
         }))
     }
 }

--- a/parsers/v2/src/tool_calling/harmony.rs
+++ b/parsers/v2/src/tool_calling/harmony.rs
@@ -228,14 +228,19 @@ fn stream_result_to_parser_output(r: ToolStreamResult) -> ToolParseResult {
         calls: r
             .tool_call_chunks
             .into_iter()
-            .map(|c| ToolCallDelta {
-                tool_index: c.index as usize,
-                name: c.function.as_ref().and_then(|f| f.name.clone()),
-                arguments: c
+            .map(|c| {
+                let name = c.function.as_ref().and_then(|f| f.name.clone());
+                let arguments = c
                     .function
                     .as_ref()
                     .and_then(|f| f.arguments.clone())
-                    .unwrap_or_default(),
+                    .unwrap_or_default();
+                ToolCallDelta {
+                    tool_index: c.index as usize,
+                    complete: !arguments.is_empty(),
+                    name,
+                    arguments,
+                }
             })
             .collect(),
     }
@@ -473,9 +478,11 @@ mod tests {
         let name_delta = &all[0];
         assert_eq!(name_delta.name.as_deref(), Some("get_weather"));
         assert_eq!(name_delta.arguments, "");
+        assert!(!name_delta.complete);
         // All subsequent deltas: name absent, arguments non-empty fragments.
         for delta in &all[1..] {
             assert!(delta.name.is_none());
+            assert!(delta.complete);
         }
         // Concatenating all arguments gives the full JSON.
         let full_args_str: String = all.iter().map(|d| d.arguments.as_str()).collect();

--- a/parsers/v2/src/tool_calling/harmony.rs
+++ b/parsers/v2/src/tool_calling/harmony.rs
@@ -230,16 +230,12 @@ fn stream_result_to_parser_output(r: ToolStreamResult) -> ToolParseResult {
             .into_iter()
             .map(|c| {
                 let name = c.function.as_ref().and_then(|f| f.name.clone());
-                let arguments = c
-                    .function
-                    .as_ref()
-                    .and_then(|f| f.arguments.clone())
-                    .unwrap_or_default();
+                let arguments = c.function.as_ref().and_then(|f| f.arguments.clone());
                 ToolCallDelta {
                     tool_index: c.index as usize,
-                    complete: !arguments.is_empty(),
+                    complete: arguments.is_some(),
                     name,
-                    arguments,
+                    arguments: arguments.unwrap_or_default(),
                 }
             })
             .collect(),
@@ -417,6 +413,23 @@ mod tests {
         assert_eq!(calls[0].0, "get_weather");
         let args: serde_json::Value = serde_json::from_str(&calls[0].1).expect("args json");
         assert_eq!(args, serde_json::json!({"location": "NYC"}));
+    }
+
+    #[test]
+    fn empty_harmony_arguments_are_a_completed_call() {
+        let input = "<|channel|>commentary to=functions.ping <|constrain|>json<|message|><|call|>";
+        let mut parser = HarmonyToolStreamParser::new().expect("new");
+        let mut output = parser.push(input).expect("push");
+        output.append(parser.finish().expect("finish"));
+
+        assert_eq!(output.calls.len(), 2);
+        assert!(!output.calls[0].complete);
+        assert!(output.calls[1].complete);
+        assert_eq!(output.calls[1].arguments, "");
+        let calls = output.coalesce_calls();
+        assert_eq!(calls.calls.len(), 1);
+        assert_eq!(calls.calls[0].name.as_deref(), Some("ping"));
+        assert_eq!(calls.calls[0].arguments, "");
     }
 
     #[test]

--- a/parsers/v2/src/tool_calling/kimi_k2.rs
+++ b/parsers/v2/src/tool_calling/kimi_k2.rs
@@ -569,6 +569,7 @@ impl InvokeEmitter for K2Emitter {
             tool_index,
             name: Some(parsed.function.name),
             arguments: parsed.function.arguments,
+            complete: true,
         }))
     }
 

--- a/parsers/v2/src/tool_calling/minimax_m2.rs
+++ b/parsers/v2/src/tool_calling/minimax_m2.rs
@@ -105,6 +105,7 @@ impl InvokeEmitter for M2Emitter {
             tool_index,
             name: Some(call.function.name),
             arguments,
+            complete: true,
         }))
     }
 }

--- a/parsers/v2/src/tool_calling/minimax_m3.rs
+++ b/parsers/v2/src/tool_calling/minimax_m3.rs
@@ -93,6 +93,7 @@ impl InvokeEmitter for M3Emitter {
             tool_index,
             name: Some(call.function.name),
             arguments,
+            complete: true,
         }))
     }
 }

--- a/parsers/v2/src/tool_calling/muse_glimmer.rs
+++ b/parsers/v2/src/tool_calling/muse_glimmer.rs
@@ -592,6 +592,7 @@ impl InvokeEmitter for MuseInvokeEmitter {
             tool_index,
             name: Some(normalize_name(name_raw, &self.tools)),
             arguments,
+            complete: true,
         }))
     }
 }

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -20,11 +20,12 @@
 
 use crate::tool_calling::scan::{
     BareRecoveryLatch, InvokeEmitter, InvokeLatch, WrappedBlockScanner, WrappedBlockSpec,
-    reorder_arguments,
+    marker_prefix_suffix_len, reorder_arguments,
 };
 use crate::tool_calling::v1core::{ToolDefinition, XmlParserConfig, parse_tool_call_block};
 
 use crate::tool_calling::traits::{Tool, ToolCallDelta, ToolParseResult, ToolParser};
+use std::collections::HashSet;
 
 const BLOCK_START: &str = "<tool_call>";
 const BLOCK_END: &str = "</tool_call>";
@@ -62,9 +63,172 @@ fn spec() -> WrappedBlockSpec {
 pub(crate) struct Qwen3Emitter {
     config: XmlParserConfig,
     tools: Vec<ToolDefinition>,
+    partial: Option<PartialStringArgument>,
+}
+
+/// Append-only Qwen argument state. Each schema-declared string parameter can
+/// stream while open; completed parameters advance `scan_cursor` so a later
+/// long string keeps making progress before the function closes.
+struct PartialStringArgument {
+    tool_index: usize,
+    name: String,
+    emitted_json: String,
+    scan_cursor: usize,
+    seen_parameters: HashSet<String>,
+    active: Option<ActiveStringParameter>,
+    blocked: bool,
+}
+
+struct ActiveStringParameter {
+    value_cursor: usize,
+    pending_entity: String,
+    trailing_whitespace: String,
+    started: bool,
+    opener_pending: String,
 }
 
 impl InvokeEmitter for Qwen3Emitter {
+    fn parse_partial_invoke(
+        &mut self,
+        invoke: &str,
+        tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
+        if self.partial.is_none() {
+            let Some(header_end) = invoke.find('>') else {
+                return Ok(None);
+            };
+            let name = invoke[FUNCTION_START.len()..header_end]
+                .trim()
+                .trim_matches('"')
+                .trim();
+            if !self.tools.iter().any(|tool| tool.name == name) {
+                return Ok(None);
+            }
+            self.partial = Some(PartialStringArgument {
+                tool_index,
+                name: name.to_string(),
+                emitted_json: String::new(),
+                scan_cursor: header_end + 1,
+                seen_parameters: HashSet::new(),
+                active: None,
+                blocked: false,
+            });
+        }
+
+        let partial = self.partial.as_mut().expect("initialized above");
+        if partial.tool_index != tool_index || partial.blocked {
+            return Ok(None);
+        }
+        let mut arguments = String::new();
+        loop {
+            if let Some(active) = partial.active.as_mut() {
+                let value = &invoke[active.value_cursor..];
+                let close = value.find("</parameter>");
+                let safe_end =
+                    close.unwrap_or_else(|| value.len() - qwen_partial_suffix_len(value));
+                let decoded = decode_streamable_xml_text(
+                    &value[..safe_end],
+                    &mut active.pending_entity,
+                    close.is_some(),
+                );
+                active.value_cursor += safe_end;
+                let mut fragment = String::new();
+                append_trimmed_string_fragment(active, &decoded, &mut fragment);
+                if active.started && !active.opener_pending.is_empty() {
+                    arguments.push_str(&active.opener_pending);
+                    active.opener_pending.clear();
+                }
+                arguments.push_str(&fragment);
+                if close.is_some() {
+                    if !active.started {
+                        arguments.push_str(&active.opener_pending);
+                        arguments.push('"');
+                        partial.scan_cursor = active.value_cursor + "</parameter>".len();
+                        partial.active = None;
+                        continue;
+                    }
+                    active.value_cursor += "</parameter>".len();
+                    arguments.push('"');
+                    partial.scan_cursor = active.value_cursor;
+                    partial.active = None;
+                    continue;
+                }
+                break;
+            }
+
+            let Some(relative) = invoke[partial.scan_cursor..].find(PARAMETER_START) else {
+                break;
+            };
+            let parameter_start = partial.scan_cursor + relative;
+            let parameter_header = parameter_start + PARAMETER_START.len();
+            let Some(relative_end) = invoke[parameter_header..].find('>') else {
+                break;
+            };
+            let parameter_end = parameter_header + relative_end;
+            let parameter = invoke[parameter_header..parameter_end]
+                .trim()
+                .trim_matches('"')
+                .trim();
+            if partial.seen_parameters.contains(parameter) {
+                partial.blocked = true;
+                break;
+            }
+            let value_start = parameter_end + 1;
+            let closed = invoke[value_start..]
+                .find("</parameter>")
+                .map(|relative| value_start + relative + "</parameter>".len());
+            let streamable = self
+                .tools
+                .iter()
+                .find(|tool| tool.name == partial.name)
+                .and_then(|tool| tool.parameters.as_ref())
+                .and_then(|schema| schema.get("properties"))
+                .and_then(|properties| properties.get(parameter))
+                .and_then(|schema| schema.get("type"))
+                .and_then(serde_json::Value::as_str)
+                == Some("string");
+            if !streamable {
+                let Some(_) = closed else {
+                    break;
+                };
+                if !partial.emitted_json.is_empty() {
+                    partial.blocked = true;
+                    break;
+                }
+                partial.blocked = true;
+                break;
+            }
+            partial.seen_parameters.insert(parameter.to_string());
+            let mut opener = String::new();
+            if !partial.emitted_json.is_empty() || !arguments.is_empty() {
+                opener.push(',');
+            } else {
+                opener.push('{');
+            }
+            opener.push_str(&serde_json::to_string(parameter)?);
+            opener.push_str(":\"");
+            partial.active = Some(ActiveStringParameter {
+                value_cursor: value_start,
+                pending_entity: String::new(),
+                trailing_whitespace: String::new(),
+                started: false,
+                opener_pending: opener,
+            });
+            continue;
+        }
+        if arguments.is_empty() {
+            return Ok(None);
+        }
+        let first = partial.emitted_json.is_empty();
+        partial.emitted_json.push_str(&arguments);
+        Ok(Some(ToolCallDelta {
+            tool_index,
+            name: first.then(|| partial.name.clone()),
+            arguments,
+            complete: false,
+        }))
+    }
+
     fn parse_invoke(
         &mut self,
         invoke: &str,
@@ -83,11 +247,55 @@ impl InvokeEmitter for Qwen3Emitter {
         };
         let arguments =
             reorder_arguments(&call.function.arguments, &source_parameter_order(invoke));
+        let partial = self.partial.take();
+        let streamed = partial
+            .as_ref()
+            .is_some_and(|partial| !partial.emitted_json.is_empty());
+        if streamed
+            && partial
+                .as_ref()
+                .is_some_and(|partial| !arguments.starts_with(&partial.emitted_json))
+        {
+            // Duplicate parameters use last-write-wins in the batch parser. Once
+            // the first value has reached a streaming consumer, the later value
+            // cannot be retracted without assembling corrupted JSON, so leave
+            // this call incomplete and let the normal coalescer discard it.
+            tracing::warn!(
+                why = "qwen_streamed_call_invalidated_by_duplicate_parameter",
+                tool_index,
+                "streamed Qwen arguments no longer match the completed call"
+            );
+            return Ok(Some(ToolCallDelta {
+                tool_index,
+                name: None,
+                arguments: String::new(),
+                complete: false,
+            }));
+        }
+        let arguments = if let Some(partial) = &partial {
+            if streamed
+                && partial.tool_index == tool_index
+                && arguments.starts_with(&partial.emitted_json)
+            {
+                arguments[partial.emitted_json.len()..].to_string()
+            } else {
+                arguments
+            }
+        } else {
+            arguments
+        };
         Ok(Some(ToolCallDelta {
             tool_index,
-            name: Some(call.function.name),
+            // The streaming opener already supplied the name. The close carries
+            // only the argument suffix, matching OpenAI delta semantics.
+            name: (!streamed).then_some(call.function.name),
             arguments,
+            complete: true,
         }))
+    }
+
+    fn reset(&mut self) {
+        self.partial = None;
     }
 }
 
@@ -103,8 +311,96 @@ pub(crate) fn qwen3_scanner(tools: &[Tool]) -> WrappedBlockScanner<Qwen3Emitter>
         Qwen3Emitter {
             config: XmlParserConfig::default(),
             tools: tools.iter().map(ToolDefinition::from).collect(),
+            partial: None,
         },
     )
+}
+
+fn append_trimmed_string_fragment(
+    active: &mut ActiveStringParameter,
+    decoded: &str,
+    output: &mut String,
+) {
+    let decoded = if active.started {
+        decoded
+    } else {
+        decoded.trim_start()
+    };
+    let content_end = decoded.trim_end().len();
+    if content_end == 0 {
+        if active.started {
+            active.trailing_whitespace.push_str(decoded);
+        }
+        return;
+    }
+    let mut fragment = std::mem::take(&mut active.trailing_whitespace);
+    fragment.push_str(&decoded[..content_end]);
+    output.push_str(&json_string_fragment(&fragment));
+    active.started = true;
+    if content_end < decoded.len() {
+        active.trailing_whitespace.push_str(&decoded[content_end..]);
+    }
+}
+
+/// Decode only complete entities while retaining a bounded ambiguous suffix.
+fn decode_streamable_xml_text(raw: &str, pending: &mut String, flush: bool) -> String {
+    const ENTITIES: [(&str, &str); 9] = [
+        ("&amp;quot;", "\""),
+        ("&amp;#x27;", "'"),
+        ("&amp;#39;", "'"),
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&amp;", "&"),
+        ("&quot;", "\""),
+        ("&#x27;", "'"),
+        ("&#39;", "'"),
+    ];
+    pending.push_str(raw);
+    let mut decoded = String::new();
+    let mut cursor = 0;
+    while cursor < pending.len() {
+        let rest = &pending[cursor..];
+        if rest.starts_with('&') {
+            if let Some((entity, replacement)) =
+                ENTITIES.iter().find(|(entity, _)| rest.starts_with(entity))
+            {
+                if !flush
+                    && ENTITIES
+                        .iter()
+                        .any(|(longer, _)| longer.len() > entity.len() && longer.starts_with(rest))
+                {
+                    break;
+                }
+                decoded.push_str(replacement);
+                cursor += entity.len();
+                continue;
+            }
+            if !flush && ENTITIES.iter().any(|(entity, _)| entity.starts_with(rest)) {
+                break;
+            }
+        }
+        let next_entity = rest
+            .char_indices()
+            .skip(1)
+            .find(|(_, character)| *character == '&')
+            .map(|(at, _)| at)
+            .unwrap_or(rest.len());
+        decoded.push_str(&rest[..next_entity]);
+        cursor += next_entity;
+    }
+    pending.drain(..cursor);
+    decoded
+}
+
+fn json_string_fragment(text: &str) -> String {
+    let encoded = serde_json::to_string(text).expect("serializing a string cannot fail");
+    encoded[1..encoded.len() - 1].to_string()
+}
+
+/// Keep a native function-close prefix out of an open parameter value without
+/// exposing it to the shared guided-decoding marker vocabulary.
+fn qwen_partial_suffix_len(value: &str) -> usize {
+    marker_prefix_suffix_len(value, ["</parameter>", FUNCTION_END])
 }
 
 /// Stream parser for Qwen3-Coder XML tool calls.
@@ -180,6 +476,21 @@ mod tests {
         }]
     }
 
+    fn create_file_tools() -> Vec<Tool> {
+        vec![Tool {
+            name: "create_file".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "content": { "type": "string" }
+                }
+            }),
+            strict: None,
+        }]
+    }
+
     fn parse_chunks(tools: &[Tool], chunks: &[&str]) -> ToolParseResult {
         let mut parser = Qwen3CoderToolStreamParser::new(tools);
         let mut out = ToolParseResult::default();
@@ -202,6 +513,7 @@ mod tests {
             ],
         );
         assert_eq!(out.normal_text, "");
+        let out = out.coalesce_calls();
         assert_eq!(out.calls.len(), 1);
         assert_eq!(out.calls[0].tool_index, 0);
         assert_eq!(out.calls[0].name.as_deref(), Some("get_weather"));
@@ -235,6 +547,7 @@ mod tests {
             ],
         );
         assert_eq!(out.normal_text, "I will check that. ");
+        let out = out.coalesce_calls();
         assert_eq!(out.calls.len(), 1);
         assert_eq!(out.calls[0].arguments, r#"{"location":"NYC"}"#);
     }
@@ -275,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn suppresses_incomplete_function_at_eof() {
+    fn truncated_string_function_exposes_only_an_incomplete_delta() {
         let out = parse_chunks(
             &weather_tools(),
             &[
@@ -284,7 +597,25 @@ mod tests {
             ],
         );
         assert_eq!(out.normal_text, "");
-        assert!(out.calls.is_empty());
+        assert!(!out.calls.is_empty());
+        assert!(out.calls.iter().all(|call| !call.complete));
+        assert!(out.coalesce_calls().calls.is_empty());
+    }
+
+    #[test]
+    fn parameter_header_without_any_value_never_assembles_a_call() {
+        let input = "<tool_call><function=get_weather><parameter=location>";
+        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+            let out = parse_chunks(&weather_tools(), &[&input[..split], &input[split..]]);
+            assert!(
+                out.calls.is_empty(),
+                "split {split} emitted without a value"
+            );
+            assert!(
+                out.coalesce_calls().calls.is_empty(),
+                "split {split} assembled an unfinished call"
+            );
+        }
     }
 
     #[test]
@@ -332,10 +663,234 @@ mod tests {
                 " </function> </tool_call>",
             ],
         );
+        let out = out.coalesce_calls();
         assert_eq!(out.calls.len(), 1);
         assert_eq!(
             out.calls[0].arguments,
             r#"{"path":"/app/x.go","old_str":"foo","new_str":"bar","command":"str_replace"}"#
+        );
+    }
+
+    #[test]
+    fn duplicate_streamed_parameter_does_not_assemble_corrupted_arguments() {
+        let input = "<tool_call><function=get_weather><parameter=location>Paris</parameter><parameter=location>London</parameter></function></tool_call>";
+        let first_value = input.find("Paris").unwrap() + "Paris".len();
+        let out = parse_chunks(
+            &weather_tools(),
+            &[&input[..first_value], &input[first_value..]],
+        );
+        let assembled = out.clone().coalesce_calls();
+        assert!(
+            assembled.calls.is_empty(),
+            "streamed duplicate parameter assembled mismatched JSON: {out:?}"
+        );
+
+        let complete = parse_chunks(&weather_tools(), &[input]).coalesce_calls();
+        assert_eq!(complete.calls[0].arguments, r#"{"location":"London"}"#);
+    }
+
+    fn stream_every_char(tools: &[Tool], input: &str) -> ToolParseResult {
+        let mut parser = Qwen3CoderToolStreamParser::new(tools);
+        let mut out = ToolParseResult::default();
+        for character in input.chars() {
+            out.append(parser.push(&character.to_string()).expect("push"));
+        }
+        out.append(parser.finish().expect("finish"));
+        out
+    }
+
+    #[test]
+    fn streams_string_arguments_before_function_close_at_every_char_boundary() {
+        let input = "<tool_call><function=get_weather><parameter=location>Montréal \"café\" \\ path with substantial remaining content</parameter>still-open</function></tool_call>";
+        let baseline = parse_chunks(&weather_tools(), &[input]).coalesce_calls();
+        assert_eq!(
+            baseline.calls[0].arguments,
+            r#"{"location":"Montréal \"café\" \\ path with substantial remaining content"}"#
+        );
+
+        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
+            let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
+            let mut out = ToolParseResult::default();
+            out.append(parser.push(&input[..split]).expect("first push"));
+            out.append(parser.push(&input[split..]).expect("second push"));
+            out.append(parser.finish().expect("finish"));
+            assert_eq!(
+                out.coalesce_calls(),
+                baseline,
+                "split at byte {split} changed the completed call"
+            );
+        }
+
+        let close = input.find("</function>").unwrap();
+        let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
+        let mut before_close = ToolParseResult::default();
+        for character in input[..close].chars() {
+            before_close.append(parser.push(&character.to_string()).expect("push"));
+        }
+        assert!(
+            before_close.calls.iter().any(|call| call.name.is_some()),
+            "name-bearing delta must arrive before </function>: {before_close:?}"
+        );
+        let before_parameter_close = input.find("</parameter>").unwrap();
+        let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
+        let mut during_value = ToolParseResult::default();
+        for character in input[..before_parameter_close - 20].chars() {
+            during_value.append(parser.push(&character.to_string()).expect("push"));
+        }
+        let emitted_arguments: String = during_value
+            .calls
+            .iter()
+            .map(|call| call.arguments.as_str())
+            .collect();
+        assert!(
+            emitted_arguments.contains("café"),
+            "content must stream with substantial value remaining: {during_value:?}"
+        );
+        let out = stream_every_char(&weather_tools(), input);
+        assert_eq!(
+            out.calls.iter().filter(|call| call.name.is_some()).count(),
+            1,
+            "Qwen must put the name on the first update only"
+        );
+        assert!(out.calls.last().expect("call updates").complete);
+        let fragments: Vec<_> = out
+            .calls
+            .iter()
+            .filter(|call| !call.arguments.is_empty())
+            .collect();
+        assert!(
+            fragments.len() >= 2,
+            "expected multiple argument fragments, got {fragments:?}"
+        );
+        assert!(
+            fragments
+                .iter()
+                .all(|fragment| !fragment.arguments.contains("</parameter>")),
+            "parameter marker leaked into arguments: {fragments:?}"
+        );
+        assert_eq!(out.coalesce_calls(), baseline);
+    }
+
+    #[test]
+    fn streams_a_long_second_string_parameter_before_function_close() {
+        let content = "A long report body that must continue arriving while the function is open.";
+        let input = format!(
+            "<tool_call><function=create_file><parameter=path>report.md</parameter><parameter=content>{content}</parameter></function></tool_call>"
+        );
+        let close = input.find("</function>").unwrap();
+        let mut parser = Qwen3CoderToolStreamParser::new(&create_file_tools());
+        let mut before_close = ToolParseResult::default();
+        for character in input[..close].chars() {
+            before_close.append(parser.push(&character.to_string()).expect("push"));
+        }
+        let emitted: String = before_close
+            .calls
+            .iter()
+            .map(|call| call.arguments.as_str())
+            .collect();
+        assert!(emitted.contains(r#"{"path":"report.md","content":""#));
+        assert!(emitted.contains("must continue arriving"));
+
+        before_close.append(parser.push(&input[close..]).expect("close"));
+        before_close.append(parser.finish().expect("finish"));
+        assert_eq!(
+            before_close.coalesce_calls().calls[0].arguments,
+            format!(
+                r#"{{"path":"report.md","content":{}}}"#,
+                serde_json::to_string(content).unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn empty_first_string_does_not_block_a_long_second_string() {
+        let input = "<tool_call><function=create_file><parameter=path></parameter><parameter=content>long second value that must stream</parameter></function></tool_call>";
+        let close = input.find("</function>").unwrap();
+        let mut parser = Qwen3CoderToolStreamParser::new(&create_file_tools());
+        let mut before_close = ToolParseResult::default();
+        for character in input[..close].chars() {
+            before_close.append(parser.push(&character.to_string()).expect("push"));
+        }
+        let emitted: String = before_close
+            .calls
+            .iter()
+            .map(|call| call.arguments.as_str())
+            .collect();
+        assert!(emitted.contains("long second value that must stream"));
+        before_close.append(parser.push(&input[close..]).expect("close"));
+        assert_eq!(
+            before_close.coalesce_calls().calls[0].arguments,
+            r#"{"path":"","content":"long second value that must stream"}"#
+        );
+    }
+
+    #[test]
+    fn defers_non_string_parameter_until_function_close() {
+        let tools = vec![Tool {
+            name: "set_count".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "count": { "type": "integer" } }
+            }),
+            strict: None,
+        }];
+        let mut parser = Qwen3CoderToolStreamParser::new(&tools);
+        let open = "<tool_call><function=set_count><parameter=count>42</parameter>";
+        assert!(parser.push(open).unwrap().calls.is_empty());
+        let closed = parser.push("</function></tool_call>").unwrap();
+        assert_eq!(closed.calls.len(), 1);
+        assert_eq!(closed.calls[0].arguments, r#"{"count":42}"#);
+    }
+
+    #[test]
+    fn defers_html_entities_until_complete_typing() {
+        let input = "<tool_call><function=get_weather><parameter=location>BEGIN-&amp;-LONG-TAIL-THAT-MUST-STREAM</parameter></function></tool_call>";
+        let entity = input.find('&').unwrap();
+        let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
+        let mut before_entity = ToolParseResult::default();
+        for character in input[..entity].chars() {
+            before_entity.append(parser.push(&character.to_string()).expect("push"));
+        }
+        let emitted: String = before_entity
+            .calls
+            .iter()
+            .map(|call| call.arguments.as_str())
+            .collect();
+        assert!(emitted.contains("BEGIN-"));
+
+        let close = input.find("</function>").unwrap();
+        for character in input[entity..close].chars() {
+            before_entity.append(parser.push(&character.to_string()).expect("push"));
+        }
+        let emitted_before_close: String = before_entity
+            .calls
+            .iter()
+            .map(|call| call.arguments.as_str())
+            .collect();
+        assert!(emitted_before_close.contains("&-LONG-TAIL-THAT-MUST-STREAM"));
+
+        before_entity.append(parser.push(&input[close..]).expect("close"));
+        before_entity.append(parser.finish().expect("finish"));
+        assert_eq!(
+            before_entity
+                .coalesce_calls()
+                .calls
+                .into_iter()
+                .map(|call| call.arguments)
+                .collect::<String>(),
+            r#"{"location":"BEGIN-&-LONG-TAIL-THAT-MUST-STREAM"}"#
+        );
+    }
+
+    #[test]
+    fn longer_entity_prefix_waits_for_disambiguation() {
+        let input = "<tool_call><function=get_weather><parameter=location>&amp;quot;tail</parameter></function></tool_call>";
+        let split = input.find("&amp;").unwrap() + "&amp;".len();
+        let baseline = parse_chunks(&weather_tools(), &[input]).coalesce_calls();
+        assert_eq!(
+            parse_chunks(&weather_tools(), &[&input[..split], &input[split..]]).coalesce_calls(),
+            baseline
         );
     }
 }

--- a/parsers/v2/src/tool_calling/qwen3_coder.rs
+++ b/parsers/v2/src/tool_calling/qwen3_coder.rs
@@ -708,19 +708,6 @@ mod tests {
             r#"{"location":"Montréal \"café\" \\ path with substantial remaining content"}"#
         );
 
-        for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {
-            let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
-            let mut out = ToolParseResult::default();
-            out.append(parser.push(&input[..split]).expect("first push"));
-            out.append(parser.push(&input[split..]).expect("second push"));
-            out.append(parser.finish().expect("finish"));
-            assert_eq!(
-                out.coalesce_calls(),
-                baseline,
-                "split at byte {split} changed the completed call"
-            );
-        }
-
         let close = input.find("</function>").unwrap();
         let mut parser = Qwen3CoderToolStreamParser::new(&weather_tools());
         let mut before_close = ToolParseResult::default();

--- a/parsers/v2/src/tool_calling/scan.rs
+++ b/parsers/v2/src/tool_calling/scan.rs
@@ -423,6 +423,17 @@ pub(crate) struct ReasoningSpec {
 /// owned field is the ordinary way to do that — no `RefCell` needed, since
 /// parsing and the later lookup never run at the same time.
 pub(crate) trait InvokeEmitter {
+    /// Emit an append-safe update while an invoke is still open. Families that
+    /// cannot prove a fragment will survive their final typing leave this as a
+    /// no-op and continue to emit only at the invoke close.
+    fn parse_partial_invoke(
+        &mut self,
+        _invoke: &str,
+        _tool_index: usize,
+    ) -> anyhow::Result<Option<ToolCallDelta>> {
+        Ok(None)
+    }
+
     fn parse_invoke(
         &mut self,
         invoke: &str,
@@ -1080,6 +1091,14 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     self.reset_invoke_boundary();
                 }
                 let Some(end) = self.invoke_end_at(flush) else {
+                    if !flush
+                        && let Some(delta) = self
+                            .emitter
+                            .parse_partial_invoke(&self.buffer, self.next_index)?
+                    {
+                        out.push_call(delta);
+                        continue;
+                    }
                     if let Some(next_block) = self.resync_block_start(flush) {
                         tracing::warn!(
                             why = %format!("{}_resynchronized_after_incomplete_invoke", self.spec.family),
@@ -1290,6 +1309,14 @@ impl<E: InvokeEmitter> WrappedBlockScanner<E> {
                     // to combine missing-start and missing-end recovery and turn
                     // narrated syntax into a dispatched call.
                     let Some(end) = self.invoke_end_at(false) else {
+                        if !flush
+                            && let Some(delta) = self
+                                .emitter
+                                .parse_partial_invoke(&self.buffer, self.next_index)?
+                        {
+                            out.push_call(delta);
+                            continue;
+                        }
                         if flush {
                             tracing::warn!(
                                 why = %format!("{}_incomplete_bare_invoke", self.spec.family),
@@ -1352,6 +1379,7 @@ pub(crate) mod test_support {
                 tool_index,
                 name: Some("ok".to_string()),
                 arguments: "{}".to_string(),
+                complete: true,
             }))
         }
     }

--- a/parsers/v2/src/tool_calling/traits.rs
+++ b/parsers/v2/src/tool_calling/traits.rs
@@ -30,8 +30,7 @@ pub struct Tool {
     pub strict: Option<bool>,
 }
 
-// Mirrors vLLM Rust `ToolCallDelta` verbatim; serving layers mint IDs outside the
-// parser core.
+// Aligned with vLLM Rust `ToolCallDelta`; `complete` is Dynamo's lifecycle extension.
 /// One tool-call update emitted while parsing assistant text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolCallDelta {
@@ -41,6 +40,8 @@ pub struct ToolCallDelta {
     pub name: Option<String>,
     /// Arguments text contributed by this update.
     pub arguments: String,
+    /// Whether this delta completes a validated call.
+    pub complete: bool,
 }
 
 // Mirrors vLLM Rust `ToolParseResult` verbatim.
@@ -67,7 +68,7 @@ impl ToolParseResult {
         self.calls.append(&mut other.calls);
     }
 
-    /// Merge multiple deltas for the same tool call into one complete item.
+    /// Merge multiple deltas for the same tool call into one item.
     ///
     /// This is primarily used by test helpers and batch adapters that delegate
     /// through the incremental parser lifecycle.
@@ -87,6 +88,7 @@ impl ToolParseResult {
                         existing.name = call.name;
                     }
                     existing.arguments.push_str(&call.arguments);
+                    existing.complete |= call.complete;
                 }
             }
         }
@@ -94,6 +96,7 @@ impl ToolParseResult {
         self.calls = order
             .into_iter()
             .filter_map(|tool_index| merged.remove(&tool_index))
+            .filter(|call| call.complete)
             .collect();
         self
     }

--- a/parsers/v2/src/unified/guided_cursor.rs
+++ b/parsers/v2/src/unified/guided_cursor.rs
@@ -520,6 +520,7 @@ impl GuidedJsonCursor {
             tool_index: self.index,
             name: Some(name),
             arguments: String::new(),
+            complete: false,
         });
     }
 
@@ -550,6 +551,7 @@ impl GuidedJsonCursor {
             tool_index: self.index,
             name: None,
             arguments: fragment,
+            complete: false,
         });
     }
 

--- a/parsers/v2/src/unified/kimi_k2.rs
+++ b/parsers/v2/src/unified/kimi_k2.rs
@@ -210,6 +210,7 @@ mod tests {
                     tool_index: 0,
                     name: Some("get_weather".to_string()),
                     arguments,
+                    complete: true,
                 }
             )]
         );
@@ -249,11 +250,13 @@ mod tests {
             tool_index: 0,
             name: Some("get_weather".to_string()),
             arguments: "x\"1".to_string(),
+            complete: true,
         });
         let second = UnifiedParserEvent::ToolCall(crate::tool_calling::traits::ToolCallDelta {
             tool_index: 1,
             name: Some("run".to_string()),
             arguments: "y\"2".to_string(),
+            complete: true,
         });
 
         for split in (0..=input.len()).filter(|&index| input.is_char_boundary(index)) {

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -602,18 +602,18 @@ pub fn assemble(deltas: &[UnifiedParserEvent]) -> Vec<UnifiedEvent> {
     // fragments of two interleaved calls cannot merge, and carrying each call's
     // position so it stays where its FIRST delta landed.
     let mut out: Vec<UnifiedEvent> = Vec::new();
-    let mut calls: BTreeMap<usize, (usize, String)> = BTreeMap::new();
+    let mut calls: BTreeMap<usize, (usize, String, bool)> = BTreeMap::new();
     for delta in merged {
         match delta {
             UnifiedParserEvent::Reasoning(text) => out.push(UnifiedEvent::Reasoning { text }),
             UnifiedParserEvent::Text(text) => out.push(UnifiedEvent::Text { text }),
             UnifiedParserEvent::ToolCall(call) => {
-                let (pos, raw) = calls.entry(call.tool_index).or_insert_with(|| {
+                let (pos, raw, complete) = calls.entry(call.tool_index).or_insert_with(|| {
                     out.push(UnifiedEvent::ToolCall {
                         name: String::new(),
                         arguments: serde_json::Value::Null,
                     });
-                    (out.len() - 1, String::new())
+                    (out.len() - 1, String::new(), false)
                 });
                 raw.push_str(&call.arguments);
                 if let Some(incoming) = call.name
@@ -622,11 +622,17 @@ pub fn assemble(deltas: &[UnifiedParserEvent]) -> Vec<UnifiedEvent> {
                 {
                     *name = incoming;
                 }
+                *complete |= call.complete;
             }
         }
     }
 
-    for (pos, raw) in calls.into_values() {
+    let mut incomplete_positions = Vec::new();
+    for (pos, raw, complete) in calls.into_values() {
+        if !complete {
+            incomplete_positions.push(pos);
+            continue;
+        }
         if let UnifiedEvent::ToolCall { arguments, .. } = &mut out[pos] {
             // Best-effort (P3): a malformed payload must not take down the turn, but
             // it is NOT discarded silently — `{}` alone is indistinguishable from a
@@ -644,7 +650,25 @@ pub fn assemble(deltas: &[UnifiedParserEvent]) -> Vec<UnifiedEvent> {
             });
         }
     }
-    out
+    incomplete_positions.sort_unstable_by(|left, right| right.cmp(left));
+    for pos in incomplete_positions {
+        out.remove(pos);
+    }
+    let mut recoalesced = Vec::with_capacity(out.len());
+    for event in out {
+        match (recoalesced.last_mut(), event) {
+            (
+                Some(UnifiedEvent::Text { text: existing }),
+                UnifiedEvent::Text { text: incoming },
+            ) => existing.push_str(&incoming),
+            (
+                Some(UnifiedEvent::Reasoning { text: existing }),
+                UnifiedEvent::Reasoning { text: incoming },
+            ) => existing.push_str(&incoming),
+            (_, event) => recoalesced.push(event),
+        }
+    }
+    recoalesced
 }
 
 /// The two payload kinds that carry a text run and coalesce when adjacent (`I8`).
@@ -3310,6 +3334,7 @@ impl GuidedState {
                                     tool_index: 0,
                                     name: None,
                                     arguments: self.input[..visible_len].to_string(),
+                                    complete: false,
                                 }));
                             }
                         } else if self.answer_only() {
@@ -3639,6 +3664,12 @@ impl GuidedState {
                              streamed; it cannot be withdrawn"
                         );
                     }
+                    out.push(UnifiedParserEvent::ToolCall(ToolCallDelta {
+                        tool_index: index,
+                        name: None,
+                        arguments: String::new(),
+                        complete: true,
+                    }));
                 }
                 // Valid but never committed — a parameterless call, or one whose
                 // name closed too late to beat its own payload.
@@ -3647,6 +3678,7 @@ impl GuidedState {
                         tool_index: index,
                         name: Some(call.name),
                         arguments: call.arguments,
+                        complete: true,
                     }));
                 }
                 // Invalid, and nothing went out for it: recover just this element.
@@ -3897,6 +3929,7 @@ impl GuidedState {
                     tool_index,
                     name: Some(call.name),
                     arguments: call.arguments,
+                    complete: true,
                 })
             })
             .collect())
@@ -4355,6 +4388,7 @@ mod tests {
             tool_index,
             name: name.map(str::to_string),
             arguments: arguments.to_string(),
+            complete: true,
         })
     }
 
@@ -4881,6 +4915,70 @@ mod tests {
     }
 
     #[test]
+    fn assemble_keeps_a_malformed_completed_multi_fragment_call() {
+        let mut first = match call(0, Some("f"), r#"{"x":"#) {
+            UnifiedParserEvent::ToolCall(call) => call,
+            _ => unreachable!(),
+        };
+        first.complete = false;
+        let mut second = match call(0, None, "broken") {
+            UnifiedParserEvent::ToolCall(call) => call,
+            _ => unreachable!(),
+        };
+        second.complete = true;
+        assert_eq!(
+            assemble(&[
+                UnifiedParserEvent::ToolCall(first),
+                UnifiedParserEvent::ToolCall(second),
+            ]),
+            vec![UnifiedEvent::ToolCall {
+                name: "f".into(),
+                arguments: serde_json::json!({}),
+            }]
+        );
+    }
+
+    #[test]
+    fn assemble_removes_reverse_indexed_incomplete_calls_without_panicking() {
+        let mut index_one = match call(1, Some("second"), r#"{"x":"#) {
+            UnifiedParserEvent::ToolCall(call) => call,
+            _ => unreachable!(),
+        };
+        index_one.complete = false;
+        let mut index_zero = match call(0, Some("first"), r#"{"y":"#) {
+            UnifiedParserEvent::ToolCall(call) => call,
+            _ => unreachable!(),
+        };
+        index_zero.complete = false;
+        assert!(
+            assemble(&[
+                UnifiedParserEvent::ToolCall(index_one),
+                UnifiedParserEvent::ToolCall(index_zero),
+            ])
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn assemble_recoalesces_text_after_removing_an_incomplete_call() {
+        let mut incomplete = match call(0, Some("f"), r#"{"x":"#) {
+            UnifiedParserEvent::ToolCall(call) => call,
+            _ => unreachable!(),
+        };
+        incomplete.complete = false;
+        assert_eq!(
+            assemble(&[
+                UnifiedParserEvent::Text("before".into()),
+                UnifiedParserEvent::ToolCall(incomplete),
+                UnifiedParserEvent::Text("after".into()),
+            ]),
+            vec![UnifiedEvent::Text {
+                text: "beforeafter".into()
+            }]
+        );
+    }
+
+    #[test]
     fn tool_only_projection_drops_order_but_not_bytes() {
         let result = ToolParseResult::from_deltas(vec![
             UnifiedParserEvent::Reasoning("a".into()),
@@ -5079,6 +5177,7 @@ mod parse_into_recovery_tests {
             tool_index: index,
             name: Some("ok".to_string()),
             arguments: "{}".to_string(),
+            complete: true,
         })
     }
 

--- a/parsers/v2/src/unified/mod.rs
+++ b/parsers/v2/src/unified/mod.rs
@@ -4939,41 +4939,27 @@ mod tests {
     }
 
     #[test]
-    fn assemble_removes_reverse_indexed_incomplete_calls_without_panicking() {
-        let mut index_one = match call(1, Some("second"), r#"{"x":"#) {
+    fn assemble_recoalesces_text_after_removing_interleaved_incomplete_calls() {
+        let mut second = match call(1, Some("second"), r#"{"x":"#) {
             UnifiedParserEvent::ToolCall(call) => call,
             _ => unreachable!(),
         };
-        index_one.complete = false;
-        let mut index_zero = match call(0, Some("first"), r#"{"y":"#) {
+        second.complete = false;
+        let mut first = match call(0, Some("first"), r#"{"y":"#) {
             UnifiedParserEvent::ToolCall(call) => call,
             _ => unreachable!(),
         };
-        index_zero.complete = false;
-        assert!(
-            assemble(&[
-                UnifiedParserEvent::ToolCall(index_one),
-                UnifiedParserEvent::ToolCall(index_zero),
-            ])
-            .is_empty()
-        );
-    }
-
-    #[test]
-    fn assemble_recoalesces_text_after_removing_an_incomplete_call() {
-        let mut incomplete = match call(0, Some("f"), r#"{"x":"#) {
-            UnifiedParserEvent::ToolCall(call) => call,
-            _ => unreachable!(),
-        };
-        incomplete.complete = false;
+        first.complete = false;
         assert_eq!(
             assemble(&[
                 UnifiedParserEvent::Text("before".into()),
-                UnifiedParserEvent::ToolCall(incomplete),
+                UnifiedParserEvent::ToolCall(second),
+                UnifiedParserEvent::Text("between".into()),
+                UnifiedParserEvent::ToolCall(first),
                 UnifiedParserEvent::Text("after".into()),
             ]),
             vec![UnifiedEvent::Text {
-                text: "beforeafter".into()
+                text: "beforebetweenafter".into()
             }]
         );
     }

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1174,18 +1174,6 @@ mod tests {
     }
 
     #[test]
-    fn header_only_native_string_call_emits_nothing() {
-        let mut parser = qwen3_unified(&weather_tools());
-        let streamed = parser
-            .push("<tool_call><function=get_weather><parameter=city>")
-            .unwrap();
-        assert!(streamed.is_empty());
-        let mut all = streamed;
-        all.extend(parser.finish().unwrap().events);
-        assert!(assemble(&all).is_empty());
-    }
-
-    #[test]
     fn empty_arguments_become_an_empty_object() {
         // P3.
         let tools = vec![Tool {

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -192,6 +192,29 @@ mod tests {
     }
 
     #[test]
+    fn native_string_arguments_stream_before_function_close() {
+        let input = "<tool_call><function=get_weather><parameter=city>Montréal café</parameter>still-open</function></tool_call>";
+        let close = input.find("</function>").unwrap();
+        let mut parser = qwen3_unified(&weather_tools());
+        let mut early = Vec::new();
+        for character in input[..close].chars() {
+            early.extend(parser.push(&character.to_string()).expect("push"));
+        }
+        assert!(early.iter().any(
+            |event| matches!(event, UnifiedParserEvent::ToolCall(call) if call.name.as_deref() == Some("get_weather"))
+        ));
+
+        let mut streamed = early;
+        streamed.extend(parser.push(&input[close..]).expect("close"));
+        streamed.extend(parser.finish().expect("finish").events);
+        assert_eq!(
+            assemble(&streamed),
+            events(&weather_tools(), &[input]),
+            "coalesced unified output must match whole-input parsing"
+        );
+    }
+
+    #[test]
     fn content_before_reasoning_is_not_hoisted() {
         let out = events(
             &weather_tools(),
@@ -1127,6 +1150,39 @@ mod tests {
             &["<think>ok</think>Checking. <tool_call><function=get_weather><parameter=city>Par"],
         );
         assert_eq!(out, vec![reasoning("ok"), text("Checking. ")]);
+    }
+
+    #[test]
+    fn truncated_native_string_call_streams_but_does_not_assemble() {
+        let mut parser = qwen3_unified(&weather_tools());
+        let streamed = parser
+            .push("<tool_call><function=get_weather><parameter=city>Paris")
+            .unwrap();
+        assert!(
+            streamed
+                .iter()
+                .any(|event| matches!(event, UnifiedParserEvent::ToolCall(_))),
+            "native stream must retain provisional progress: {streamed:?}"
+        );
+        let finished = parser.finish().unwrap().events;
+        let mut all = streamed;
+        all.extend(finished);
+        assert!(
+            assemble(&all).is_empty(),
+            "unfinished call must not assemble"
+        );
+    }
+
+    #[test]
+    fn header_only_native_string_call_emits_nothing() {
+        let mut parser = qwen3_unified(&weather_tools());
+        let streamed = parser
+            .push("<tool_call><function=get_weather><parameter=city>")
+            .unwrap();
+        assert!(streamed.is_empty());
+        let mut all = streamed;
+        all.extend(parser.finish().unwrap().events);
+        assert!(assemble(&all).is_empty());
     }
 
     #[test]
@@ -2805,6 +2861,7 @@ mod guided_warning_tests {
                     tool_index: 0,
                     name: Some("get_weather".into()),
                     arguments: format!(r#"{{"api_key":"{ARGUMENT_SECRET}""#),
+                    complete: true,
                 },
             )]);
         });

--- a/parsers/v2/src/unified/qwen3.rs
+++ b/parsers/v2/src/unified/qwen3.rs
@@ -1479,51 +1479,6 @@ mod tests {
     }
 
     #[test]
-    fn response_prefilled_named_text_and_arguments_are_exact_at_every_utf8_split() {
-        let ordinary = "ordinary ";
-        let payload = r#"{"city":"Paris"}"#;
-        let input = format!("{ordinary}{payload}");
-
-        for split in input
-            .char_indices()
-            .map(|(at, _)| at)
-            .chain(std::iter::once(input.len()))
-        {
-            let mut parser = qwen3_unified(&weather_tools());
-            parser
-                .initialize_request(UnifiedParserInit {
-                    starting_state: UnifiedParserStartingState::Response,
-                    tool_output_mode: UnifiedToolOutputMode::GuidedJson {
-                        named_tool: Some("get_weather".to_string()),
-                    },
-                    invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
-                    ..UnifiedParserInit::default()
-                })
-                .unwrap();
-            let mut deltas = parser.push(&input[..split]).unwrap();
-            deltas.extend(parser.push(&input[split..]).unwrap());
-            deltas.extend(parser.finish().unwrap().events);
-
-            assert_eq!(
-                assemble(&deltas),
-                vec![
-                    text(ordinary),
-                    call("get_weather", serde_json::json!({"city":"Paris"}))
-                ],
-                "split {split}"
-            );
-            let arguments = deltas
-                .iter()
-                .filter_map(|event| match event {
-                    UnifiedParserEvent::ToolCall(call) => Some(call.arguments.as_str()),
-                    _ => None,
-                })
-                .collect::<String>();
-            assert_eq!(arguments, payload, "split {split} changed argument bytes");
-        }
-    }
-
-    #[test]
     fn required_choice_recovers_the_whole_array_when_any_call_is_invalid() {
         // Invalid = missing `name` (the one required field). A missing ARGUMENT key is
         // not invalid — that is a parameterless call, per `UNIFIED.6.a`.


### PR DESCRIPTION
#### Overview:

This PR makes Qwen3 Coder native XML tool calls stream long string arguments before the closing function marker, so `tool_choice: auto` clients do not wait for a complete long argument. It affects the Qwen3 Coder v2 parser only.

#### Example (before -> after):

Input: `<parameter=content>long file contents...</parameter>`

```text
before: one complete `arguments` frame at `</function>`
after:  the JSON argument opener and escaped content fragments stream before `</parameter>`; the validated suffix follows at `</function>`
```

#### Details:

- Streams only the first schema-declared string parameter, where the JSON prefix is stable; non-string values remain close-only.
- Holds partial closing markers, preserves UTF-8 and JSON escaping, and keeps incomplete streams out of final assembly.
- Uses the same behavior for wrapped and bare Qwen XML calls; shared scanner hooks leave all other families unchanged.

#### Verification:

`cargo test --locked -p dynamo-parsers-v2 --lib` (427 passed); conformance stream compilation; and `conformance_toolcalling_batch_via_stream` (7 passed).

#### Where should the reviewer start?

`parsers/v2/src/tool_calling/qwen3_coder.rs`, then `parsers/v2/src/tool_calling/scan.rs`

Refs ai-dynamo/dynamo#13821

/coderabbit profile chill