### PR TITLE
feat(GUI): preserve conformance labels while scrolling

### DIFF
--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -29,6 +29,65 @@ th a:hover { background: #ffd; }
 td.model, td.parser { white-space: nowrap; }
 td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
+/* Separate borders keep sticky table cells composited reliably in Chromium while zero
+   spacing preserves the existing one-pixel grid appearance. */
+[data-parity-table], .transpose-table { border-collapse: separate; border-spacing: 0; }
+
+/* Keep both axes identifiable while the matrix is scrolled. The left offsets are measured
+   by conformance.js because labels differ by tab and the parser column is optional. */
+[data-parity-table] > thead > tr.matrix-groups > th,
+[data-parity-table] > thead > tr.matrix-labels > th {
+  position: sticky;
+  background: #f5f5f5;
+}
+[data-parity-table] > thead > tr.matrix-groups > th { top: 0; z-index: 10; }
+[data-parity-table] > thead > tr.matrix-labels > th {
+  top: var(--sticky-top-row-height, 0px);
+  z-index: 9;
+}
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"] {
+  z-index: 20;
+}
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
+[data-parity-table] > tbody > tr:not(.section) > td.model { left: 0; }
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"],
+[data-parity-table] > tbody > tr:not(.section) > td.parser {
+  left: var(--sticky-model-width, 0px);
+}
+[data-parity-table] > tbody > tr:not(.section) > td.model,
+[data-parity-table] > tbody > tr:not(.section) > td.parser {
+  position: sticky;
+  z-index: 3;
+  background: #fff;
+}
+
+/* The transposed matrix has one optional section header row, model names across the top,
+   and case names down the left. Its measured case-column width is shared by the corner and
+   every body row label. */
+.transpose-table > thead > tr.transpose-sections > th,
+.transpose-table > thead > tr.transpose-models > th {
+  position: sticky;
+  background: #f5f5f5;
+}
+.transpose-table > thead > tr.transpose-sections > th { top: 0; z-index: 10; }
+.transpose-table > thead > tr.transpose-models > th {
+  top: var(--sticky-top-row-height, 0px);
+  z-index: 9;
+}
+.transpose-table > thead > tr.transpose-sections > th.tcorner-case,
+.transpose-table > thead > tr.transpose-models > th.tcorner-case {
+  left: 0;
+  z-index: 20;
+}
+.transpose-table > tbody > tr:not(.section) > th.trow-case {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  width: var(--sticky-case-width, auto);
+  min-width: var(--sticky-case-width, auto);
+  background: #fff;
+}
 /* Unified tab: per-family parser-variant badge (vLLM Rust unified vs combined). */
 .arch-badge { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px;
   font-weight: 700; letter-spacing: .02em; border: 1px solid transparent; }
