### PR TITLE
feat(protocols): add experimental realtime text input events

### DIFF
--- a/protocols/src/types/realtime.rs
+++ b/protocols/src/types/realtime.rs
@@ -1,13 +1,63 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Re-exports upstream async-openai realtime event types. Per the ownership
-// rubric in `protocols/AGENTS.md`, no local overrides are needed today:
-// upstream covers the full event surface (`RealtimeClientEvent`,
-// `RealtimeServerEvent`, and their per-variant payloads) and no real client
-// has been observed to send a shape upstream rejects.
+// Re-exports upstream async-openai realtime types and adds a narrow wrapper for
+// Dynamo-specific client events without replacing the upstream public enum.
 
 pub use async_openai::types::realtime::*;
+use serde::{Deserialize, Serialize};
+
+/// Append UTF-8 text to the current incremental input buffer.
+///
+/// This is a Dynamo extension for clients that receive text progressively,
+/// such as cascaded ASR -> LLM pipelines. Like `input_audio_buffer.append`, an
+/// append does not finalize a conversation item or request a response.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RealtimeClientEventInputTextBufferAppend {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+    pub text: String,
+}
+
+/// Finalize the current incremental text buffer as a user conversation item.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct RealtimeClientEventInputTextBufferCommit {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+}
+
+/// Discard the current incremental text buffer without creating an item.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct RealtimeClientEventInputTextBufferClear {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+}
+
+/// Dynamo-specific extensions to the OpenAI Realtime client event set.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RealtimeClientEventExtension {
+    #[serde(rename = "input_text_buffer.append")]
+    InputTextBufferAppend(RealtimeClientEventInputTextBufferAppend),
+    #[serde(rename = "input_text_buffer.commit")]
+    InputTextBufferCommit(RealtimeClientEventInputTextBufferCommit),
+    #[serde(rename = "input_text_buffer.clear")]
+    InputTextBufferClear(RealtimeClientEventInputTextBufferClear),
+}
+
+/// OpenAI Realtime client events plus inference-serving extensions from Dynamo.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DynamoRealtimeClientEvent {
+    OpenAI(RealtimeClientEvent),
+    Extension(RealtimeClientEventExtension),
+}
+
+impl From<RealtimeClientEvent> for DynamoRealtimeClientEvent {
+    fn from(event: RealtimeClientEvent) -> Self {
+        Self::OpenAI(event)
+    }
+}
 
 /// Returns the `type` wire-tag string for a realtime event variant — useful
 /// for logging, error messages, and metric labels that need a stable name
@@ -21,8 +71,8 @@ pub use async_openai::types::realtime::*;
 /// async_openai::traits::EventType;` in here and remove the impls below; call
 /// sites need no changes.
 ///
-/// Implemented today only for `RealtimeClientEvent`. The `RealtimeServerEvent`
-/// impl can be added when a consumer needs it.
+/// Implemented for the upstream and Dynamo client event sets. The
+/// `RealtimeServerEvent` impl can be added when a consumer needs it.
 ///
 /// [NOTE] Could be replaced with a serde-introspection helper (e.g. the
 /// `serde_variant` crate) that reads the wire tag from `#[serde(rename)]`
@@ -48,6 +98,25 @@ impl EventType for RealtimeClientEvent {
             RealtimeClientEvent::ResponseCreate(_) => "response.create",
             RealtimeClientEvent::ResponseCancel(_) => "response.cancel",
             RealtimeClientEvent::OutputAudioBufferClear(_) => "output_audio_buffer.clear",
+        }
+    }
+}
+
+impl EventType for RealtimeClientEventExtension {
+    fn event_type(&self) -> &'static str {
+        match self {
+            RealtimeClientEventExtension::InputTextBufferAppend(_) => "input_text_buffer.append",
+            RealtimeClientEventExtension::InputTextBufferCommit(_) => "input_text_buffer.commit",
+            RealtimeClientEventExtension::InputTextBufferClear(_) => "input_text_buffer.clear",
+        }
+    }
+}
+
+impl EventType for DynamoRealtimeClientEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            DynamoRealtimeClientEvent::OpenAI(event) => event.event_type(),
+            DynamoRealtimeClientEvent::Extension(event) => event.event_type(),
         }
     }
 }
@@ -80,5 +149,50 @@ mod tests {
             panic!("expected transcription session");
         };
         assert!(session.audio.input.turn_detection.is_none());
