### PR TITLE
ci: publish conformance report to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      pages: read
       pull-requests: write
     steps:
       - name: Checkout
@@ -119,15 +120,31 @@ jobs:
           # the render + guard steps extract them locally on first use.
           lfs: true
 
+      - name: Configure GitHub Pages
+        if: ${{ github.ref == 'refs/heads/main' }}
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       # Single stable entry point: render both charts, structural sanity, fixture-
       # coverage + marker-registration lint (DIS-2442), chart-invariant guards.
       # Add/change conformance gates in check.sh's run_ci(), NOT here — this
       # workflow step should never need another edit for a new gate.
       - name: Conformance gate (render + lint + invariants)
+        env:
+          PAGES_BASE_URL: ${{ steps.pages.outputs.base_url }}
         run: |
           python3 -m venv /tmp/pvenv
           /tmp/pvenv/bin/pip install --quiet pyyaml jinja2 pytest
-          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/check.sh ci
+          render_args=()
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            test -n "$PAGES_BASE_URL"
+            render_args=(
+              --github-repository "$GITHUB_REPOSITORY"
+              --github-revision "$GITHUB_SHA"
+              --fixture-base-url "${PAGES_BASE_URL%/}/fixtures/"
+            )
+          fi
+          PATH="/tmp/pvenv/bin:$PATH" conformance/utils/check.sh ci "${render_args[@]}"
 
       - name: Upload conformance matrix
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -135,6 +152,38 @@ jobs:
           name: conformity-html
           path: conformance/utils/CONFORMITY.html
           retention-days: 14
+
+      - name: Prepare GitHub Pages artifact
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          set -euo pipefail
+          site="$RUNNER_TEMP/pages"
+          fixtures_root="$(python3 conformance/utils/src/extract_fixtures.py)"
+          mkdir -p "$site"
+          cp conformance/CONFORMANCE_v2.html "$site/index.html"
+          for relative in \
+            toolcalling/fixtures-batch-v1/inputs \
+            toolcalling/fixtures-stream-v2/inputs \
+            reasoning/fixtures-v1/inputs
+          do
+            test -d "$fixtures_root/$relative"
+            mkdir -p "$site/fixtures/$(dirname "$relative")"
+            cp -R "$fixtures_root/$relative" "$site/fixtures/$relative"
+          done
+          if find "$site" -type l -print -quit | grep -q .; then
+            echo "GitHub Pages artifact must not contain symbolic links" >&2
+            exit 1
+          fi
+          if find "$site" -type f -links +1 -print -quit | grep -q .; then
+            echo "GitHub Pages artifact must not contain hard links" >&2
+            exit 1
+          fi
+
+      - name: Upload GitHub Pages artifact
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: ${{ runner.temp }}/pages
 
       - name: Comment on PR
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/pull-request/') }}
@@ -145,3 +194,24 @@ jobs:
           gh pr comment "$PR_NUMBER" \
             --edit-last --create-if-none \
             --body "📊 **Conformance matrix** rendered — [view in CI summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+  deploy-pages:
+    name: Deploy conformance matrix to GitHub Pages
+    needs: conformance-table
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/conformance/utils/README.md
+++ b/conformance/utils/README.md
@@ -178,9 +178,19 @@ conformance/utils/render_table_v2.sh --output index.html
 
 # Prints the render command without writing the table.
 conformance/utils/render_table_v2.sh --dry-run
+
+# Generate immutable GitHub source links and Pages-hosted fixture links.
+conformance/utils/render_table_v2.sh \
+  --github-repository ai-dynamo/frontend-crates \
+  --github-revision "$(git rev-parse HEAD)" \
+  --fixture-base-url https://ai-dynamo.github.io/frontend-crates/fixtures/
 ```
 
 Open the generated HTML file in a browser. The table is generated from extracted fixture directories staged by `render_table_v2.sh`.
+
+The three web-link options must be supplied together. They change only link destinations: source files and directories use immutable GitHub `blob/<sha>` and `tree/<sha>` URLs, while case links use the fixture base URL and the extracted snapshot layout. Local renders without these options retain filesystem-relative source links and `file://` fixture links. `check.sh ci` accepts and forwards the same render options so CI can validate and publish one render.
+
+The CI workflow automatically publishes this report for matching pushes to `main`, and `workflow_dispatch` can republish it when run from `main`. Mirror branches still run the conformance gate but never upload or deploy the Pages artifact. Before the first deployment, configure the repository's Pages source as **GitHub Actions** and restrict the `github-pages` environment's deployment branches to `main`.
 
 Every successful render also writes `conformance/CONFORMANCE_v2.json`, derived from the same inlined model the browser renders, and prints the aggregate empty/red count. The standard compiler-like gate for one or more models and tabs is:
 

