### PR TITLE
feat(mm-preprocessor): [PR 3/N] prompt layout, content identity, spec resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,8 +1143,10 @@ dependencies = [
 name = "dynamo-mm-preprocessor"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "serde",
  "serde_json",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -5848,6 +5850,12 @@ dependencies = [
  "whoami",
  "winapi",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2.5"
 uuid = "1.18.1"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,9 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    # Boost Software License (xxhash-rust, the XXH3 crate Dynamo's canonical
+    # media identity uses).
+    "BSL-1.0",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",

--- a/mm-preprocessor/Cargo.toml
+++ b/mm-preprocessor/Cargo.toml
@@ -30,5 +30,7 @@ fetch = []
 parallel = []
 
 [dependencies]
+blake3.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+xxhash-rust.workspace = true

--- a/mm-preprocessor/src/lib.rs
+++ b/mm-preprocessor/src/lib.rs
@@ -75,6 +75,20 @@ impl MmError {
             source: Some(Box::new(source)),
         }
     }
+
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+            source: None,
+        }
+    }
 }
 
 impl std::fmt::Display for MmError {
@@ -104,8 +118,8 @@ pub type Result<T> = std::result::Result<T, MmError>;
 
 /// BLAKE3 over encoded media bytes, truncated to a big-endian `u64`.
 pub fn content_hash_bytes(data: &[u8]) -> u64 {
-    let _ = data;
-    todo!("sglang rust native blake3, first 8 bytes BE")
+    let digest = blake3::hash(data);
+    u64::from_be_bytes(digest.as_bytes()[..8].try_into().unwrap())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,6 +134,46 @@ pub enum MediaDtype {
 /// modalities have separate identity contracts; in particular, Dynamo's
 /// video identity also covers decoded metadata.
 pub fn content_hash_canonical_image(shape: &[usize], dtype: MediaDtype, data: &[u8]) -> u64 {
-    let _ = (shape, dtype, data);
-    todo!("dynamo canonical decoded-image hash")
+    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    // Rank and dimensions are fixed-width so distinct shapes cannot alias
+    // after concatenation.
+    hasher.update(&(shape.len() as u64).to_le_bytes());
+    for &dim in shape {
+        hasher.update(&(dim as u64).to_le_bytes());
+    }
+    let dtype_byte: u8 = match dtype {
+        MediaDtype::U8 => 0,
+    };
+    hasher.update(&[dtype_byte]);
+    hasher.update(data);
+    hasher.digest()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Both identities are cross-process contracts — a router hashes and an
+    /// engine looks the key up — so they are pinned to the values the mirrored
+    /// implementations produce, not merely to being stable here.
+    #[test]
+    fn identities_match_the_mirrored_implementations() {
+        // Dynamo's `canonical_content_hash` (lib/llm preprocessor::media::rdma).
+        assert_eq!(
+            content_hash_canonical_image(&[1, 2, 3], MediaDtype::U8, &[0, 1, 2, 3, 4, 5]),
+            0x7a9b_bcb1_1a89_8630
+        );
+        // SGLang's fallback: BLAKE3 of b"abc", first 8 bytes big-endian.
+        assert_eq!(content_hash_bytes(b"abc"), 0x6437_b3ac_3846_5133);
+    }
+
+    /// Shape and dtype are hashed alongside the pixels, so two buffers that
+    /// differ only in geometry cannot collide into one cache entry.
+    #[test]
+    fn canonical_image_identity_covers_geometry() {
+        let data = [0u8, 1, 2, 3, 4, 5];
+        let hash = |shape: &[usize]| content_hash_canonical_image(shape, MediaDtype::U8, &data);
+        assert_ne!(hash(&[1, 2, 3]), hash(&[3, 2, 1]));
+        assert_ne!(hash(&[1, 2, 3]), hash(&[2, 3]));
+    }
 }

--- a/mm-preprocessor/src/registry.rs
+++ b/mm-preprocessor/src/registry.rs
@@ -6,6 +6,10 @@
 //! consumer selects one by its typed [`ProcessorSpec`] or by serializing a
 //! spec (`{"family": ..., resolved processor params}`).
 
+use crate::models::qwen_vl::{QwenVlSpec, Resampler};
+use crate::{MmError, Result};
+use serde_json::Value;
+
 /// Resolved parameters of one family processor, one variant per family.
 /// Built directly or deserialized via [`processor_from_spec`], where the
 /// `family` key selects the variant.
@@ -13,14 +17,14 @@
 #[serde(tag = "family", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ProcessorSpec {
-    QwenVl(crate::models::qwen_vl::QwenVlSpec),
+    QwenVl(QwenVlSpec),
 }
 
 /// Build a family processor from a typed spec. `Err` when the family
 /// rejects its parameters (e.g. a zero patch size).
 pub fn build_processor(
     spec: ProcessorSpec,
-) -> crate::Result<Box<dyn crate::processor::MmFamilyProcessor>> {
+) -> Result<Box<dyn crate::processor::MmFamilyProcessor>> {
     match spec {
         ProcessorSpec::QwenVl(spec) => Ok(Box::new(crate::models::qwen_vl::QwenVlProcessor::new(
             spec,
@@ -31,11 +35,9 @@ pub fn build_processor(
 /// Build a family processor from the consumer-side spec JSON
 /// (`{"family": ..., resolved processor params}`). `Err` on an unknown family
 /// or malformed spec — the caller treats that as "no native processor".
-pub fn processor_from_spec(
-    json: &str,
-) -> crate::Result<Box<dyn crate::processor::MmFamilyProcessor>> {
+pub fn processor_from_spec(json: &str) -> Result<Box<dyn crate::processor::MmFamilyProcessor>> {
     let spec: ProcessorSpec = serde_json::from_str(json)
-        .map_err(|error| crate::MmError::invalid_input_with_source("invalid mm spec", error))?;
+        .map_err(|error| MmError::invalid_input_with_source("invalid mm spec", error))?;
     build_processor(spec)
 }
 
@@ -51,15 +53,263 @@ pub fn processor_from_spec(
 pub fn spec_from_hf_configs(
     config_json: &str,
     preprocessor_config_json: &str,
-) -> crate::Result<ProcessorSpec> {
-    let _ = (config_json, preprocessor_config_json);
-    todo!("model_type → family arm; validate + map processor knobs")
+) -> Result<ProcessorSpec> {
+    let config: Value = serde_json::from_str(config_json)
+        .map_err(|error| MmError::invalid_input_with_source("invalid config.json", error))?;
+    let pre: Value = serde_json::from_str(preprocessor_config_json).map_err(|error| {
+        MmError::invalid_input_with_source("invalid preprocessor_config.json", error)
+    })?;
+    match config["model_type"].as_str() {
+        Some("qwen2_vl" | "qwen2_5_vl" | "qwen3_vl" | "qwen3_vl_moe") => {
+            Ok(ProcessorSpec::QwenVl(resolve_qwen_vl(&config, &pre)?))
+        }
+        Some(other) => Err(MmError::unsupported(format!(
+            "no native processor for model_type {other:?}"
+        ))),
+        None => Err(MmError::invalid_input("config.json is missing model_type")),
+    }
 }
 
 /// [`spec_from_hf_configs`] over a local model directory (reads `config.json`
 /// and `preprocessor_config.json`). Downloading from a hub stays the
 /// consumer's concern — hand this the resolved local dir.
-pub fn spec_from_model_dir(dir: &std::path::Path) -> crate::Result<ProcessorSpec> {
-    let _ = dir;
-    todo!("read the two config files, delegate to spec_from_hf_configs")
+pub fn spec_from_model_dir(dir: &std::path::Path) -> Result<ProcessorSpec> {
+    let read = |name: &str| {
+        std::fs::read_to_string(dir.join(name)).map_err(|error| {
+            MmError::invalid_input_with_source(format!("cannot read {name}"), error)
+        })
+    };
+    spec_from_hf_configs(&read("config.json")?, &read("preprocessor_config.json")?)
+}
+
+/// Knobs the qwen resolution reads: patch geometry, pixel bounds,
+/// normalization.
+const CONSUMED: &[&str] = &[
+    "patch_size",
+    "merge_size",
+    "temporal_patch_size",
+    "min_pixels",
+    "max_pixels",
+    "size",
+    "image_mean",
+    "image_std",
+];
+
+/// Knobs whose value must hold for the Rust arithmetic to match HF's: the
+/// stages this pipeline hardcodes stay enabled, the ones it omits stay
+/// disabled, and PIL BICUBIC (3) is the only mirrored kernel.
+type Predicate = fn(&Value) -> bool;
+const PINNED: &[(&str, Predicate)] = &[
+    ("do_resize", |v| v.as_bool() == Some(true)),
+    ("do_rescale", |v| v.as_bool() == Some(true)),
+    ("do_normalize", |v| v.as_bool() == Some(true)),
+    ("do_convert_rgb", |v| v.as_bool() == Some(true)),
+    ("do_center_crop", |v| v.as_bool() == Some(false)),
+    ("do_pad", |v| v.as_bool() == Some(false)),
+    ("resample", |v| v.as_i64() == Some(3)),
+    ("rescale_factor", |v| v.as_f64() == Some(1.0 / 255.0)),
+    ("data_format", |v| v.as_str() == Some("channels_first")),
+    ("input_data_format", |v| {
+        v.as_str() == Some("channels_first")
+    }),
+    ("image_processor_type", |v| {
+        matches!(
+            v.as_str(),
+            Some("Qwen2VLImageProcessor" | "Qwen2VLImageProcessorFast")
+        )
+    }),
+];
+
+/// Knobs recognized but irrelevant to the output: batching, output
+/// packaging, naming, or gated behind a [`PINNED`] flag that stays off.
+const INERT: &[&str] = &[
+    "crop_size",
+    "default_to_square",
+    "disable_grouping",
+    "return_tensors",
+    "processor_class",
+];
+
+fn resolve_qwen_vl(config: &Value, pre: &Value) -> Result<QwenVlSpec> {
+    let knobs = pre
+        .as_object()
+        .ok_or_else(|| MmError::invalid_input("preprocessor_config.json is not an object"))?;
+    let set = |knob: &str| knobs.get(knob).filter(|value| !value.is_null());
+    for (knob, value) in knobs {
+        let knob = knob.as_str();
+        if value.is_null() || CONSUMED.contains(&knob) || INERT.contains(&knob) {
+            continue;
+        }
+        match PINNED.iter().find(|(name, _)| *name == knob) {
+            Some((_, honored)) if honored(value) => {}
+            Some(_) => {
+                return Err(MmError::unsupported(format!(
+                    "preprocessor knob {knob} = {value} cannot be honored bit-exactly"
+                )));
+            }
+            None => {
+                return Err(MmError::unsupported(format!(
+                    "unrecognized preprocessor knob {knob}"
+                )));
+            }
+        }
+    }
+
+    let usize_knob = |knob: &str| {
+        set(knob)
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .ok_or_else(|| MmError::invalid_input(format!("preprocessor knob {knob} is missing")))
+    };
+    let rgb_knob = |knob: &str| -> Result<[f32; 3]> {
+        let values = set(knob)
+            .and_then(Value::as_array)
+            .map(|values| values.iter().filter_map(Value::as_f64).collect::<Vec<_>>())
+            .filter(|values| values.len() == 3)
+            .ok_or_else(|| {
+                MmError::invalid_input(format!("preprocessor knob {knob} must be 3 numbers"))
+            })?;
+        Ok([values[0] as f32, values[1] as f32, values[2] as f32])
+    };
+    // Qwen2/2.5 carry the pixel bounds at the top level; Qwen3 as
+    // `size.{shortest,longest}_edge` (pixel counts despite the names).
+    let pixels = |knob: &str, edge: &str| {
+        set(knob)
+            .or_else(|| pre["size"].get(edge).filter(|value| !value.is_null()))
+            .or_else(|| pre["size"].get(knob).filter(|value| !value.is_null()))
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .ok_or_else(|| MmError::invalid_input(format!("preprocessor {knob} is missing")))
+    };
+
+    Ok(QwenVlSpec {
+        image_token_id: config["image_token_id"]
+            .as_i64()
+            .and_then(|id| i32::try_from(id).ok())
+            .ok_or_else(|| MmError::invalid_input("config.json is missing image_token_id"))?,
+        patch_size: usize_knob("patch_size")?,
+        merge_size: usize_knob("merge_size")?,
+        temporal_patch_size: usize_knob("temporal_patch_size")?,
+        min_pixels: pixels("min_pixels", "shortest_edge")?,
+        max_pixels: pixels("max_pixels", "longest_edge")?,
+        image_mean: rgb_knob("image_mean")?,
+        image_std: rgb_knob("image_std")?,
+        // Both HF processor names run torchvision's uint8 path on a default
+        // server; `Resampler::Pil` stays reachable through the spec JSON.
+        resample: Resampler::AtenU8,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Trimmed from Qwen/Qwen2.5-VL-7B-Instruct.
+    const QWEN25_CONFIG: &str = r#"{
+        "architectures": ["Qwen2_5_VLForConditionalGeneration"],
+        "image_token_id": 151655, "video_token_id": 151656,
+        "model_type": "qwen2_5_vl", "vision_config": {"patch_size": 14}
+    }"#;
+    const QWEN25_PREPROCESSOR: &str = r#"{
+        "min_pixels": 3136, "max_pixels": 12845056,
+        "patch_size": 14, "temporal_patch_size": 2, "merge_size": 2,
+        "image_mean": [0.48145466, 0.4578275, 0.40821073],
+        "image_std": [0.26862954, 0.26130258, 0.27577711],
+        "image_processor_type": "Qwen2VLImageProcessor",
+        "processor_class": "Qwen2_5_VLProcessor"
+    }"#;
+    // Trimmed from Qwen/Qwen3-VL-8B-Instruct (a fast-processor dump: pixel
+    // bounds under `size`, inert knobs serialized as null).
+    const QWEN3_CONFIG: &str = r#"{
+        "architectures": ["Qwen3VLForConditionalGeneration"],
+        "image_token_id": 151655, "model_type": "qwen3_vl"
+    }"#;
+    const QWEN3_PREPROCESSOR: &str = r#"{
+        "size": {"longest_edge": 16777216, "shortest_edge": 65536},
+        "patch_size": 16, "temporal_patch_size": 2, "merge_size": 2,
+        "image_mean": [0.5, 0.5, 0.5], "image_std": [0.5, 0.5, 0.5],
+        "do_resize": true, "do_rescale": true, "do_normalize": true,
+        "do_convert_rgb": true, "do_center_crop": null, "do_pad": null,
+        "resample": 3, "rescale_factor": 0.00392156862745098,
+        "crop_size": null, "data_format": "channels_first", "device": null,
+        "default_to_square": true, "disable_grouping": null,
+        "input_data_format": null, "return_tensors": null,
+        "processor_class": "Qwen3VLProcessor",
+        "image_processor_type": "Qwen2VLImageProcessorFast"
+    }"#;
+
+    fn qwen_spec(config: &str, pre: &str) -> Result<QwenVlSpec> {
+        spec_from_hf_configs(config, pre).map(|ProcessorSpec::QwenVl(spec)| spec)
+    }
+
+    #[test]
+    fn resolves_qwen25_vl() {
+        let spec = qwen_spec(QWEN25_CONFIG, QWEN25_PREPROCESSOR).unwrap();
+        assert_eq!(spec.image_token_id, 151655);
+        assert_eq!(
+            (spec.patch_size, spec.merge_size, spec.temporal_patch_size),
+            (14, 2, 2)
+        );
+        assert_eq!((spec.min_pixels, spec.max_pixels), (3136, 12845056));
+        assert_eq!(spec.image_mean, [0.48145466, 0.4578275, 0.40821073]);
+        assert_eq!(spec.resample, Resampler::AtenU8);
+        assert!(build_processor(ProcessorSpec::QwenVl(spec)).is_ok());
+    }
+
+    #[test]
+    fn resolves_qwen3_vl_size_edges() {
+        let spec = qwen_spec(QWEN3_CONFIG, QWEN3_PREPROCESSOR).unwrap();
+        assert_eq!((spec.min_pixels, spec.max_pixels), (65536, 16777216));
+        assert_eq!(spec.patch_size, 16);
+    }
+
+    #[test]
+    fn unknown_model_type_is_unsupported() {
+        let config = r#"{"model_type": "llava", "image_token_id": 32000}"#;
+        assert!(matches!(
+            spec_from_hf_configs(config, QWEN25_PREPROCESSOR),
+            Err(MmError::Unsupported { .. })
+        ));
+    }
+
+    /// Any knob the pipeline cannot mirror bit-exactly must refuse resolution,
+    /// whether it is a disabled stage, a foreign kernel, or a knob this crate
+    /// has never seen.
+    #[test]
+    fn unhonorable_or_unknown_knobs_are_refused() {
+        let mut refused =
+            vec![QWEN25_PREPROCESSOR.replace("Qwen2VLImageProcessor", "LlavaImageProcessor")];
+        for knob in [
+            r#""do_normalize": false"#,
+            r#""do_center_crop": true"#,
+            r#""resample": 2"#,
+            r#""rescale_factor": 0.5"#,
+            r#""device": "cuda""#,
+            r#""pad_size": {"height": 512}"#,
+        ] {
+            refused.push(QWEN25_PREPROCESSOR.replacen('{', &format!("{{{knob},"), 1));
+        }
+        for pre in refused {
+            assert!(
+                matches!(
+                    qwen_spec(QWEN25_CONFIG, &pre),
+                    Err(MmError::Unsupported { .. })
+                ),
+                "{pre} should refuse resolution"
+            );
+        }
+    }
+
+    #[test]
+    fn model_dir_resolution_reads_both_configs() {
+        let dir = std::env::temp_dir().join(format!("mm-registry-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), QWEN25_CONFIG).unwrap();
+        std::fs::write(dir.join("preprocessor_config.json"), QWEN25_PREPROCESSOR).unwrap();
+        let ProcessorSpec::QwenVl(spec) = spec_from_model_dir(&dir).unwrap();
+        assert_eq!(spec.max_pixels, 12845056);
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(spec_from_model_dir(std::path::Path::new("/nonexistent")).is_err());
+    }
 }

--- a/mm-preprocessor/src/token_layout.rs
+++ b/mm-preprocessor/src/token_layout.rs
@@ -8,7 +8,8 @@
 //! already-tokenized prompt means non-media tokens can never drift from a
 //! retokenize.
 
-use crate::processor::TokenLayout;
+use crate::processor::{ExpansionPart, Segment, TokenLayout};
+use crate::{MmError, Result};
 
 /// The expanded prompt. `offsets` and `feature_ranges` are indexed by media
 /// item, in layout order:
@@ -35,9 +36,104 @@ pub fn apply_layout(
     src: &[i32],
     layout: &TokenLayout,
     feature_token_counts: &[usize],
-) -> crate::Result<ExpandedPrompt> {
-    let _ = (src, layout, feature_token_counts);
-    todo!("validating single-pass expansion")
+) -> Result<ExpandedPrompt> {
+    let n_items = feature_token_counts.len();
+    let mut out = Vec::new();
+    let mut offsets: Vec<Option<(u32, u32)>> = vec![None; n_items];
+    let mut feature_ranges: Vec<Vec<std::ops::Range<u32>>> = vec![Vec::new(); n_items];
+    // Source tokens consumed so far: `Text` copies a range, `Media` replaces
+    // its `src` range.
+    let mut consumed = 0usize;
+    for segment in &layout.segments {
+        match segment {
+            Segment::Text(range) => {
+                let text = src.get(range.clone()).ok_or_else(|| {
+                    MmError::internal(format!("layout: text range {range:?} out of bounds"))
+                })?;
+                if range.start != consumed {
+                    return Err(MmError::internal(format!(
+                        "layout: text range {range:?} does not resume at source index {consumed}"
+                    )));
+                }
+                consumed = range.end;
+                out.extend_from_slice(text);
+            }
+            Segment::Media {
+                item,
+                src: replaced,
+                expansion,
+            } => {
+                if replaced.start != consumed || replaced.end < replaced.start {
+                    return Err(MmError::internal(format!(
+                        "layout: media item {item} src range {replaced:?} does not resume at \
+                         source index {consumed}"
+                    )));
+                }
+                if replaced.end > src.len() {
+                    return Err(MmError::internal(format!(
+                        "layout: media item {item} src range {replaced:?} out of bounds"
+                    )));
+                }
+                consumed = replaced.end;
+
+                let start = out.len() as u32;
+                let mut features = 0usize;
+                let mut ranges = Vec::new();
+                for part in expansion {
+                    match part {
+                        ExpansionPart::Feature { id, n } => {
+                            let part_start = out.len() as u32;
+                            out.resize(out.len() + n, *id);
+                            features += n;
+                            if *n > 0 {
+                                ranges.push(part_start..out.len() as u32);
+                            }
+                        }
+                        ExpansionPart::Literal(ids) => out.extend_from_slice(ids),
+                    }
+                }
+                let n = out.len() as u32 - start;
+                if n == 0 {
+                    return Err(MmError::internal(format!(
+                        "layout: media item {item} expands to zero tokens"
+                    )));
+                }
+                let expected = *feature_token_counts.get(*item).ok_or_else(|| {
+                    MmError::internal(format!("layout: media item {item} out of range"))
+                })?;
+                if features != expected {
+                    return Err(MmError::internal(format!(
+                        "layout: media item {item} expands to {features} feature token(s), \
+                         expected {expected}"
+                    )));
+                }
+                if offsets[*item].replace((start, start + n - 1)).is_some() {
+                    return Err(MmError::internal(format!(
+                        "layout: media item {item} placed twice"
+                    )));
+                }
+                feature_ranges[*item] = ranges;
+            }
+        }
+    }
+    if consumed != src.len() {
+        return Err(MmError::internal(format!(
+            "layout: covers {consumed} of {} source token(s)",
+            src.len()
+        )));
+    }
+    let offsets = offsets
+        .into_iter()
+        .enumerate()
+        .map(|(i, slot)| {
+            slot.ok_or_else(|| MmError::internal(format!("layout: media item {i} not placed")))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(ExpandedPrompt {
+        input_ids: out,
+        offsets,
+        feature_ranges,
+    })
 }
 
 /// Build the simplest layout: the i-th occurrence of `placeholder_id` in
@@ -48,7 +144,161 @@ pub fn layout_by_placeholder(
     ids: &[i32],
     placeholder_id: i32,
     counts: &[usize],
-) -> crate::Result<TokenLayout> {
-    let _ = (ids, placeholder_id, counts);
-    todo!("qwen-style repeat layout")
+) -> Result<TokenLayout> {
+    let found = ids.iter().filter(|&&id| id == placeholder_id).count();
+    if found != counts.len() {
+        return Err(MmError::invalid_input(format!(
+            "prompt has {found} media placeholder(s) but {} media item(s)",
+            counts.len()
+        )));
+    }
+    let mut segments = Vec::new();
+    let mut text_start = 0;
+    let mut item = 0;
+    for (pos, &id) in ids.iter().enumerate() {
+        if id == placeholder_id {
+            if text_start < pos {
+                segments.push(Segment::Text(text_start..pos));
+            }
+            segments.push(Segment::Media {
+                item,
+                src: pos..pos + 1,
+                expansion: vec![ExpansionPart::Feature {
+                    id: placeholder_id,
+                    n: counts[item],
+                }],
+            });
+            item += 1;
+            text_start = pos + 1;
+        }
+    }
+    if text_start < ids.len() {
+        segments.push(Segment::Text(text_start..ids.len()));
+    }
+    Ok(TokenLayout { segments })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand(ids: &[i32], placeholder: i32, counts: &[usize]) -> Result<ExpandedPrompt> {
+        apply_layout(
+            ids,
+            &layout_by_placeholder(ids, placeholder, counts)?,
+            counts,
+        )
+    }
+
+    #[test]
+    fn expands_in_order_with_inclusive_offsets() {
+        // [7, PAD, 8, PAD, 9] with counts [2, 3]
+        let e = expand(&[7, 1, 8, 1, 9], 1, &[2, 3]).unwrap();
+        assert_eq!(e.input_ids, vec![7, 1, 1, 8, 1, 1, 1, 9]);
+        assert_eq!(e.offsets, vec![(1, 2), (4, 6)]);
+        // Feature-only expansions: the feature range is the whole expansion.
+        assert_eq!(e.feature_ranges, vec![vec![1..3], vec![4..7]]);
+    }
+
+    #[test]
+    fn count_mismatch_errs() {
+        assert!(expand(&[7, 1, 9], 1, &[2, 3]).is_err());
+        assert!(expand(&[7, 1, 1, 9], 1, &[2]).is_err());
+    }
+
+    #[test]
+    fn zero_count_errs() {
+        assert!(expand(&[7, 1, 9], 1, &[0]).is_err());
+    }
+
+    #[test]
+    fn no_placeholders_no_items_ok() {
+        let e = expand(&[7, 8], 1, &[]).unwrap();
+        assert_eq!(e.input_ids, vec![7, 8]);
+        assert!(e.offsets.is_empty());
+    }
+
+    /// A structured expansion mixing `Literal` markers with `Feature` tokens:
+    /// the offsets cover the whole expansion, the feature ranges only the
+    /// `Feature` parts.
+    #[test]
+    fn literal_parts_are_skipped_by_feature_ranges() {
+        let layout = TokenLayout {
+            segments: vec![
+                Segment::Text(0..1),
+                Segment::Media {
+                    item: 0,
+                    src: 1..2,
+                    expansion: vec![
+                        ExpansionPart::Literal(vec![90]),
+                        ExpansionPart::Feature { id: 5, n: 2 },
+                        ExpansionPart::Literal(vec![91]),
+                    ],
+                },
+                Segment::Text(2..3),
+            ],
+        };
+        let e = apply_layout(&[7, 1, 9], &layout, &[2]).unwrap();
+        assert_eq!(e.input_ids, vec![7, 90, 5, 5, 91, 9]);
+        assert_eq!(e.offsets, vec![(1, 4)]);
+        assert_eq!(e.feature_ranges, vec![vec![2..4]]);
+    }
+
+    #[test]
+    fn feature_count_mismatch_and_missing_placement_err() {
+        let media = |n| Segment::Media {
+            item: 0,
+            src: 1..2,
+            expansion: vec![ExpansionPart::Feature { id: 5, n }],
+        };
+        // The family's expansion must produce exactly the item's feature count.
+        let wrong = TokenLayout {
+            segments: vec![Segment::Text(0..1), media(3), Segment::Text(2..3)],
+        };
+        assert!(apply_layout(&[7, 1, 9], &wrong, &[2]).is_err());
+        // Every item must be placed; ranges must be in bounds.
+        let missing = TokenLayout {
+            segments: vec![Segment::Text(0..3)],
+        };
+        assert!(apply_layout(&[7, 1, 9], &missing, &[2]).is_err());
+        let out_of_bounds = TokenLayout {
+            segments: vec![Segment::Text(0..4)],
+        };
+        assert!(apply_layout(&[7, 1, 9], &out_of_bounds, &[]).is_err());
+    }
+
+    /// A family that skips, repeats, or reorders source tokens would silently
+    /// serve a truncated or scrambled prompt; the layout must reject it instead.
+    #[test]
+    fn incomplete_or_disordered_coverage_errs() {
+        let media = || Segment::Media {
+            item: 0,
+            src: 1..2,
+            expansion: vec![ExpansionPart::Feature { id: 5, n: 2 }],
+        };
+        let cases = [
+            // Dropped tail: [7, PAD, 9] expanded without the trailing 9.
+            vec![Segment::Text(0..1), media()],
+            // Dropped head.
+            vec![media(), Segment::Text(2..3)],
+            // Gap in the middle (source index 1 never consumed).
+            vec![Segment::Text(0..1), Segment::Text(2..3)],
+            // Duplicated source span.
+            vec![
+                Segment::Text(0..1),
+                Segment::Text(0..1),
+                media(),
+                Segment::Text(2..3),
+            ],
+            // Out of order.
+            vec![Segment::Text(2..3), media(), Segment::Text(0..1)],
+        ];
+        for (i, segments) in cases.into_iter().enumerate() {
+            let layout = TokenLayout { segments };
+            assert!(
+                apply_layout(&[7, 1, 9], &layout, &[2]).is_err(),
+                "case {i} should be rejected"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Routers and engines need identical prompt expansion, media identity, and processor configuration to agree on routing keys and token accounting. This implements those shared contracts in `dynamo-mm-preprocessor`, replacing the corresponding skeleton functions from #204.

Second slice of #222. Independent of #225: the implementation changes are in disjoint files and do not require a merge order. The family processing pipeline remains separate work; this PR does not complete end-to-end image preprocessing.

## Changes

- **Prompt layout:** `layout_by_placeholder` describes repeated image placeholders; `apply_layout` expands already-tokenized IDs and returns inclusive media offsets plus half-open feature ranges. It validates ordered, complete source coverage, exactly one placement per item in prompt order, nonempty expansions, and matching feature-token counts. Literal markers and timestamps remain in the expanded prompt but are excluded from embedding scatter ranges.
- **Content identity:** `content_hash_bytes` uses the first eight BLAKE3 bytes as a big-endian `u64`. `content_hash_canonical_image` uses XXH3-64 over rank, dimensions, dtype, and decoded bytes. Tests pin both hashes to mirrored implementation values and check that image geometry affects identity. Adds `xxhash-rust` and its BSL-1.0 license allowance.
- **HF configuration resolution:** `spec_from_hf_configs` and `spec_from_model_dir` resolve Qwen2-VL, Qwen2.5-VL, Qwen3-VL/MoE, and Qwen3.5/MoE configurations into `QwenVlSpec`. Resolution reads token IDs, patch geometry, normalization, and pixel bounds from either top-level fields or nested `size` fields. Tables distinguish consumed, pinned, and inert knobs; unsupported settings, including null required settings, return an error for caller fallback. Normalization arrays must contain exactly three numbers, and nested `size` keys are validated even when top-level bounds are present. Resolved HF specs select `AtenU8`; explicit specs can select `Pil`.