@@ -732,6 +791,11 @@ body.cmp-loading .cmp-loading-note { display: block; position: fixed; top: 8px; 
 :root[data-theme="dark"] body { background: #0f172a; color: #e5e7eb; }
 :root[data-theme="dark"] th, :root[data-theme="dark"] td { border-color: #334155; }
 :root[data-theme="dark"] th { background: #1e293b; color: #cbd5e1; }
+:root[data-theme="dark"] [data-parity-table] > tbody > tr:not(.section) > td.model,
+:root[data-theme="dark"] [data-parity-table] > tbody > tr:not(.section) > td.parser,
+:root[data-theme="dark"] .transpose-table > tbody > tr:not(.section) > th.trow-case {
+  background: #0f172a;
+}
 :root[data-theme="dark"] th.case-group.case-band-0 { background: #1a2436; }
 :root[data-theme="dark"] th.case-group.case-band-1 { background: #0f172a; }
 :root[data-theme="dark"] th.case-sub.case-band-0,

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -535,9 +535,47 @@
         el.colSpan = visibleColumnCount;
       });
     });
+    updateStickyOffsets();
     if (shouldUpdateUrl) {
       updateUrl(visible);
     }
+  }
+
+  // Label widths and header heights vary by tab, view, and collapsed column group. Measure
+  // them after each layout change so CSS sticky positioning does not hide either axis.
+  function updateStickyOffsets() {
+    document.querySelectorAll('table[data-parity-table], table[data-transpose-table]')
+      .forEach(function (table) {
+        const topRow = table.querySelector(
+          'thead > tr.matrix-groups, thead > tr.transpose-sections'
+        );
+        table.style.setProperty(
+          '--sticky-top-row-height',
+          topRow ? topRow.getBoundingClientRect().height + 'px' : '0px'
+        );
+        if (table.matches('[data-parity-table]')) {
+          const modelHeader = table.querySelector(
+            'thead th[data-col-control-group="model"]'
+          );
+          const parserHeader = table.querySelector(
+            'thead th[data-col-control-group="parser"]'
+          );
+          const modelWidth = modelHeader && modelHeader.offsetParent !== null
+            ? modelHeader.getBoundingClientRect().width : 0;
+          const parserWidth = parserHeader && parserHeader.offsetParent !== null
+            ? parserHeader.getBoundingClientRect().width : 0;
+          table.style.setProperty('--sticky-model-width', modelWidth + 'px');
+          table.style.setProperty('--sticky-parser-width', parserWidth + 'px');
+        } else {
+          const caseHeaders = Array.from(table.querySelectorAll(
+            'thead th.tcorner-case, tbody th.trow-case'
+          )).filter(function (header) { return header.offsetParent !== null; });
+          const caseWidth = caseHeaders.reduce(function (width, header) {
+            return Math.max(width, header.getBoundingClientRect().width);
+          }, 0);
+          table.style.setProperty('--sticky-case-width', caseWidth + 'px');
+        }
+      });
   }
 
   let visibleColumns = readVisibleColumns();
@@ -598,6 +636,7 @@
     if (shouldUpdateUrl) {
       updateTabUrl(id);
     }
+    updateStickyOffsets();
   }
   activateTab(readActiveTab(), false);
   tabButtons.forEach(function (button) {
@@ -1002,6 +1041,7 @@
     });
     if (sections.some(function (s) { return s.label; })) {
       const r0 = outHead.insertRow();
+      r0.className = 'transpose-sections';
       const corner = document.createElement('th');
       corner.className = 'tcorner-case';
       r0.appendChild(corner);
@@ -1018,6 +1058,7 @@
     // the panel's case prefix (e.g. "Case TOOLCALLING.batch.*"), rotated the same
     // way as the model names.
     const r1 = outHead.insertRow();
+    r1.className = 'transpose-models';
     const cornerCase = document.createElement('th');
     cornerCase.className = 'tcol-model tcorner-case';
     let prefix = (table.dataset.casePrefix || '').trim();
@@ -1152,6 +1193,7 @@
       // Apply the current column-collapse state so a case group hidden in the
       // original table stays hidden (as rows) in the freshly-built mirror.
       applyColumnState(visibleColumns, false);
+      updateStickyOffsets();
     }
   }
 
@@ -1169,6 +1211,8 @@
   }
 
   applyTransposeMode(readTransposeMode(), false);