--- a/conformance/utils/check.sh
+++ b/conformance/utils/check.sh
@@ -11,9 +11,10 @@
 #                                    case-taxonomy.yaml (defaults to --all families)
 #     status [--model F ...] [--tab T ...]
 #                                    render, then fail on every empty/red selected cell
-#     ci     what the conformance-table CI job runs, and the ONLY thing it runs:
+#     ci [render options]
+#            what the conformance-table CI job runs, and the ONLY thing it runs:
 #            render the conformance chart, structural sanity, coverage lint,
-#            invariant pytest.
+#            invariant pytest. Render options are forwarded to render_table_v2.sh.
 #            Add/change conformance gates in run_ci below — never in .github/workflows.
 #     all    [--container-vllm N --container-sglang M] [--allow-peer-failures]
 #            dynamo(all) + vllm + sglang + coverage. Fails the run on any parser
@@ -68,9 +69,12 @@ run_status() {  # $@ = passthrough (--model F ... --tab T ...)
 }
 
 run_ci() {  # the conformance-table CI gate; fail-fast, also runnable locally
-  if [ "$DRY" = 1 ]; then echo "[dry-run] render v2, sanity greps, coverage lint, invariant pytest"; return; fi
+  if [ "$DRY" = 1 ]; then
+    echo "[dry-run] render v2 $*, sanity greps, coverage lint, invariant pytest"
+    return
+  fi
   set -e
-  "$UTILS/render_table_v2.sh"
+  "$UTILS/render_table_v2.sh" "$@"
   local out="$ROOT/conformance/CONFORMANCE_v2.html"
   local status="$ROOT/conformance/CONFORMANCE_v2.json"
   test -s "$out"
@@ -97,7 +101,7 @@ case "$engine" in
   sglang) run_engine sglang "$@" ;;
   coverage) run_coverage "$@" ;;
   status) run_status "$@" ;;