+    }
+
+    #[test]
+    fn text_buffer_events_round_trip() {
+        let values = [
+            (
+                serde_json::json!({
+                    "type": "input_text_buffer.append",
+                    "event_id": "append-1",
+                    "text": "hello "
+                }),
+                "input_text_buffer.append",
+            ),
+            (
+                serde_json::json!({
+                    "type": "input_text_buffer.commit",
+                    "event_id": "commit-1"
+                }),
+                "input_text_buffer.commit",
+            ),
+            (
+                serde_json::json!({
+                    "type": "input_text_buffer.clear",
+                    "event_id": "clear-1"
+                }),
+                "input_text_buffer.clear",
+            ),
+        ];
+
+        for (value, event_type) in values {
+            let event: DynamoRealtimeClientEvent =
+                serde_json::from_value(value.clone()).expect("event should deserialize");
+            assert_eq!(event.event_type(), event_type);
+            assert_eq!(serde_json::to_value(event).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn text_buffer_append_requires_non_null_text() {
+        for value in [
+            serde_json::json!({"type": "input_text_buffer.append"}),
+            serde_json::json!({"type": "input_text_buffer.append", "text": null}),
+        ] {
+            assert!(serde_json::from_value::<DynamoRealtimeClientEvent>(value).is_err());
+        }
     }
 }

--- a/protocols/src/types/realtime.rs
+++ b/protocols/src/types/realtime.rs
@@ -71,9 +71,6 @@ impl From<RealtimeClientEvent> for DynamoRealtimeClientEvent {
 /// async_openai::traits::EventType;` in here and remove the impls below; call
 /// sites need no changes.
 ///
-/// Implemented for the upstream and Dynamo client event sets. The
-/// `RealtimeServerEvent` impl can be added when a consumer needs it.
-///
 /// [NOTE] Could be replaced with a serde-introspection helper (e.g. the
 /// `serde_variant` crate) that reads the wire tag from `#[serde(rename)]`
 /// at runtime; deferred until as clean up work.

--- a/protocols/src/types/realtime.rs
+++ b/protocols/src/types/realtime.rs
@@ -7,42 +7,49 @@
 pub use async_openai::types::realtime::*;
 use serde::{Deserialize, Serialize};
 
-/// Append UTF-8 text to the current incremental input buffer.
+/// Append UTF-8 text to the current incremental input.
 ///
 /// This is a Dynamo extension for clients that receive text progressively,
-/// such as cascaded ASR -> LLM pipelines. Like `input_audio_buffer.append`, an
-/// append does not finalize a conversation item or request a response.
+/// such as cascaded ASR -> LLM pipelines. The event name follows NVIDIA Speech
+/// NIM's realtime TTS protocol. An append does not finalize a conversation item
+/// or request a response.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RealtimeClientEventInputTextBufferAppend {
+pub struct RealtimeClientEventInputTextAppend {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
     pub text: String,
 }
 
-/// Finalize the current incremental text buffer as a user conversation item.
+/// Finalize the current incremental text as a user conversation item.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct RealtimeClientEventInputTextBufferCommit {
+pub struct RealtimeClientEventInputTextCommit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
 }
 
-/// Discard the current incremental text buffer without creating an item.
+/// Discard the current incremental text without creating an item.
+///
+/// This extends NVIDIA Speech NIM's append/commit lifecycle so clients can
+/// replace revisable ASR hypotheses.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct RealtimeClientEventInputTextBufferClear {
+pub struct RealtimeClientEventInputTextClear {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
 }
 
-/// Dynamo-specific extensions to the OpenAI Realtime client event set.
+/// Experimental Dynamo extensions to the OpenAI Realtime client event set.
+///
+/// These events are not part of the OpenAI Realtime API and may change before
+/// stabilization.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum RealtimeClientEventExtension {
-    #[serde(rename = "input_text_buffer.append")]
-    InputTextBufferAppend(RealtimeClientEventInputTextBufferAppend),
-    #[serde(rename = "input_text_buffer.commit")]
-    InputTextBufferCommit(RealtimeClientEventInputTextBufferCommit),
-    #[serde(rename = "input_text_buffer.clear")]
-    InputTextBufferClear(RealtimeClientEventInputTextBufferClear),
+    #[serde(rename = "input_text.append")]
+    InputTextAppend(RealtimeClientEventInputTextAppend),
+    #[serde(rename = "input_text.commit")]
+    InputTextCommit(RealtimeClientEventInputTextCommit),
+    #[serde(rename = "input_text.clear")]
+    InputTextClear(RealtimeClientEventInputTextClear),
 }
 
 /// OpenAI Realtime client events plus inference-serving extensions from Dynamo.
@@ -102,9 +109,9 @@ impl EventType for RealtimeClientEvent {
 impl EventType for RealtimeClientEventExtension {
     fn event_type(&self) -> &'static str {
         match self {
-            RealtimeClientEventExtension::InputTextBufferAppend(_) => "input_text_buffer.append",
-            RealtimeClientEventExtension::InputTextBufferCommit(_) => "input_text_buffer.commit",
-            RealtimeClientEventExtension::InputTextBufferClear(_) => "input_text_buffer.clear",
+            RealtimeClientEventExtension::InputTextAppend(_) => "input_text.append",
+            RealtimeClientEventExtension::InputTextCommit(_) => "input_text.commit",
+            RealtimeClientEventExtension::InputTextClear(_) => "input_text.clear",
         }
     }
 }
@@ -149,29 +156,29 @@ mod tests {
     }
 
     #[test]
-    fn text_buffer_events_round_trip() {
+    fn text_events_round_trip() {
         let values = [
             (
                 serde_json::json!({
-                    "type": "input_text_buffer.append",
+                    "type": "input_text.append",
                     "event_id": "append-1",
                     "text": "hello "
                 }),
-                "input_text_buffer.append",
+                "input_text.append",
             ),
             (
                 serde_json::json!({
-                    "type": "input_text_buffer.commit",
+                    "type": "input_text.commit",
                     "event_id": "commit-1"
                 }),
-                "input_text_buffer.commit",
+                "input_text.commit",
             ),
             (
                 serde_json::json!({
-                    "type": "input_text_buffer.clear",
+                    "type": "input_text.clear",
                     "event_id": "clear-1"
                 }),
-                "input_text_buffer.clear",
+                "input_text.clear",
             ),
         ];
 
@@ -184,10 +191,10 @@ mod tests {
     }
 
     #[test]
-    fn text_buffer_append_requires_non_null_text() {
+    fn text_append_requires_non_null_text() {
         for value in [
-            serde_json::json!({"type": "input_text_buffer.append"}),
-            serde_json::json!({"type": "input_text_buffer.append", "text": null}),
+            serde_json::json!({"type": "input_text.append"}),
+            serde_json::json!({"type": "input_text.append", "text": null}),
         ] {
             assert!(serde_json::from_value::<DynamoRealtimeClientEvent>(value).is_err());
         }


### PR DESCRIPTION
Design and API discussion: [DEP: Experimental incremental text input for `/v1/realtime`](https://github.com/ai-dynamo/dynamo/issues/14476). Please use the DEP for cross-repository design feedback; this PR adds the protocol types.

## Summary

Add experimental Dynamo client events for incremental text input over `/v1/realtime`. This lets an external orchestrator such as Pipecat forward ASR text as it arrives so the LLM can prefill before the user finishes speaking. OpenAI Realtime provides an incremental audio-input buffer, but no equivalent text-input buffer.

## Protocol

The append/commit terminology follows the [NVIDIA Speech NIM Realtime TTS API](https://docs.nvidia.com/nim/speech/latest/reference/api-references/tts/realtime-tts.html):

- `input_text.append`: append text without finalizing a conversation item or requesting a response.
- `input_text.commit`: finalize the buffered text as a user conversation item while keeping the session open.
- `input_text.clear`: discard uncommitted text so the client can replace a revised ASR hypothesis. This is a Dynamo addition to the NIM vocabulary.

`input_text.done` is omitted: Speech NIM uses it to drain input and stop the inference task, whereas this protocol keeps the LLM session open across turns. Existing OpenAI events still control response generation and cancellation. A final ASR correction can use `input_text.clear` followed by `conversation.item.create`, without another custom event.

## Compatibility and Scope

These events are **experimental Dynamo extensions**, not part of the OpenAI Realtime API, and may change before stabilization.

The additive `DynamoRealtimeClientEvent` wrapper accepts either an upstream OpenAI event or one of the three extensions. It preserves the public `async-openai` `RealtimeClientEvent` enum and standard event serialization. This PR adds no worker logic or orchestration.

## Related Work

- [Dynamo #14326](https://github.com/ai-dynamo/dynamo/pull/14326): vLLM implementation and measured overlap results. It requires this protocol change to be merged and published before it can merge.
- [Dynamo #14327](https://github.com/ai-dynamo/dynamo/pull/14327): external ASR-to-LLM handoff example using separate frontend connections.

## Validation

Tests cover extension wire tags, serialization round trips, and rejection of missing or null append text.

- `cargo test -p dynamo-protocols` (128 tests passed)
- `cargo clippy -p dynamo-protocols --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
