### PR TITLE
fix(protocols): accept chat-style max_tokens as an alias for max_output_tokens

### DIFF
--- a/protocols/src/types/responses/mod.rs
+++ b/protocols/src/types/responses/mod.rs
@@ -500,7 +500,10 @@ pub struct CreateResponse {
     pub input: InputParam,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Output cap. Also accepts the Chat Completions spelling `max_tokens`
+    /// as an alias so a caller's cap is honored instead of silently dropped;
+    /// serialization always emits `max_output_tokens`.
+    #[serde(alias = "max_tokens", skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tool_calls: Option<u32>,
@@ -1393,6 +1396,33 @@ mod tests {
             }
             other => panic!("expected Item::Message(Output), got {other:?}"),
         }
+    }
+
+    /// The Chat Completions spelling `max_tokens` is honored as the output cap
+    /// rather than silently dropped (#207); the wire echo is `max_output_tokens`.
+    #[test]
+    fn create_response_accepts_max_tokens_as_alias_for_max_output_tokens() {
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "model": "m", "input": "hi", "max_tokens": 16
+        }))
+        .unwrap();
+        assert_eq!(req.max_output_tokens, Some(16));
+        let back = serde_json::to_value(&req).unwrap();
+        assert_eq!(back["max_output_tokens"], 16);
+        assert!(back.get("max_tokens").is_none());
+
+        let req: CreateResponse = serde_json::from_value(serde_json::json!({
+            "model": "m", "input": "hi", "max_tokens": null
+        }))
+        .unwrap();
+        assert_eq!(req.max_output_tokens, None);
+
+        // Both spellings at once is ambiguous and fails as a duplicate field.
+        let err = serde_json::from_value::<CreateResponse>(serde_json::json!({
+            "model": "m", "input": "hi", "max_tokens": 16, "max_output_tokens": 32
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("duplicate field"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes the `max_tokens` half of #207.

## Problem

`CreateResponse` mirrors the OpenAI Responses request, whose output cap is `max_output_tokens`. The Chat Completions spelling `max_tokens` is not a field on the type and there is no unknown-field handling, so

```json
{"model": "example-model", "input": "Write a long essay about the ocean.", "max_tokens": 16}
```

deserializes with `max_output_tokens: None`. A server built on this type then generates uncapped and reports `status: "completed"` with `max_output_tokens: null`, while the caller believes a 16-token limit is in force. Reproduced on `main` @ 974145ea with a focused test.

## Change

Per the maintainer suggestion, `max_output_tokens` gains `#[serde(alias = "max_tokens")]`. The caller's cap is honored, and because serialization always emits `max_output_tokens`, the applied cap is visible in the echoed request/response fields. Both spellings in one body fail as a serde duplicate-field error; a JSON `null` deserializes as absent. No public API change, no breaking release.

One test covers: alias honored and echoed as `max_output_tokens`; `null` treated as absent; both spellings rejected.

This diverges from OpenAI, which rejects `max_tokens` with 400 (observed for a numeric value in a canonical sweep on 2026-08-18); the source issue allowed either honoring or rejecting, and honoring avoids a breaking change to the type.

## Not in this PR

The other half of #207 (request `metadata` echoed back as `{}`) is in the consumer's response builder (`chat_completion_to_response` and the stream converter in ai-dynamo/dynamo `lib/llm`), not in this crate. I will leave #207 open for that half with a pointer.

## Checks

Run locally on this branch: `cargo fmt --all -- --check` clean; `cargo clippy -p dynamo-protocols --all-targets --all-features -- -D warnings` clean; `cargo test -p dynamo-protocols` pass (122 lib tests including the new one); `cargo doc` clean. The Rust CI here runs only after a maintainer's `/ok to test <sha>`.