-  ci)     run_ci ;;
+  ci)     run_ci "$@" ;;
   all)
     cv=""; cs=""; allow_peer=0; rc=0
     while [ $# -gt 0 ]; do case "$1" in

--- a/conformance/utils/render_table_v2.sh
+++ b/conformance/utils/render_table_v2.sh
@@ -2,20 +2,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# render_table_v2.sh [--dry-run] [--output PATH]
+# render_table_v2.sh [--dry-run] [--output PATH] [web-link options]
 #   Render the conformance matrix to an HTML file
 #   (all four tabs: TC batch / TC stream / TC batch-on-stream / Reasoning).
 #   No engines needed.
 
 usage() {
   cat <<'EOF'
-usage: conformance/utils/render_table_v2.sh [--dry-run] [--output PATH]
+usage: conformance/utils/render_table_v2.sh [--dry-run] [--output PATH] [web-link options]
 
   Render the v2 conformance matrix to an HTML file and write a sibling status JSON.
 
 Options:
   --output PATH   Write to PATH. Relative paths resolve from the repo root.
                   Default: conformance/CONFORMANCE_v2.html
+  --github-repository OWNER/REPO
+                  Repository used for immutable GitHub source links.
+  --github-revision SHA
+                  Full 40-character commit SHA used for source links.
+  --fixture-base-url URL
+                  HTTPS base URL for published fixture YAMLs.
+                  All three web-link options must be supplied together.
   --dry-run       Print what would run.
   --help          Show this help.
 EOF
@@ -23,6 +30,9 @@ EOF
 
 DRY=0
 OUT_ARG=""
+GITHUB_REPOSITORY=""
+GITHUB_REVISION=""
+FIXTURE_BASE_URL=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run|--dryrun)
@@ -37,6 +47,21 @@ while [ $# -gt 0 ]; do
       OUT_ARG="$2"
       shift 2
       ;;
+    --github-repository)
+      [ $# -ge 2 ] || { echo "error: --github-repository requires a value" >&2; exit 2; }
+      GITHUB_REPOSITORY="$2"
+      shift 2
+      ;;
+    --github-revision)
+      [ $# -ge 2 ] || { echo "error: --github-revision requires a value" >&2; exit 2; }
+      GITHUB_REVISION="$2"
+      shift 2
+      ;;
+    --fixture-base-url)
+      [ $# -ge 2 ] || { echo "error: --fixture-base-url requires a value" >&2; exit 2; }
+      FIXTURE_BASE_URL="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -48,6 +73,26 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+if [ -n "$GITHUB_REPOSITORY$GITHUB_REVISION$FIXTURE_BASE_URL" ] &&
+   { [ -z "$GITHUB_REPOSITORY" ] || [ -z "$GITHUB_REVISION" ] || [ -z "$FIXTURE_BASE_URL" ]; }; then
+  echo "error: --github-repository, --github-revision, and --fixture-base-url must be supplied together" >&2
+  exit 2
+fi
+if [ -n "$GITHUB_REPOSITORY" ]; then
+  if [[ ! "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    echo "error: invalid --github-repository: $GITHUB_REPOSITORY" >&2
+    exit 2
+  fi
+  if [[ ! "$GITHUB_REVISION" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "error: --github-revision must be a full 40-character commit SHA" >&2
+    exit 2
+  fi
+  if [[ ! "$FIXTURE_BASE_URL" =~ ^https://[^?#]+$ ]]; then
+    echo "error: --fixture-base-url must be an HTTPS URL without query or fragment" >&2
+    exit 2
+  fi
+fi
 source "$(dirname "$0")/src/_common.sh"
 
 OUT="$ROOT/conformance/CONFORMANCE_v2.html"
@@ -59,6 +104,9 @@ if [ -n "$OUT_ARG" ]; then
 fi
 if [ "$DRY" = 1 ]; then
   echo "[dry-run] build .stage, then render the conformance table > $OUT"
+  if [ -n "$GITHUB_REPOSITORY" ]; then
+    echo "[dry-run] link source to $GITHUB_REPOSITORY@$GITHUB_REVISION and fixtures under $FIXTURE_BASE_URL"
+  fi
   exit 0
 fi
 build_stage_conformance
@@ -74,7 +122,19 @@ case "$OUT" in
   *.html) WORK="${OUT%.html}.working.html" ;;
   *)      WORK="$OUT.working" ;;
 esac
-if ( cd "$STAGE" && PYTHONPATH="$STAGE" python3 tests/parity/generate_conformance_table.py all --html --output-path "$OUT" --artifact-root "$ROOT" ) > "$WORK"; then
+RENDER_ARGS=(
+  all --html
+  --output-path "$OUT"
+  --artifact-root "$ROOT"
+)
+if [ -n "$GITHUB_REPOSITORY" ]; then
+  RENDER_ARGS+=(
+    --github-repository "$GITHUB_REPOSITORY"
+    --github-revision "$GITHUB_REVISION"
+    --fixture-base-url "$FIXTURE_BASE_URL"
+  )
+fi
+if ( cd "$STAGE" && PYTHONPATH="$STAGE" python3 tests/parity/generate_conformance_table.py "${RENDER_ARGS[@]}" ) > "$WORK"; then
   mv -f "$WORK" "$OUT"
   case "$OUT" in
     *.html) STATUS="${OUT%.html}.json" ;;

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -448,7 +448,9 @@ def _parser_inheritance_tooltip_html(
     head_parts = [f"ParserConfig::{variant}"]
     if sub_variant:
         head_parts[-1] = f"ParserConfig::{variant}::{sub_variant}"
-    bf_href = html_lib.escape(f"{common.LINKS['toolcalling_src']}{backend_file}")
+    bf_href = html_lib.escape(
+        common.repository_href(f"parsers/v1/src/tool_calling/{backend_file}")
+    )
     bf_link = f'<a href="{bf_href}">{html_lib.escape(backend_file)}</a>'
 
     anchor = alias_of or family
@@ -675,9 +677,11 @@ def _parser_cell_html(
     # useful (factory calls). For families with no inheritance info, fall back
     # to the refs entry (config.rs or parsers.rs).
     if info and info["backend_file"] != "unknown":
-        href = f"{common.LINKS['toolcalling_src']}{info['backend_file']}"
+        href = common.repository_href(
+            f"parsers/v1/src/tool_calling/{info['backend_file']}"
+        )
     elif ref is not None:
-        href = f"{common.LINKS['toolcalling_src']}{ref[0]}"
+        href = common.repository_href(f"parsers/v1/src/tool_calling/{ref[0]}")
     else:
         return (
             f'<td class="parser" data-col-hide-group="parser">'
@@ -698,6 +702,9 @@ def _v2_parser_cell_html(
     fixtures: str,
     note: str,
 ) -> str:
+    source_href = common.repository_href(
+        f"parsers/v2/src/tool_calling/{source_file}"
+    )
     tooltip = (
         '<div class="ttip">'
         f'<div class="ttip-head">`{html_lib.escape(family)}` (v2 stream)</div>'
@@ -706,13 +713,13 @@ def _v2_parser_cell_html(
         f"Tool calling parser row: {html_lib.escape(family)}\n"
         f"Effective parser/backend: {html_lib.escape(backend)}\n"
         f"Dynamo parser v2 implementation: parsers/v2/src/tool_calling/{html_lib.escape(source_file)} -> "
-        f'<a href="{common.LINKS["streaming_src"]}{html_lib.escape(source_file)}">{html_lib.escape(entrypoint)}</a>\n'
+        f'<a href="{source_href}">{html_lib.escape(entrypoint)}</a>\n'
         f"Note: {html_lib.escape(note)}"
         "</pre></div>"
     )
     return (
         f'<td class="parser" data-col-hide-group="parser">'
-        f'<a href="{common.LINKS["streaming_src"]}{html_lib.escape(source_file)}">{row_label}</a>{tooltip}</td>'
+        f'<a href="{source_href}">{row_label}</a>{tooltip}</td>'
     )
 
 
@@ -2815,13 +2822,22 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
 
 def build_combined_model(output_path: Path | None = None,
                          artifact_root: Path | None = None,
-                         *, stamp: str, sha: str | None) -> dict:
+                         *, stamp: str, sha: str | None,
+                         github_repository: str | None = None,
+                         github_revision: str | None = None,
+                         fixture_base_url: str | None = None) -> dict:
     """Assemble the whole-page JSON model (both toolcalling tabs + both reasoning
     tabs). Same loaded data + comparison semantics as render_combined_html."""
     artifact_root = (artifact_root or REPO_ROOT).resolve()
     resolved_output_path = _resolve_output_path(
         output_path, artifact_root, "tests/parity/CONFORMANCE.html")
-    hrefs = common.set_links(resolved_output_path, artifact_root)
+    hrefs = common.set_links(
+        resolved_output_path,
+        artifact_root,
+        github_repository=github_repository,
+        github_revision=github_revision,
+        fixture_base_url=fixture_base_url,
+    )
 
     tabs: list[dict] = []
 
@@ -2848,7 +2864,7 @@ def build_combined_model(output_path: Path | None = None,
             f'plus <strong>v2</strong> streaming on the same batch text '
             f'(<a href="{hrefs["streaming_src"]}">parsers_v2/src/tool_calling/*</a>) · '
             f'Input: <strong>v1</strong> batch fixtures '
-            f'(<a href="{hrefs["toolcalling_fixtures"]}">conformance/toolcalling/fixtures-batch-v1/</a>).'),
+            f'(<a href="{hrefs["toolcalling_fixture_store"]}">conformance/fixtures/toolcalling/fixtures-batch-v1/</a>).'),
         "details_note_html": None,
     })
     tabs.append(batch_tab)
@@ -2873,7 +2889,7 @@ def build_combined_model(output_path: Path | None = None,
             f'Parser: <strong>v2</strong> Dynamo parser v2 token-incremental streaming '
             f'(<a href="{hrefs["streaming_src"]}">parsers_v2/src/tool_calling/*</a>) · '
             f'Input: <strong>v2</strong> stream fixtures '
-            f'(<a href="{hrefs["toolcalling_stream_fixtures"]}">conformance/toolcalling/fixtures-stream-v2/</a>).'),
+            f'(<a href="{hrefs["toolcalling_stream_fixture_store"]}">conformance/fixtures/toolcalling/fixtures-stream-v2/</a>).'),
         "details_note_html": f"<p>{_stream_parity_explainer_html('streamv2')}</p>",
     })
     tabs.append(stream_tab)
@@ -2909,7 +2925,7 @@ def build_combined_model(output_path: Path | None = None,
                 f'Parser: <strong>v1</strong> reasoning parser '
                 f'(<a href="{hrefs["reasoning_src"]}">parsers/v1/src/reasoning/</a>) · '
                 f'Input: <strong>v1</strong> reasoning fixtures '
-                f'(<a href="{hrefs["reasoning_fixtures"]}">conformance/reasoning/fixtures/</a>).'),
+                f'(<a href="{hrefs["reasoning_fixture_store"]}">conformance/fixtures/reasoning/fixtures-v1/</a>).'),
             "details_note_html": None,
         })
         tabs.append(rtab)
