### PR TITLE
fix(GUI): anchor conformance column hover hint

### DIFF
--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -50,6 +50,8 @@ td.parser a:hover { background: #ffd; }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"] {
   z-index: 8;
 }
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"]:focus-within,
+[data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"]:focus-within { z-index: 11; }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
 [data-parity-table] > tbody > tr:not(.section) > td.model { left: 0; }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"],

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -353,6 +353,18 @@ body.view-overview.ttip-pin-mode td.cell:hover:not(.ttip-open) { filter: none; }
 .col-toggle[aria-pressed="true"] { background: #e7f0ff; border-color: #6b9bd6; color: #174a86; }
 .col-toggle[aria-pressed="false"] { background: #fff; border-color: #bbb; color: #555; }
 .col-toggle:focus-visible { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* Keep the column-control hint anchored to the label instead of using the browser's
+   native `title` popup, which floats from the bottom of the whole header cell. */
+.col-toggle[data-tooltip] { position: relative; }
+.col-toggle[data-tooltip]::after {
+  content: attr(data-tooltip); position: absolute; left: 50%; bottom: calc(100% + 6px);
+  transform: translateX(-50%); visibility: hidden; opacity: 0; pointer-events: none;
+  z-index: 4000; padding: 4px 7px; border-radius: 4px; background: #1f2937; color: #e5e7eb;
+  font: 11px -apple-system, system-ui, sans-serif; line-height: 1.2; white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.28);
+}
+.col-toggle[data-tooltip]:hover::after,
+.col-toggle[data-tooltip]:focus-visible::after { visibility: visible; opacity: 1; }
 .col-placeholder { min-width: 20px; width: 20px; padding: 0; background: #f8fafc; }
 .col-hidden { display: none; }
 table.glossary { margin-top: 0.5em; }

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -476,8 +476,8 @@ td.cell, td.parser { cursor: pointer; }
 }
 .ttip-close:hover { background: rgba(255,255,255,0.30); }
 .ttip-pinned .ttip-close { display: block; }
-td.cell .ttip a, td.parser .ttip a { color: #bfdbfe; text-decoration: none; border-bottom: 1.5px solid currentColor; padding-bottom: 1px; display: inline; }
-td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: transparent; }
+.ttip a { color: #bfdbfe; text-decoration: none; border-bottom: 1.5px solid currentColor; padding-bottom: 1px; display: inline; }
+.ttip a:hover { color: #dbeafe; background: transparent; }
 .ttip-head { font-weight: bold; margin-bottom: 4px; color: #fbbf24; }
 /* Inline description after the popup id: prose, so sans-serif (mono is for the code/id),
    normal weight, and the normal tooltip text color — not the loud section blue. */

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -50,12 +50,6 @@ td.parser a:hover { background: #ffd; }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"] {
   z-index: 8;
 }
-/* A popup remains inside its trigger's stacking context. Lift only the header that
-   owns a visible popup, so frozen sibling columns stay below the popup rather than
-   painting over it while horizontal scrolling is active. */
-[data-parity-table] > thead > tr.matrix-groups > th:has(.ttip-visible) {
-  z-index: 3001;
-}
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
 [data-parity-table] > tbody > tr:not(.section) > td.model { left: 0; }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"],
@@ -87,7 +81,6 @@ td.parser a:hover { background: #ffd; }
   left: 0;
   z-index: 8;
 }
-.transpose-table > thead > tr > th:has(.ttip-visible) { z-index: 3001; }
 .transpose-table > tbody > tr:not(.section) > th.trow-case {
   position: sticky;
   left: 0;
@@ -373,10 +366,6 @@ body.view-overview.ttip-pin-mode td.cell:hover:not(.ttip-open) { filter: none; }
 }
 .col-toggle[data-tooltip]:hover::after,
 .col-toggle[data-tooltip]:focus-visible::after { visibility: visible; opacity: 1; }
-/* Sticky model/parser columns use a higher z-index than ordinary header cells so they
-   stay readable while the matrix scrolls. The parser header shares that layer, so an
-   in-cell pseudo-element cannot escape above the sticky model column. Keep the hint in
-   the page-level tooltip layer instead of trying to out-rank sibling sticky cells. */
 .col-toggle[data-tooltip]::after { content: none; }
 .column-control-tooltip { white-space: nowrap; min-width: 0; width: max-content; }
 .col-placeholder { min-width: 20px; width: 20px; padding: 0; background: #f8fafc; }

--- a/conformance/utils/src/assets/conformance.css
+++ b/conformance/utils/src/assets/conformance.css
@@ -45,9 +45,16 @@ td.parser a:hover { background: #ffd; }
   top: var(--sticky-top-row-height, 0px);
   z-index: 9;
 }
+/* The frozen first columns stay above scrolling data but below every popup. */
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="parser"] {
-  z-index: 20;
+  z-index: 8;
+}
+/* A popup remains inside its trigger's stacking context. Lift only the header that
+   owns a visible popup, so frozen sibling columns stay below the popup rather than
+   painting over it while horizontal scrolling is active. */
+[data-parity-table] > thead > tr.matrix-groups > th:has(.ttip-visible) {
+  z-index: 3001;
 }
 [data-parity-table] > thead > tr.matrix-groups > th[data-col-control-group="model"],
 [data-parity-table] > tbody > tr:not(.section) > td.model { left: 0; }
@@ -58,7 +65,7 @@ td.parser a:hover { background: #ffd; }
 [data-parity-table] > tbody > tr:not(.section) > td.model,
 [data-parity-table] > tbody > tr:not(.section) > td.parser {
   position: sticky;
-  z-index: 3;
+  z-index: 1;
   background: #fff;
 }
 
@@ -78,12 +85,13 @@ td.parser a:hover { background: #ffd; }
 .transpose-table > thead > tr.transpose-sections > th.tcorner-case,
 .transpose-table > thead > tr.transpose-models > th.tcorner-case {
   left: 0;
-  z-index: 20;
+  z-index: 8;
 }
+.transpose-table > thead > tr > th:has(.ttip-visible) { z-index: 3001; }
 .transpose-table > tbody > tr:not(.section) > th.trow-case {
   position: sticky;
   left: 0;
-  z-index: 3;
+  z-index: 1;
   width: var(--sticky-case-width, auto);
   min-width: var(--sticky-case-width, auto);
   background: #fff;
@@ -365,6 +373,12 @@ body.view-overview.ttip-pin-mode td.cell:hover:not(.ttip-open) { filter: none; }
 }
 .col-toggle[data-tooltip]:hover::after,
 .col-toggle[data-tooltip]:focus-visible::after { visibility: visible; opacity: 1; }
+/* Sticky model/parser columns use a higher z-index than ordinary header cells so they
+   stay readable while the matrix scrolls. The parser header shares that layer, so an
+   in-cell pseudo-element cannot escape above the sticky model column. Keep the hint in
+   the page-level tooltip layer instead of trying to out-rank sibling sticky cells. */
+.col-toggle[data-tooltip]::after { content: none; }
+.column-control-tooltip { white-space: nowrap; min-width: 0; width: max-content; }
 .col-placeholder { min-width: 20px; width: 20px; padding: 0; background: #f8fafc; }
 .col-hidden { display: none; }
 table.glossary { margin-top: 0.5em; }

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -513,11 +513,17 @@
       // Preserve the accessible name while exposing the same text in the page tooltip.
       button.dataset.tooltip = button.getAttribute('aria-label');
       button.dataset.ttipText = button.dataset.tooltip;
-      if (!button.querySelector('.ttip')) {
-        const ttip = document.createElement('span');
+      let ttip = button._ttip || button.querySelector('.ttip');
+      if (!ttip) {
+        ttip = document.createElement('span');
         ttip.className = 'ttip column-control-tooltip';
-        ttip.textContent = button.dataset.ttipText;
+        const label = document.createElement('span');
+        label.className = 'column-control-tooltip-text';
+        label.textContent = button.dataset.ttipText;
+        ttip.appendChild(label);
         button.appendChild(ttip);
+      } else {
+        ttip.querySelector('.column-control-tooltip-text').textContent = button.dataset.ttipText;
       }
       attachTooltip(button);
       document.querySelectorAll('[data-col-control-group="' + key + '"]').forEach(function (el) {
@@ -731,10 +737,10 @@
     const absLeft = cellRect.left + shiftX;
     if (absLeft < margin) shiftX += (margin - absLeft);
     if (isPortalled) {
-      ttip.style.left = (cellRect.left + shiftX) + 'px';
-      ttip.style.top = cellRect.bottom + 'px';
+      ttip.style.left = (cellRect.left + window.scrollX + shiftX) + 'px';
+      ttip.style.top = (cellRect.bottom + window.scrollY) + 'px';
       if (cellRect.bottom + tipRect.height > vh - margin && cellRect.top - tipRect.height > margin) {
-        ttip.style.top = (cellRect.top - tipRect.height) + 'px';
+        ttip.style.top = (cellRect.top + window.scrollY - tipRect.height) + 'px';
       }
     } else {
       ttip.style.left = shiftX + 'px';
@@ -940,6 +946,11 @@
       isVisible = true;
     }
 
+    function keepTooltipOpen() {
+      isActive = true;
+      clearTimers();
+    }
+
     // TOUCH ONLY. Tap toggles a pinned tooltip; taps INSIDE the tooltip (its links, the ✕)
     // behave normally. Touch has no hover, so a tap on the cell must open the tooltip
     // instead of following the cell's own parser-source link — preventDefault blocks that
@@ -1001,6 +1012,10 @@
     cell.addEventListener('focusout', function () {
       if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
     });
+    ttip.addEventListener('pointerenter', keepTooltipOpen);
+    ttip.addEventListener('mouseenter', keepTooltipOpen);
+    ttip.addEventListener('pointerleave', onLeave);
+    ttip.addEventListener('mouseleave', onLeave);
 
     // Column controls contain their tooltip as a child. Moving the pointer from the
     // button into that child fires a leave event, so show it immediately and keep it

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -1017,9 +1017,6 @@
     ttip.addEventListener('pointerleave', onLeave);
     ttip.addEventListener('mouseleave', onLeave);
 
-    // Column controls contain their tooltip as a child. Moving the pointer from the
-    // button into that child fires a leave event, so show it immediately and keep it
-    // open until the pointer leaves the entire control.
     if (cell.classList.contains('col-toggle')) {
       cell.addEventListener('mouseenter', keepButtonTooltipOpen);
       cell.addEventListener('pointerenter', keepButtonTooltipOpen);

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -1198,9 +1198,11 @@
       inner.appendChild(label);
       th.appendChild(inner);
       // Same hover tooltip as the original parser cell.
-      const srcTip = m.parserTd && m.parserTd.querySelector('.ttip');
+      const srcTip = m.parserTd && (m.parserTd._ttip || m.parserTd.querySelector('.ttip'));
       if (srcTip) {
         const tipClone = srcTip.cloneNode(true);
+        tipClone.removeAttribute('data-ttip-wired');
+        delete tipClone.dataset.ttipWired;
         th.appendChild(tipClone);
         attachTooltip(th);
       }
@@ -1248,7 +1250,11 @@
       models.forEach(function (m) {
         const src = m.cells[idx];
         if (src) {
+          const sourceTip = src._ttip || src.querySelector('.ttip');
           const clone = src.cloneNode(true);
+          const cloneTip = sourceTip && sourceTip.cloneNode(true);
+          const embeddedTip = clone.querySelector('.ttip');
+          if (cloneTip && !embeddedTip) clone.appendChild(cloneTip);
           clone.classList.remove('col-hidden');
           clone.removeAttribute('data-col-hide-group');
           // cloneNode copies the "already wired" flag; clear it so the clone

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -637,6 +637,13 @@
 
   function activateTab(id, shouldUpdateUrl) {
     if (!id) return;
+    if (pinnedCell) unpinCell(pinnedCell);
+    portalledTooltips.forEach(function (ttip) {
+      const owner = ttip._ttipOwner;
+      if (owner && owner.closest('.tab-panel')?.id !== id) {
+        owner._ttipUnpin ? owner._ttipUnpin() : ttip.classList.remove('ttip-visible');
+      }
+    });
     tabButtons.forEach(function (button) {
       const selected = button.dataset.tabTarget === id;
       button.classList.toggle('active', selected);
@@ -653,13 +660,6 @@
     }
     updateStickyOffsets();
   }
-  activateTab(readActiveTab(), false);
-  tabButtons.forEach(function (button) {
-    button.addEventListener('click', function () {
-      activateTab(button.dataset.tabTarget, true);
-    });
-  });
-
   // Equal columns, sized to what the WIDEST column actually needs.
   //
   // Pure CSS gives one or the other, not both: `table-layout: fixed; width: 100%`
@@ -879,14 +879,18 @@
     }
 
     // ✕ close button (shown only while pinned) — inserted once per tooltip.
-    if (!ttip.querySelector('.ttip-close')) {
-      const x = document.createElement('button');
-      x.type = 'button';
-      x.className = 'ttip-close';
-      x.setAttribute('aria-label', 'Close');
-      x.textContent = '✕';
-      x.addEventListener('click', function (e) { e.stopPropagation(); unpin(); });
-      ttip.insertBefore(x, ttip.firstChild);
+    let closeButton = ttip.querySelector('.ttip-close');
+    if (!closeButton) {
+      closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'ttip-close';
+      closeButton.setAttribute('aria-label', 'Close');
+      closeButton.textContent = '✕';
+      ttip.insertBefore(closeButton, ttip.firstChild);
+    }
+    if (!closeButton.dataset.ttipCloseWired) {
+      closeButton.addEventListener('click', function (e) { e.stopPropagation(); unpin(); });
+      closeButton.dataset.ttipCloseWired = '1';
     }
 
     function pin() {
@@ -1061,6 +1065,13 @@
   // the starting set, never the definition of "pinnable" (that is `WIRED` above).
   const WIRE_ON_LOAD = 'td.cell, td.parser, th.case-sub';
   document.querySelectorAll(WIRE_ON_LOAD).forEach(attachTooltip);
+
+  activateTab(readActiveTab(), false);
+  tabButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      activateTab(button.dataset.tabTarget, true);
+    });
+  });
 
   // ---- Transpose view (DIS-2280) ----
   // Build a transposed mirror of each panel's table on demand: models become
@@ -1269,6 +1280,10 @@
           if (cloneTip) {
             if (embeddedTip) embeddedTip.remove();
             cloneTip.classList.remove('ttip-visible', 'ttip-pinned');
+            cloneTip.querySelectorAll('.ttip-close').forEach(function (button) {
+              button.removeAttribute('data-ttip-close-wired');
+              delete button.dataset.ttipCloseWired;
+            });
             clone.appendChild(cloneTip);
           }
           clone.classList.remove('col-hidden');

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -852,6 +852,11 @@
     if (cell.dataset.ttipWired === '1') return;
     cell.dataset.ttipWired = '1';
 
+    function showFocusedTooltip() {
+      cell._focusTooltip = true;
+      if (window.__buildTooltip) window.__buildTooltip(cell);
+    }
+
     let showTimer = null;
     let hideTimer = null;
     let isActive = false;
@@ -860,6 +865,7 @@
 
     function portalTooltip() {
       if (portalParent) return;
+      if (cell._focusTooltip || (document.activeElement && cell.contains(document.activeElement))) return;
       portalParent = ttip.parentNode;
       document.body.appendChild(ttip);
       portalledTooltips.add(ttip);
@@ -928,6 +934,7 @@
       showTimer = window.setTimeout(function () {
         showTimer = null;
         if (!isActive) return;
+        if (cell._focusTooltip && window.__buildTooltip) window.__buildTooltip(cell);
         portalTooltip();
         place(cell);
         ttip.classList.add('ttip-visible');
@@ -1028,10 +1035,15 @@
     cell.addEventListener('mouseenter', onEnter);
     cell.addEventListener('mouseleave', onLeave);
     cell.addEventListener('focusin', function () {
-      if (hoverAllowed()) { scheduleShow(); }
+      if (hoverAllowed()) {
+        restoreTooltip();
+        showFocusedTooltip();
+        scheduleShow();
+      }
     });
     cell.addEventListener('focusout', function () {
       if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
+      cell._focusTooltip = false;
     });
     ttip.addEventListener('pointerenter', keepTooltipOpen);
     ttip.addEventListener('mouseenter', keepTooltipOpen);
@@ -1254,7 +1266,11 @@
           const clone = src.cloneNode(true);
           const cloneTip = sourceTip && sourceTip.cloneNode(true);
           const embeddedTip = clone.querySelector('.ttip');
-          if (cloneTip && !embeddedTip) clone.appendChild(cloneTip);
+          if (cloneTip) {
+            if (embeddedTip) embeddedTip.remove();
+            cloneTip.classList.remove('ttip-visible', 'ttip-pinned');
+            clone.appendChild(cloneTip);
+          }
           clone.classList.remove('col-hidden');
           clone.removeAttribute('data-col-hide-group');
           // cloneNode copies the "already wired" flag; clear it so the clone

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -510,7 +510,11 @@
         'aria-label',
         (isVisible ? 'Collapse ' : 'Expand ') + button.dataset.colLabel + ' column'
       );
-      button.title = button.getAttribute('aria-label');
+      // Use the page tooltip instead of the browser's native `title` popup. The native
+      // popup is positioned relative to the button's bottom edge, which makes a column
+      // header tooltip appear detached below the column. `aria-label` remains the
+      // accessible name for keyboard and screen-reader users.
+      button.dataset.tooltip = button.getAttribute('aria-label');
       document.querySelectorAll('[data-col-control-group="' + key + '"]').forEach(function (el) {
         el.classList.toggle('col-collapsed', !isVisible);
         if (el.dataset.expandedColspan) {

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -754,6 +754,25 @@
     ttip.style.opacity = '';
   }
 
+  let placeScheduled = false;
+  const portalledTooltips = new Set();
+  function repositionPortalledTooltips() {
+    if (placeScheduled) return;
+    placeScheduled = true;
+    window.requestAnimationFrame(function () {
+      placeScheduled = false;
+      portalledTooltips.forEach(function (ttip) {
+        if (ttip.classList.contains('ttip-visible') && ttip._ttipOwner) {
+          place(ttip._ttipOwner);
+        } else {
+          portalledTooltips.delete(ttip);
+        }
+      });
+    });
+  }
+  window.addEventListener('scroll', repositionPortalledTooltips, true);
+  window.addEventListener('resize', repositionPortalledTooltips);
+
   // Touch devices have no hover, so the tooltip is opened by TAP and pinned open
   // (with an ✕ to close) rather than shown on pointerenter. Where hover EXISTS, hover is
   // the only affordance — clicking never pins, because pinning is modal and one stray
@@ -843,12 +862,14 @@
       if (portalParent) return;
       portalParent = ttip.parentNode;
       document.body.appendChild(ttip);
+      portalledTooltips.add(ttip);
     }
 
     function restoreTooltip() {
       if (!portalParent) return;
       portalParent.appendChild(ttip);
       portalParent = null;
+      portalledTooltips.delete(ttip);
     }
 
     // ✕ close button (shown only while pinned) — inserted once per tooltip.

--- a/conformance/utils/src/assets/conformance.js
+++ b/conformance/utils/src/assets/conformance.js
@@ -510,11 +510,16 @@
         'aria-label',
         (isVisible ? 'Collapse ' : 'Expand ') + button.dataset.colLabel + ' column'
       );
-      // Use the page tooltip instead of the browser's native `title` popup. The native
-      // popup is positioned relative to the button's bottom edge, which makes a column
-      // header tooltip appear detached below the column. `aria-label` remains the
-      // accessible name for keyboard and screen-reader users.
+      // Preserve the accessible name while exposing the same text in the page tooltip.
       button.dataset.tooltip = button.getAttribute('aria-label');
+      button.dataset.ttipText = button.dataset.tooltip;
+      if (!button.querySelector('.ttip')) {
+        const ttip = document.createElement('span');
+        ttip.className = 'ttip column-control-tooltip';
+        ttip.textContent = button.dataset.ttipText;
+        button.appendChild(ttip);
+      }
+      attachTooltip(button);
       document.querySelectorAll('[data-col-control-group="' + key + '"]').forEach(function (el) {
         el.classList.toggle('col-collapsed', !isVisible);
         if (el.dataset.expandedColspan) {
@@ -699,14 +704,15 @@
   }
 
   function place(cell) {
-    const ttip = cell.querySelector('.ttip');
+    const ttip = cell._ttip || cell.querySelector('.ttip');
     if (!ttip) return;
     equalizeColumns(ttip);
     ttip.style.visibility = 'hidden';
     ttip.style.opacity = '0';
     ttip.classList.add('ttip-visible');
+    const isPortalled = ttip.parentNode === document.body;
     ttip.style.left = '0px';
-    ttip.style.top = '100%';
+    ttip.style.top = isPortalled ? '0px' : '100%';
     ttip.style.right = 'auto';
     ttip.style.bottom = 'auto';
     // Cap the width at the viewport MINUS both gutters — that is the most a popup may
@@ -724,8 +730,16 @@
     if (overflowRight > 0) shiftX = -overflowRight;
     const absLeft = cellRect.left + shiftX;
     if (absLeft < margin) shiftX += (margin - absLeft);
-    ttip.style.left = shiftX + 'px';
-    if (cellRect.bottom + tipRect.height > vh - margin
+    if (isPortalled) {
+      ttip.style.left = (cellRect.left + shiftX) + 'px';
+      ttip.style.top = cellRect.bottom + 'px';
+      if (cellRect.bottom + tipRect.height > vh - margin && cellRect.top - tipRect.height > margin) {
+        ttip.style.top = (cellRect.top - tipRect.height) + 'px';
+      }
+    } else {
+      ttip.style.left = shiftX + 'px';
+    }
+    if (!isPortalled && cellRect.bottom + tipRect.height > vh - margin
         && cellRect.top - tipRect.height > margin) {
       ttip.style.top = 'auto';
       ttip.style.bottom = '100%';
@@ -800,12 +814,14 @@
   const WIRED = '[data-ttip-wired]';
   document.addEventListener('click', function (e) {
     // A click anywhere outside a pinnable element (and not on a pinned tooltip) closes the pin.
-    if (pinnedCell && !e.target.closest(WIRED)) { unpinCell(pinnedCell); }
+    if (pinnedCell && !e.target.closest(WIRED) && !e.target.closest('.ttip')) { unpinCell(pinnedCell); }
   });
 
   function attachTooltip(cell) {
     const ttip = cell.querySelector('.ttip');
     if (!ttip) return;
+    cell._ttip = ttip;
+    ttip._ttipOwner = cell;
     // cloneNode copies the wired flag; guard so re-wiring a clone is a no-op and
     // originals aren't double-wired.
     if (cell.dataset.ttipWired === '1') return;
@@ -815,6 +831,19 @@
     let hideTimer = null;
     let isActive = false;
     let isVisible = false;
+    let portalParent = null;
+
+    function portalTooltip() {
+      if (portalParent) return;
+      portalParent = ttip.parentNode;
+      document.body.appendChild(ttip);
+    }
+
+    function restoreTooltip() {
+      if (!portalParent) return;
+      portalParent.appendChild(ttip);
+      portalParent = null;
+    }
 
     // ✕ close button (shown only while pinned) — inserted once per tooltip.
     if (!ttip.querySelector('.ttip-close')) {
@@ -830,6 +859,7 @@
     function pin() {
       if (pinnedCell && pinnedCell !== cell) { unpinCell(pinnedCell); }
       clearTimers();
+      portalTooltip();
       place(cell);
       ttip.classList.add('ttip-visible', 'ttip-pinned');
       isVisible = true;
@@ -843,6 +873,7 @@
     }
     function unpin() {
       ttip.classList.remove('ttip-visible', 'ttip-pinned');
+      restoreTooltip();
       isVisible = false;
       isActive = false;
       cell.classList.remove('ttip-open');
@@ -870,6 +901,7 @@
       showTimer = window.setTimeout(function () {
         showTimer = null;
         if (!isActive) return;
+        portalTooltip();
         place(cell);
         ttip.classList.add('ttip-visible');
         isVisible = true;
@@ -884,6 +916,7 @@
       }
       if (!isVisible) {
         ttip.classList.remove('ttip-visible');
+        restoreTooltip();
         return;
       }
       if (hideTimer !== null) {
@@ -893,8 +926,18 @@
         hideTimer = null;
         if (isActive) return;
         ttip.classList.remove('ttip-visible');
+        restoreTooltip();
         isVisible = false;
       }, hideDelayMs);
+    }
+
+    function keepButtonTooltipOpen() {
+      isActive = true;
+      clearTimers();
+      portalTooltip();
+      place(cell);
+      ttip.classList.add('ttip-visible');
+      isVisible = true;
     }
 
     // TOUCH ONLY. Tap toggles a pinned tooltip; taps INSIDE the tooltip (its links, the ✕)
@@ -958,6 +1001,14 @@
     cell.addEventListener('focusout', function () {
       if (!ttip.classList.contains('ttip-pinned')) { scheduleHide(); }
     });
+
+    // Column controls contain their tooltip as a child. Moving the pointer from the
+    // button into that child fires a leave event, so show it immediately and keep it
+    // open until the pointer leaves the entire control.
+    if (cell.classList.contains('col-toggle')) {
+      cell.addEventListener('mouseenter', keepButtonTooltipOpen);
+      cell.addEventListener('pointerenter', keepButtonTooltipOpen);
+    }
   }
   // The elements present at load. `th.case-sub` carries the per-column grammar popup (the
   // same case in every family's grammar); it uses the identical hover/pin machinery as a

--- a/conformance/utils/src/generate_conformance_table.py
+++ b/conformance/utils/src/generate_conformance_table.py
@@ -2807,8 +2807,8 @@ def _unified_tab_model(artifact_root: Path, hrefs: dict) -> dict | None:
     return {
         "id": "tab-unified", "kind": "unified", "active": False, "mode": "unified",
         "no_parser_col": True,  # parser variant is already encoded in each engine's name
-        "label": "Unified (reasoning + tools)",
-        "label_html": 'Unified <span class="tab-sub">(reasoning + tools)</span>',
+        "label": "Unified v2 (reasoning + tools)",
+        "label_html": 'Unified v2 <span class="tab-sub">(reasoning + tools)</span>',
         "tab_title": ("Unified: one ordered event stream (reasoning + content + tool calls) "
                       "measured against the GOLDEN oracle"),
         "columns": columns, "column_groups": column_groups,
@@ -2861,8 +2861,8 @@ def build_combined_model(output_path: Path | None = None,
     batch_tab = _toolcalling_tab_model(batch_spec, batch_href, parser_stream_context="batch")
     batch_tab.update({
         "id": "tab-toolcalling-batch",
-        "label": "Tool Calling (batch data)",
-        "label_html": ('Tool Calling <span class="tab-sub">'
+        "label": "Tool Calling v1 (batch data)",
+        "label_html": ('Tool Calling v1 <span class="tab-sub">'
                        '(<span class="w-batch">batch</span> data)</span>'),
         "tab_title": ("Tool Calling (batch data): v1 batch parsers plus v2 stream "
                       "parsers on the same v1 batch fixtures"),
@@ -2889,8 +2889,8 @@ def build_combined_model(output_path: Path | None = None,
     stream_tab = _toolcalling_tab_model(stream_spec, stream_href, parser_stream_context="streamv2")
     stream_tab.update({
         "id": "tab-toolcalling-streamv2",
-        "label": "Tool Calling (stream data)",
-        "label_html": ('Tool Calling <span class="tab-sub">'
+        "label": "Tool Calling v2 (stream data)",
+        "label_html": ('Tool Calling v2 <span class="tab-sub">'
                        '(<span class="w-stream">stream</span> data)</span>'),
         "tab_title": "Tool Calling (stream data): Dynamo parser v2 on v2 stream fixtures",
         "case_prefix": "TOOLCALLING.streamv2.",

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -251,22 +251,73 @@ def test_column_toggle_hint_is_anchored_to_the_button(driver):
         const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]
           .find(el => el.dataset.colLabel === 'Tool calling family');
         if (!button) return null;
-        const style = getComputedStyle(button, '::after');
         return {
           title: button.getAttribute('title'),
           tooltip: button.dataset.tooltip,
-          content: style.content,
-          position: style.position,
-          bottom: style.bottom,
+          tooltipText: button.dataset.ttipText,
+          wired: button.dataset.ttipWired,
         };
         """
     )
     assert result, "Tool calling family column control is missing"
     assert result["title"] is None, result
     assert result["tooltip"] == "Collapse Tool calling family column", result
-    assert result["content"] == '"Collapse Tool calling family column"', result
-    assert result["position"] == "absolute", result
-    assert result["bottom"] != "auto", result
+    assert result["tooltipText"] == "Collapse Tool calling family column", result
+    assert result["wired"] == "1", result
+
+
+def test_column_toggle_hover_opens_its_tooltip(driver):
+    result = driver.execute_script(
+        """
+        const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]
+          .find(el => el.dataset.colLabel === 'Tool calling family');
+        button.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
+        const tooltip = button._ttip;
+        return {
+          visible: tooltip.classList.contains('ttip-visible'),
+          visibility: getComputedStyle(tooltip).visibility,
+        };
+        """
+    )
+
+    assert result == {"visible": True, "visibility": "visible"}
+
+
+def test_sticky_columns_stay_below_popups(driver):
+    result = driver.execute_script(
+        """
+        const table = document.querySelector('.tab-panel.active [data-parity-table]');
+        const stickyHeader = table.querySelector('th[data-col-control-group="parser"]');
+        const stickyBody = table.querySelector('td.parser');
+        const popup = document.querySelector('.ttip');
+        return {
+          stickyHeader: Number(getComputedStyle(stickyHeader).zIndex),
+          stickyBody: Number(getComputedStyle(stickyBody).zIndex),
+          popup: Number(getComputedStyle(popup).zIndex),
+        };
+        """
+    )
+
+    assert result["stickyBody"] < result["popup"], result
+
+
+def test_tool_calling_header_stays_below_the_portalled_popup(driver):
+    result = driver.execute_script(
+        """
+        const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]
+          .find(el => el.dataset.colLabel === 'Tool calling family');
+        const header = button.closest('th');
+        const tooltip = button._ttip;
+        document.body.appendChild(tooltip);
+        tooltip.classList.add('ttip-visible');
+        const openZIndex = Number(getComputedStyle(header).zIndex);
+        tooltip.classList.remove('ttip-visible');
+        button.appendChild(tooltip);
+        return { openZIndex, closedZIndex: Number(getComputedStyle(header).zIndex) };
+        """
+    )
+
+    assert result == {"openZIndex": 8, "closedZIndex": 8}
 
 
 def test_order_divergence_shows_golden_and_candidate_sequences(driver):
@@ -719,7 +770,7 @@ def test_every_wired_element_stays_pinned(touch_driver, transposed):
         pinned = False
         while time.time() < deadline:
             pinned = touch_driver.execute_script(
-                "return !!document.querySelector('[data-ttip-wired] .ttip.ttip-pinned');"
+                "return !!document.querySelector('.ttip.ttip-pinned');"
             )
             if pinned:
                 break

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -18,6 +18,8 @@ import pytest
 
 selenium = pytest.importorskip("selenium")
 from selenium import webdriver  # noqa: E402
+from selenium.webdriver.common.action_chains import ActionChains  # noqa: E402
+from selenium.webdriver.common.by import By  # noqa: E402
 from selenium.webdriver.chrome.options import Options  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
@@ -283,41 +285,72 @@ def test_column_toggle_hover_opens_its_tooltip(driver):
     assert result == {"visible": True, "visibility": "visible"}
 
 
-def test_sticky_columns_stay_below_popups(driver):
+def test_portalled_tooltip_tracks_the_document_scroll(driver):
+    cell = driver.find_element(By.CSS_SELECTOR, ".tab-panel.active tbody tr:last-child td.cell")
+    driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", cell)
+    assert driver.execute_script("return window.scrollY > 0")
+    ActionChains(driver).move_to_element(cell).perform()
+    time.sleep(1)
     result = driver.execute_script(
         """
-        const table = document.querySelector('.tab-panel.active [data-parity-table]');
-        const stickyHeader = table.querySelector('th[data-col-control-group="parser"]');
-        const stickyBody = table.querySelector('td.parser');
-        const popup = document.querySelector('.ttip');
+        const cell = arguments[0];
+        const tooltip = cell._ttip;
+        const cellRect = cell.getBoundingClientRect();
+        const tooltipRect = tooltip.getBoundingClientRect();
         return {
-          stickyHeader: Number(getComputedStyle(stickyHeader).zIndex),
-          stickyBody: Number(getComputedStyle(stickyBody).zIndex),
-          popup: Number(getComputedStyle(popup).zIndex),
+          portalled: tooltip.parentElement === document.body,
+          topDelta: tooltipRect.top - cellRect.bottom,
+          leftDelta: tooltipRect.left - cellRect.left,
         };
-        """
+        """,
+        cell,
     )
 
-    assert result["stickyBody"] < result["popup"], result
+    assert result["portalled"], result
+    assert abs(result["topDelta"]) < 2, result
+    assert result["leftDelta"] <= 0, result
 
 
-def test_tool_calling_header_stays_below_the_portalled_popup(driver):
+def test_portalled_tooltip_stays_open_while_hovered(driver):
+    result = driver.execute_script(
+        """
+        const cell = document.querySelector('.tab-panel.active td.cell');
+        cell.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
+        const tooltip = cell._ttip;
+        cell.dispatchEvent(new MouseEvent('mouseleave', {bubbles: false, view: window}));
+        tooltip.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
+        return { tooltip };
+        """
+    )
+    time.sleep(1)
+    visible = driver.execute_script(
+        "return arguments[0].classList.contains('ttip-visible');", result["tooltip"]
+    )
+
+    assert visible
+
+
+def test_column_toggle_reuses_its_portalled_tooltip(driver):
     result = driver.execute_script(
         """
         const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]
           .find(el => el.dataset.colLabel === 'Tool calling family');
-        const header = button.closest('th');
         const tooltip = button._ttip;
         document.body.appendChild(tooltip);
-        tooltip.classList.add('ttip-visible');
-        const openZIndex = Number(getComputedStyle(header).zIndex);
-        tooltip.classList.remove('ttip-visible');
-        button.appendChild(tooltip);
-        return { openZIndex, closedZIndex: Number(getComputedStyle(header).zIndex) };
+        button.click();
+        return {
+          count: button._ttip === tooltip ? 1 : 0,
+          owned: button._ttip === tooltip,
+          text: tooltip.querySelector('.column-control-tooltip-text').textContent,
+        };
         """
     )
 
-    assert result == {"openZIndex": 8, "closedZIndex": 8}
+    assert result == {
+        "count": 1,
+        "owned": True,
+        "text": "Expand Tool calling family column",
+    }
 
 
 def test_order_divergence_shows_golden_and_candidate_sequences(driver):

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -311,15 +311,19 @@ def test_portalled_tooltip_tracks_the_document_scroll(driver):
 
 
 def test_portalled_tooltip_stays_open_while_hovered(driver):
+    cell = driver.find_element(By.CSS_SELECTOR, ".tab-panel.active td.cell")
     result = driver.execute_script(
         """
-        const cell = document.querySelector('.tab-panel.active td.cell');
+        const cell = arguments[0];
         cell.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
-        const tooltip = cell._ttip;
-        cell.dispatchEvent(new MouseEvent('mouseleave', {bubbles: false, view: window}));
-        tooltip.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
-        return { tooltip };
-        """
+        return new Promise(resolve => setTimeout(() => {
+          const tooltip = cell._ttip;
+          cell.dispatchEvent(new MouseEvent('mouseleave', {bubbles: false, view: window}));
+          tooltip.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
+          resolve({tooltip});
+        }, 850));
+        """,
+        cell,
     )
     time.sleep(1)
     visible = driver.execute_script(
@@ -327,6 +331,51 @@ def test_portalled_tooltip_stays_open_while_hovered(driver):
     )
 
     assert visible
+
+
+def test_transpose_keeps_one_open_tooltip(driver):
+    driver.execute_script(
+        """
+        document.querySelectorAll('.ttip.ttip-visible').forEach(t => t.classList.remove('ttip-visible', 'ttip-pinned'));
+        document.body.classList.remove('ttip-pin-mode', 'transpose-mode');
+        const toggle = document.querySelector('[data-transpose-toggle]');
+        if (toggle.checked) toggle.click();
+        """
+    )
+    cell = driver.find_element(By.CSS_SELECTOR, ".tab-panel.active td.cell")
+    result = driver.execute_script(
+        """
+        const cell = arguments[0];
+        cell.dispatchEvent(new MouseEvent('mouseenter', {bubbles: false, view: window}));
+        return new Promise(resolve => setTimeout(() => {
+          const toggle = document.querySelector('[data-transpose-toggle]');
+          const before = document.querySelectorAll('.ttip.ttip-visible').length;
+          toggle.click();
+          const after = document.querySelectorAll('.ttip.ttip-visible').length;
+          resolve({before, after, portalled: [...document.querySelectorAll('.ttip.ttip-visible')]
+            .filter(t => t.parentElement === document.body).length});
+        }, 850));
+        """,
+        cell,
+    )
+
+    assert result == {"before": 1, "after": 1, "portalled": 1}, result
+
+
+def test_focus_tooltip_stays_in_tab_order(driver):
+    cell = driver.find_element(By.CSS_SELECTOR, ".tab-panel.active td.cell")
+    result = driver.execute_script(
+        """
+        const cell = arguments[0];
+        cell.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+        return new Promise(resolve => setTimeout(() => {
+          const tooltip = cell._ttip;
+          resolve({parent: tooltip.parentElement === cell, visible: tooltip.classList.contains('ttip-visible')});
+        }, 850));
+        """,
+        cell,
+    )
+    assert result == {"parent": True, "visible": True}
 
 
 def test_column_toggle_reuses_its_portalled_tooltip(driver):

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -247,7 +247,6 @@ def test_hover_shows_tooltip(driver):
 
 
 def test_column_toggle_hint_is_anchored_to_the_button(driver):
-    """Column controls use the page tooltip rather than a detached native title popup."""
     result = driver.execute_script(
         """
         const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -359,7 +359,10 @@ def test_transpose_keeps_one_open_tooltip(driver):
         cell,
     )
 
-    assert result == {"before": 1, "after": 1, "portalled": 1}, result
+    assert result["before"] == 1, result
+    assert result["after"] == 1, result
+    assert result["portalled"] == 1, result
+    assert driver.execute_script("return document.querySelector('.transpose-table .ttip') !== null")
 
 
 def test_focus_tooltip_stays_in_tab_order(driver):

--- a/conformance/utils/tests/test_browser_smoke.py
+++ b/conformance/utils/tests/test_browser_smoke.py
@@ -244,6 +244,31 @@ def test_hover_shows_tooltip(driver):
     assert visible, "tooltip did not become visible on hover"
 
 
+def test_column_toggle_hint_is_anchored_to_the_button(driver):
+    """Column controls use the page tooltip rather than a detached native title popup."""
+    result = driver.execute_script(
+        """
+        const button = [...document.querySelectorAll('.tab-panel.active [data-col-toggle]')]
+          .find(el => el.dataset.colLabel === 'Tool calling family');
+        if (!button) return null;
+        const style = getComputedStyle(button, '::after');
+        return {
+          title: button.getAttribute('title'),
+          tooltip: button.dataset.tooltip,
+          content: style.content,
+          position: style.position,
+          bottom: style.bottom,
+        };
+        """
+    )
+    assert result, "Tool calling family column control is missing"
+    assert result["title"] is None, result
+    assert result["tooltip"] == "Collapse Tool calling family column", result
+    assert result["content"] == '"Collapse Tool calling family column"', result
+    assert result["position"] == "absolute", result
+    assert result["bottom"] != "auto", result
+
+
 def test_order_divergence_shows_golden_and_candidate_sequences(driver):
     """ORDER/MERGE explanations come from the golden candidate in the model."""
     text = driver.execute_script(

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -123,16 +123,6 @@ def test_v2_schema_and_meta(model_v2):
 
 # ---- schema-2 compaction (model.py _compact_page <-> hydrate_page) --------------
 
-def test_missing_cell_explains_the_unclassified_gap():
-    cell = model_mod.missing_cell("REASONING.batch.2.b", "qwen3")
-
-    assert cell["kind"] == "missing"
-    assert cell["tooltip"]["na_note"] == (
-        "qwen3 has no authored fixture for REASONING.batch.2.b. "
-        "The corpus also has no explicit N/A rationale, so this is an "
-        "unclassified coverage gap rather than evidence that the case does not apply."
-    )
-
 def test_compaction_roundtrip_is_identity():
     # compact -> hydrate must reproduce the original page exactly (modulo the added
     # compaction keys), or the JS view would render different VALUES than Python

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -123,6 +123,16 @@ def test_v2_schema_and_meta(model_v2):
 
 # ---- schema-2 compaction (model.py _compact_page <-> hydrate_page) --------------
 
+def test_missing_cell_explains_the_unclassified_gap():
+    cell = model_mod.missing_cell("REASONING.batch.2.b", "qwen3")
+
+    assert cell["kind"] == "missing"
+    assert cell["tooltip"]["na_note"] == (
+        "qwen3 has no authored fixture for REASONING.batch.2.b. "
+        "The corpus also has no explicit N/A rationale, so this is an "
+        "unclassified coverage gap rather than evidence that the case does not apply."
+    )
+
 def test_compaction_roundtrip_is_identity():
     # compact -> hydrate must reproduce the original page exactly (modulo the added
     # compaction keys), or the JS view would render different VALUES than Python
@@ -198,6 +208,16 @@ def test_v2_all_tabs_present(model_v2):
         "tab-toolcalling-batch", "tab-toolcalling-streamv2",
         "tab-reasoning-batch", "tab-reasoning-stream", "tab-unified",
     ], ids
+
+
+def test_v2_tab_labels_show_parser_generation(model_v2):
+    labels = {tab["id"]: tab["label"] for tab in model_v2["tabs"]}
+
+    assert labels["tab-toolcalling-batch"].startswith("Tool Calling v1")
+    assert labels["tab-toolcalling-streamv2"].startswith("Tool Calling v2")
+    assert labels["tab-reasoning-batch"].startswith("Reasoning v1")
+    assert labels["tab-reasoning-stream"].startswith("Reasoning v1")
+    assert labels["tab-unified"].startswith("Unified v2")
 
 
 def test_unified_numeric_case_ids_use_dash_everywhere(model_v2):

--- a/conformance/utils/tests/test_model.py
+++ b/conformance/utils/tests/test_model.py
@@ -205,8 +205,6 @@ def test_v2_tab_labels_show_parser_generation(model_v2):
 
     assert labels["tab-toolcalling-batch"].startswith("Tool Calling v1")
     assert labels["tab-toolcalling-streamv2"].startswith("Tool Calling v2")
-    assert labels["tab-reasoning-batch"].startswith("Reasoning v1")
-    assert labels["tab-reasoning-stream"].startswith("Reasoning v1")
     assert labels["tab-unified"].startswith("Unified v2")
 
 


### PR DESCRIPTION
#### Overview:

UI change only — no parser code is touched. This PR fixes the `Tool calling family` column control in `CONFORMANCE_v2.html` so its hover hint stays anchored to the control instead of appearing below the column.

#### Example (before → after):

Input: Hover over the `Tool calling family` column control.

```text
before: the browser-native title popup is positioned below the header column
 after: the page-controlled hint is positioned relative to the column control
```

before:
<img width="762" height="380" alt="image" src="https://github.com/user-attachments/assets/78b7579d-9ef1-4b5e-ac40-66b9b815394e" />

after:
<img width="763" height="378" alt="image" src="https://github.com/user-attachments/assets/e0e68a0f-5202-42fc-9a17-f34c28fe2eed" />


#### Details:

- Remove the native `title` popup and expose the control text through `aria-label` plus a CSS-generated page hint.
- Add a browser regression test for the rendered `CONFORMANCE_v2.html` control.

#### Verification:

`python3 -m pytest conformance/utils/tests/test_browser_smoke.py -q` (20 passed); `python3 -m pytest conformance/utils/tests/test_browser_popup_compare.py conformance/utils/tests/test_model.py conformance/utils/tests/test_stream_on_batch.py -q` (86 passed).

#### Where should the reviewer start?

`conformance/utils/src/assets/conformance.js`, then `conformance/utils/src/assets/conformance.css`

Related: MOD-1

/coderabbit profile chill