+  updateStickyOffsets();
+  window.addEventListener('resize', updateStickyOffsets);
   if (transposeToggle) {
     transposeToggle.addEventListener('change', function () {
       applyTransposeMode(transposeToggle.checked, true);

--- a/conformance/utils/src/assets/conformance_view.js
+++ b/conformance/utils/src/assets/conformance_view.js
@@ -1007,7 +1007,8 @@
     table.setAttribute('data-case-prefix', tab.case_prefix || '');
     table.setAttribute('data-mode', tab.mode || '');
     var thead = document.createElement('thead');
-    thead.innerHTML = '<tr>' + groupHeadersHtml(tab) + '</tr><tr>' + subHeadersHtml(tab) + '</tr>';
+    thead.innerHTML = '<tr class="matrix-groups">' + groupHeadersHtml(tab)
+      + '</tr><tr class="matrix-labels">' + subHeadersHtml(tab) + '</tr>';
     // The sub-case headers were emitted as a string; key their grammar popups now that
     // they are real nodes. Built lazily like every other tooltip (a grammar table for
     // ~20 families is far too much to render up front for every column).

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -872,3 +872,62 @@ def test_touch_outside_a_host_does_not_arm_a_pointerdownless_activation(driver):
         "a pointerdown-less activation pinned because an unrelated touch elsewhere left "
         "the provenance armed — pinning must require the gesture to start in this host"
     )
+
+
+@pytest.mark.parametrize("transposed", [False, True], ids=["normal", "transposed"])
+def test_matrix_labels_stay_visible_when_scrolled(driver, rendered_page, transposed):
+    """SCROLL: both matrix axes keep their labels visible and aligned."""
+    driver.get(f"file://{rendered_page}?view=details")
+    if transposed:
+        toggled = driver.execute_script(
+            """
+            const t = document.querySelector('[data-transpose-toggle]');
+            if (!t) return false;
+            t.checked = true;
+            t.dispatchEvent(new Event('change'));
+            return true;
+            """
+        )
+        if not toggled:
+            pytest.skip("no transpose toggle on this page")
+
+    result = driver.execute_script(
+        """
+        const table = document.querySelector(arguments[0]
+          ? '.tab-panel.active table[data-transpose-table]'
+          : '.tab-panel.active table[data-parity-table]');
+        if (!table) return {error: 'active matrix not found'};
+        const header = arguments[0]
+          ? table.querySelector('thead tr.transpose-models th.tcorner-case')
+          : table.querySelector('thead tr.matrix-groups th[data-col-control-group="model"]');
+        const label = arguments[0]
+          ? table.querySelector('tbody tr:not(.section) th.trow-case')
+          : table.querySelector('tbody tr:not(.section) td.model');
+        if (!header || !label) return {error: 'matrix labels not found'};
+        const before = header.getBoundingClientRect();
+        window.scrollTo(500, Math.max(0, table.getBoundingClientRect().top + window.scrollY + 500));
+        const afterHeader = header.getBoundingClientRect();
+        const afterLabel = label.getBoundingClientRect();
+        return {
+          beforeTop: before.top,
+          afterTop: afterHeader.top,
+          afterLeft: afterLabel.left,
+          headerLeft: afterHeader.left,
+          headerPosition: getComputedStyle(header).position,
+          labelPosition: getComputedStyle(label).position,
+          labelWidth: afterLabel.width,
+          headerWidth: afterHeader.width,
+          viewportHeight: window.innerHeight,
+        };
+        """,
+        transposed,
+    )
+    try:
+        assert "error" not in result, result.get("error")
+        assert result["headerPosition"] == "sticky"
+        assert result["labelPosition"] == "sticky"
+        assert 0 <= result["afterTop"] < result["viewportHeight"]
+        assert abs(result["afterLeft"] - result["headerLeft"]) < 2
+        assert result["labelWidth"] > 0 and result["headerWidth"] > 0
+    finally:
+        driver.get(f"file://{rendered_page}")

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -876,7 +876,6 @@ def test_touch_outside_a_host_does_not_arm_a_pointerdownless_activation(driver):
 
 @pytest.mark.parametrize("transposed", [False, True], ids=["normal", "transposed"])
 def test_matrix_labels_stay_visible_when_scrolled(driver, rendered_page, transposed):
-    """SCROLL: both matrix axes keep their labels visible and aligned."""
     driver.get(f"file://{rendered_page}?view=details")
     if transposed:
         toggled = driver.execute_script(

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -967,3 +967,15 @@ def test_transpose_feature_is_wired() -> None:
     # CSS shows the mirror in transpose mode and hides the original
     assert "body.transpose-mode" in css and ".transpose-table" in css
     assert "sideways-lr" in css  # rotated bottom-up model headers
+
+
+def test_matrix_axis_labels_are_sticky() -> None:
+    css = (SRC / "assets" / "conformance.css").read_text(encoding="utf-8")
+    view = (SRC / "assets" / "conformance_view.js").read_text(encoding="utf-8")
+    js = (SRC / "assets" / "conformance.js").read_text(encoding="utf-8")
+    assert "matrix-groups" in view and "matrix-labels" in view
+    assert "transpose-sections" in js and "transpose-models" in js
+    assert "--sticky-model-width" in js and "--sticky-case-width" in js
+    assert "position: sticky" in css
+    assert "data-col-control-group=\"model\"" in css
+    assert ".transpose-table > tbody > tr:not(.section) > th.trow-case" in css

--- a/conformance/utils/tests/test_stream_on_batch.py
+++ b/conformance/utils/tests/test_stream_on_batch.py
@@ -967,15 +967,3 @@ def test_transpose_feature_is_wired() -> None:
     # CSS shows the mirror in transpose mode and hides the original
     assert "body.transpose-mode" in css and ".transpose-table" in css
     assert "sideways-lr" in css  # rotated bottom-up model headers
-
-
-def test_matrix_axis_labels_are_sticky() -> None:
-    css = (SRC / "assets" / "conformance.css").read_text(encoding="utf-8")
-    view = (SRC / "assets" / "conformance_view.js").read_text(encoding="utf-8")
-    js = (SRC / "assets" / "conformance.js").read_text(encoding="utf-8")
-    assert "matrix-groups" in view and "matrix-labels" in view
-    assert "transpose-sections" in js and "transpose-models" in js
-    assert "--sticky-model-width" in js and "--sticky-case-width" in js
-    assert "position: sticky" in css
-    assert "data-col-control-group=\"model\"" in css
-    assert ".transpose-table > tbody > tr:not(.section) > th.trow-case" in css


### PR DESCRIPTION
#### Overview:

UI change only — no parser code is touched. This PR keeps model, parser, and case labels visible while scrolling the conformance matrix across all report tabs and the transposed view.

#### Details:

- Makes the two matrix header rows and left-side model/parser labels sticky.
- Measures rendered label widths so optional parser columns and collapsed groups stay aligned.
- Keeps browser regression coverage for normal and transposed scrolling; the optional browser test remains dependency-free in the standard conformance gate.

#### Verification:

43 focused conformance tests and 21 browser smoke tests passed; both JavaScript assets pass syntax checks; the conformance table and Rust CI checks pass.

#### Where should the reviewer start?

`conformance/utils/src/assets/conformance.css`, then `conformance/utils/src/assets/conformance.js` and `conformance/utils/tests/test_browser_smoke.py`

/coderabbit profile chill

Related: DIS-2859