@@ -2948,6 +2964,10 @@ def _captured_note(mode: str) -> str:
 def render_combined_html(
     output_path: Path | None = None,
     artifact_root: Path | None = None,
+    *,
+    github_repository: str | None = None,
+    github_revision: str | None = None,
+    fixture_base_url: str | None = None,
 ) -> str:
     artifact_root = (artifact_root or REPO_ROOT).resolve()
     resolved_output_path = _resolve_output_path(
@@ -2955,17 +2975,30 @@ def render_combined_html(
         artifact_root,
         "tests/parity/CONFORMANCE.html",
     )
-    common.set_links(resolved_output_path, artifact_root)
+    common.set_links(
+        resolved_output_path,
+        artifact_root,
+        github_repository=github_repository,
+        github_revision=github_revision,
+        fixture_base_url=fixture_base_url,
+    )
 
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
-    sha = _commit_sha()
+    sha = github_revision.lower() if github_revision else _commit_sha()
 
     # DIS-2434: the page is now rendered ENTIRELY by the JS view from this JSON model —
     # the Python HTML emitters (render_html_panel/render_cell_html/tooltip builders) are
     # gone; the template emits a skeleton and the model blob, the view builds the DOM.
     page_model = build_combined_model(
-        output_path=output_path, artifact_root=artifact_root, stamp=stamp, sha=sha)
+        output_path=output_path,
+        artifact_root=artifact_root,
+        stamp=stamp,
+        sha=sha,
+        github_repository=github_repository,
+        github_revision=github_revision,
+        fixture_base_url=fixture_base_url,
+    )
     # Per-family declared markers (pairs/singletons) for the JS colorizer's declared
     # lookup — the same table markup.py's _declared_lookup consults server-side.
     page_model["family_markers"] = declared_markers()
