### PR TITLE
feat(tokenizers): expose vocab introspection on the Tokenizer trait

### DIFF
--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -193,19 +193,19 @@ impl Tokenizer for BasetenTokenizer {
         Ok(self.tokenizer.token_to_id(token))
     }
 
-    fn special_token_ids(&self) -> Vec<TokenIdType> {
+    fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
         let Some(added_tokens) = self.tokenizer.added_tokens() else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
         let mut ids: Vec<TokenIdType> = added_tokens
             .iter()
             .filter_map(|info| info.special.then_some(info.id))
             .collect();
         ids.sort_unstable();
-        ids
+        Ok(ids)
     }
 
-    fn num_special_tokens_added(&self) -> usize {
+    fn num_special_tokens_added(&self) -> Result<usize> {
         // basetenkenizer exposes no direct count, but post-processing an
         // empty sequence with add_special_tokens=true is content-length
         // independent for every basetenkenizer::PostProcessor variant:
@@ -216,7 +216,7 @@ impl Tokenizer for BasetenTokenizer {
         // content length; Sequence(steps) folds that same guarantee across
         // steps. So this reveals exactly what the post-processor inserts
         // around a bare encoding, for real content of any length.
-        self.tokenizer.post_process(Vec::new(), true).len()
+        Ok(self.tokenizer.post_process(Vec::new(), true).len())
     }
 }
 
@@ -437,10 +437,10 @@ mod tests {
         std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
 
         let with_bos = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
-        assert_eq!(with_bos.num_special_tokens_added(), 1);
+        assert_eq!(with_bos.num_special_tokens_added().unwrap(), 1);
 
         let plain = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
-        assert_eq!(plain.num_special_tokens_added(), 0);
+        assert_eq!(plain.num_special_tokens_added().unwrap(), 0);
     }
 
     #[test]
@@ -507,7 +507,7 @@ mod tests {
         std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
 
         let tokenizer = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
-        assert_eq!(tokenizer.num_special_tokens_added(), 2);
+        assert_eq!(tokenizer.num_special_tokens_added().unwrap(), 2);
 
         let with_specials = tokenizer.with_options(TokenizerOptions {
             add_special_tokens: true,
@@ -567,7 +567,7 @@ mod tests {
         assert_eq!(plain.vocab_size(), Some(23));
         assert_eq!(plain.token_to_id("hello").unwrap(), None);
         assert_eq!(plain.token_to_id("h").unwrap(), Some(10));
-        assert!(plain.special_token_ids().is_empty());
+        assert!(plain.special_token_ids().unwrap().is_empty());
 
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("tokenizer.json");
@@ -592,7 +592,7 @@ mod tests {
         // double-count it -- 24, not 25.
         assert_eq!(with_added.vocab_size(), Some(24));
         assert_eq!(with_added.token_to_id("<bos>").unwrap(), Some(23));
-        assert_eq!(with_added.special_token_ids(), vec![23]);
+        assert_eq!(with_added.special_token_ids().unwrap(), vec![23]);
 
         // A second fixture where the added token is genuinely absent from
         // the model vocab (as opposed to documenting an existing entry)

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -189,8 +189,8 @@ impl Tokenizer for BasetenTokenizer {
         Some(model_size + extra)
     }
 
-    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
-        self.tokenizer.token_to_id(token)
+    fn token_to_id(&self, token: &str) -> Result<Option<TokenIdType>> {
+        Ok(self.tokenizer.token_to_id(token))
     }
 
     fn special_token_ids(&self) -> Vec<TokenIdType> {
@@ -565,8 +565,8 @@ mod tests {
         // added tokens: vocab_size is the model vocab, and there are no
         // special-token ids to report.
         assert_eq!(plain.vocab_size(), Some(23));
-        assert_eq!(plain.token_to_id("hello"), None);
-        assert_eq!(plain.token_to_id("h"), Some(10));
+        assert_eq!(plain.token_to_id("hello").unwrap(), None);
+        assert_eq!(plain.token_to_id("h").unwrap(), Some(10));
         assert!(plain.special_token_ids().is_empty());
 
         let temp = tempfile::tempdir().unwrap();
@@ -591,7 +591,7 @@ mod tests {
         // tokens: the model vocab already covers it, so vocab_size must not
         // double-count it -- 24, not 25.
         assert_eq!(with_added.vocab_size(), Some(24));
-        assert_eq!(with_added.token_to_id("<bos>"), Some(23));
+        assert_eq!(with_added.token_to_id("<bos>").unwrap(), Some(23));
         assert_eq!(with_added.special_token_ids(), vec![23]);
 
         // A second fixture where the added token is genuinely absent from
@@ -614,6 +614,6 @@ mod tests {
 
         let genuinely_added = BasetenTokenizer::from_file(path2.to_str().unwrap()).unwrap();
         assert_eq!(genuinely_added.vocab_size(), Some(24));
-        assert_eq!(genuinely_added.token_to_id("<extra>"), Some(23));
+        assert_eq!(genuinely_added.token_to_id("<extra>").unwrap(), Some(23));
     }
 }

--- a/tokenizers/src/basetenkenizer.rs
+++ b/tokenizers/src/basetenkenizer.rs
@@ -170,6 +170,54 @@ impl Tokenizer for BasetenTokenizer {
         self.options = options;
         self
     }
+
+    fn vocab_size(&self) -> Option<usize> {
+        // `basetenkenizer::Tokenizer::vocab_size` sums the model vocab size
+        // and the added-tokens count with no dedup, but real tokenizer.json
+        // files (this crate's own TinyLlama_v1.1 fixture included) list
+        // `added_tokens` entries whose ids already exist in `model.vocab` --
+        // metadata for special tokens, not additional vocabulary. Count only
+        // added tokens whose content isn't already in the model vocab.
+        let model = self.tokenizer.model();
+        let model_size = model.vocab_size();
+        let extra = self.tokenizer.added_tokens().map_or(0, |added| {
+            added
+                .iter()
+                .filter(|info| model.token_to_id(info.content).is_none())
+                .count()
+        });
+        Some(model_size + extra)
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        self.tokenizer.token_to_id(token)
+    }
+
+    fn special_token_ids(&self) -> Vec<TokenIdType> {
+        let Some(added_tokens) = self.tokenizer.added_tokens() else {
+            return Vec::new();
+        };
+        let mut ids: Vec<TokenIdType> = added_tokens
+            .iter()
+            .filter_map(|info| info.special.then_some(info.id))
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn num_special_tokens_added(&self) -> usize {
+        // basetenkenizer exposes no direct count, but post-processing an
+        // empty sequence with add_special_tokens=true is content-length
+        // independent for every basetenkenizer::PostProcessor variant:
+        // ByteLevel is identity (adds 0); TemplateProcessing::apply_single
+        // walks a fixed template where SpecialToken pieces insert a
+        // fixed-length id vector and Sequence pieces are replaced 1:1 by
+        // whatever content came in, so the *added* length never depends on
+        // content length; Sequence(steps) folds that same guarantee across
+        // steps. So this reveals exactly what the post-processor inserts
+        // around a bare encoding, for real content of any length.
+        self.tokenizer.post_process(Vec::new(), true).len()
+    }
 }
 
 #[cfg(test)]
@@ -352,6 +400,135 @@ mod tests {
     }
 
     #[test]
+    fn num_special_tokens_added_reflects_bos_post_processor() {
+        // Same TemplateProcessing-prepends-<bos> fixture as
+        // segments_honor_add_special_tokens_option, which already proves
+        // encode()/add_special_tokens=true inserts one BOS id (23); this
+        // exercises num_special_tokens_added() against that same real path.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("tokenizer.json");
+        let mut json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        json["model"]["vocab"]["<bos>"] = serde_json::json!(23);
+        json["added_tokens"] = serde_json::json!([{
+            "id": 23,
+            "content": "<bos>",
+            "single_word": false,
+            "lstrip": false,
+            "rstrip": false,
+            "normalized": false,
+            "special": true
+        }]);
+        json["post_processor"] = serde_json::json!({
+            "type": "TemplateProcessing",
+            "single": [
+                {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                {"Sequence": {"id": "A", "type_id": 0}}
+            ],
+            "pair": [
+                {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                {"Sequence": {"id": "A", "type_id": 0}},
+                {"Sequence": {"id": "B", "type_id": 0}}
+            ],
+            "special_tokens": {
+                "<bos>": {"id": "<bos>", "ids": [23], "tokens": ["<bos>"]}
+            }
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        let with_bos = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(with_bos.num_special_tokens_added(), 1);
+
+        let plain = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        assert_eq!(plain.num_special_tokens_added(), 0);
+    }
+
+    #[test]
+    fn num_special_tokens_added_is_length_independent_under_sequence_post_processor() {
+        // Proves the invariant num_special_tokens_added's doc comment
+        // relies on: a Sequence post-processor chaining two
+        // TemplateProcessing steps (one prepending <bos>, one appending
+        // <eos>) adds a fixed 2 tokens regardless of how many content
+        // tokens flow through it, so post_process(Vec::new(), true).len()
+        // is a safe stand-in for the real-content addition count.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("tokenizer.json");
+        let mut json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        json["model"]["vocab"]["<bos>"] = serde_json::json!(23);
+        json["model"]["vocab"]["<eos>"] = serde_json::json!(24);
+        json["added_tokens"] = serde_json::json!([
+            {
+                "id": 23,
+                "content": "<bos>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            },
+            {
+                "id": 24,
+                "content": "<eos>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            }
+        ]);
+        json["post_processor"] = serde_json::json!({
+            "type": "Sequence",
+            "processors": [
+                {
+                    "type": "TemplateProcessing",
+                    "single": [
+                        {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                        {"Sequence": {"id": "A", "type_id": 0}}
+                    ],
+                    "pair": [],
+                    "special_tokens": {
+                        "<bos>": {"id": "<bos>", "ids": [23], "tokens": ["<bos>"]}
+                    }
+                },
+                {
+                    "type": "TemplateProcessing",
+                    "single": [
+                        {"Sequence": {"id": "A", "type_id": 0}},
+                        {"SpecialToken": {"id": "<eos>", "type_id": 0}}
+                    ],
+                    "pair": [],
+                    "special_tokens": {
+                        "<eos>": {"id": "<eos>", "ids": [24], "tokens": ["<eos>"]}
+                    }
+                }
+            ]
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        let tokenizer = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(tokenizer.num_special_tokens_added(), 2);
+
+        let with_specials = tokenizer.with_options(TokenizerOptions {
+            add_special_tokens: true,
+        });
+        let plain = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+
+        // Two inputs of different real content length must each grow by
+        // exactly num_special_tokens_added() (2), not by some
+        // content-dependent amount.
+        for text in ["h", "hello there world"] {
+            let without = plain.encode(text).unwrap().token_ids().len();
+            let with = with_specials.encode(text).unwrap().token_ids().len();
+            assert_eq!(
+                with - without,
+                2,
+                "'{text}' should grow by exactly num_special_tokens_added()"
+            );
+        }
+    }
+
+    #[test]
     fn merges_config_only_special_tokens() {
         let temp = tempfile::tempdir().unwrap();
         let tokenizer_path = temp.path().join("tokenizer.json");
@@ -379,5 +556,64 @@ mod tests {
         assert_eq!(encoding.token_ids(), &[23]);
         assert_eq!(tokenizer.decode(&[23], false).unwrap().as_str(), "<ctl>");
         assert_eq!(tokenizer.decode(&[23], true).unwrap().as_str(), "");
+    }
+
+    #[test]
+    fn vocab_introspection_accessors() {
+        let plain = BasetenTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        // `minimal-bpe/tokenizer.json` has 23 model-vocab entries and no
+        // added tokens: vocab_size is the model vocab, and there are no
+        // special-token ids to report.
+        assert_eq!(plain.vocab_size(), Some(23));
+        assert_eq!(plain.token_to_id("hello"), None);
+        assert_eq!(plain.token_to_id("h"), Some(10));
+        assert!(plain.special_token_ids().is_empty());
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("tokenizer.json");
+        let mut json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        json["model"]["vocab"]["<bos>"] = serde_json::json!(23);
+        json["added_tokens"] = serde_json::json!([{
+            "id": 23,
+            "content": "<bos>",
+            "single_word": false,
+            "lstrip": false,
+            "rstrip": false,
+            "normalized": false,
+            "special": true
+        }]);
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        let with_added = BasetenTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        // "<bos>" (id 23) is listed in both `model.vocab` and `added_tokens`,
+        // which is the layout real tokenizer.json files use for special
+        // tokens: the model vocab already covers it, so vocab_size must not
+        // double-count it -- 24, not 25.
+        assert_eq!(with_added.vocab_size(), Some(24));
+        assert_eq!(with_added.token_to_id("<bos>"), Some(23));
+        assert_eq!(with_added.special_token_ids(), vec![23]);
+
+        // A second fixture where the added token is genuinely absent from
+        // the model vocab (as opposed to documenting an existing entry)
+        // confirms vocab_size still counts real additions, not just always
+        // falling back to the model size.
+        let path2 = temp.path().join("tokenizer2.json");
+        let mut json2: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(TOKENIZER_PATH).unwrap()).unwrap();
+        json2["added_tokens"] = serde_json::json!([{
+            "id": 23,
+            "content": "<extra>",
+            "single_word": false,
+            "lstrip": false,
+            "rstrip": false,
+            "normalized": false,
+            "special": true
+        }]);
+        std::fs::write(&path2, serde_json::to_vec(&json2).unwrap()).unwrap();
+
+        let genuinely_added = BasetenTokenizer::from_file(path2.to_str().unwrap()).unwrap();
+        assert_eq!(genuinely_added.vocab_size(), Some(24));
+        assert_eq!(genuinely_added.token_to_id("<extra>"), Some(23));
     }
 }

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -271,7 +271,23 @@ impl Decoder for CachedTokenizer {
     }
 }
 
-impl Tokenizer for CachedTokenizer {}
+impl Tokenizer for CachedTokenizer {
+    fn vocab_size(&self) -> Option<usize> {
+        self.inner.vocab_size()
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        self.inner.token_to_id(token)
+    }
+
+    fn special_token_ids(&self) -> Vec<TokenIdType> {
+        self.inner.special_token_ids()
+    }
+
+    fn num_special_tokens_added(&self) -> usize {
+        self.inner.num_special_tokens_added()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -315,6 +331,22 @@ mod tests {
         fn validate_prefix_cache(&self) -> Result<()> {
             Ok(())
         }
+
+        fn vocab_size(&self) -> Option<usize> {
+            None
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+
+        fn special_token_ids(&self) -> Vec<TokenIdType> {
+            Vec::new()
+        }
+
+        fn num_special_tokens_added(&self) -> usize {
+            0
+        }
     }
 
     impl Encoder for FailingTokenizer {
@@ -340,6 +372,22 @@ mod tests {
     impl Tokenizer for FailingTokenizer {
         fn validate_prefix_cache(&self) -> Result<()> {
             Ok(())
+        }
+
+        fn vocab_size(&self) -> Option<usize> {
+            None
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+
+        fn special_token_ids(&self) -> Vec<TokenIdType> {
+            Vec::new()
+        }
+
+        fn num_special_tokens_added(&self) -> usize {
+            0
         }
     }
 
@@ -574,5 +622,23 @@ mod tests {
         assert!(events[1..].iter().all(|event| event.cached_tokens > 0));
         // First call populates, second/third hit.
         assert!(cached.cache_stats().hits >= 2, "expected hits on q2 and q3");
+    }
+
+    #[test]
+    fn vocab_introspection_forwards_to_inner() {
+        // CachedTokenizer wraps `inner` behind an opaque cache; without
+        // forwarding, every caller reaching a tokenizer through the cache
+        // wrapper would see None/empty/zero regardless of what `inner`
+        // actually reports.
+        let tok = inner();
+        let cached = CachedTokenizer::new(tok.clone(), specials(), 4096)
+            .expect("TinyLlama must support prefix caching");
+        assert_eq!(cached.vocab_size(), tok.vocab_size());
+        assert_eq!(cached.token_to_id("<s>"), tok.token_to_id("<s>"));
+        assert_eq!(cached.special_token_ids(), tok.special_token_ids());
+        assert_eq!(
+            cached.num_special_tokens_added(),
+            tok.num_special_tokens_added()
+        );
     }
 }

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -276,7 +276,7 @@ impl Tokenizer for CachedTokenizer {
         self.inner.vocab_size()
     }
 
-    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+    fn token_to_id(&self, token: &str) -> Result<Option<TokenIdType>> {
         self.inner.token_to_id(token)
     }
 
@@ -336,10 +336,6 @@ mod tests {
             None
         }
 
-        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
-            None
-        }
-
         fn special_token_ids(&self) -> Vec<TokenIdType> {
             Vec::new()
         }
@@ -375,10 +371,6 @@ mod tests {
         }
 
         fn vocab_size(&self) -> Option<usize> {
-            None
-        }
-
-        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
             None
         }
 
@@ -634,7 +626,10 @@ mod tests {
         let cached = CachedTokenizer::new(tok.clone(), specials(), 4096)
             .expect("TinyLlama must support prefix caching");
         assert_eq!(cached.vocab_size(), tok.vocab_size());
-        assert_eq!(cached.token_to_id("<s>"), tok.token_to_id("<s>"));
+        assert_eq!(
+            cached.token_to_id("<s>").unwrap(),
+            tok.token_to_id("<s>").unwrap()
+        );
         assert_eq!(cached.special_token_ids(), tok.special_token_ids());
         assert_eq!(
             cached.num_special_tokens_added(),

--- a/tokenizers/src/cache/mod.rs
+++ b/tokenizers/src/cache/mod.rs
@@ -280,11 +280,11 @@ impl Tokenizer for CachedTokenizer {
         self.inner.token_to_id(token)
     }
 
-    fn special_token_ids(&self) -> Vec<TokenIdType> {
+    fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
         self.inner.special_token_ids()
     }
 
-    fn num_special_tokens_added(&self) -> usize {
+    fn num_special_tokens_added(&self) -> Result<usize> {
         self.inner.num_special_tokens_added()
     }
 }
@@ -335,14 +335,6 @@ mod tests {
         fn vocab_size(&self) -> Option<usize> {
             None
         }
-
-        fn special_token_ids(&self) -> Vec<TokenIdType> {
-            Vec::new()
-        }
-
-        fn num_special_tokens_added(&self) -> usize {
-            0
-        }
     }
 
     impl Encoder for FailingTokenizer {
@@ -372,14 +364,6 @@ mod tests {
 
         fn vocab_size(&self) -> Option<usize> {
             None
-        }
-
-        fn special_token_ids(&self) -> Vec<TokenIdType> {
-            Vec::new()
-        }
-
-        fn num_special_tokens_added(&self) -> usize {
-            0
         }
     }
 
@@ -630,10 +614,27 @@ mod tests {
             cached.token_to_id("<s>").unwrap(),
             tok.token_to_id("<s>").unwrap()
         );
-        assert_eq!(cached.special_token_ids(), tok.special_token_ids());
         assert_eq!(
-            cached.num_special_tokens_added(),
-            tok.num_special_tokens_added()
+            cached.special_token_ids().unwrap(),
+            tok.special_token_ids().unwrap()
         );
+        assert_eq!(
+            cached.num_special_tokens_added().unwrap(),
+            tok.num_special_tokens_added().unwrap()
+        );
+    }
+
+    #[test]
+    fn unoverridden_vocab_methods_default_to_unsupported() {
+        // SegmentTokenizer only overrides `vocab_size`; `token_to_id`,
+        // `special_token_ids`, and `num_special_tokens_added` are left at
+        // the trait default. Guards against that default silently
+        // regressing to a trivial `Ok`/empty/zero value, which would make
+        // "unsupported" indistinguishable from a genuine miss/empty/zero
+        // answer.
+        let tokenizer = SegmentTokenizer;
+        assert!(tokenizer.token_to_id("anything").is_err());
+        assert!(tokenizer.special_token_ids().is_err());
+        assert!(tokenizer.num_special_tokens_added().is_err());
     }
 }

--- a/tokenizers/src/fastokens.rs
+++ b/tokenizers/src/fastokens.rs
@@ -76,6 +76,24 @@ impl Tokenizer for FastTokenizer {
     fn validate_prefix_cache(&self) -> Result<()> {
         Ok(())
     }
+
+    // `fast_encoder` and `hf_decoder` are loaded from the same tokenizer.json,
+    // so the HF side's vocabulary introspection applies to both.
+    fn vocab_size(&self) -> Option<usize> {
+        self.hf_decoder.vocab_size()
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        self.hf_decoder.token_to_id(token)
+    }
+
+    fn special_token_ids(&self) -> Vec<TokenIdType> {
+        self.hf_decoder.special_token_ids()
+    }
+
+    fn num_special_tokens_added(&self) -> usize {
+        self.hf_decoder.num_special_tokens_added()
+    }
 }
 
 #[cfg(test)]
@@ -227,6 +245,23 @@ mod tests {
         assert_eq!(
             accumulated, expected,
             "streamed chunks must equal context-aware decoded continuation"
+        );
+    }
+
+    #[test]
+    fn vocab_introspection_forwards_to_hf_decoder() {
+        // Guards against the same class of bug CachedTokenizer's
+        // delegating overrides are exposed to: one-line forwarding methods
+        // silently reverting to trait defaults, or delegating to the
+        // wrong field.
+        let fast = FastTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        let hf = HuggingFaceTokenizer::from_file(TOKENIZER_PATH).unwrap();
+        assert_eq!(fast.vocab_size(), hf.vocab_size());
+        assert_eq!(fast.token_to_id("Hello"), hf.token_to_id("Hello"));
+        assert_eq!(fast.special_token_ids(), hf.special_token_ids());
+        assert_eq!(
+            fast.num_special_tokens_added(),
+            hf.num_special_tokens_added()
         );
     }
 }

--- a/tokenizers/src/fastokens.rs
+++ b/tokenizers/src/fastokens.rs
@@ -83,7 +83,7 @@ impl Tokenizer for FastTokenizer {
         self.hf_decoder.vocab_size()
     }
 
-    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+    fn token_to_id(&self, token: &str) -> Result<Option<TokenIdType>> {
         self.hf_decoder.token_to_id(token)
     }
 
@@ -257,7 +257,10 @@ mod tests {
         let fast = FastTokenizer::from_file(TOKENIZER_PATH).unwrap();
         let hf = HuggingFaceTokenizer::from_file(TOKENIZER_PATH).unwrap();
         assert_eq!(fast.vocab_size(), hf.vocab_size());
-        assert_eq!(fast.token_to_id("Hello"), hf.token_to_id("Hello"));
+        assert_eq!(
+            fast.token_to_id("Hello").unwrap(),
+            hf.token_to_id("Hello").unwrap()
+        );
         assert_eq!(fast.special_token_ids(), hf.special_token_ids());
         assert_eq!(
             fast.num_special_tokens_added(),

--- a/tokenizers/src/fastokens.rs
+++ b/tokenizers/src/fastokens.rs
@@ -87,11 +87,11 @@ impl Tokenizer for FastTokenizer {
         self.hf_decoder.token_to_id(token)
     }
 
-    fn special_token_ids(&self) -> Vec<TokenIdType> {
+    fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
         self.hf_decoder.special_token_ids()
     }
 
-    fn num_special_tokens_added(&self) -> usize {
+    fn num_special_tokens_added(&self) -> Result<usize> {
         self.hf_decoder.num_special_tokens_added()
     }
 }
@@ -261,10 +261,13 @@ mod tests {
             fast.token_to_id("Hello").unwrap(),
             hf.token_to_id("Hello").unwrap()
         );
-        assert_eq!(fast.special_token_ids(), hf.special_token_ids());
         assert_eq!(
-            fast.num_special_tokens_added(),
-            hf.num_special_tokens_added()
+            fast.special_token_ids().unwrap(),
+            hf.special_token_ids().unwrap()
+        );
+        assert_eq!(
+            fast.num_special_tokens_added().unwrap(),
+            hf.num_special_tokens_added().unwrap()
         );
     }
 }

--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use tokenizers::tokenizer::{AddedToken, Tokenizer as HfTokenizer};
+use tokenizers::tokenizer::{AddedToken, PostProcessor as _, Tokenizer as HfTokenizer};
 
 use super::{
     Encoding, Error, Result, TokenIdType, TokenizerOptions,
@@ -192,6 +192,31 @@ impl Tokenizer for HuggingFaceTokenizer {
         self.options = options;
         self
     }
+
+    fn vocab_size(&self) -> Option<usize> {
+        Some(self.tokenizer.get_vocab_size(true))
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        self.tokenizer.token_to_id(token)
+    }
+
+    fn special_token_ids(&self) -> Vec<TokenIdType> {
+        let mut ids: Vec<TokenIdType> = self
+            .tokenizer
+            .get_added_tokens_decoder()
+            .into_iter()
+            .filter_map(|(id, token)| token.special.then_some(id))
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn num_special_tokens_added(&self) -> usize {
+        self.tokenizer
+            .get_post_processor()
+            .map_or(0, |processor| processor.added_tokens(false))
+    }
 }
 
 impl From<HfTokenizer> for HuggingFaceTokenizer {
@@ -379,5 +404,87 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ids(&wrapper_bos.encode("hello").unwrap()), vec![3, 1]);
+    }
+
+    #[test]
+    fn vocab_introspection_accessors() {
+        // `Encoder`/`Decoder` expose no vocab size, token->id lookup, or
+        // special-token accounting; these narrow accessors let a caller
+        // answer those questions directly against an already-loaded
+        // tokenizer, without backend-specific access to the underlying
+        // library.
+        const TOKENIZER_JSON: &str = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {"id": 0, "content": "<unk>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false}
+            ],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {"<unk>": 0, "hello": 1, "world": 2},
+                "unk_token": "<unk>"
+            }
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("tokenizer.json"), TOKENIZER_JSON).unwrap();
+        let path = dir.path().join("tokenizer.json");
+
+        let tokenizer = HuggingFaceTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(tokenizer.vocab_size(), Some(3));
+        assert_eq!(tokenizer.token_to_id("hello"), Some(1));
+        assert_eq!(tokenizer.special_token_ids(), vec![0]);
+        assert_eq!(tokenizer.num_special_tokens_added(), 0);
+    }
+
+    #[test]
+    fn num_special_tokens_added_reflects_post_processor_additions() {
+        // The `post_processor: null` case above only proves the `None` arm
+        // of `map_or`; this exercises the actual `added_tokens(false)` count
+        // against a TemplateProcessing post-processor that prepends <bos>.
+        const TOKENIZER_JSON: &str = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {"id": 0, "content": "<unk>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false},
+                {"id": 3, "content": "<bos>", "special": true, "single_word": false, "lstrip": false, "rstrip": false, "normalized": false}
+            ],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": {
+                "type": "TemplateProcessing",
+                "single": [
+                    {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}}
+                ],
+                "pair": [
+                    {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}},
+                    {"Sequence": {"id": "B", "type_id": 0}}
+                ],
+                "special_tokens": {
+                    "<bos>": {"id": "<bos>", "ids": [3], "tokens": ["<bos>"]}
+                }
+            },
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {"<unk>": 0, "hello": 1, "world": 2, "<bos>": 3},
+                "unk_token": "<unk>"
+            }
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("tokenizer.json"), TOKENIZER_JSON).unwrap();
+        let path = dir.path().join("tokenizer.json");
+
+        let tokenizer = HuggingFaceTokenizer::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(tokenizer.num_special_tokens_added(), 1);
     }
 }

--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -197,8 +197,8 @@ impl Tokenizer for HuggingFaceTokenizer {
         Some(self.tokenizer.get_vocab_size(true))
     }
 
-    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
-        self.tokenizer.token_to_id(token)
+    fn token_to_id(&self, token: &str) -> Result<Option<TokenIdType>> {
+        Ok(self.tokenizer.token_to_id(token))
     }
 
     fn special_token_ids(&self) -> Vec<TokenIdType> {
@@ -437,7 +437,7 @@ mod tests {
 
         let tokenizer = HuggingFaceTokenizer::from_file(path.to_str().unwrap()).unwrap();
         assert_eq!(tokenizer.vocab_size(), Some(3));
-        assert_eq!(tokenizer.token_to_id("hello"), Some(1));
+        assert_eq!(tokenizer.token_to_id("hello").unwrap(), Some(1));
         assert_eq!(tokenizer.special_token_ids(), vec![0]);
         assert_eq!(tokenizer.num_special_tokens_added(), 0);
     }

--- a/tokenizers/src/hf.rs
+++ b/tokenizers/src/hf.rs
@@ -201,7 +201,7 @@ impl Tokenizer for HuggingFaceTokenizer {
         Ok(self.tokenizer.token_to_id(token))
     }
 
-    fn special_token_ids(&self) -> Vec<TokenIdType> {
+    fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
         let mut ids: Vec<TokenIdType> = self
             .tokenizer
             .get_added_tokens_decoder()
@@ -209,13 +209,14 @@ impl Tokenizer for HuggingFaceTokenizer {
             .filter_map(|(id, token)| token.special.then_some(id))
             .collect();
         ids.sort_unstable();
-        ids
+        Ok(ids)
     }
 
-    fn num_special_tokens_added(&self) -> usize {
-        self.tokenizer
+    fn num_special_tokens_added(&self) -> Result<usize> {
+        Ok(self
+            .tokenizer
             .get_post_processor()
-            .map_or(0, |processor| processor.added_tokens(false))
+            .map_or(0, |processor| processor.added_tokens(false)))
     }
 }
 
@@ -438,8 +439,8 @@ mod tests {
         let tokenizer = HuggingFaceTokenizer::from_file(path.to_str().unwrap()).unwrap();
         assert_eq!(tokenizer.vocab_size(), Some(3));
         assert_eq!(tokenizer.token_to_id("hello").unwrap(), Some(1));
-        assert_eq!(tokenizer.special_token_ids(), vec![0]);
-        assert_eq!(tokenizer.num_special_tokens_added(), 0);
+        assert_eq!(tokenizer.special_token_ids().unwrap(), vec![0]);
+        assert_eq!(tokenizer.num_special_tokens_added().unwrap(), 0);
     }
 
     #[test]
@@ -485,6 +486,6 @@ mod tests {
         let path = dir.path().join("tokenizer.json");
 
         let tokenizer = HuggingFaceTokenizer::from_file(path.to_str().unwrap()).unwrap();
-        assert_eq!(tokenizer.num_special_tokens_added(), 1);
+        assert_eq!(tokenizer.num_special_tokens_added().unwrap(), 1);
     }
 }

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -202,7 +202,42 @@ pub mod traits {
             let _ = options;
             self
         }
-        // fn get_vocab_size(&self) -> usize;
+        /// Vocabulary cardinality including added tokens, when the backend
+        /// can expose one. `None` for backends without a bounded id space.
+        ///
+        /// No default body: every implementor must state its answer
+        /// explicitly (`None` where genuinely unsupported) rather than risk
+        /// silently inheriting `None` for a backend that could report one.
+        fn vocab_size(&self) -> Option<usize>;
+
+        /// Resolve a token string to its vocabulary id, when the backend
+        /// supports lookup. `None` for backends without one, or when the
+        /// token is not in the vocabulary.
+        ///
+        /// No default body: every implementor must state its answer
+        /// explicitly (`None` where genuinely unsupported) rather than risk
+        /// silently inheriting `None` for a backend that could report one.
+        fn token_to_id(&self, token: &str) -> Option<TokenIdType>;
+
+        /// Ids of added tokens marked special (e.g. BOS/EOS/PAD/control
+        /// tokens), as distinct from ordinary vocabulary tokens. Empty for
+        /// backends that do not distinguish special from ordinary
+        /// vocabulary ids.
+        ///
+        /// No default body: every implementor must state its answer
+        /// explicitly (`Vec::new()` where genuinely unsupported) rather
+        /// than risk silently inheriting an empty set for a backend that
+        /// could report one.
+        fn special_token_ids(&self) -> Vec<TokenIdType>;
+
+        /// Count of special tokens `encode`'s `add_special_tokens: true`
+        /// path would add to a bare encoding (e.g. BOS/EOS), available
+        /// without performing an encode. Zero for backends that add none.
+        ///
+        /// No default body: every implementor must state its answer
+        /// explicitly (`0` where genuinely none are added) rather than risk
+        /// silently inheriting zero for a backend that adds some.
+        fn num_special_tokens_added(&self) -> usize;
         // fn make_unique_clone(&self) -> Box<dyn Tokenizer>;
     }
 }
@@ -552,7 +587,23 @@ mod decode_stream_unicode_tests {
         }
     }
 
-    impl super::traits::Tokenizer for RewritingTokenizer {}
+    impl super::traits::Tokenizer for RewritingTokenizer {
+        fn vocab_size(&self) -> Option<usize> {
+            None
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+
+        fn special_token_ids(&self) -> Vec<TokenIdType> {
+            Vec::new()
+        }
+
+        fn num_special_tokens_added(&self) -> usize {
+            0
+        }
+    }
 
     #[test]
     fn allows_boundary_recovery_before_generated_text_is_emitted() {

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -211,13 +211,19 @@ pub mod traits {
         fn vocab_size(&self) -> Option<usize>;
 
         /// Resolve a token string to its vocabulary id, when the backend
-        /// supports lookup. `None` for backends without one, or when the
-        /// token is not in the vocabulary.
+        /// supports lookup. `Ok(None)` when the token is not in the
+        /// vocabulary. `Err` when this backend cannot do id lookup at all —
+        /// kept distinct from a genuine vocabulary miss so callers can tell
+        /// "unsupported" from "looked up, not found".
         ///
-        /// No default body: every implementor must state its answer
-        /// explicitly (`None` where genuinely unsupported) rather than risk
-        /// silently inheriting `None` for a backend that could report one.
-        fn token_to_id(&self, token: &str) -> Option<TokenIdType>;
+        /// Defaults to unsupported, matching `encode_segments` and
+        /// `validate_prefix_cache`: only backends that can perform lookup
+        /// need to override it.
+        fn token_to_id(&self, _token: &str) -> Result<Option<TokenIdType>> {
+            Err(Error::msg(
+                "tokenizer backend does not support token lookup",
+            ))
+        }
 
         /// Ids of added tokens marked special (e.g. BOS/EOS/PAD/control
         /// tokens), as distinct from ordinary vocabulary tokens. Empty for
@@ -589,10 +595,6 @@ mod decode_stream_unicode_tests {
 
     impl super::traits::Tokenizer for RewritingTokenizer {
         fn vocab_size(&self) -> Option<usize> {
-            None
-        }
-
-        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
             None
         }
 

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -226,24 +226,35 @@ pub mod traits {
         }
 
         /// Ids of added tokens marked special (e.g. BOS/EOS/PAD/control
-        /// tokens), as distinct from ordinary vocabulary tokens. Empty for
-        /// backends that do not distinguish special from ordinary
-        /// vocabulary ids.
+        /// tokens), as distinct from ordinary vocabulary tokens. `Ok(vec![])`
+        /// for backends that genuinely have none, or that do not distinguish
+        /// special from ordinary vocabulary ids. `Err` when the backend
+        /// cannot enumerate added tokens at all — an empty `Vec` alone
+        /// cannot carry that distinction.
         ///
-        /// No default body: every implementor must state its answer
-        /// explicitly (`Vec::new()` where genuinely unsupported) rather
-        /// than risk silently inheriting an empty set for a backend that
-        /// could report one.
-        fn special_token_ids(&self) -> Vec<TokenIdType>;
+        /// Defaults to unsupported, matching `token_to_id`: only backends
+        /// that can enumerate special ids need to override it.
+        fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
+            Err(Error::msg(
+                "tokenizer backend does not support special token enumeration",
+            ))
+        }
 
         /// Count of special tokens `encode`'s `add_special_tokens: true`
         /// path would add to a bare encoding (e.g. BOS/EOS), available
-        /// without performing an encode. Zero for backends that add none.
+        /// without performing an encode. `Ok(0)` for backends that
+        /// genuinely add none. `Err` when the backend cannot determine this
+        /// at all — a plain `0` alone cannot carry that distinction, and
+        /// this value feeds token-budget accounting where a silent `0`
+        /// would under-count rather than fail loudly.
         ///
-        /// No default body: every implementor must state its answer
-        /// explicitly (`0` where genuinely none are added) rather than risk
-        /// silently inheriting zero for a backend that adds some.
-        fn num_special_tokens_added(&self) -> usize;
+        /// Defaults to unsupported, matching `token_to_id`: only backends
+        /// that can determine this count need to override it.
+        fn num_special_tokens_added(&self) -> Result<usize> {
+            Err(Error::msg(
+                "tokenizer backend does not support special token accounting",
+            ))
+        }
         // fn make_unique_clone(&self) -> Box<dyn Tokenizer>;
     }
 }
@@ -596,14 +607,6 @@ mod decode_stream_unicode_tests {
     impl super::traits::Tokenizer for RewritingTokenizer {
         fn vocab_size(&self) -> Option<usize> {
             None
-        }
-
-        fn special_token_ids(&self) -> Vec<TokenIdType> {
-            Vec::new()
-        }
-
-        fn num_special_tokens_added(&self) -> usize {
-            0
         }
     }
 

--- a/tokenizers/src/tiktoken.rs
+++ b/tokenizers/src/tiktoken.rs
@@ -156,6 +156,29 @@ impl Tokenizer for TikTokenTokenizer {
     fn validate_prefix_cache(&self) -> Result<()> {
         Ok(())
     }
+
+    // `tiktoken_rs::CoreBPE`'s `encoder` field is `pub(crate)`, so this
+    // crate has no way to enumerate or size the vocab.
+    fn vocab_size(&self) -> Option<usize> {
+        None
+    }
+
+    fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+        None
+    }
+
+    fn special_token_ids(&self) -> Vec<TokenIdType> {
+        let mut ids: Vec<TokenIdType> = self.special_token_ids.iter().copied().collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    // tiktoken applies no post-processor: `encode`'s `add_special_tokens`
+    // option (handled entirely by this crate, not tiktoken_rs) never adds
+    // tokens beyond what the caller passed in.
+    fn num_special_tokens_added(&self) -> usize {
+        0
+    }
 }
 
 /// Parse a tiktoken model file (base64-encoded token + rank per line).
@@ -454,6 +477,21 @@ mod tests {
         // Decode with skip_special_tokens=false should include them
         let decoded_all: String = tokenizer.decode(&ids, false).unwrap().into();
         assert!(decoded_all.contains("hello"));
+    }
+
+    #[test]
+    fn test_special_token_ids_reports_configured_ids_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = create_test_tiktoken_file(dir.path());
+
+        let mut special_tokens = FxHashMap::default();
+        special_tokens.insert("[EOS]".to_string(), 22_u32);
+        special_tokens.insert("[BOS]".to_string(), 21_u32);
+
+        let pattern = r"[\w]+|[^\w\s]+|\s+";
+        let tokenizer = TikTokenTokenizer::from_file(&file_path, pattern, special_tokens).unwrap();
+
+        assert_eq!(tokenizer.special_token_ids(), vec![21, 22]);
     }
 
     #[test]

--- a/tokenizers/src/tiktoken.rs
+++ b/tokenizers/src/tiktoken.rs
@@ -165,17 +165,17 @@ impl Tokenizer for TikTokenTokenizer {
         None
     }
 
-    fn special_token_ids(&self) -> Vec<TokenIdType> {
+    fn special_token_ids(&self) -> Result<Vec<TokenIdType>> {
         let mut ids: Vec<TokenIdType> = self.special_token_ids.iter().copied().collect();
         ids.sort_unstable();
-        ids
+        Ok(ids)
     }
 
     // tiktoken applies no post-processor: `encode`'s `add_special_tokens`
     // option (handled entirely by this crate, not tiktoken_rs) never adds
     // tokens beyond what the caller passed in.
-    fn num_special_tokens_added(&self) -> usize {
-        0
+    fn num_special_tokens_added(&self) -> Result<usize> {
+        Ok(0)
     }
 }
 
@@ -489,7 +489,25 @@ mod tests {
         let pattern = r"[\w]+|[^\w\s]+|\s+";
         let tokenizer = TikTokenTokenizer::from_file(&file_path, pattern, special_tokens).unwrap();
 
-        assert_eq!(tokenizer.special_token_ids(), vec![21, 22]);
+        assert_eq!(tokenizer.special_token_ids().unwrap(), vec![21, 22]);
+    }
+
+    #[test]
+    fn test_vocab_size_and_token_to_id_are_unsupported() {
+        // `tiktoken_rs::CoreBPE`'s `encoder` field is `pub(crate)`, so
+        // neither method can be implemented; `token_to_id` inherits the
+        // trait default (`Err`) rather than a hand-rolled `None` override.
+        // Guards against that default silently regressing to `Ok(None)`,
+        // which would make "unsupported" indistinguishable from "not
+        // found" again -- the exact bug this default exists to prevent.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = create_test_tiktoken_file(dir.path());
+        let pattern = r"[\w]+|[^\w\s]+|\s+";
+        let tokenizer =
+            TikTokenTokenizer::from_file(&file_path, pattern, FxHashMap::default()).unwrap();
+
+        assert_eq!(tokenizer.vocab_size(), None);
+        assert!(tokenizer.token_to_id("hello").is_err());
     }
 
     #[test]

--- a/tokenizers/src/tiktoken.rs
+++ b/tokenizers/src/tiktoken.rs
@@ -158,12 +158,10 @@ impl Tokenizer for TikTokenTokenizer {
     }
 
     // `tiktoken_rs::CoreBPE`'s `encoder` field is `pub(crate)`, so this
-    // crate has no way to enumerate or size the vocab.
+    // crate has no way to enumerate, size, or look up ids in the vocab.
+    // `token_to_id` is left at the trait default (unsupported) for the
+    // same reason.
     fn vocab_size(&self) -> Option<usize> {
-        None
-    }
-
-    fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
         None
     }
 


### PR DESCRIPTION
## Summary
- Adds vocab-introspection accessors (`vocab_size`, `token_to_id`, `special_token_ids`, `num_special_tokens_added`) to the `Tokenizer` trait, needed by a downstream consumer for raw-prompt generation and special-token accounting.
- `token_to_id`, `special_token_ids`, and `num_special_tokens_added` return `Result<T>` rather than a bare `Option`/`Vec`/`usize`: those bare types can't distinguish "this backend cannot determine the answer at all" from a genuine empty/miss/zero result (e.g. tiktoken's `token_to_id` always returning `None` vs. HuggingFace's `None` meaning "looked up, not in vocab"). `Err` = unsupported, `Ok(_)` = the real answer. All three default to `Err(unsupported)`, so only backends that can actually answer need to override.
- `vocab_size` stays `Option<usize>` — `Option` already separates `None` (can't determine) from `Some(0)` (empty vocab), so there's no ambiguity to fix there.
- HuggingFace, Baseten, and tiktoken backends implement the accessors they can determine; `FastTokenizer` and `CachedTokenizer` delegate to their inner tokenizer.

## Test plan
- [x] `cargo test -p dynamo-tokenizers` — 77 unit + 8 integration tests, including new coverage for the unsupported-path default (`tiktoken::tests::test_vocab_size_and_token_to_id_are_unsupported`, `cache::tests::unoverridden_vocab_methods_default_to_unsupported`)
- [x] `cargo fmt -p dynamo-tokenizers --check`
- [x] `cargo clippy -p dynamo-tokenizers --all-targets -- -D warnings`
- [x] `cargo build --workspace`