@@ -3022,6 +3055,18 @@ def main(argv: list[str] | None = None) -> None:
         type=Path,
         help="Repo root that output links should target. Defaults to the staged repo root.",
     )
+    stage_parser.add_argument(
+        "--github-repository",
+        help="GitHub OWNER/REPO used for immutable source links (requires the other web-link options).",
+    )
+    stage_parser.add_argument(
+        "--github-revision",
+        help="Full commit SHA used for immutable source links (requires the other web-link options).",
+    )
+    stage_parser.add_argument(
+        "--fixture-base-url",
+        help="HTTPS base URL for published fixture YAMLs (requires the other web-link options).",
+    )
     stage_args = stage_parser.parse_args(rest)
     if not stage_args.html:
         parser.error("stage 'all' currently supports --html only")
@@ -3029,6 +3074,9 @@ def main(argv: list[str] | None = None) -> None:
         render_combined_html(
             output_path=stage_args.output_path,
             artifact_root=stage_args.artifact_root,
+            github_repository=stage_args.github_repository,
+            github_revision=stage_args.github_revision,
+            fixture_base_url=stage_args.fixture_base_url,
         )
     )
 

--- a/conformance/utils/src/tables/common.py
+++ b/conformance/utils/src/tables/common.py
@@ -16,6 +16,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote, urlsplit
 
 from fixture_snapshot import fixture_snapshot_root
 
@@ -28,44 +29,136 @@ from fixture_snapshot import fixture_snapshot_root
 # ---------------------------------------------------------------------------
 
 
-def _href_from_output(output_path: Path, artifact_root: Path, repo_relative: str) -> str:
+@dataclass(frozen=True)
+class _LinkContext:
+    output_path: Path
+    artifact_root: Path
+    github_repository: str | None = None
+    github_revision: str | None = None
+    fixture_base_url: str | None = None
+
+
+_LINK_CONTEXT: _LinkContext | None = None
+
+
+def _href_from_output(
+    output_path: Path, artifact_root: Path, repo_relative: str
+) -> str:
     trailing_slash = repo_relative.endswith("/")
     target = artifact_root / repo_relative.rstrip("/")
     href = Path(os.path.relpath(target, output_path.parent)).as_posix()
     return f"{href}/" if trailing_slash else href
 
 
-def _hrefs_for_output(output_path: Path, artifact_root: Path) -> dict[str, str]:
-    def h(rel: str) -> str:
-        return _href_from_output(output_path, artifact_root, rel)
+def _url_join(base: str, relative: str) -> str:
+    return base.rstrip("/") + "/" + quote(relative.lstrip("/"), safe="/._-~")
 
-    return {
-        "toolcalling_fixtures": h("conformance/toolcalling/fixtures-v1/"),
-        "toolcalling_stream_fixtures": h("conformance/toolcalling/fixtures-stream-v2/"),
-        "toolcalling_batch_on_stream_fixtures": h(
-            "conformance/toolcalling/fixtures-batch-on-stream-v2/"
+
+def repository_href(repo_relative: str) -> str:
+    """Resolve a repository file/directory for the active render destination."""
+    if _LINK_CONTEXT is None:
+        raise RuntimeError("link context is not configured")
+    if _LINK_CONTEXT.github_repository and _LINK_CONTEXT.github_revision:
+        trailing_slash = repo_relative.endswith("/")
+        kind = "tree" if trailing_slash else "blob"
+        href = (
+            f"https://github.com/{_LINK_CONTEXT.github_repository}/{kind}/"
+            f"{_LINK_CONTEXT.github_revision}/"
+            f"{quote(repo_relative.rstrip('/'), safe='/._-~')}"
+        )
+        return f"{href}/" if trailing_slash else href
+    return _href_from_output(
+        _LINK_CONTEXT.output_path,
+        _LINK_CONTEXT.artifact_root,
+        repo_relative,
+    )
+
+
+def _hrefs_for_context() -> dict[str, str]:
+    if _LINK_CONTEXT is None:
+        raise RuntimeError("link context is not configured")
+
+    if _LINK_CONTEXT.fixture_base_url:
+        fixture_roots = {
+            "toolcalling_fixtures": _url_join(
+                _LINK_CONTEXT.fixture_base_url,
+                "toolcalling/fixtures-batch-v1/inputs/",
+            ),
+            "toolcalling_stream_fixtures": _url_join(
+                _LINK_CONTEXT.fixture_base_url,
+                "toolcalling/fixtures-stream-v2/inputs/",
+            ),
+            # Batch-on-stream reuses the v1 batch inputs.
+            "toolcalling_batch_on_stream_fixtures": _url_join(
+                _LINK_CONTEXT.fixture_base_url,
+                "toolcalling/fixtures-batch-v1/inputs/",
+            ),
+            "reasoning_fixtures": _url_join(
+                _LINK_CONTEXT.fixture_base_url,
+                "reasoning/fixtures-v1/inputs/",
+            ),
+        }
+        fixture_stores = {
+            "toolcalling_fixture_store": repository_href(
+                "conformance/fixtures/toolcalling/fixtures-batch-v1/"
+            ),
+            "toolcalling_stream_fixture_store": repository_href(
+                "conformance/fixtures/toolcalling/fixtures-stream-v2/"
+            ),
+            "reasoning_fixture_store": repository_href(
+                "conformance/fixtures/reasoning/fixtures-v1/"
+            ),
+        }
+    else:
+        fixture_roots = {
+            "toolcalling_fixtures": repository_href(
+                "conformance/toolcalling/fixtures-v1/"
+            ),
+            "toolcalling_stream_fixtures": repository_href(
+                "conformance/toolcalling/fixtures-stream-v2/"
+            ),
+            "toolcalling_batch_on_stream_fixtures": repository_href(
+                "conformance/toolcalling/fixtures-batch-on-stream-v2/"
+            ),
+            "reasoning_fixtures": repository_href("conformance/reasoning/fixtures/"),
+        }
+        fixture_stores = {
+            "toolcalling_fixture_store": fixture_roots["toolcalling_fixtures"],
+            "toolcalling_stream_fixture_store": fixture_roots[
+                "toolcalling_stream_fixtures"
+            ],
+            "reasoning_fixture_store": fixture_roots["reasoning_fixtures"],
+        }
+
+    return fixture_roots | fixture_stores | {
+        "toolcalling_cases": repository_href(
+            "conformance/utils/lib/parsers/TOOLCALLING_CASES.md"
         ),
-        "reasoning_fixtures": h("conformance/reasoning/fixtures/"),
-        "toolcalling_cases": h("conformance/utils/lib/parsers/TOOLCALLING_CASES.md"),
-        "toolcalling_streaming_cases": h(
+        "toolcalling_streaming_cases": repository_href(
             "conformance/utils/lib/parsers/TOOLCALLING_STREAMING_V2_CASES.md"
         ),
-        "reasoning_cases": h("conformance/utils/lib/parsers/REASONING_CASES.md"),
-        "toolcalling_src": h("parsers/v1/src/tool_calling/"),
-        "reasoning_src": h("parsers/v1/src/reasoning/"),
-        "streaming_src": h("parsers/v2/src/tool_calling/"),
-        "streaming_harmony_src": h("parsers/v2/src/tool_calling/harmony.rs"),
-        "pyproject_stub": h("conformance/utils/src/pyproject.stub.toml"),
+        "reasoning_cases": repository_href(
+            "conformance/utils/lib/parsers/REASONING_CASES.md"
+        ),
+        "toolcalling_src": repository_href("parsers/v1/src/tool_calling/"),
+        "reasoning_src": repository_href("parsers/v1/src/reasoning/"),
+        "streaming_src": repository_href("parsers/v2/src/tool_calling/"),
+        "streaming_harmony_src": repository_href(
+            "parsers/v2/src/tool_calling/harmony.rs"
+        ),
+        "pyproject_stub": repository_href(
+            "conformance/utils/src/pyproject.stub.toml"
+        ),
     }
 
 
 # Fixture YAMLs aren't loose in the repo — they're LFS tarballs under
 # conformance/fixtures/, extracted into an immutable snapshot selected through
 # $CONFORMANCE_FIXTURES_ROOT or `extract_fixtures.py`. The store
-# holds only the tarballs (no per-file URL), so a
-# per-cell YAML link points at the extracted file in that cache via file://. The
+# holds only the tarballs (no per-file URL), so a per-cell YAML link points at the
+# extracted file in that cache for local renders or its bundled copy for Pages. The
 # rendered `__fixture_path` is the flat resolved-tree path the readers use; remap it to
-# the versioned cache layout (the shared `inputs/` tree carries the model_text /
+# the versioned snapshot layout (the shared `inputs/` tree carries the model_text /
 # description a viewer wants to see).
 def _fixtures_cache_root() -> str:
     return str(fixture_snapshot_root())
@@ -82,7 +175,8 @@ def _fixture_cache_relpath(rel: str) -> str:
         corpus = "reasoning/fixtures-v1/inputs"
     elif fname.startswith("TOOLCALLING.streamv2"):
         corpus = "toolcalling/fixtures-stream-v2/inputs"
-    elif fname.startswith("TOOLCALLING."):  # batch + v1 stream both live in the v1 corpus
+    # Batch + v1 stream both live in the v1 corpus.
+    elif fname.startswith("TOOLCALLING."):
         corpus = "toolcalling/fixtures-batch-v1/inputs"
     else:
         return rel.lstrip("./")
@@ -90,10 +184,14 @@ def _fixture_cache_relpath(rel: str) -> str:
 
 
 def fixture_href(rel: str) -> str:
-    """Map a rendered fixture path to a file:// link into the local fixture cache.
-    Leaves absolute URLs and empty strings untouched."""
+    """Map a rendered fixture path to its configured local or published root.
+
+    Leaves absolute URLs and empty strings untouched.
+    """
     if not rel or "://" in rel:
         return rel
+    if _LINK_CONTEXT and _LINK_CONTEXT.fixture_base_url:
+        return _url_join(_LINK_CONTEXT.fixture_base_url, _fixture_cache_relpath(rel))
     return "file://" + _fixtures_cache_root() + "/" + _fixture_cache_relpath(rel)
 
 
@@ -102,11 +200,49 @@ def fixture_href(rel: str) -> str:
 LINKS: dict[str, str] = {}
 
 
-def set_links(output_path: Path, artifact_root: Path) -> dict[str, str]:
+def set_links(
+    output_path: Path,
+    artifact_root: Path,
+    *,
+    github_repository: str | None = None,
+    github_revision: str | None = None,
+    fixture_base_url: str | None = None,
+) -> dict[str, str]:
     """Resolve all link bases for `output_path`, install them as the active
     render context, and return them for callers that also want the dict."""
-    global LINKS
-    LINKS = _hrefs_for_output(output_path, artifact_root)
+    configured = (github_repository, github_revision, fixture_base_url)
+    if any(configured) and not all(configured):
+        raise ValueError(
+            "github_repository, github_revision, and fixture_base_url must be set together"
+        )
+    if github_repository and not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", github_repository
+    ):
+        raise ValueError(f"invalid GitHub repository: {github_repository!r}")
+    if github_revision and not re.fullmatch(r"[0-9a-fA-F]{40}", github_revision):
+        raise ValueError("GitHub revision must be a full 40-character commit SHA")
+    if fixture_base_url:
+        parsed = urlsplit(fixture_base_url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.netloc
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "fixture base URL must be an HTTPS URL without query or fragment"
+            )
+        fixture_base_url = fixture_base_url.rstrip("/") + "/"
+
+    global LINKS, _LINK_CONTEXT
+    _LINK_CONTEXT = _LinkContext(
+        output_path=output_path,
+        artifact_root=artifact_root,
+        github_repository=github_repository,
+        github_revision=github_revision.lower() if github_revision else None,
+        fixture_base_url=fixture_base_url,
+    )
+    LINKS = _hrefs_for_context()
     return LINKS
 
 

--- a/conformance/utils/tests/test_web_links.py
+++ b/conformance/utils/tests/test_web_links.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Link-target guards for local reports and GitHub Pages publication."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+UTILS = Path(__file__).resolve().parents[1]
+REPO = UTILS.parents[1]
+if str(UTILS / "src") not in sys.path:
+    sys.path.insert(0, str(UTILS / "src"))
+
+from tables import common  # noqa: E402
+
+OUTPUT = REPO / "conformance" / "CONFORMANCE_v2.html"
+REVISION = "A" * 40
+
+
+@pytest.fixture(autouse=True)
+def restore_local_link_context():
+    yield
+    common.set_links(OUTPUT, REPO)
+
+
+def test_local_links_keep_destination_relative_behavior(monkeypatch):
+    links = common.set_links(OUTPUT, REPO)
+    monkeypatch.setattr(common, "_fixtures_cache_root", lambda: "/fixture-cache")
+
+    assert links["toolcalling_src"] == "../parsers/v1/src/tool_calling/"
+    assert links["toolcalling_cases"] == "utils/lib/parsers/TOOLCALLING_CASES.md"
+    assert common.repository_href("parsers/v1/src/tool_calling/config.rs") == (
+        "../parsers/v1/src/tool_calling/config.rs"
+    )
+    assert common.fixture_href("deepseek_v4/TOOLCALLING.batch.1.yaml") == (
+        "file:///fixture-cache/toolcalling/fixtures-batch-v1/inputs/"
+        "deepseek_v4/TOOLCALLING.batch.1.yaml"
+    )
+
+
+def test_web_links_pin_sources_and_publish_fixture_inputs():
+    links = common.set_links(
+        OUTPUT,
+        REPO,
+        github_repository="ai-dynamo/frontend-crates",
+        github_revision=REVISION,
+        fixture_base_url="https://ai-dynamo.github.io/frontend-crates/fixtures",
+    )
+    revision = REVISION.lower()
+
+    assert links["toolcalling_src"] == (
+        f"https://github.com/ai-dynamo/frontend-crates/tree/{revision}/"
+        "parsers/v1/src/tool_calling/"
+    )
+    assert common.repository_href("parsers/v1/src/tool_calling/config.rs") == (
+        f"https://github.com/ai-dynamo/frontend-crates/blob/{revision}/"
+        "parsers/v1/src/tool_calling/config.rs"
+    )
+    assert links["toolcalling_cases"] == (
+        f"https://github.com/ai-dynamo/frontend-crates/blob/{revision}/"
+        "conformance/utils/lib/parsers/TOOLCALLING_CASES.md"
+    )
+    assert links["toolcalling_fixture_store"] == (
+        f"https://github.com/ai-dynamo/frontend-crates/tree/{revision}/"
+        "conformance/fixtures/toolcalling/fixtures-batch-v1/"
+    )
+    assert common.fixture_href("deepseek_v4/TOOLCALLING.streamv2.1.yaml") == (
+        "https://ai-dynamo.github.io/frontend-crates/fixtures/toolcalling/"
+        "fixtures-stream-v2/inputs/deepseek_v4/TOOLCALLING.streamv2.1.yaml"
+    )
+    assert common.fixture_href("deepseek_r1/REASONING.batch.1.yaml") == (
+        "https://ai-dynamo.github.io/frontend-crates/fixtures/reasoning/"
+        "fixtures-v1/inputs/deepseek_r1/REASONING.batch.1.yaml"
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"github_repository": "ai-dynamo/frontend-crates"},
+        {
+            "github_repository": "ai-dynamo/frontend-crates/extra",
+            "github_revision": "a" * 40,
+            "fixture_base_url": "https://example.test/fixtures/",
+        },
+        {
+            "github_repository": "ai-dynamo/frontend-crates",
+            "github_revision": "short",
+            "fixture_base_url": "https://example.test/fixtures/",
+        },
+        {
+            "github_repository": "ai-dynamo/frontend-crates",
+            "github_revision": "a" * 40,
+            "fixture_base_url": "http://example.test/fixtures/",
+        },
+        {
+            "github_repository": "ai-dynamo/frontend-crates",
+            "github_revision": "a" * 40,
+            "fixture_base_url": "https://example.test/fixtures/?snapshot=1",
+        },
+    ],
+)
+def test_web_link_configuration_rejects_partial_or_mutable_targets(kwargs):
+    with pytest.raises(ValueError):
+        common.set_links(OUTPUT, REPO, **kwargs)


### PR DESCRIPTION
## Summary

- publish the generated conformance report through GitHub Pages using the `github-pages` environment
- render main-branch reports with exact-commit GitHub source links and Pages-hosted fixture links
- bundle the referenced tool-calling and reasoning fixture inputs in the Pages artifact
- restrict automatic upload and deployment to matching pushes on `main`; manual dispatch must also target `main`
- keep mirror-branch conformance validation without publishing

## Validation

- `conformance/utils/check.sh ci` in Pages mode: 197 passed, 2 skipped
- coverage lint: 0 failures, 51 existing warnings
- focused web-link tests: 7 passed
- validated 1,921 rendered fixture links, covering 391 unique YAML files, against the packaged 14 MB Pages artifact
- validated 71 GitHub source links pinned to the exact render commit
- shell syntax, Python compilation, Ruff checks, workflow YAML parsing, and `git diff --check`

## One-time repository setup

Before the first deployment, enable Pages with **GitHub Actions** as the source and configure the `github-pages` environment deployment branch policy to allow `main` only. At PR creation time, Pages is disabled and that environment does not yet exist.